### PR TITLE
refactor(vscode-ext): add `AIAssistantDestinationType` derived from `DestinationType`

### DIFF
--- a/packages/rangelink-vscode-extension/src/destinations/ComposablePasteDestination.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/ComposablePasteDestination.ts
@@ -10,7 +10,11 @@ import { AlwaysEligibleChecker } from './capabilities/AlwaysEligibleChecker';
 import type { EligibilityChecker } from './capabilities/EligibilityChecker';
 import type { FocusManager } from './capabilities/FocusManager';
 import type { TextInserter } from './capabilities/TextInserter';
-import type { DestinationType, PasteDestination } from './PasteDestination';
+import type {
+  AIAssistantDestinationType,
+  DestinationType,
+  PasteDestination,
+} from './PasteDestination';
 
 // ============================================================================
 // Factory Method Parameter Types
@@ -56,11 +60,6 @@ export interface EditorDestinationParams {
 }
 
 /**
- * AI assistant destination IDs (singletons with no bound VSCode resource).
- */
-export type AiAssistantId = 'claude-code' | 'cursor-ai' | 'github-copilot-chat';
-
-/**
  * Parameters for creating an AI assistant destination via factory method.
  *
  * AI assistant destinations:
@@ -70,7 +69,7 @@ export type AiAssistantId = 'claude-code' | 'cursor-ai' | 'github-copilot-chat';
  * - May provide user instructions for manual paste fallback
  */
 export interface AiAssistantDestinationParams {
-  readonly id: AiAssistantId;
+  readonly id: AIAssistantDestinationType;
   readonly displayName: string;
   readonly textInserter: TextInserter;
   readonly focusManager: FocusManager;

--- a/packages/rangelink-vscode-extension/src/destinations/DestinationRegistry.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/DestinationRegistry.ts
@@ -7,7 +7,11 @@ import type { VscodeAdapter } from '../ide/vscode/VscodeAdapter';
 import type { EligibilityCheckerFactory } from './capabilities/EligibilityCheckerFactory';
 import type { FocusManagerFactory } from './capabilities/FocusManagerFactory';
 import type { TextInserterFactory } from './capabilities/TextInserterFactory';
-import type { DestinationType, PasteDestination } from './PasteDestination';
+import type {
+  AIAssistantDestinationType,
+  DestinationType,
+  PasteDestination,
+} from './PasteDestination';
 
 /**
  * Display names for destination types
@@ -31,7 +35,7 @@ const DISPLAY_NAMES: Record<DestinationType, string> = {
 export type CreateOptions =
   | { type: 'terminal'; terminal: vscode.Terminal }
   | { type: 'text-editor'; editor: vscode.TextEditor }
-  | { type: 'cursor-ai' | 'claude-code' | 'github-copilot-chat' };
+  | { type: AIAssistantDestinationType };
 
 /**
  * Factory bundle passed to destination builders.

--- a/packages/rangelink-vscode-extension/src/destinations/PasteDestination.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/PasteDestination.ts
@@ -23,6 +23,17 @@ export const DESTINATION_TYPES = [
 export type DestinationType = (typeof DESTINATION_TYPES)[number];
 
 /**
+ * AI assistant destination types (subset of DestinationType)
+ *
+ * These destinations require extension availability checks rather than
+ * resource binding (like terminal or text-editor).
+ */
+export type AIAssistantDestinationType = Extract<
+  DestinationType,
+  'claude-code' | 'cursor-ai' | 'github-copilot-chat'
+>;
+
+/**
  * Interface for RangeLink paste destinations
  *
  * Destinations are targets where generated RangeLinks can be automatically pasted.

--- a/packages/rangelink-vscode-extension/src/destinations/PasteDestinationManager.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/PasteDestinationManager.ts
@@ -10,7 +10,11 @@ import { MessageCode } from '../types/MessageCode';
 import { formatMessage, isEditorDestination, isTextLikeFile, type PaddingMode } from '../utils';
 
 import type { DestinationRegistry } from './DestinationRegistry';
-import type { DestinationType, PasteDestination } from './PasteDestination';
+import type {
+  AIAssistantDestinationType,
+  DestinationType,
+  PasteDestination,
+} from './PasteDestination';
 
 /**
  * Unified destination manager for RangeLink (Phase 3)
@@ -30,7 +34,7 @@ export class PasteDestinationManager implements vscode.Disposable {
    * Static lookup table mapping AI assistant destination types to unavailable error message codes
    */
   private static readonly AI_ASSISTANT_ERROR_CODES: Record<
-    'cursor-ai' | 'claude-code' | 'github-copilot-chat',
+    AIAssistantDestinationType,
     MessageCode
   > = {
     'claude-code': MessageCode.ERROR_CLAUDE_CODE_NOT_AVAILABLE,
@@ -452,9 +456,7 @@ export class PasteDestinationManager implements vscode.Disposable {
    * @param type - The destination type (AI assistants only)
    * @returns true if binding succeeded, false if destination not available
    */
-  private async bindGenericDestination(
-    type: 'cursor-ai' | 'claude-code' | 'github-copilot-chat',
-  ): Promise<boolean> {
+  private async bindGenericDestination(type: AIAssistantDestinationType): Promise<boolean> {
     // Generic destinations don't require resources at construction
     const newDestination = this.registry.create({ type });
 


### PR DESCRIPTION
Consolidates 4 hardcoded AI assistant type unions into a single source of truth. Uses TypeScript's `Extract` utility to derive the subset from `DestinationType`.

## Problem

The codebase had the same union `'claude-code' | 'cursor-ai' | 'github-copilot-chat'` duplicated in 4 locations:
- `PasteDestinationManager.ts` (error codes record + method parameter)
- `ComposablePasteDestination.ts` (AiAssistantId type)
- `DestinationRegistry.ts` (CreateOptions union)

This violated DRY and risked drift if a new AI assistant was added.

## Solution

Define `AIAssistantDestinationType` in `PasteDestination.ts` using `Extract`:

```typescript
export type AIAssistantDestinationType = Extract<
  DestinationType,
  'claude-code' | 'cursor-ai' | 'github-copilot-chat'
>;
```

All 4 locations now import and use this shared type.

## Benefits

- Single source of truth for AI assistant destination types
- TypeScript enforces consistency (compile error if values don't exist in DestinationType)
- Removes redundant `AiAssistantId` type from ComposablePasteDestination
- Foundation for DestinationAvailabilityService (issue #173)