### PR TITLE
[issues/278] Add R-M keybinding for RangeLink menu

### DIFF
--- a/packages/rangelink-vscode-extension/CHANGELOG.md
+++ b/packages/rangelink-vscode-extension/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Terminal** (right-click on terminal tabs or inside terminal):
     - "RangeLink: Bind Here" - Bind this terminal as paste destination
     - "RangeLink: Unbind" - Unbind current paste destination (when bound)
-- **Status Bar Menu** - Click the `🔗 RangeLink` status bar item to access ⚡ quick actions
+- **RangeLink Menu (R-M)** - Press `Cmd+R Cmd+M` (Mac) / `Ctrl+R Ctrl+M` (Win/Linux) or click the `🔗 RangeLink` status bar item to access ⚡ quick actions
   - Jump to Bound Destination (shows quick pick of available destinations when unbound)
   - Go to Link
   - List Bookmarks / Manage Bookmarks

--- a/packages/rangelink-vscode-extension/README.md
+++ b/packages/rangelink-vscode-extension/README.md
@@ -185,15 +185,15 @@ RangeLinks in editor files (markdown, text, code, untitled) are also clickable:
 
 ---
 
-### ⚡ Status Bar Menu
+### ⚡ RangeLink Menu
 
-Click the **RangeLink** item in the status bar (bottom right) to access quick actions:
+Press `Cmd+R Cmd+M` (Mac) / `Ctrl+R Ctrl+M` (Win/Linux) or click the **RangeLink** item in the status bar to access quick actions:
 
 - **Jump to Bound Destination** — Focus your currently bound paste destination (shows quick pick of available destinations when unbound)
 - **Go to Link** — Paste or type a RangeLink to go directly to that code location
 - **Show Version Info** — Display extension version and build details
 
-The menu provides quick access without memorizing keyboard shortcuts. More actions coming in future releases.
+The menu provides quick access to common actions. More items coming in future releases.
 
 ---
 
@@ -261,6 +261,7 @@ Access via `Cmd+Shift+P` (Mac) or `Ctrl+Shift+P` (Windows/Linux), then type "Ran
 | Save Selection as Bookmark                 | `Cmd+R Cmd+B Cmd+S` | `Ctrl+R Ctrl+B Ctrl+S` | Save current selection as a reusable bookmark            |
 | List Bookmarks                             | `Cmd+R Cmd+B Cmd+L` | `Ctrl+R Ctrl+B Ctrl+L` | Show bookmarks, paste to destination, or manage          |
 | Go to Link                                 | `Cmd+R Cmd+G`       | `Ctrl+R Ctrl+G`        | Paste/type a RangeLink to go to that code location       |
+| Open Menu                                  | `Cmd+R Cmd+M`       | `Ctrl+R Ctrl+M`        | Open the RangeLink menu                                  |
 | Bind to Claude Code                        | —                   | —                      | Auto-send links to Claude Code chat                      |
 | Bind to Cursor AI                          | —                   | —                      | Auto-send links to Cursor AI chat                        |
 | Bind to GitHub Copilot Chat                | —                   | —                      | Auto-send links to Copilot Chat                          |

--- a/packages/rangelink-vscode-extension/package.json
+++ b/packages/rangelink-vscode-extension/package.json
@@ -465,6 +465,11 @@
         "command": "rangelink.goToRangeLink",
         "key": "ctrl+r ctrl+g",
         "mac": "cmd+r cmd+g"
+      },
+      {
+        "command": "rangelink.openStatusBarMenu",
+        "key": "ctrl+r ctrl+m",
+        "mac": "cmd+r cmd+m"
       }
     ],
     "menus": {

--- a/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
@@ -659,8 +659,16 @@ describe('package.json contributions', () => {
       });
     });
 
+    it('rangelink.openStatusBarMenu keybinding', () => {
+      expect(findKeybinding('rangelink.openStatusBarMenu')).toStrictEqual({
+        command: 'rangelink.openStatusBarMenu',
+        key: 'ctrl+r ctrl+m',
+        mac: 'cmd+r cmd+m',
+      });
+    });
+
     it('has the expected number of keybindings', () => {
-      expect(keybindings).toHaveLength(13);
+      expect(keybindings).toHaveLength(14);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds keyboard shortcut `Cmd+R Cmd+M` (Mac) / `Ctrl+R Ctrl+M` (Win/Linux) to open the RangeLink menu. This enables keyboard-only access to quick actions like Jump to Destination, Go to Link, and Bookmarks management without requiring mouse interaction.

User-facing documentation now uses "RangeLink Menu" instead of "Status Bar Menu" since the keyboard shortcut makes it accessible without knowing about the status bar item.

## Changes

- Added keybinding `R-M` for `rangelink.openStatusBarMenu` command
- Updated README:
  - Renamed section from "Status Bar Menu" to "RangeLink Menu" (user-centric naming)
  - Commands table includes "Open Menu" with `R-M` shortcut
  - Keyboard shortcut now listed first (primary access method)
- Updated CHANGELOG entry with user-centric "RangeLink Menu" naming
- Added contract test for the new keybinding

## Test Plan

- [x] New test added for: `rangelink.openStatusBarMenu` keybinding contract
- [ ] Manual testing: Press `Cmd+R Cmd+M` to verify menu opens

## Documentation

- [x] CHANGELOG.md: Entry renamed to "RangeLink Menu (R-M)" with keybinding info
- [x] README.md: Section renamed to "RangeLink Menu", added to commands table

## Related

- Closes #278