### PR TITLE
Unify `jest.config.js` files to explicitly call-out some configs

### DIFF
--- a/packages/barebone-logger/jest.config.js
+++ b/packages/barebone-logger/jest.config.js
@@ -1,6 +1,17 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+
+  // Mock cleanup - automatic between tests
+  clearMocks: true, // Clear mock.calls, mock.instances, mock.contexts, mock.results
+  resetMocks: true, // Reset mock implementations to empty functions
+  restoreMocks: true, // Restore original implementations for jest.spyOn
+
+  // Test execution settings
+  errorOnDeprecated: true, // Throw on deprecated API usage
+  testTimeout: 5000, // 5s timeout (explicit)
+  maxWorkers: '50%', // Use 50% of CPU cores
+
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.test.ts'],
   collectCoverageFrom: [

--- a/packages/rangelink-core-ts/jest.config.js
+++ b/packages/rangelink-core-ts/jest.config.js
@@ -1,6 +1,17 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+
+  // Mock cleanup - automatic between tests
+  clearMocks: true, // Clear mock.calls, mock.instances, mock.contexts, mock.results
+  resetMocks: true, // Reset mock.calls, mock.instances, mock.contexts, mock.results
+  restoreMocks: true, // Restore original implementations for jest.spyOn
+
+  // Test execution settings
+  errorOnDeprecated: true, // Throw on deprecated API usage
+  testTimeout: 5000, // 5s timeout (explicit)
+  maxWorkers: '50%', // Use 50% of CPU cores
+
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.test.ts'],
   setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup/matchers.ts'],

--- a/packages/rangelink-vscode-extension/jest.config.js
+++ b/packages/rangelink-vscode-extension/jest.config.js
@@ -1,6 +1,17 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+
+  // Mock cleanup - automatic between tests
+  clearMocks: true, // Clear mock.calls, mock.instances, mock.contexts, mock.results
+  resetMocks: true, // Reset mock.calls, mock.instances, mock.contexts, mock.results
+  restoreMocks: true, // Restore original implementations for jest.spyOn
+
+  // Test execution settings
+  errorOnDeprecated: true, // Throw on deprecated API usage
+  testTimeout: 5000, // 5s timeout (explicit)
+  maxWorkers: '50%', // Use 50% of CPU cores
+
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.test.ts', '**/*.test.ts'],
   collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts', '!src/__tests__/**'],

--- a/packages/rangelink-vscode-extension/src/__tests__/RangeLinkService.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/RangeLinkService.test.ts
@@ -46,8 +46,6 @@ describe('RangeLinkService', () => {
 
       // Create service
       service = new RangeLinkService(delimiters, mockIdeAdapter, mockDestinationManager);
-
-      jest.clearAllMocks();
     });
 
     describe('when no destination is bound', () => {

--- a/packages/rangelink-vscode-extension/src/__tests__/extension.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/extension.test.ts
@@ -149,8 +149,6 @@ describe('RangeLinkService', () => {
   let service: RangeLinkService;
 
   beforeEach(() => {
-    // Clear all mocks
-    jest.clearAllMocks();
     mockClipboard.writeText.mockResolvedValue(undefined);
 
     // Wire up the external mock objects to the vscode mock
@@ -185,10 +183,6 @@ describe('RangeLinkService', () => {
       ideAdapter,
       createMockDestinationManager() as any,
     );
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
   });
 
   describe('createLink - Empty selection handling', () => {
@@ -1267,7 +1261,6 @@ describe('RangeLinkService', () => {
 
 describe('Configuration loading and validation', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
     mockOutputChannel.appendLine.mockClear();
 
     // Wire up mocks - use arrow function to allow dynamic reassignment
@@ -2979,8 +2972,6 @@ describe('Configuration loading and validation', () => {
 
 describe('Portable links (Phase 1C)', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
-
     // Wire up mocks
     (vscode.window.createOutputChannel as jest.Mock).mockReturnValue(mockOutputChannel);
     (vscode.window.showErrorMessage as jest.Mock).mockImplementation(mockWindow.showErrorMessage);
@@ -3104,8 +3095,6 @@ describe('Portable links (Phase 1C)', () => {
 });
 describe('Extension lifecycle', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
-
     // Wire up mocks
     (vscode.window.createOutputChannel as jest.Mock).mockReturnValue(mockOutputChannel);
     (vscode.window.showErrorMessage as jest.Mock).mockImplementation(mockWindow.showErrorMessage);

--- a/packages/rangelink-vscode-extension/src/__tests__/navigation/RangeLinkTerminalProvider.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/navigation/RangeLinkTerminalProvider.test.ts
@@ -54,9 +54,6 @@ describe('RangeLinkTerminalProvider', () => {
     // Create handler and provider
     const handler = new RangeLinkNavigationHandler(delimiters, mockLogger);
     provider = new RangeLinkTerminalProvider(handler, mockLogger);
-
-    // Reset mocks
-    jest.clearAllMocks();
   });
 
   describe('handleTerminalLink - Safety Net Validation', () => {

--- a/packages/rangelink-vscode-extension/src/__tests__/utils/resolveWorkspacePath.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/utils/resolveWorkspacePath.test.ts
@@ -34,10 +34,6 @@ describe('resolveWorkspacePath', () => {
   const mockUri = vscode.Uri as jest.Mocked<typeof vscode.Uri>;
   const mockStat = mockWorkspace.fs.stat as jest.MockedFunction<typeof mockWorkspace.fs.stat>;
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   afterEach(() => {
     // Reset workspaceFolders to undefined
     Object.defineProperty(mockWorkspace, 'workspaceFolders', {


### PR DESCRIPTION
Removed all calls to `jest.clearAllMocks()` from the tests; not needed anymore