### PR TITLE
[issues/306] Fix toInputSelection zero-width selection bug

### DIFF
--- a/packages/rangelink-vscode-extension/CHANGELOG.md
+++ b/packages/rangelink-vscode-extension/CHANGELOG.md
@@ -101,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Full-line link generation with newline** - Fixed link generation when selection includes trailing newline. Selecting "line 20 + newline" now correctly generates `#L20` instead of `#L20-L21`.
 - **Smart padding preserves whitespace-only text** - Fixed `applySmartPadding()` incorrectly trimming whitespace-only strings to empty. Now whitespace-only content is preserved when using paste destinations.
 - **Web URLs no longer hijacked as RangeLinks** - Fixed clickable links incorrectly capturing URLs like `https://example.com/path/file.ts#L10`, which caused "file not found" errors when clicked. HTTP, HTTPS, and FTP URLs are now properly ignored while local file paths continue to work. (#288)
+- **Full-line selection validation error** - Fixed `SELECTION_ZERO_WIDTH` error when using Ctrl+L or triple-click to select full lines. The selection normalization now correctly sets the end character to the line length instead of 0. (#306)
 
 ## [1.0.0]
 

--- a/packages/rangelink-vscode-extension/src/__tests__/toInputSelection.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/toInputSelection.test.ts
@@ -110,7 +110,7 @@ describe('toInputSelection', () => {
           expect(value.selections[0].coverage).toBe('FullLine');
           // Verify normalized coordinates: end line adjusted from 2 to 1
           expect(value.selections[0].start).toStrictEqual({ line: 0, character: 0 });
-          expect(value.selections[0].end).toStrictEqual({ line: 1, character: 0 });
+          expect(value.selections[0].end).toStrictEqual({ line: 1, character: 8 });
         });
       });
 
@@ -126,7 +126,7 @@ describe('toInputSelection', () => {
         expect(result).toBeOkWith((value: InputSelection) => {
           expect(value.selections[0].coverage).toBe('FullLine');
           expect(value.selections[0].start).toStrictEqual({ line: 0, character: 0 });
-          expect(value.selections[0].end).toStrictEqual({ line: 0, character: 0 }); // Normalized to line 0, not 1
+          expect(value.selections[0].end).toStrictEqual({ line: 0, character: 17 });
         });
       });
 
@@ -142,7 +142,7 @@ describe('toInputSelection', () => {
         expect(result).toBeOkWith((value: InputSelection) => {
           expect(value.selections[0].coverage).toBe('FullLine');
           expect(value.selections[0].start).toStrictEqual({ line: 0, character: 0 });
-          expect(value.selections[0].end).toStrictEqual({ line: 2, character: 0 }); // Normalized to line 2, not 3
+          expect(value.selections[0].end).toStrictEqual({ line: 2, character: 8 });
         });
       });
     });
@@ -214,7 +214,7 @@ describe('toInputSelection', () => {
         expect(result).toBeOkWith((value: InputSelection) => {
           expect(value.selections[0].coverage).toBe('PartialLine'); // NOT FullLine (start != 0)
           expect(value.selections[0].start).toStrictEqual({ line: 0, character: 5 });
-          expect(value.selections[0].end).toStrictEqual({ line: 0, character: 0 }); // Normalized to line 0
+          expect(value.selections[0].end).toStrictEqual({ line: 0, character: 17 });
         });
       });
     });

--- a/packages/rangelink-vscode-extension/src/__tests__/utils/generateLinkFromSelections.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/utils/generateLinkFromSelections.test.ts
@@ -347,4 +347,151 @@ describe('generateLinkFromSelections', () => {
       );
     });
   });
