### PR TITLE
fix(vscode-ext): prevent binding loss when IDE dynamically renames untitled files

### DIFF
--- a/packages/rangelink-vscode-extension/src/destinations/TextEditorDestination.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/TextEditorDestination.ts
@@ -562,10 +562,18 @@ export class TextEditorDestination implements PasteDestination {
       return false;
     }
 
-    // Compare document URIs (unique per file)
-    return (
-      this.vscodeAdapter.getDocumentUri(this.editor).toString() ===
-      this.vscodeAdapter.getDocumentUri(otherEditor).toString()
-    );
+    // Get URIs for comparison
+    const thisUri = this.vscodeAdapter.getDocumentUri(this.editor);
+    const otherUri = this.vscodeAdapter.getDocumentUri(otherEditor);
+
+    // For untitled files, use editor object identity (survives URI changes during dynamic renames)
+    // Issue #137: VSCode/Cursor dynamically rename untitled files based on content, causing URI changes
+    // Example: "untitled:Untitled-1" → "untitled:index.ts" when typing TypeScript code
+    if (thisUri.scheme === 'untitled' && otherUri.scheme === 'untitled') {
+      return this.editor === otherEditor;
+    }
+
+    // For regular files, use URI comparison (unique per file)
+    return thisUri.toString() === otherUri.toString();
   }
 }


### PR DESCRIPTION
Fixes issue #137 where text editor bindings automatically unbind when VSCode/Cursor dynamically renames untitled files based on content.

**Problem:**
When typing in an untitled file, IDEs suggest filenames (e.g., "Untitled-1" → <the content typed in the file>). This URI change caused `TextEditorDestination.equals()` to return false, triggering automatic unbinding and confusing UX.

**Root Cause:**
`equals()` compared document URIs, which change during dynamic renames:
- Before: `untitled:Untitled-1`
- After: `untitled:<the content typed in the file>`

**Solution (Option 1 from issue):**
For untitled files, use editor object identity instead of URI comparison:
```typescript
if (thisUri.scheme === 'untitled' && otherUri.scheme === 'untitled') {
  return this.editor === otherEditor;
}
```

Editor object remains stable across URI changes, preserving bindings.

**Benefits:**
- Bindings persist during IDE-suggested filename changes
- No unexpected unbind notifications during normal editing
- Regular files still use URI comparison (unchanged behavior)

Closes #137 