### PR TITLE
[issues/183] full-line notation now selects entire line instead of first character

### DIFF
--- a/packages/rangelink-vscode-extension/CHANGELOG.md
+++ b/packages/rangelink-vscode-extension/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Show Version Info
   - Foundation for future features (bookmarks, paste destination display)
 
+### Fixed
+
+- **Full-line navigation selection** - Fixed `#L10` selecting only first character instead of entire line. Full-line links (`#L10`, `#L10-L15`) now correctly select from start of first line to end of last line.
+
 ## [1.0.0]
 
 ### Added


### PR DESCRIPTION
## Summary

Full-line links like `#L10` were selecting only the first character instead of the entire line.

## Problem

When navigating to `file.ts#L10`, the selection showed only 1 character at position (10, 0) instead of the full line content.

**Root cause**: `convertRangeLinkPosition` defaults undefined `char` to 0. For full-line links:
- `start.char = undefined` → converted to 0
- `end.char = undefined` → converted to 0
- Result: `vsStart = vsEnd = (line, 0)` → triggered single-position extension (1 char)

## Solution

Detect full-line selection BEFORE position conversion by checking if both `start.char` and `end.char` are undefined. When true, extend the end position to the line length instead of defaulting to 0.

```typescript
// Before: both paths could fall through to single-position extension
if (isFullLineSelection) { ... }
else { vsEnd = ... }
// single-position check here (wrong for full-line empty lines)

// After: clean separation of concerns
if (isFullLineSelection) {
  // Complete handling: extend to lineLength
} else {
  // Explicit positions: may need single-position extension
}
```

## Behavior Matrix

| Link Format | Before | After |
|-------------|--------|-------|
| `#L10` | Selects 1 char at (10,0) | ✅ Selects entire line 10 | | `#L10-L15` | Selects from (10,0) to (15,0) | ✅ Selects L10:0 to L15:end | | `#L10C5` | Extends by 1 char ✅ | Extends by 1 char ✅ | | `#L10C5-L15C10` | No change ✅ | No change ✅ |
| `#L10C5-L15` | Explicit start, end=0 | Explicit start, end=0 | | `#L10-L15C10` | start=0, explicit end | start=0, explicit end |

Closes #183