### PR TITLE
chore(vscode-ext): add UNRELEASED section to CHANGELOG

### DIFF
--- a/packages/rangelink-vscode-extension/CHANGELOG.md
+++ b/packages/rangelink-vscode-extension/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the RangeLink VS Code extension will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
 ## [0.3.0]
 
 ### Added


### PR DESCRIPTION
## Summary

Prepares CHANGELOG for post-0.3.0 development by adding standard UNRELEASED section with Added/Changed/Fixed categories.

## Changes

- Added UNRELEASED section at top of extension CHANGELOG
- Includes standard categories: Added, Changed, Fixed
- Link reference already correctly configured to compare against v0.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)