### PR TITLE
Improve `/start-issue` command

### DIFF
--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -138,7 +138,7 @@ Answer: <prefilled with recommendation>
 
 ### 5. Report Status and STOP
 
-Print the branch name and paths of created files so the user knows what was prepared.
+Print the branch name (`issues/<NUMBER>`) and paths of any created scratchpad/questions files.
 
 **IMPORTANT: Do NOT proceed with implementation.**
 


### PR DESCRIPTION
1. Ensures feature branches are created consistently when starting work on GitHub issues. The branch naming pattern `issues/<NUMBER>` provides clear traceability from branch to issue.
2. Make example format generic (no project-specific references)
3. Add explicit STOP instruction - command is planning-only, waits for user approval before implementing

Benefits:
- Prevents accidentally working on main branch
- Consistent branch naming across the project
- Clear audit trail from branches to issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added explicit feature-branch creation steps using a standardized issues/<NUMBER> naming pattern.
  * Restored and expanded "Gather Full Context" guidance with additional code-exploration tips.
  * Renumbered workflow steps and updated status-reporting to include printing branch/files and an explicit STOP for planning-only mode.
  * Revised checklist header wording and standardized step headings/placeholders.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->