### PR TITLE
[issues/176] add `PaddingMode` parameter to `applySmartPadding()`

### DIFF
--- a/packages/rangelink-vscode-extension/src/__tests__/utils/applySmartPadding.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/utils/applySmartPadding.test.ts
@@ -143,4 +143,102 @@ describe('applySmartPadding', () => {
       expect(applySmartPadding('text   ')).toBe(' text   ');
     });
   });
+
+  describe('Padding modes', () => {
+    describe('mode: both (default)', () => {
+      it('should add both leading and trailing spaces when explicit', () => {
+        expect(applySmartPadding('link', 'both')).toBe(' link ');
+      });
+
+      it('should use both as default when mode omitted', () => {
+        expect(applySmartPadding('link')).toBe(' link ');
+      });
+
+      it('should preserve existing leading space', () => {
+        expect(applySmartPadding(' link', 'both')).toBe(' link ');
+      });
+
+      it('should preserve existing trailing space', () => {
+        expect(applySmartPadding('link ', 'both')).toBe(' link ');
+      });
+
+      it('should preserve whitespace-only strings', () => {
+        expect(applySmartPadding('   ', 'both')).toBe('   ');
+      });
+
+      it('should add both spaces to empty string', () => {
+        expect(applySmartPadding('', 'both')).toBe('  ');
+      });
+    });
+
+    describe('mode: before', () => {
+      it('should add only leading space', () => {
+        expect(applySmartPadding('link', 'before')).toBe(' link');
+      });
+
+      it('should preserve existing leading space', () => {
+        expect(applySmartPadding(' link', 'before')).toBe(' link');
+      });
+
+      it('should not add trailing space', () => {
+        expect(applySmartPadding('link', 'before')).toBe(' link');
+      });
+
+      it('should preserve whitespace-only strings', () => {
+        expect(applySmartPadding('   ', 'before')).toBe('   ');
+      });
+
+      it('should add leading space to empty string', () => {
+        expect(applySmartPadding('', 'before')).toBe(' ');
+      });
+    });
+
+    describe('mode: after', () => {
+      it('should add only trailing space', () => {
+        expect(applySmartPadding('link', 'after')).toBe('link ');
+      });
+
+      it('should not add leading space', () => {
+        expect(applySmartPadding('link', 'after')).toBe('link ');
+      });
+
+      it('should preserve existing trailing space', () => {
+        expect(applySmartPadding('link ', 'after')).toBe('link ');
+      });
+
+      it('should preserve whitespace-only strings', () => {
+        expect(applySmartPadding('   ', 'after')).toBe('   ');
+      });
+
+      it('should add trailing space to empty string', () => {
+        expect(applySmartPadding('', 'after')).toBe(' ');
+      });
+    });
+
+    describe('mode: none', () => {
+      it('should return text unchanged', () => {
+        expect(applySmartPadding('link', 'none')).toBe('link');
+      });
+
+      it('should preserve existing leading space', () => {
+        expect(applySmartPadding(' link', 'none')).toBe(' link');
+      });
+
+      it('should preserve existing trailing space', () => {
+        expect(applySmartPadding('link ', 'none')).toBe('link ');
+      });
+
+      it('should preserve whitespace-only strings', () => {
+        expect(applySmartPadding('   ', 'none')).toBe('   ');
+      });
+
+      it('should preserve empty string', () => {
+        expect(applySmartPadding('', 'none')).toBe('');
+      });
+
+      it('should preserve text with both leading and trailing spaces', () => {
+        expect(applySmartPadding(' link ', 'none')).toBe(' link ');
+      });
+    });
+  });
 });

--- a/packages/rangelink-vscode-extension/src/utils/applySmartPadding.ts
+++ b/packages/rangelink-vscode-extension/src/utils/applySmartPadding.ts
@@ -1,31 +1,56 @@
 /**
+ * Padding modes for smart padding operations.
+ *
+ * - `both` - Add leading and trailing spaces (prevents concatenation on both sides)
+ * - `before` - Add leading space only
+ * - `after` - Add trailing space only
+ * - `none` - No padding (return text as-is)
+ */
+export type PaddingMode = 'both' | 'before' | 'after' | 'none';
+
+interface PaddingBehavior {
+  readonly addBefore: boolean;
+  readonly addAfter: boolean;
+}
+
+const PADDING_BEHAVIORS: Record<PaddingMode, PaddingBehavior> = {
+  both: { addBefore: true, addAfter: true },
+  before: { addBefore: true, addAfter: false },
+  after: { addBefore: false, addAfter: true },
+  none: { addBefore: false, addAfter: false },
+};
+
+/**
  * Apply smart padding to text for paste operations
  *
- * Adds leading and trailing spaces to text only when needed, preventing
- * double-spacing issues when user has already padded text manually.
+ * Adds leading and/or trailing spaces to text based on the specified mode,
+ * preventing double-spacing when text already has appropriate whitespace.
  *
  * Padding strategy:
- * - Add leading space only if text doesn't start with whitespace
- * - Add trailing space only if text doesn't end with whitespace
+ * - `none` mode: Return text unchanged
+ * - `before` mode: Add leading space only if text doesn't start with whitespace
+ * - `after` mode: Add trailing space only if text doesn't end with whitespace
+ * - `both` mode: Add both leading and trailing spaces where missing
  * - Preserve existing whitespace (don't double-pad)
  *
  * @param text - The text to pad
- * @returns Padded text with smart spacing
+ * @param mode - Padding mode: 'both' (default), 'before', 'after', or 'none'
+ * @returns Padded text with smart spacing based on mode
  *
  * @remarks
  * Content validation (empty/whitespace-only) should be done by isEligibleForPaste()
  * before calling this function if filtering is needed.
  */
-export const applySmartPadding = (text: string): string => {
+export const applySmartPadding = (text: string, mode: PaddingMode = 'both'): string => {
+  const { addBefore, addAfter } = PADDING_BEHAVIORS[mode];
+
   let result = text;
 
-  // Add leading space if not present
-  if (!/^\s/.test(text)) {
+  if (addBefore && !/^\s/.test(text)) {
     result = ` ${result}`;
   }
 
-  // Add trailing space if not present
-  if (!/\s$/.test(text)) {
+  if (addAfter && !/\s$/.test(text)) {
     result = `${result} `;
   }
 


### PR DESCRIPTION
Extends applySmartPadding() to accept an optional mode parameter supporting four padding behaviors: 'both' (default), 'before', 'after', and 'none'. This is a prerequisite for user-configurable smart padding settings.

Design uses object map pattern (PADDING_BEHAVIORS) for behavior encapsulation:
- Declarative behavior table is self-documenting
- Type-safe: Record<PaddingMode, PaddingBehavior> ensures all modes defined
- Reduced cyclomatic complexity from ~5 to ~2 decision points
- Extensible: new mode = new entry in the map

Backward compatible - default 'both' mode preserves existing behavior.

Fixes #176