### PR TITLE
refactor(vscode-ext): extract `RangeLinkParser` from `RangeLinkNavigationHandler`

### DIFF
--- a/packages/rangelink-vscode-extension/src/RangeLinkParser.ts
+++ b/packages/rangelink-vscode-extension/src/RangeLinkParser.ts
@@ -1,0 +1,55 @@
+import type { Logger } from 'barebone-logger';
+import type { DelimiterConfig, ParsedLink, Result } from 'rangelink-core-ts';
+import { buildLinkPattern, parseLink, RangeLinkError } from 'rangelink-core-ts';
+
+import { formatLinkTooltip } from './utils';
+
+/**
+ * Pure parser for RangeLink format detection and validation.
+ *
+ * Provides parsing functionality without IDE dependencies:
+ * - Pattern building for link detection
+ * - Link parsing and validation
+ * - Tooltip formatting
+ */
+export class RangeLinkParser {
+  private readonly pattern: RegExp;
+
+  constructor(
+    private readonly delimiters: DelimiterConfig,
+    private readonly logger: Logger,
+  ) {
+    this.pattern = buildLinkPattern(delimiters);
+    this.logger.debug(
+      { fn: 'RangeLinkParser.constructor', delimiters },
+      'RangeLinkParser initialized',
+    );
+  }
+
+  /**
+   * Get the compiled RegExp pattern for link detection.
+   */
+  getPattern(): RegExp {
+    return this.pattern;
+  }
+
+  /**
+   * Parse a RangeLink string into structured data.
+   *
+   * @param linkText - Raw link text to parse
+   * @returns Result with ParsedLink or RangeLinkError
+   */
+  parseLink(linkText: string): Result<ParsedLink, RangeLinkError> {
+    return parseLink(linkText, this.delimiters);
+  }
+
+  /**
+   * Format tooltip text for a parsed link.
+   *
+   * @param parsed - Parsed link data
+   * @returns Formatted tooltip string or undefined
+   */
+  formatTooltip(parsed: ParsedLink): string | undefined {
+    return formatLinkTooltip(parsed);
+  }
+}

