### PR TITLE
docs(.claude): add documentation and discoverability guidance to `start-issue` command

### DIFF
--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -35,8 +35,8 @@ Where `<NUMBER>` is the GitHub issue number (e.g., `issues/223`).
   - Existing patterns to follow
   - Test files that will need updates
 - **Check integration points** - For new commands/features, review:
-  - `RangeLinkStatusBar.ts` for status bar menu integration
-  - `package.json` menus/keybindings sections
+  - `packages/rangelink-vscode-extension/src/statusBar/RangeLinkStatusBar.ts` for status bar menu integration
+  - `packages/rangelink-vscode-extension/package.json` contributes section (menus/keybindings)
   - README.md feature documentation
   - CHANGELOG.md for release notes pattern
 


### PR DESCRIPTION
Ensures developers remember to plan `CHANGELOG`/`README` updates and consider UI integration points when starting new features.

Changes:
- Add "Check integration points" to Gather Full Context section
- Add "Documentation & Discoverability" section to scratchpad template
- Add two Quality Checklist items for docs and discoverability

Discovered while planning issue #97 where status bar menu integration and documentation updates were initially overlooked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance to review integration points and document user-facing changes.
  * Introduced a "Documentation & Discoverability" checklist covering changelog entries, README updates, and placement in UI touchpoints (status bar, context menus, keybindings, command palette).
  * Expanded issue acceptance criteria to require planned CHANGELOG/README updates and explicit discoverability considerations for user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->