### PR TITLE
[side-quest/tackle-pr-comment-clarity] Improve scratchpad boundary clarity

### DIFF
--- a/.claude/commands/tackle-pr-comment.md
+++ b/.claude/commands/tackle-pr-comment.md
@@ -125,6 +125,8 @@ Source: {FULL_PR_COMMENT_URL}
 - `path/to/file2.ts` - {what changes}
 ```
 
+**STOP HERE** - The scratchpad template ends above. Do NOT add commit message sections to scratchpads. Commit messages are created separately in Step 8 (after user approval) using the `.commit-msgs/` workflow.
+
 ## Step 6: Questions (If Needed)
 
 If there are decisions that need user input (not clarification from reviewer), use the `questions` workflow in CLAUDE.md:


### PR DESCRIPTION
## Summary

Adds explicit "STOP HERE" marker to the tackle-pr-comment command template to prevent Claude from adding extraneous sections (like commit messages) to scratchpads.

## Changes

- Add boundary marker after scratchpad template in `.claude/commands/tackle-pr-comment.md`
- Note references Step 8 and `.commit-msgs/` workflow for proper commit message handling