### PR TITLE
refactor(vscode-ext): rename "Open RangeLink Status Bar Menu" to "Open RangeLink Menu"

### DIFF
--- a/packages/rangelink-vscode-extension/package.json
+++ b/packages/rangelink-vscode-extension/package.json
@@ -151,7 +151,7 @@
       },
       {
         "command": "rangelink.openStatusBarMenu",
-        "title": "Open RangeLink Status Bar Menu",
+        "title": "Open RangeLink Menu",
         "category": "RangeLink",
         "icon": "$(link)"
       },

--- a/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
@@ -186,7 +186,7 @@ describe('package.json contributions', () => {
       it('rangelink.openStatusBarMenu', () => {
         expect(findCommand('rangelink.openStatusBarMenu')).toStrictEqual({
           command: 'rangelink.openStatusBarMenu',
-          title: 'Open RangeLink Status Bar Menu',
+          title: 'Open RangeLink Menu',
           category: 'RangeLink',
           icon: '$(link)',
         });


### PR DESCRIPTION
The "Status Bar" reference is contextually awkward in the Command Palette where users don't think in terms of UI components. "Open RangeLink Menu" works well in both contexts:
- When clicking the status bar item
- When searching in Command Palette

Benefits:
- Cleaner, more intuitive title
- Establishes pattern for other menu commands (e.g., "Open Bookmarks Menu")