### PR TITLE
[issues/273] remove broken configuration guide link from `README`

### DIFF
--- a/packages/rangelink-vscode-extension/README.md
+++ b/packages/rangelink-vscode-extension/README.md
@@ -337,8 +337,6 @@ Customize delimiters in VSCode settings (Preferences > Settings > search "rangel
 
 Invalid configurations will fall back to defaults with a warning in the output channel (`Cmd+Shift+U` / `Ctrl+Shift+U`, select "RangeLink"). See [DEVELOPMENT.md](./DEVELOPMENT.md#development-workflow) for details.
 
-[Full configuration guide →](https://github.com/couimet/rangelink#configuration)
-
 ## What's Next
 
 RangeLink is under active development. See the [full roadmap](https://github.com/couimet/rangelink/blob/main/docs/ROADMAP.md) for planned features and other editor integrations.


### PR DESCRIPTION
The link pointed to a non-existent #configuration anchor in the root repo README. The extension README already contains the full configuration guide in its own Configuration section, making this link both broken and redundant.

Closes #273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed a navigation link from the Configuration section in the README.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->