### PR TITLE
[issues/323] prevent explorer context menu items from being split (#323)

### DIFF
--- a/packages/rangelink-vscode-extension/package.json
+++ b/packages/rangelink-vscode-extension/package.json
@@ -633,11 +633,11 @@
       "explorer/context": [
         {
           "command": "rangelink.explorer.pasteFilePath",
-          "group": "6_copypath@100"
+          "group": "6_copypath@1"
         },
         {
           "command": "rangelink.explorer.pasteRelativeFilePath",
-          "group": "6_copypath@101"
+          "group": "6_copypath@2"
         }
       ],
       "terminal/title/context": [

--- a/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
@@ -823,14 +823,14 @@ describe('package.json contributions', () => {
       it('explorer.pasteFilePath in explorer context menu', () => {
         expect(explorerContextMenu[0]).toStrictEqual({
           command: 'rangelink.explorer.pasteFilePath',
-          group: '6_copypath@100',
+          group: '6_copypath@1',
         });
       });
 
       it('explorer.pasteRelativeFilePath in explorer context menu', () => {
         expect(explorerContextMenu[1]).toStrictEqual({
           command: 'rangelink.explorer.pasteRelativeFilePath',
-          group: '6_copypath@101',
+          group: '6_copypath@2',
         });
       });
     });


### PR DESCRIPTION
## Summary

Fixes #323 — "Paste File Path" and "Paste Relative File Path" were being separated by other extensions' commands (e.g., GitLens's "Copy Remote File Url From...") in the explorer right-click menu.

Root cause: both RangeLink and GitLens independently chose `6_copypath@100` and `6_copypath@101` for their explorer/context entries. VSCode has no tiebreaker for identical `@` values from different extensions, causing the 4 items to interleave unpredictably.

## Changes

- Changed explorer/context menu group ordering from `@100`/`@101` to `@1`/`@2` to avoid collision with GitLens
- Items stay in the `6_copypath` group for visual proximity to the built-in "Copy Path" / "Copy Relative Path" commands
- Updated contract tests to match new ordering values

## Test Plan

- [x] All 1392 tests pass (including updated contract tests)
- [x] Manual testing: verify items appear consecutively in explorer context menu

## Related

- Closes #323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized context menu grouping for paste commands in the VS Code extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->