+
+  /**
+   * Integration tests for trailing newline normalization (issue #306)
+   *
+   * These tests verify the full flow from VSCode selection to link output WITHOUT mocking
+   * toInputSelection or formatLink. They ensure that selections ending at the start of the
+   * next line (e.g., Ctrl+L) produce line-only links (#L5, #L5-L10) without character positions.
+   */
+  describe('trailing newline normalization integration', () => {
+    const createDocumentWithLines = (lines: string[]): vscode.TextDocument => {
+      return createMockDocument({
+        uri: { fsPath: '/project/src/file.ts' } as vscode.Uri,
+        lineCount: lines.length,
+        getText: jest.fn(() => lines.join('\n')),
+        lineAt: jest.fn((line: number) => ({
+          text: lines[line] || '',
+          lineNumber: line,
+          range: { end: { character: (lines[line] || '').length } },
+          rangeIncludingLineBreak: { end: { character: (lines[line] || '').length + 1 } },
+          firstNonWhitespaceCharacterIndex: 0,
+          isEmptyOrWhitespace: (lines[line] || '').trim() === '',
+        })) as unknown as vscode.TextDocument['lineAt'],
+      });
+    };
+
+    it('single full-line selection (Ctrl+L) produces #L5 without character positions', () => {
+      const lines = ['line 0', 'line 1', 'line 2', 'line 3', 'line 4 content here', 'line 5'];
+      const doc = createDocumentWithLines(lines);
+      const selection = mockSelection(4, 0, 5, 0);
+
+      const options: GenerateLinkFromSelectionsOptions = {
+        referencePath: 'src/file.ts',
+        document: doc,
+        selections: [selection],
+        delimiters: DELIMITERS,
+        linkType: LinkType.Regular,
+        logger: mockLogger,
+      };
+
+      const result = generateLinkFromSelections(options);
+
+      const expectedFormattedLink = {
+        link: 'src/file.ts#L5',
+        linkType: 'regular',
+        delimiters: DELIMITERS,
+        computedSelection: {
+          startLine: 5,
+          endLine: 5,
+          rangeFormat: 'LineOnly',
+        },
+        rangeFormat: 'LineOnly',
+        selectionType: 'Normal',
+      };
+      expect(result).toBeOkWith((value: FormattedLink) => {
+        expect(value).toStrictEqual(expectedFormattedLink);
+      });
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        { fn: 'generateLinkFromSelections', formattedLink: expectedFormattedLink },
+        'Generated link: src/file.ts#L5',
+      );
+    });
+
+    it('multi-line full selection (Ctrl+L x3) produces #L5-L7 without character positions', () => {
+      const lines = [
+        'line 0',
+        'line 1',
+        'line 2',
+        'line 3',
+        'line 4',
+        'line 5',
+        'line 6',
+        'line 7',
+      ];
+      const doc = createDocumentWithLines(lines);
+      const selection = mockSelection(4, 0, 7, 0);
+
+      const options: GenerateLinkFromSelectionsOptions = {
+        referencePath: 'src/file.ts',
+        document: doc,
+        selections: [selection],
+        delimiters: DELIMITERS,
+        linkType: LinkType.Regular,
+        logger: mockLogger,
+      };
+
+      const result = generateLinkFromSelections(options);
+
+      const expectedFormattedLink = {
+        link: 'src/file.ts#L5-L7',
+        linkType: 'regular',
+        delimiters: DELIMITERS,
+        computedSelection: {
+          startLine: 5,
+          endLine: 7,
+          rangeFormat: 'LineOnly',
+        },
+        rangeFormat: 'LineOnly',
+        selectionType: 'Normal',
+      };
+      expect(result).toBeOkWith((value: FormattedLink) => {
+        expect(value).toStrictEqual(expectedFormattedLink);
+      });
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        { fn: 'generateLinkFromSelections', formattedLink: expectedFormattedLink },
+        'Generated link: src/file.ts#L5-L7',
+      );
+    });
+
+    it('partial selection ending at next line start produces link with character positions', () => {
+      const lines = ['line 0', 'line 1', 'line 2', 'line 3', 'partial start here', 'line 5'];
+      const doc = createDocumentWithLines(lines);
+      const selection = mockSelection(4, 8, 5, 0);
+
+      const options: GenerateLinkFromSelectionsOptions = {
+        referencePath: 'src/file.ts',
+        document: doc,
+        selections: [selection],
+        delimiters: DELIMITERS,
+        linkType: LinkType.Regular,
+        logger: mockLogger,
+      };
+
+      const result = generateLinkFromSelections(options);
+
+      const expectedFormattedLink = {
+        link: 'src/file.ts#L5C9-L5C19',
+        linkType: 'regular',
+        delimiters: DELIMITERS,
+        computedSelection: {
+          startLine: 5,
+          endLine: 5,
+          startPosition: 9,
+          endPosition: 19,
+          rangeFormat: 'WithPositions',
+        },
+        rangeFormat: 'WithPositions',
+        selectionType: 'Normal',
+      };
+      expect(result).toBeOkWith((value: FormattedLink) => {
+        expect(value).toStrictEqual(expectedFormattedLink);
+      });
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        { fn: 'generateLinkFromSelections', formattedLink: expectedFormattedLink },
+        'Generated link: src/file.ts#L5C9-L5C19',
+      );
+    });
+  });
 });

