### PR TITLE
docs(claude): add code-references rule to scratchpads workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -460,6 +460,24 @@
     - Commit messages → .commit-msgs/
     - Permanent documentation → docs/ or package READMEs
   </when-NOT-to-use>
+
+  <code-references>
+    <do>Use RangeLink-format links for all code references so they are clickable from within the scratchpad</do>
+    <do>Use workspace-relative paths (from project root)</do>
+    <never>Use plain text line references like "(lines 26-37)" or "Line 539"</never>
+    <never>Wrap RangeLink links in backticks — backticks become part of the parsed path and break navigation</never>
+    <format>path/to/file.ts#L10-L20 for ranges, path/to/file.ts#L10 for single lines</format>
+    <bad-examples>
+      - file.ts (lines 26-37)
+      - Line 539 mentions "TextInserter"
+      - `packages/rangelink-vscode-extension/src/file.ts#L26-L37` (backticks break the link)
+    </bad-examples>
+    <good-examples>
+      - packages/rangelink-vscode-extension/src/file.ts#L26-L37
+      - packages/rangelink-vscode-extension/src/file.ts#L539 mentions "TextInserter"
+      - Remove the standalone logging tests at packages/.../file.test.ts#L54-L85
+    </good-examples>
+  </code-references>
 </workflow>
 
 <workflow id="creating-github-issues">


### PR DESCRIPTION
Discovered while working on PR #308 that scratchpads are much more useful when code references use RangeLink-format clickable links instead of plain text like "(lines 26-37)". Also documents that wrapping links in backticks breaks RangeLink navigation (tracked in #310).

Benefits:
- Scratchpad references become one-click navigable
- Prevents the backtick-wrapping pitfall that breaks link parsing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added code-references guidance blocks to two documentation sections with formatting instructions, accepted formats, and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->