### PR TITLE
[side-quest] Consolidate logging-only tests into behavior tests (T007)

### DIFF
--- a/packages/rangelink-vscode-extension/src/config/__tests__/ConfigReader.test.ts
+++ b/packages/rangelink-vscode-extension/src/config/__tests__/ConfigReader.test.ts
@@ -41,33 +41,19 @@ describe('ConfigReader', () => {
       const result = reader.getWithDefault('myKey', 'default-value');
 
       expect(result).toBe('configured-value');
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        { fn: 'ConfigReader.getSetting', key: 'myKey', value: 'configured-value' },
+        'Using configured value',
+      );
     });
 
     it('should return default value when setting not configured', () => {
       const result = reader.getWithDefault('missingKey', 'default-value');
 
       expect(result).toBe('default-value');
-    });
-
-    it('should log debug when using default value', () => {
-      reader.getWithDefault('missingKey', 'default-value');
-
       expect(mockLogger.debug).toHaveBeenCalledWith(
         { fn: 'ConfigReader.getSetting', key: 'missingKey', defaultValue: 'default-value' },
         'No missingKey configured, using default: default-value',
-      );
-    });
-
-    it('should log debug when using configured value', () => {
-      const factory: ConfigGetterFactory = () =>
-        createMockConfigGetter({ myKey: 'configured-value' });
-      const reader = new (ConfigReader as any)(factory, mockLogger) as ConfigReader;
-
-      reader.getWithDefault('myKey', 'default-value');
-
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'ConfigReader.getSetting', key: 'myKey', value: 'configured-value' },
-        'Using configured value',
       );
     });
 
@@ -121,6 +107,10 @@ describe('ConfigReader', () => {
       const result = reader.getPaddingMode('smartPadding.pasteLink', 'both');
 
       expect(result).toBe('both');
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        { fn: 'ConfigReader.getSetting', key: 'smartPadding.pasteLink', defaultValue: 'both' },
+        'No smartPadding.pasteLink configured, using default: both',
+      );
     });
 
     it('should support all PaddingMode values', () => {
@@ -134,15 +124,6 @@ describe('ConfigReader', () => {
 
         expect(result).toBe(mode);
       }
-    });
-
-    it('should log when using default padding mode', () => {
-      reader.getPaddingMode('smartPadding.pasteContent', 'none');
-
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'ConfigReader.getSetting', key: 'smartPadding.pasteContent', defaultValue: 'none' },
-        'No smartPadding.pasteContent configured, using default: none',
-      );
     });
   });
 });


### PR DESCRIPTION
Addresses CLAUDE.md rule T007: "Never create separate tests just for logging - consolidate with behavior tests." Logging assertions are now part of the tests that verify the corresponding behavior.

Changes:
- ConfigReader.test.ts: Merged 2 logging-only tests into behavior tests
- PasteDestinationManager.test.ts: Merged 4 logging-only tests into behavior tests

Test count reduced from 1374 to 1368 (6 tests consolidated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for logging behavior in terminal destination management and configuration reading, verifying debug logs are properly emitted during link operations, terminal focusing, and configuration defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->