--- a/packages/rangelink-vscode-extension/src/utils/toInputSelection.ts
+++ b/packages/rangelink-vscode-extension/src/utils/toInputSelection.ts
@@ -96,10 +96,13 @@ export const toInputSelection = (
     // Normalize end line when selection includes trailing newline
     // VSCode reports (21, 0) for "line 20 + newline" - adjust to point to actual content line
     const adjustedEndLine = includesTrailingNewline ? sel.end.line - 1 : sel.end.line;
+    const adjustedEndCharacter = includesTrailingNewline
+      ? document.lineAt(adjustedEndLine).text.length
+      : sel.end.character;
 
     selections.push({
       start: { line: sel.start.line, character: sel.start.character },
-      end: { line: adjustedEndLine, character: sel.end.character },
+      end: { line: adjustedEndLine, character: adjustedEndCharacter },
       coverage,
     });
   }


### PR DESCRIPTION
## Summary

Fixes `SELECTION_ZERO_WIDTH` validation error when using Ctrl+L or triple-click to select full lines. When VSCode reports a selection ending at the start of the next line (e.g., `{line: 20, char: 0}` to `{line: 21, char: 0}`), the normalization now correctly sets the end character to the line length instead of 0.

## Changes

- Add `adjustedEndCharacter` calculation in `toInputSelection.ts` when normalizing trailing newline selections
- Update 4 tests that previously codified the buggy behavior (expected `character: 0` instead of line length)
- Add 3 integration tests in `generateLinkFromSelections.test.ts` that verify full flow without mocking

## Key Discoveries

- The bug triggers when `sel.end.line > sel.start.line && sel.end.character === 0` (the `includesTrailingNewline` condition)
- Affects both single-line (Ctrl+L) and multi-line (multiple Ctrl+L) selections
- Character positions are ignored when `coverage = FullLine`, so the fix only prevents validation failure - link output (`#L5`, `#L5-L10`) remains unchanged
- Issue #260 (external file modification causing stale selections) was closed as won't-do since the logs revealed this different root cause

## Test Plan

- [x] All 1403 tests pass
- [x] 4 test expectations updated to expect correct line lengths
- [x] 3 integration tests added to verify link format preservation:
  - Single full-line selection (Ctrl+L) → `#L5` (no char positions)
  - Multi-line full selection (Ctrl+L x3) → `#L5-L7` (no char positions)
  - Partial selection ending at next line → `#L5C9-L5C19` (with char positions)
- [ ] Manual testing: Open any file, Ctrl+L to select a line, generate link - should work without error

## Documentation

- [x] CHANGELOG.md: Entry added to Fixed section
- [x] README.md: Not needed - internal bug fix, no user-facing API changes

## Related

- Closes #306
- Related to #258 (parent issue for stale selection debugging)
- Closes #260 as won't-do (original hypothesis was wrong)