### PR TITLE
docs(CLAUDE.md): enhance E001 shell environment setup rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,13 +167,14 @@
 
   <prerequisites>
     1. Ensure working directory is project root (where pnpm-workspace.yaml lives)
-    2. Use zsh shell (default on this machine)
+    2. Shell config must have nvm configured (Claude Code runs non-interactive shells that don't auto-source config files)
   </prerequisites>
 
   <setup-sequence>
     Run this sequence to initialize the environment:
-    ```bash
-    source ~/.zshrc && nvm use && npm run enable-pnpm
+    ```
+    For zsh:  source ~/.zshrc && nvm use && npm run enable-pnpm
+    For bash: source ~/.bashrc && nvm use && npm run enable-pnpm
     ```
   </setup-sequence>
 
@@ -187,8 +188,8 @@
 
   <troubleshooting>
     <problem symptom="nvm: command not found">
-      <cause>zshrc not sourced - nvm function not loaded</cause>
-      <fix>Run: `source ~/.zshrc`</fix>
+      <cause>Shell config not sourced - nvm function not loaded</cause>
+      <fix>Run: `source ~/.zshrc` (zsh) or `source ~/.bashrc` (bash)</fix>
     </problem>
 
     <problem symptom="N/A: version 'N/A' not found" or ".nvmrc not found">
@@ -198,7 +199,7 @@
 
     <problem symptom="command not found: node">
       <cause>nvm not loaded OR node not installed</cause>
-      <fix>Run: `source ~/.zshrc && nvm install && nvm use`</fix>
+      <fix>Run: `source ~/.zshrc && nvm install && nvm use` (zsh) or `source ~/.bashrc && nvm install && nvm use` (bash)</fix>
     </problem>
 
     <problem symptom="command not found: pnpm">


### PR DESCRIPTION
The minimal E001 rule was causing repeated failures when running JS tooling commands. Claude Code runs non-interactive shells where node/pnpm aren't in PATH by default, and the previous rule didn't provide enough guidance for recovery.

Enhanced with:
- Prerequisites (working directory, shell type)
- Setup sequence with verification step
- Troubleshooting decision tree for 5 common failure modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured setup guide: replaced a single bootstrap instruction with a guided, multi-step workflow that includes prerequisite checks, explicit setup sequences, verification steps, and expanded troubleshooting scenarios to ensure reliable environment preparation and clearer failure diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->