### PR TITLE
Add `|| []` fallback to all array-returning `VscodeAdapter` members

### DIFF
--- a/packages/rangelink-vscode-extension/src/__tests__/ide/vscode/VscodeAdapter.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/ide/vscode/VscodeAdapter.test.ts
@@ -1685,6 +1685,36 @@ describe('VscodeAdapter', () => {
     });
   });
 
+  describe('getCommands', () => {
+    it('should return commands from VSCode API', async () => {
+      const commands = ['workbench.action.files.save', 'editor.action.formatDocument'];
+      mockVSCode.commands.getCommands.mockResolvedValue(commands);
+
+      const result = await adapter.getCommands();
+
+      expect(mockVSCode.commands.getCommands).toHaveBeenCalledWith(false);
+      expect(result).toStrictEqual(commands);
+    });
+
+    it('should pass filterInternal parameter', async () => {
+      const commands = ['workbench.action.files.save'];
+      mockVSCode.commands.getCommands.mockResolvedValue(commands);
+
+      const result = await adapter.getCommands(true);
+
+      expect(mockVSCode.commands.getCommands).toHaveBeenCalledWith(true);
+      expect(result).toStrictEqual(commands);
+    });
+
+    it('should return empty array when getCommands returns undefined', async () => {
+      mockVSCode.commands.getCommands.mockResolvedValue(undefined);
+
+      const result = await adapter.getCommands();
+
+      expect(result).toStrictEqual([]);
+    });
+  });
+
   describe('parseUri', () => {
     it('should parse file:// URI using VSCode API', () => {
       const uriString = 'file:///workspace/file.ts';
@@ -2205,6 +2235,14 @@ describe('VscodeAdapter', () => {
         expect(result).toStrictEqual(mockEditors);
         expect(result).toHaveLength(3);
       });
+
+      it('should return empty array when visibleTextEditors is undefined', () => {
+        mockVSCode.window.visibleTextEditors = undefined;
+
+        const result = adapter.visibleTextEditors;
+
+        expect(result).toStrictEqual([]);
+      });
     });
   });
 
@@ -2467,6 +2505,14 @@ describe('VscodeAdapter', () => {
 
         expect(result).toStrictEqual([]);
         expect(result).toHaveLength(0);
+      });
+
+      it('should return empty array when extensions.all is undefined', () => {
+        mockVSCode.extensions.all = undefined;
+
+        const result = adapter.extensions;
+
+        expect(result).toStrictEqual([]);
       });
     });
   });

--- a/packages/rangelink-vscode-extension/src/ide/vscode/VscodeAdapter.ts
+++ b/packages/rangelink-vscode-extension/src/ide/vscode/VscodeAdapter.ts
@@ -372,7 +372,7 @@ export class VscodeAdapter implements ConfigurationProvider, ErrorFeedbackProvid
    * @returns Array of all extensions
    */
   get extensions(): readonly vscode.Extension<unknown>[] {
-    return this.ideInstance.extensions.all;
+    return this.ideInstance.extensions.all || [];
   }
 
   /**
@@ -414,7 +414,7 @@ export class VscodeAdapter implements ConfigurationProvider, ErrorFeedbackProvid
    * @returns Promise resolving to array of command identifiers
    */
   async getCommands(filterInternal = false): Promise<string[]> {
-    return this.ideInstance.commands.getCommands(filterInternal);
+    return (await this.ideInstance.commands.getCommands(filterInternal)) || [];
   }
 
   // ============================================================================
@@ -682,7 +682,7 @@ export class VscodeAdapter implements ConfigurationProvider, ErrorFeedbackProvid
    * @returns Array of visible text editors
    */
   get visibleTextEditors(): readonly vscode.TextEditor[] {
-    return this.ideInstance.window.visibleTextEditors;
+    return this.ideInstance.window.visibleTextEditors || [];
   }
 
   /**


### PR DESCRIPTION
The `terminals` getter already defaulted to [] when the API returned undefined, but `visibleTextEditors`, `extensions`, and `getCommands()` did not. A misbehaving VSCode API could return undefined and crash callers that assume arrays.

Benefits:
- Consistent defensive pattern across all array-returning members
- Callers can safely iterate without null checks
- Each fallback has a matching "returns empty array when undefined" test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the VSCode extension to return empty arrays instead of undefined values when interacting with VSCode APIs for commands, visible editors, and extensions, improving overall reliability and preventing potential crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->