### PR TITLE
[issues/258]improve error message for stale selection scenario

### DIFF
--- a/packages/rangelink-vscode-extension/CHANGELOG.md
+++ b/packages/rangelink-vscode-extension/CHANGELOG.md
@@ -79,6 +79,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **After:** Select destination → binds and pastes in one action
   - Dismisses silently when user presses Escape (no clipboard fallback — user can retry)
   - Edge case: Shows info notification if no destinations exist
+- **Improved error message for stale selections** - Better guidance when external file changes cause selection loss (#258)
+  - **Before:** "No text selected. Select text and try again."
+  - **After:** "No text selected. Click in the file, select text, and try again."
+  - Addresses VSCode behavior where `editor.selections` returns stale data after external modifications
 
 ### Fixed
 

--- a/packages/rangelink-vscode-extension/src/__tests__/RangeLinkService.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/RangeLinkService.test.ts
@@ -731,7 +731,7 @@ describe('RangeLinkService', () => {
         await service.pasteSelectedTextToDestination();
 
         expect(mockShowErrorMessage).toHaveBeenCalledWith(
-          'RangeLink: No text selected. Select text and try again.',
+          'RangeLink: No text selected. Click in the file, select text, and try again.',
         );
         expect(mockLogger.debug).toHaveBeenCalledWith(
           {
@@ -801,7 +801,7 @@ describe('RangeLinkService', () => {
         await service.pasteSelectedTextToDestination();
 
         expect(mockShowErrorMessage).toHaveBeenCalledWith(
-          'RangeLink: No text selected. Select text and try again.',
+          'RangeLink: No text selected. Click in the file, select text, and try again.',
         );
         expect(mockLogger.debug).toHaveBeenCalledWith(
           {

--- a/packages/rangelink-vscode-extension/src/i18n/messages.en.ts
+++ b/packages/rangelink-vscode-extension/src/i18n/messages.en.ts
@@ -51,7 +51,8 @@ export const messagesEn: Record<MessageCode, string> = {
     'RangeLink: No active terminal. Open a terminal and try again.',
   [MessageCode.ERROR_NO_ACTIVE_TEXT_EDITOR]:
     'RangeLink: No active text editor. Open a file and try again.',
-  [MessageCode.ERROR_NO_TEXT_SELECTED]: 'RangeLink: No text selected. Select text and try again.',
+  [MessageCode.ERROR_NO_TEXT_SELECTED]:
+    'RangeLink: No text selected. Click in the file, select text, and try again.',
   [MessageCode.ERROR_PASTE_FILE_PATH_NO_ACTIVE_FILE]:
     'RangeLink: No active file. Open a file and try again.',
   [MessageCode.ERROR_TERMINAL_LINK_INVALID_FORMAT]:


### PR DESCRIPTION
When a file is modified externally (e.g., by Claude Code), VSCode's editor.selections property returns stale/collapsed data until the user interacts with the editor. This causes RangeLink to show "No text selected" even though the user had text selected.

The actual workaround is simple: click anywhere in the file and re-select. The previous error message didn't hint at this, leaving users confused.

This change updates the error message to guide users with the correct recovery action.

Relates to #258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message guidance when no text is selected, now instructing users to click in the file before selecting text.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->