### PR TITLE
refactor(bookmarks): BookmarksStore.remove() returns deleted bookmark

### DIFF
--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockBookmarksStore.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockBookmarksStore.ts
@@ -7,6 +7,15 @@
 import type { Bookmark, BookmarksStore } from '../../bookmarks';
 import { ExtensionResult } from '../../types';
 
+const DEFAULT_BOOKMARK: Bookmark = {
+  id: 'test-id',
+  label: 'Test Bookmark',
+  link: '/path/to/file.ts#L10',
+  scope: 'global',
+  createdAt: '2025-01-01T00:00:00.000Z',
+  accessCount: 0,
+};
+
 /**
  * Options for creating a mock bookmarks store
  */
@@ -29,9 +38,9 @@ export const createMockBookmarksStore = (
   return {
     getAll: jest.fn(() => bookmarks),
     getById: jest.fn((id: string) => bookmarks.find((b) => b.id === id)),
-    add: jest.fn().mockResolvedValue(ExtensionResult.ok({})),
-    update: jest.fn().mockResolvedValue(ExtensionResult.ok({})),
-    remove: jest.fn().mockResolvedValue(ExtensionResult.ok(undefined)),
+    add: jest.fn().mockResolvedValue(ExtensionResult.ok(DEFAULT_BOOKMARK)),
+    update: jest.fn().mockResolvedValue(ExtensionResult.ok(DEFAULT_BOOKMARK)),
+    remove: jest.fn().mockResolvedValue(ExtensionResult.ok(DEFAULT_BOOKMARK)),
     recordAccess: jest.fn().mockResolvedValue(ExtensionResult.ok(undefined)),
   } as unknown as jest.Mocked<BookmarksStore>;
 };

--- a/packages/rangelink-vscode-extension/src/bookmarks/BookmarksStore.ts
+++ b/packages/rangelink-vscode-extension/src/bookmarks/BookmarksStore.ts
@@ -211,8 +211,9 @@ export class BookmarksStore {
 
   /**
    * Removes a bookmark by its id.
+   * Returns the deleted bookmark on success, enabling undo or confirmation messages.
    */
-  async remove(id: BookmarkId): Promise<ExtensionResult<void>> {
+  async remove(id: BookmarkId): Promise<ExtensionResult<Bookmark>> {
     try {
       const data = this.load();
       const index = this.findBookmarkIndex(data, id, 'remove');
@@ -236,7 +237,7 @@ export class BookmarksStore {
         `Removed bookmark: ${removed.label}`,
       );
 
-      return ExtensionResult.ok(undefined);
+      return ExtensionResult.ok(removed);
     } catch (error) {
       if (error instanceof RangeLinkExtensionError) {
         return ExtensionResult.err(error);

--- a/packages/rangelink-vscode-extension/src/bookmarks/__tests__/BookmarksStore.test.ts
+++ b/packages/rangelink-vscode-extension/src/bookmarks/__tests__/BookmarksStore.test.ts
@@ -415,7 +415,7 @@ describe('BookmarksStore', () => {
   });
 
   describe('remove()', () => {
-    it('removes existing bookmark and returns Result.ok', async () => {
+    it('removes existing bookmark and returns the deleted bookmark', async () => {
       const bookmark: Bookmark = {
         id: 'to-remove',
         label: 'Remove Me',
@@ -429,7 +429,9 @@ describe('BookmarksStore', () => {
 
       const result = await store.remove('to-remove');
 
-      expect(result.success).toBe(true);
+      expect(result).toBeOkWith((deleted) => {
+        expect(deleted).toStrictEqual(bookmark);
+      });
       expect(store.getAll()).toStrictEqual([]);
       expect(mockLogger.debug).toHaveBeenCalledWith(
         {


### PR DESCRIPTION
Changes `remove()` return type from `ExtensionResult<void>` to `ExtensionResult<Bookmark>`, returning the deleted bookmark on success. This enables callers to display confirmation messages, implement undo functionality, or log what was removed.

Benefits:
- Consistent with `add()` and `update()` which return the affected bookmark
- Enables richer UX (e.g., "Deleted: My Bookmark" confirmation)
- No extra fetch needed if caller wants the deleted data

Preparation side-quest for https://github.com/couimet/rangeLink/issues/166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The bookmark remove operation now returns the deleted bookmark object, providing improved data availability for downstream operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->