### PR TITLE
fix(vscode-ext): make AI commands always discoverable with helpful guidance

### DIFF
--- a/packages/rangelink-vscode-extension/CHANGELOG.md
+++ b/packages/rangelink-vscode-extension/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cursor AI Integration** - Streamlined clipboard workflow for Cursor IDE
   - Automatically copies link and opens Cursor chat panel
   - One-paste workflow: user pastes with Cmd/Ctrl+V (workaround for API limitation)
-  - Cursor IDE only
+  - Command always discoverable in Command Palette for both VSCode and Cursor
+  - Shows helpful message in VSCode directing users to Cursor IDE
   - Command: "Bind RangeLink to Cursor AI"
 - **Text Editor Destination** - Paste generated links directly into any text-based editor
   - Works with untitled/scratch files, markdown, code files, any text document

--- a/packages/rangelink-vscode-extension/package.json
+++ b/packages/rangelink-vscode-extension/package.json
@@ -97,6 +97,12 @@
         "icon": "$(link)"
       },
       {
+        "command": "rangelink.bindToCursorAI",
+        "title": "Bind RangeLink to Cursor AI Destination",
+        "category": "RangeLink",
+        "icon": "$(link)"
+      },
+      {
         "command": "rangelink.bindToClaudeCode",
         "title": "Bind RangeLink to Claude Code Destination",
         "category": "RangeLink",

--- a/packages/rangelink-vscode-extension/src/__tests__/extension.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/extension.test.ts
@@ -3143,25 +3143,21 @@ describe('Extension lifecycle', () => {
     // Extension imported at top
     require('../extension').activate(mockContext as any);
 
-    // Wait for async IIFE to complete
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    // Note: bindToCursorAI NOT registered in non-Cursor IDE
-    // bindToClaudeCode IS always registered (even if not available)
-    expect(mockCommands.registerCommand).toHaveBeenCalledTimes(10);
+    // Both AI commands are always registered for discoverability
+    // Runtime checks show helpful messages when IDE/extension not available
+    expect(mockCommands.registerCommand).toHaveBeenCalledTimes(11);
     expect(mockContext.subscriptions.length).toBeGreaterThan(0);
     expect(vscode.window.createOutputChannel).toHaveBeenCalledWith('RangeLink');
 
-    // Verify bindToCursorAI was NOT registered (only registered in Cursor IDE)
+    // Verify both AI assistant commands are registered for discoverability
     const registeredCommands = (mockCommands.registerCommand as jest.Mock).mock.calls.map(
       (call) => call[0],
     );
-    expect(registeredCommands).not.toContain('rangelink.bindToCursorAI');
-    // Verify bindToClaudeCode WAS registered (always registered for discoverability)
+    expect(registeredCommands).toContain('rangelink.bindToCursorAI');
     expect(registeredCommands).toContain('rangelink.bindToClaudeCode');
   });
 
-  it('should register bindToCursorAI command when running in Cursor IDE', async () => {
+  it('should register both AI commands regardless of IDE (discoverability)', async () => {
     const mockContext = {
       subscriptions: [] as any[],
     };
@@ -3200,19 +3196,16 @@ describe('Extension lifecycle', () => {
     // Extension imported at top
     require('../extension').activate(mockContext as any);
 
-    // Wait for async IIFE to complete
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    // bindToCursorAI IS registered in Cursor IDE + bindToClaudeCode always registered
+    // Both AI commands always registered (even in Cursor IDE)
+    // Runtime availability determines whether they work or show help message
     expect(mockCommands.registerCommand).toHaveBeenCalledTimes(11);
     expect(mockContext.subscriptions.length).toBeGreaterThan(0);
 
-    // Verify bindToCursorAI WAS registered
+    // Verify both AI assistant commands are registered
     const registeredCommands = (mockCommands.registerCommand as jest.Mock).mock.calls.map(
       (call) => call[0],
     );
     expect(registeredCommands).toContain('rangelink.bindToCursorAI');
-    // Verify bindToClaudeCode WAS also registered
     expect(registeredCommands).toContain('rangelink.bindToClaudeCode');
   });
 


### PR DESCRIPTION
Both Cursor AI and Claude Code commands now register unconditionally in all IDEs. Runtime availability checks show context-aware messages directing users to the right environment.

**Why this matters:**
Commands registered only at runtime (not in package.json) don't appear in Command Palette. Previous approach (a144b07) removed bindToCursorAI from package.json to hide it from VSCode users, but this also hid it from Cursor users who needed it.

**The problem we solved:**
- VSCode extension API provides no `when` clause to conditionally declare commands by IDE
- Only two options: visible to everyone, or hidden from everyone
- Chose discoverability + helpful guidance over perfect segregation

**What changed:**
- Added `rangelink.bindToCursorAI` back to package.json
- Both AI commands now always register (no async IIFE conditional logic)
- Cursor command shows: "This command is designed for Cursor IDE..." in VSCode
- Claude Code command shows: "Install and activate Claude Code extension..." when unavailable
- Updated tests to reflect always-registered behavior

Benefits:
- Cursor users can discover and use their command
- VSCode users see helpful guidance when they try Cursor-specific features
- No "command not found" errors
- Consistent UX pattern across both AI integrations