### PR TITLE
[issues/211] add "Save Selection as Bookmark" to editor context menu

### DIFF
--- a/packages/rangelink-vscode-extension/package.json
+++ b/packages/rangelink-vscode-extension/package.json
@@ -335,6 +335,11 @@
           "when": "editorHasSelection",
           "command": "rangelink.pasteSelectedTextToDestination",
           "group": "8_rangelink@5"
+        },
+        {
+          "when": "editorHasSelection",
+          "command": "rangelink.bookmark.add",
+          "group": "8_rangelink@6"
         }
       ]
     }

--- a/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
@@ -428,7 +428,7 @@ describe('package.json contributions', () => {
     const editorContextMenu = packageJson.contributes.menus['editor/context'] as MenuContribution[];
 
     it('has the expected number of editor context menu items', () => {
-      expect(editorContextMenu).toHaveLength(5);
+      expect(editorContextMenu).toHaveLength(6);
     });
 
     it('copyLinkWithRelativePath in context menu', () => {
@@ -468,6 +468,14 @@ describe('package.json contributions', () => {
         when: 'editorHasSelection',
         command: 'rangelink.pasteSelectedTextToDestination',
         group: '8_rangelink@5',
+      });
+    });
+
+    it('bookmark.add in context menu', () => {
+      expect(editorContextMenu[5]).toStrictEqual({
+        when: 'editorHasSelection',
+        command: 'rangelink.bookmark.add',
+        group: '8_rangelink@6',
       });
     });
   });


### PR DESCRIPTION
Makes the bookmark command discoverable via right-click, matching how other RangeLink commands are exposed. The command already existed with Command Palette and keybinding support (Cmd+R Cmd+B Cmd+S); this adds the context menu entry.

Closes #211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a bookmark context menu item to the RangeLink extension, enabling users to save bookmarks directly from the editor when text is selected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->