### PR TITLE
[issues/285] CI should fail on lint errors in new/modified code only

### DIFF
--- a/.github/actions/check-formatting/action.yml
+++ b/.github/actions/check-formatting/action.yml
@@ -22,6 +22,14 @@ inputs:
     description: 'Allow linting to fail without blocking CI'
     required: false
     default: 'false'
+  lint-changed-only:
+    description: 'Only lint files changed in the PR (strict mode on changed files)'
+    required: false
+    default: 'false'
+  base-ref:
+    description: 'Base branch for changed file comparison (default: main)'
+    required: false
+    default: 'main'
   allow-types-failure:
     description: 'Allow type checking to fail without blocking CI'
     required: false
@@ -43,11 +51,27 @@ runs:
           fi
         fi
 
-    - name: Run ESLint
-      if: inputs.skip-lint != 'true'
+    - name: Run ESLint (changed files only)
+      if: inputs.skip-lint != 'true' && inputs.lint-changed-only == 'true'
+      shell: bash
+      env:
+        BASE_REF: ${{ inputs.base-ref }}
+      run: |
+        echo "Running linter on changed files only (strict mode)..."
+        CHANGED_FILES=$(git diff --name-only --diff-filter=d origin/${BASE_REF}...HEAD -- '*.ts' '*.tsx' || true)
+        if [ -z "$CHANGED_FILES" ]; then
+          echo "No TypeScript files changed - skipping lint"
+        else
+          echo "Linting changed files:"
+          echo "$CHANGED_FILES"
+          echo "$CHANGED_FILES" | xargs pnpm eslint
+        fi
+
+    - name: Run ESLint (all files)
+      if: inputs.skip-lint != 'true' && inputs.lint-changed-only != 'true'
       shell: bash
       run: |
-        echo "Running linter..."
+        echo "Running linter on all files..."
         if ! pnpm lint; then
           if [ "${{ inputs.allow-lint-failure }}" = "true" ]; then
             echo "::warning::Linting found issues (allowed to fail)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,11 @@ jobs:
       - name: Check formatting and linting
         uses: ./.github/actions/check-formatting
         with:
-          # Temporarily allow lint failures while progressively fixing issues
-          allow-lint-failure: 'true'
+          # For PRs: strict lint on changed files only
+          # For pushes to main: informational lint on all files
+          lint-changed-only: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          base-ref: ${{ github.base_ref || 'main' }}
+          allow-lint-failure: ${{ github.event_name != 'pull_request' && 'true' || 'false' }}
 
       - name: Run tests with coverage
         uses: ./.github/actions/run-tests

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "install-local:vscode-extension:cursor": "pnpm --filter rangelink-vscode-extension install-local:cursor",
     "install-local:vscode-extension:vscode": "pnpm --filter rangelink-vscode-extension install-local:vscode",
     "lint": "eslint .",
+    "lint:changed": "git diff --name-only --diff-filter=d origin/${BASE_REF:-main}...HEAD -- '*.ts' '*.tsx' | xargs -r eslint",
     "lint:fix": "eslint . --fix",
     "package:prepare": "pnpm clean:all && pnpm install",
     "package:vscode-extension": "pnpm --filter rangelink-vscode-extension clean && pnpm --filter rangelink-vscode-extension compile && pnpm --filter rangelink-vscode-extension test && pnpm --filter rangelink-vscode-extension package",


### PR DESCRIPTION
Previously CI had `allow-lint-failure: 'true'` which ignored ALL lint errors due to 324 existing issues. CodeRabbit caught lint problems that our CI missed.

This adds a "lint changed files only" mode:
- PRs: strict lint on changed TS files only (fails on errors)
- Pushes to main: informational lint on all files (doesn't block)

This allows gradual cleanup of legacy lint debt without blocking new work, while ensuring new code meets standards.

Closes #285

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration efficiency by enabling optional linting of changed files only during pull requests, reducing CI execution time.
  * Added configurable base branch reference for improved PR workflow flexibility.
  * Maintains existing full-project linting for push events to preserve quality standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->