### PR TITLE
[tooling] Add `/tackle-pr-comment` command for PR review workflow

### DIFF
--- a/.claude/commands/tackle-pr-comment.md
+++ b/.claude/commands/tackle-pr-comment.md
@@ -14,11 +14,11 @@ PR Comment URL: $ARGUMENTS
 
 Parse the URL to determine the comment type and extract IDs:
 
-| URL Fragment              | Type                 | API Call                                                |
-| ------------------------- | -------------------- | ------------------------------------------------------- |
-| `#pullrequestreview-{id}` | Review               | `gh api repos/{owner}/{repo}/pulls/{pr}/reviews/{id}`   |
-| `#discussion_r{id}`       | Inline code comment  | `gh api repos/{owner}/{repo}/pulls/comments/{id}`       |
-| `#issuecomment-{id}`      | Conversation comment | `gh api repos/{owner}/{repo}/issues/comments/{id}`      |
+| URL Fragment              | Type                 | API Call                                              |
+| ------------------------- | -------------------- | ----------------------------------------------------- |
+| `#pullrequestreview-{id}` | Review               | `gh api repos/{owner}/{repo}/pulls/{pr}/reviews/{id}` |
+| `#discussion_r{id}`       | Inline code comment  | `gh api repos/{owner}/{repo}/pulls/comments/{id}`     |
+| `#issuecomment-{id}`      | Conversation comment | `gh api repos/{owner}/{repo}/issues/comments/{id}`    |
 
 Extract: owner, repo, PR number, comment type, and comment ID from the URL.
 


### PR DESCRIPTION
Streamlines the process of addressing PR review comments by automating the fetch-analyze-plan workflow. The command retrieves comment/review content via `gh API`, fetches thread context for discussions, explores referenced code, and creates an implementation scratchpad.

Benefits:
- Handles all PR feedback types (reviews, inline comments, issue comments)
- Fetches full thread context automatically for discussions
- Creates traceable scratchpads with comment type and ID in filename
- Integrates with existing `CLAUDE.md` workflows (scratchpads, questions, commits)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive interactive workflow for handling PR comments: detects comment types, gathers thread context, analyzes referenced code and tests, assesses feedback clarity, and outlines step-by-step actions.
  * Introduces structured scratchpad and optional questions artifacts with naming/organization conventions, procedures for summarizing findings, prompting clarifications, and preparing commits after approval.
  * Includes a quality checklist to ensure actionable plans and clear communication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->