### PR TITLE
feat(tooling): add `/start-side-quest` Claude command

### DIFF
--- a/.claude/commands/start-side-quest.md
+++ b/.claude/commands/start-side-quest.md
@@ -123,7 +123,8 @@ Ready to implement. When done:
 1. Run tests: pnpm test
 2. Create commit message per CLAUDE.md `commits` workflow
 3. Commit and create PR
-4. Return to parent: git checkout <parent-branch> && git stash pop
+4. Return to parent: git checkout <parent-branch>
+   (run `git stash pop` only if changes were stashed)
 ```
 
 **IMPORTANT: Do NOT proceed with implementation.**


### PR DESCRIPTION
Automates the workflow for splitting orthogonal improvements from an in-progress issue into a focused side-quest branch. Reduces repetitive setup steps and ensures consistent branch/file organization.

The command:
- Stashes current work if on an issues/* branch
- Creates side-quest/<slug> branch from origin/main
- Creates implementation scratchpad with structured template
- Reports status with return-to-parent instructions

Benefits:
- Eliminates manual branch/stash/file creation overhead
- Keeps issue branches focused on their primary goal
- Documents side-quest origin for PR context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added user-facing documentation describing a command specification and a step-by-step workflow for initiating side-quest processes, including metadata and input hints, detailed task steps (state capture, branch and scratchpad setup, optional prompts, status reporting), naming conventions, usage examples, and a quality checklist to guide consistent setup and verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->