### PR TITLE
add `/finish-issue` command for PR preparation workflow

### DIFF
--- a/.claude/commands/finish-issue.md
+++ b/.claude/commands/finish-issue.md
@@ -83,23 +83,28 @@ The PR description MUST follow this template:
 [issues/NUMBER] Title
 
 ## Summary
+
 2-3 sentences on what this accomplishes.
 
 ## Changes
+
 - Bulleted list of key changes
 - Omit file lists (PR shows modified files)
 - Group related changes
 
 ## Test Plan
+
 - [ ] All existing tests pass
 - [ ] New tests added for: [list]
 - [ ] Manual testing: [describe if applicable]
 
 ## Documentation
+
 - [ ] CHANGELOG.md: [entry added / not needed - reason]
 - [ ] README.md: [updated / not needed - reason]
 
 ## Related
+
 - Closes #NUMBER
 ```
 


### PR DESCRIPTION
Symmetrical companion to /start-issue that handles the "wrap up" phase:
- Runs verification (format:fix, test, git status)
- Reviews documentation needs (CHANGELOG, README)
- Generates PR description scratchpad
- Stops for user review before creating PR

Uses questions workflow for ambiguity instead of guessing on user-facing decisions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Finish Issue workflow guide for wrapping up work, covering how to determine the issue number, pre-PR verification (formatting, tests, git status), and documentation review.
  * Describes gathering context for PR descriptions, creating a PR description scratchpad, rules for PR bodies, handling ambiguity, reporting status, and a quality checklist.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->