### PR TITLE
docs(i18n): mark issue #104 complete, update I18N.md status

### DIFF
--- a/docs/I18N.md
+++ b/docs/I18N.md
@@ -282,30 +282,28 @@ const message = getMessage(RangeLinkMessageCode.MSG_LINK_COPIED, { linkType: 'po
 vscode.window.showInformationMessage(message);
 ```
 
-## Implementation Timeline
+## Implementation Status
 
-### Phase 1 (Current) - Foundation
+### Extension-Layer i18n (Complete) — [#104](https://github.com/couimet/rangeLink/issues/104)
 
-- ✅ Separate RangeLinkMessageCode (MSG\_ only)
-- ✅ Separate RangeLinkErrorCodes (no prefixes)
-- ✅ Document i18n architecture
-- ⏳ Specification complete
+✅ **Implemented:** Extension-layer i18n system operational (English only)
 
-### Phase 2-4 - Error Migration
+**Implementation:**
 
-- Migrate all error codes to RangeLinkErrorCodes
-- Update Result types to use RangeLinkError
-- Remove ERR*/WARN* codes from RangeLinkMessageCode
-- Result: Clean separation between errors and messages
+- `formatMessage()` function with parameter substitution
+- `LocaleManager` with locale injection from VSCode
+- `MessageCode` enum for extension UI messages
+- 10 message codes migrated (status bar, user instructions, config)
 
-### Phase 5 - i18n Implementation (See [#37](https://github.com/couimet/rangeLink/issues/37))
+**Location:** `packages/rangelink-vscode-extension/src/i18n/`
 
-### Phase 6 - Additional Languages (Future)
+**Architecture:** Extension-layer only (Option D) - core library stays English for technical messages
 
-- Create `messages.fr.ts` for French
-- Create `messages.es.ts` for Spanish
-- Add language selection in extension settings
-- Document translation contribution process
+### Future Work (See [#37](https://github.com/couimet/rangeLink/issues/37))
+
+- Additional locales (French, Spanish)
+- Remaining extension messages (PasteDestinationManager, etc.)
+- Translation contribution guidelines
 
 ## Testing Strategy
 
@@ -405,9 +403,3 @@ logger.info(
 - [ERROR-HANDLING.md](./ERROR-HANDLING.md) - Error handling architecture
 - [LOGGING.md](./LOGGING.md) - Structured logging approach
 - [ARCHITECTURE.md](./ARCHITECTURE.md) - Core library design
-
----
-
-**Version:** 0.1.0 (Specification)
-**Last Updated:** 2025-11-04
-**Status:** Awaiting implementation after error migration (Phase 5)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -330,12 +330,12 @@ Integrate terminal link provider with Phase 4A.2 config change detection. Rebuil
 
 ## Phase 10: Internationalization (i18n) - (See [#37](https://github.com/couimet/rangeLink/issues/37))
 
-- [ ] **Translation Infrastructure** - VSCode i18n API, resource files, error code mapping, multiple languages
-- [ ] **Error Message Localization** - All validation errors, status bar, commands, settings
+- [x] **[#104](https://github.com/couimet/rangeLink/issues/104)** - Extension-layer i18n foundation (formatMessage, MessageCode, LocaleManager)
+- [ ] **Additional Locales** - French, Spanish translations
+- [ ] **Remaining Messages** - PasteDestinationManager strings, additional UI messages
 - [ ] **Community Contributions** - Translation process, templates, credit translators
-- [ ] **Testing** - Verify layout, test long translations, ensure code consistency
 
-See [LOGGING.md](./LOGGING.md#internationalization-readiness).
+**Status:** Foundation complete (extension-layer only, English). See [I18N.md](./I18N.md) for architecture.
 
 ---
 


### PR DESCRIPTION
Issue #104 getMessage() foundation was already fully implemented but documentation still showed "awaiting implementation". This caused confusion about what remained for the i18n system.

Updated I18N.md:
- Replaced "Implementation Timeline" (outdated phases) with "Implementation Status"
- Added concise summary of completed work (formatMessage, LocaleManager, 10 message codes)
- Removed obsolete version footer and phase descriptions
- Clarified extension-layer architecture (Option D)

Updated ROADMAP.md Phase 10:
- Marked #104 as complete [x]
- Updated remaining work to be specific and actionable
- Added status line referencing I18N.md architecture

Created follow-up issue #112 (child of #37) for remaining PasteDestinationManager strings discovered during analysis.

Benefits:
- Documentation now reflects actual implementation state
- Clear distinction between complete work (foundation) and future work (locales, remaining messages)
- Easier for contributors to understand current capabilities vs planned features

Related: #37 (parent), #104 (complete), #112 (follow-up)