--- a/packages/rangelink-vscode-extension/src/__tests__/RangeLinkParser.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/RangeLinkParser.test.ts
@@ -1,0 +1,163 @@
+import { createMockLogger } from 'barebone-logger-testing';
+import { DEFAULT_DELIMITERS, LinkType, SelectionType } from 'rangelink-core-ts';
+import type { ParsedLink } from 'rangelink-core-ts';
+
+import { RangeLinkParser } from '../RangeLinkParser';
+import * as formatLinkTooltipModule from '../utils/formatLinkTooltip';
+
+describe('RangeLinkParser', () => {
+  let mockLogger: ReturnType<typeof createMockLogger>;
+  let parser: RangeLinkParser;
+
+  beforeEach(() => {
+    mockLogger = createMockLogger();
+    parser = new RangeLinkParser(DEFAULT_DELIMITERS, mockLogger);
+  });
+
+  describe('constructor', () => {
+    it('logs initialization with delimiter config', () => {
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        { fn: 'RangeLinkParser.constructor', delimiters: DEFAULT_DELIMITERS },
+        'RangeLinkParser initialized',
+      );
+    });
+  });
+
+  describe('getPattern', () => {
+    it('returns compiled RegExp pattern', () => {
+      const pattern = parser.getPattern();
+
+      expect(pattern).toBeInstanceOf(RegExp);
+      expect(pattern.global).toBe(true);
+    });
+
+    it('returns pattern that matches RangeLink formats', () => {
+      const pattern = parser.getPattern();
+
+      expect('file.ts#L10').toMatch(pattern);
+      expect('file.ts#L10-L20').toMatch(pattern);
+      expect('file.ts#L10C5-L20C10').toMatch(pattern);
+      expect('file.ts##L10C5-L20C10').toMatch(pattern);
+    });
+
+    it('returns same pattern instance on repeated calls', () => {
+      const pattern1 = parser.getPattern();
+      const pattern2 = parser.getPattern();
+
+      expect(pattern1).toBe(pattern2);
+    });
+  });
+
+  describe('parseLink', () => {
+    it('parses single-line link', () => {
+      const result = parser.parseLink('file.ts#L10');
+
+      expect(result).toBeOkWith((value: ParsedLink) => {
+        expect(value).toStrictEqual({
+          path: 'file.ts',
+          start: { line: 10 },
+          end: { line: 10 },
+          linkType: 'regular',
+          selectionType: 'Normal',
+        });
+      });
+    });
+
+    it('parses multi-line range', () => {
+      const result = parser.parseLink('src/foo.ts#L10-L20');
+
+      expect(result).toBeOkWith((value: ParsedLink) => {
+        expect(value).toStrictEqual({
+          path: 'src/foo.ts',
+          start: { line: 10 },
+          end: { line: 20 },
+          linkType: 'regular',
+          selectionType: 'Normal',
+        });
+      });
+    });
+
+    it('parses link with column positions', () => {
+      const result = parser.parseLink('file.ts#L10C5-L20C15');
+
+      expect(result).toBeOkWith((value: ParsedLink) => {
+        expect(value).toStrictEqual({
+          path: 'file.ts',
+          start: { line: 10, char: 5 },
+          end: { line: 20, char: 15 },
+          linkType: 'regular',
+          selectionType: 'Normal',
+        });
+      });
+    });
+
+    it('parses rectangular selection (double hash)', () => {
+      const result = parser.parseLink('file.ts##L10C5-L20C10');
+
+      expect(result).toBeOkWith((value: ParsedLink) => {
+        expect(value).toStrictEqual({
+          path: 'file.ts',
+          start: { line: 10, char: 5 },
+          end: { line: 20, char: 10 },
+          linkType: 'regular',
+          selectionType: 'Rectangular',
+        });
+      });
+    });
+
+    it('returns error for invalid link without hash separator', () => {
+      const result = parser.parseLink('invalid');
+
+      expect(result).toBeRangeLinkErrorErr('PARSE_NO_HASH_SEPARATOR', {
+        message: 'Link must contain # separator',
+        functionName: 'parseLink',
+      });
+    });
+
+    it('returns error for link with invalid range format', () => {
+      const result = parser.parseLink('file.ts#X10');
+
+      expect(result).toBeRangeLinkErrorErr('PARSE_INVALID_RANGE_FORMAT', {
+        message: 'Invalid range format',
+        functionName: 'parseLink',
+      });
+    });
+  });
+
+  describe('formatTooltip', () => {
+    it('delegates to formatLinkTooltip utility', () => {
+      const parsed: ParsedLink = {
+        path: 'file.ts',
+        start: { line: 10 },
+        end: { line: 10 },
+        linkType: LinkType.Regular,
+        selectionType: SelectionType.Normal,
+      };
+      const expectedTooltip = 'Open file.ts:10 • RangeLink';
+
+      const formatLinkTooltipSpy = jest
+        .spyOn(formatLinkTooltipModule, 'formatLinkTooltip')
+        .mockReturnValue(expectedTooltip);
+
+      const result = parser.formatTooltip(parsed);
+
+      expect(formatLinkTooltipSpy).toHaveBeenCalledTimes(1);
+      expect(formatLinkTooltipSpy).toHaveBeenCalledWith(parsed);
+      expect(result).toBe(expectedTooltip);
+    });
+
+    it('passes through undefined from formatLinkTooltip', () => {
+      const parsed = {
+        path: '',
+        start: { line: 10 },
+        end: { line: 10 },
+      } as ParsedLink;
+
+      jest.spyOn(formatLinkTooltipModule, 'formatLinkTooltip').mockReturnValue(undefined);
+
+      const result = parser.formatTooltip(parsed);
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockRangeLinkParser.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockRangeLinkParser.ts
@@ -1,0 +1,37 @@
+import { DEFAULT_DELIMITERS, buildLinkPattern, parseLink, Result } from 'rangelink-core-ts';
+import type { ParsedLink, RangeLinkError } from 'rangelink-core-ts';
+
+import type { RangeLinkParser } from '../../RangeLinkParser';
+import { formatLinkTooltip } from '../../utils';
+
+export interface MockRangeLinkParserOverrides {
+  getPattern?: jest.Mock<RegExp>;
+  parseLink?: jest.Mock<Result<ParsedLink, RangeLinkError>, [string]>;
+  formatTooltip?: jest.Mock<string | undefined, [ParsedLink]>;
+}
+
+/**
+ * Creates a mock RangeLinkParser with working default implementations.
+ *
+ * Default behavior uses real parsing logic from rangelink-core-ts,
+ * making it suitable for integration-style tests. Override specific
+ * methods for unit tests that need controlled behavior.
+ */
+export const createMockRangeLinkParser = (
+  overrides?: MockRangeLinkParserOverrides,
+): jest.Mocked<RangeLinkParser> => {
+  const pattern = buildLinkPattern(DEFAULT_DELIMITERS);
+
+  const baseMock = {
+    getPattern: jest.fn(() => pattern),
+    parseLink: jest.fn((linkText: string) => parseLink(linkText, DEFAULT_DELIMITERS)),
+    formatTooltip: jest.fn((parsed: ParsedLink) => formatLinkTooltip(parsed)),
+  };
+
+  return {
+    ...baseMock,
+    ...overrides,
+  } as unknown as jest.Mocked<RangeLinkParser>;
+};
+
+export type MockRangeLinkParser = ReturnType<typeof createMockRangeLinkParser>;

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/index.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/index.ts
@@ -40,6 +40,7 @@ export * from './createBaseMockPasteDestination';
 export * from './createMockPosition';
 export * from './createMockPositionAt';
 export * from './createMockRange';
+export * from './createMockRangeLinkParser';
 export * from './createMockSelection';
 export * from './createMockSingletonComposablePasteDestination';
 export * from './createMockStatusBarItem';

--- a/packages/rangelink-vscode-extension/src/extension.ts
+++ b/packages/rangelink-vscode-extension/src/extension.ts
@@ -35,6 +35,7 @@ import { VscodeAdapter } from './ide/vscode/VscodeAdapter';
 import { RangeLinkDocumentProvider } from './navigation/RangeLinkDocumentProvider';
 import { RangeLinkNavigationHandler } from './navigation/RangeLinkNavigationHandler';
 import { RangeLinkTerminalProvider } from './navigation/RangeLinkTerminalProvider';
+import { RangeLinkParser } from './RangeLinkParser';
 import { PathFormat, RangeLinkService } from './RangeLinkService';
 import { RangeLinkStatusBar } from './statusBar';
 import type { RangeLinkClickArgs } from './types';
@@ -115,9 +116,10 @@ export function activate(context: vscode.ExtensionContext): void {
   // Register destinationManager for automatic disposal on deactivation
   context.subscriptions.push(destinationManager);
 
-  // Create shared navigation handler (used by both terminal and document providers)
-  const navigationHandler = new RangeLinkNavigationHandler(delimiters, ideAdapter, getLogger());
-  getLogger().debug({ fn: 'activate' }, 'Navigation handler created');
+  // Create parser and navigation handler (used by both terminal and document providers)
+  const parser = new RangeLinkParser(delimiters, getLogger());
+  const navigationHandler = new RangeLinkNavigationHandler(parser, ideAdapter, getLogger());
+  getLogger().debug({ fn: 'activate' }, 'Parser and navigation handler created');
 
   // Register terminal link provider for clickable links
   const terminalLinkProvider = new RangeLinkTerminalProvider(


### PR DESCRIPTION
Separates pure parsing logic from IDE-dependent navigation code, improving separation of concerns and enabling cleaner dependency injection.

The RangeLinkNavigationHandler was doing two distinct things:
1. Parsing (pure logic, no IDE dependency)
2. Navigation (heavily IDE-dependent)

This violates Single Responsibility Principle and forced consumers to depend on navigation infrastructure when they only needed parsing.

Benefits:
- RangeLinkParser can be used by AddBookmarkCommand (issue #164) without pulling in navigation concerns
- Clear separation: parser parses, navigator navigates
- Easier to test parsing in isolation
- Backward compatible: handler delegates to parser, existing providers unchanged