### PR TITLE
[issues/336] Introduce `DelimiterConfigGetter` for dynamic delimiter configuration

### DIFF
--- a/packages/rangelink-core-ts/src/types/DelimiterConfig.ts
+++ b/packages/rangelink-core-ts/src/types/DelimiterConfig.ts
@@ -7,3 +7,11 @@ export interface DelimiterConfig {
   readonly hash: string;
   readonly range: string;
 }
+
+/**
+ * Factory function that returns a fresh DelimiterConfig on each call.
+ *
+ * Enables dynamic configuration: consumers call the getter at usage time
+ * rather than capturing a static snapshot at construction time.
+ */
+export type DelimiterConfigGetter = () => DelimiterConfig;

--- a/packages/rangelink-core-ts/src/types/index.ts
+++ b/packages/rangelink-core-ts/src/types/index.ts
@@ -2,7 +2,7 @@ export { Result } from './Result';
 export { CoreResult } from './CoreResult';
 export { Selection } from './Selection';
 export { InputSelection } from './InputSelection';
-export { DelimiterConfig } from './DelimiterConfig';
+export { DelimiterConfig, DelimiterConfigGetter } from './DelimiterConfig';
 export { RangeFormat } from './RangeFormat';
 export { PathFormat } from './PathFormat';
 export { LinkType } from './LinkType';

--- a/packages/rangelink-vscode-extension/src/RangeLinkParser.ts
+++ b/packages/rangelink-vscode-extension/src/RangeLinkParser.ts
@@ -1,5 +1,5 @@
 import type { Logger } from 'barebone-logger';
-import type { CoreResult, DelimiterConfig, ParsedLink } from 'rangelink-core-ts';
+import type { CoreResult, DelimiterConfigGetter, ParsedLink } from 'rangelink-core-ts';
 import { buildLinkPattern, parseLink } from 'rangelink-core-ts';
 
 import { formatLinkTooltip } from './utils';
@@ -13,24 +13,18 @@ import { formatLinkTooltip } from './utils';
  * - Tooltip formatting
  */
 export class RangeLinkParser {
-  private readonly pattern: RegExp;
-
   constructor(
-    private readonly delimiters: DelimiterConfig,
+    private readonly getDelimiters: DelimiterConfigGetter,
     private readonly logger: Logger,
   ) {
-    this.pattern = buildLinkPattern(delimiters);
-    this.logger.debug(
-      { fn: 'RangeLinkParser.constructor', delimiters },
-      'RangeLinkParser initialized',
-    );
+    this.logger.debug({ fn: 'RangeLinkParser.constructor' }, 'RangeLinkParser initialized');
   }
 
   /**
    * Get the compiled RegExp pattern for link detection.
    */
   getPattern(): RegExp {
-    return this.pattern;
+    return buildLinkPattern(this.getDelimiters());
   }
 
   /**
@@ -39,7 +33,7 @@ export class RangeLinkParser {
    * @param linkText - Raw link text to parse
    */
   parseLink(linkText: string): CoreResult<ParsedLink> {
-    return parseLink(linkText, this.delimiters);
+    return parseLink(linkText, this.getDelimiters());
   }
 
   /**

--- a/packages/rangelink-vscode-extension/src/RangeLinkService.ts
+++ b/packages/rangelink-vscode-extension/src/RangeLinkService.ts
@@ -1,5 +1,5 @@
 import type { Logger, LoggingContext } from 'barebone-logger';
-import { DelimiterConfig, type FormattedLink, LinkType } from 'rangelink-core-ts';
+import { type DelimiterConfigGetter, type FormattedLink, LinkType } from 'rangelink-core-ts';
 import * as vscode from 'vscode';
 
 import type { DestinationPickerCommand } from './commands/DestinationPickerCommand';
@@ -94,7 +94,7 @@ interface CopyAndSendOptions<T> {
  */
 export class RangeLinkService {
   constructor(
-    private readonly delimiters: DelimiterConfig,
+    private readonly getDelimiters: DelimiterConfigGetter,
     private readonly ideAdapter: VscodeAdapter,
     private readonly destinationManager: PasteDestinationManager,
     private readonly destinationPickerCommand: DestinationPickerCommand,
@@ -395,7 +395,7 @@ export class RangeLinkService {
       referencePath,
       document,
       selections,
-      delimiters: this.delimiters,
+      delimiters: this.getDelimiters(),
       linkType,
       logger: this.logger,
     });

--- a/packages/rangelink-vscode-extension/src/__tests__/RangeLinkParser.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/RangeLinkParser.test.ts
@@ -11,13 +11,13 @@ describe('RangeLinkParser', () => {
 
   beforeEach(() => {
     mockLogger = createMockLogger();
-    parser = new RangeLinkParser(DEFAULT_DELIMITERS, mockLogger);
+    parser = new RangeLinkParser(() => DEFAULT_DELIMITERS, mockLogger);
   });
 
   describe('constructor', () => {
     it('logs initialization with delimiter config', () => {
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'RangeLinkParser.constructor', delimiters: DEFAULT_DELIMITERS },
+        { fn: 'RangeLinkParser.constructor' },
         'RangeLinkParser initialized',
       );
     });
@@ -40,11 +40,11 @@ describe('RangeLinkParser', () => {
       expect('file.ts##L10C5-L20C10').toMatch(pattern);
     });
 
-    it('returns same pattern instance on repeated calls', () => {
+    it('returns equivalent pattern on repeated calls', () => {
       const pattern1 = parser.getPattern();
       const pattern2 = parser.getPattern();
 
-      expect(pattern1).toBe(pattern2);
+      expect(pattern1).toStrictEqual(pattern2);
     });
   });
 

--- a/packages/rangelink-vscode-extension/src/__tests__/RangeLinkService.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/RangeLinkService.test.ts
@@ -1,6 +1,6 @@
 import type { Logger } from 'barebone-logger';
 import { createMockLogger } from 'barebone-logger-testing';
-import type { DelimiterConfig } from 'rangelink-core-ts';
+import type { DelimiterConfig, DelimiterConfigGetter } from 'rangelink-core-ts';
 import { Result } from 'rangelink-core-ts';
 import * as vscode from 'vscode';
 
@@ -50,12 +50,14 @@ let mockShowWarningMessage: jest.Mock;
 let mockShowErrorMessage: jest.Mock;
 let mockShowInformationMessage: jest.Mock;
 
-const delimiters: DelimiterConfig = {
+const DELIMITERS: DelimiterConfig = {
   line: 'L',
   position: 'C',
   hash: '#',
   range: '-',
 };
+
+const getDelimiters: DelimiterConfigGetter = () => DELIMITERS;
 
 const TEST_WORKSPACE_ROOT = '/workspace';
 const TEST_RELATIVE_PATH = 'src/file.ts';
@@ -119,7 +121,7 @@ describe('RangeLinkService', () => {
       });
 
       service = new RangeLinkService(
-        delimiters,
+        getDelimiters,
         mockVscodeAdapter,
         mockDestinationManager,
         mockPickerCommand,
@@ -242,7 +244,7 @@ describe('RangeLinkService', () => {
           boundDestination: mockDestination,
         });
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           mockVscodeAdapter,
           mockDestinationManager,
           mockPickerCommand,
@@ -323,7 +325,7 @@ describe('RangeLinkService', () => {
           boundDestination: terminalDest,
         });
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           mockVscodeAdapter,
           mockDestinationManager,
           mockPickerCommand,
@@ -399,7 +401,7 @@ describe('RangeLinkService', () => {
           boundDestination: mockDestination,
         });
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           mockVscodeAdapter,
           mockDestinationManager,
           mockPickerCommand,
@@ -655,7 +657,7 @@ describe('RangeLinkService', () => {
       });
 
       service = new RangeLinkService(
-        delimiters,
+        getDelimiters,
         mockVscodeAdapter,
         mockDestinationManager,
         mockPickerCommand,
@@ -674,7 +676,7 @@ describe('RangeLinkService', () => {
           },
         });
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           mockVscodeAdapter,
           mockDestinationManager,
           mockPickerCommand,
@@ -745,7 +747,7 @@ describe('RangeLinkService', () => {
           },
         });
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           mockVscodeAdapter,
           mockDestinationManager,
           mockPickerCommand,
@@ -816,7 +818,7 @@ describe('RangeLinkService', () => {
           },
         });
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           mockVscodeAdapter,
           mockDestinationManager,
           mockPickerCommand,
@@ -895,7 +897,7 @@ describe('RangeLinkService', () => {
         });
         mockVscodeAdapter = adapter;
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           mockVscodeAdapter,
           mockDestinationManager,
           mockPickerCommand,
@@ -947,7 +949,7 @@ describe('RangeLinkService', () => {
             bindResult: Result.ok({ destinationName: 'Terminal', destinationKind: 'terminal' }),
           });
           service = new RangeLinkService(
-            delimiters,
+            getDelimiters,
             mockVscodeAdapter,
             mockDestinationManager,
             mockPickerCommand,
@@ -979,7 +981,7 @@ describe('RangeLinkService', () => {
             boundDestination: mockDestination,
           });
           service = new RangeLinkService(
-            delimiters,
+            getDelimiters,
             mockVscodeAdapter,
             mockDestinationManager,
             mockPickerCommand,
@@ -1018,7 +1020,7 @@ describe('RangeLinkService', () => {
             boundDestination: mockDestination,
           });
           service = new RangeLinkService(
-            delimiters,
+            getDelimiters,
             mockVscodeAdapter,
             mockDestinationManager,
             mockPickerCommand,
@@ -1173,7 +1175,7 @@ describe('RangeLinkService', () => {
         });
 
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           mockVscodeAdapter,
           mockDestinationManager,
           mockPickerCommand,
@@ -1198,7 +1200,7 @@ describe('RangeLinkService', () => {
           boundDestination: mockDestination,
         });
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           mockVscodeAdapter,
           mockDestinationManager,
           mockPickerCommand,
@@ -1256,7 +1258,7 @@ describe('RangeLinkService', () => {
         });
 
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           mockVscodeAdapter,
           mockDestinationManager,
           mockPickerCommand,
@@ -1281,7 +1283,7 @@ describe('RangeLinkService', () => {
           boundDestination: mockDestination,
         });
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           mockVscodeAdapter,
           mockDestinationManager,
           mockPickerCommand,
@@ -1315,7 +1317,7 @@ describe('RangeLinkService', () => {
           boundDestination: mockDestination,
         });
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           adapter,
           boundDestinationManager,
           mockPickerCommand,
@@ -1348,7 +1350,7 @@ describe('RangeLinkService', () => {
           boundDestination: mockDestination,
         });
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           adapter,
           boundDestinationManager,
           mockPickerCommand,
@@ -1376,7 +1378,7 @@ describe('RangeLinkService', () => {
           boundDestination: mockDestination,
         });
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           adapter,
           boundDestinationManager,
           mockPickerCommand,
@@ -1409,7 +1411,7 @@ describe('RangeLinkService', () => {
       });
       mockDestinationManager = createMockDestinationManager({ isBound: false });
       service = new RangeLinkService(
-        delimiters,
+        getDelimiters,
         mockVscodeAdapter,
         mockDestinationManager,
         mockPickerCommand,
@@ -1488,7 +1490,7 @@ describe('RangeLinkService', () => {
           },
         });
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           mockVscodeAdapter,
           mockDestinationManager,
           mockPickerCommand,
@@ -1557,7 +1559,7 @@ describe('RangeLinkService', () => {
       });
       mockDestinationManager = createMockDestinationManager({ isBound: false });
       service = new RangeLinkService(
-        delimiters,
+        getDelimiters,
         mockVscodeAdapter,
         mockDestinationManager,
         mockPickerCommand,
@@ -1655,7 +1657,7 @@ describe('RangeLinkService', () => {
 
       mockDestinationManager = createMockDestinationManager({ isBound: false });
       service = new RangeLinkService(
-        delimiters,
+        getDelimiters,
         mockVscodeAdapter,
         mockDestinationManager,
         mockPickerCommand,
@@ -1679,7 +1681,7 @@ describe('RangeLinkService', () => {
         referencePath: 'file.ts',
         document: mockVscodeAdapter.activeTextEditor!.document,
         selections: mockVscodeAdapter.activeTextEditor!.selections,
-        delimiters,
+        delimiters: DELIMITERS,
         linkType: 'regular',
         logger: mockLogger,
       });
@@ -1703,7 +1705,7 @@ describe('RangeLinkService', () => {
         referencePath: 'file.ts',
         document: mockVscodeAdapter.activeTextEditor!.document,
         selections: mockVscodeAdapter.activeTextEditor!.selections,
-        delimiters,
+        delimiters: DELIMITERS,
         linkType: 'portable',
         logger: mockLogger,
       });
@@ -1806,7 +1808,7 @@ describe('RangeLinkService', () => {
       });
 
       const localService = new RangeLinkService(
-        delimiters,
+        getDelimiters,
         localMockVscodeAdapter,
         createMockDestinationManager({ isBound: false }),
         mockPickerCommand,
@@ -1965,7 +1967,7 @@ describe('RangeLinkService', () => {
 
       mockDestinationManager = createMockDestinationManager({ isBound: false });
       service = new RangeLinkService(
-        delimiters,
+        getDelimiters,
         mockVscodeAdapter,
         mockDestinationManager,
         mockPickerCommand,
@@ -1979,7 +1981,7 @@ describe('RangeLinkService', () => {
         referencePath: 'src/file.ts',
         document: mockDocument,
         selections: mockSelections,
-        delimiters,
+        delimiters: DELIMITERS,
         linkType: 'regular',
         logger: mockLogger,
       });
@@ -2003,7 +2005,7 @@ describe('RangeLinkService', () => {
 
       mockDestinationManager = createMockDestinationManager({ isBound: false });
       service = new RangeLinkService(
-        delimiters,
+        getDelimiters,
         mockVscodeAdapter,
         mockDestinationManager,
         mockPickerCommand,
@@ -2017,7 +2019,7 @@ describe('RangeLinkService', () => {
         referencePath: '/standalone/file.ts',
         document: mockDocument,
         selections: mockSelections,
-        delimiters,
+        delimiters: DELIMITERS,
         linkType: 'regular',
         logger: mockLogger,
       });
@@ -2041,7 +2043,7 @@ describe('RangeLinkService', () => {
 
       mockDestinationManager = createMockDestinationManager({ isBound: false });
       service = new RangeLinkService(
-        delimiters,
+        getDelimiters,
         mockVscodeAdapter,
         mockDestinationManager,
         mockPickerCommand,
@@ -2055,7 +2057,7 @@ describe('RangeLinkService', () => {
         referencePath: '/workspace/src/file.ts',
         document: mockDocument,
         selections: mockSelections,
-        delimiters,
+        delimiters: DELIMITERS,
         linkType: 'regular',
         logger: mockLogger,
       });
@@ -2069,7 +2071,7 @@ describe('RangeLinkService', () => {
     beforeEach(() => {
       mockDestinationManager = createMockDestinationManager({ isBound: false });
       service = new RangeLinkService(
-        delimiters,
+        getDelimiters,
         mockVscodeAdapter,
         mockDestinationManager,
         mockPickerCommand,
@@ -2148,7 +2150,7 @@ describe('RangeLinkService', () => {
         boundDestination: createMockEditorComposablePasteDestination({ displayName: 'Editor' }),
       });
       service = new RangeLinkService(
-        delimiters,
+        getDelimiters,
         mockVscodeAdapter,
         mockDestinationManager,
         mockPickerCommand,
@@ -2242,7 +2244,7 @@ describe('RangeLinkService', () => {
         });
         mockPickerCommand.execute.mockResolvedValue({ outcome: 'cancelled' });
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           mockVscodeAdapter,
           mockDestinationManager,
           mockPickerCommand,
@@ -2288,7 +2290,7 @@ describe('RangeLinkService', () => {
           }),
         });
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           mockVscodeAdapter,
           mockDestinationManager,
           mockPickerCommand,
@@ -2364,7 +2366,7 @@ describe('RangeLinkService', () => {
           }),
         });
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           mockVscodeAdapter,
           mockDestinationManager,
           mockPickerCommand,
@@ -2415,7 +2417,7 @@ describe('RangeLinkService', () => {
         windowOptions: { activeTextEditor: mockEditor, showErrorMessage: mockShowErrorMessage },
       });
       service = new RangeLinkService(
-        delimiters,
+        getDelimiters,
         mockVscodeAdapter,
         mockDestinationManager,
         mockPickerCommand,
@@ -2439,7 +2441,7 @@ describe('RangeLinkService', () => {
         windowOptions: { activeTextEditor: undefined, showErrorMessage: mockShowErrorMessage },
       });
       service = new RangeLinkService(
-        delimiters,
+        getDelimiters,
         mockVscodeAdapter,
         mockDestinationManager,
         mockPickerCommand,
@@ -2472,7 +2474,7 @@ describe('RangeLinkService', () => {
           .mockReturnValue({ uri: { fsPath: TEST_WORKSPACE_ROOT } });
         mockVscodeAdapter.asRelativePath = jest.fn().mockReturnValue(TEST_RELATIVE_PATH);
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           mockVscodeAdapter,
           mockDestinationManager,
           mockPickerCommand,
@@ -2498,7 +2500,7 @@ describe('RangeLinkService', () => {
       beforeEach(() => {
         mockVscodeAdapter.getWorkspaceFolder = jest.fn().mockReturnValue(undefined);
         service = new RangeLinkService(
-          delimiters,
+          getDelimiters,
           mockVscodeAdapter,
           mockDestinationManager,
           mockPickerCommand,

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/AddBookmarkCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/AddBookmarkCommand.test.ts
@@ -33,7 +33,7 @@ describe('AddBookmarkCommand', () => {
 
       new AddBookmarkCommand(
         mockParser,
-        DEFAULT_DELIMITERS,
+        () => DEFAULT_DELIMITERS,
         mockAdapter,
         mockBookmarkService,
         mockLogger,
@@ -58,7 +58,7 @@ describe('AddBookmarkCommand', () => {
         });
         command = new AddBookmarkCommand(
           mockParser,
-          DEFAULT_DELIMITERS,
+          () => DEFAULT_DELIMITERS,
           mockAdapter,
           mockBookmarkService,
           mockLogger,
@@ -92,7 +92,7 @@ describe('AddBookmarkCommand', () => {
         });
         command = new AddBookmarkCommand(
           mockParser,
-          DEFAULT_DELIMITERS,
+          () => DEFAULT_DELIMITERS,
           mockAdapter,
           mockBookmarkService,
           mockLogger,
@@ -126,7 +126,7 @@ describe('AddBookmarkCommand', () => {
         });
         command = new AddBookmarkCommand(
           mockParser,
-          DEFAULT_DELIMITERS,
+          () => DEFAULT_DELIMITERS,
           mockAdapter,
           mockBookmarkService,
           mockLogger,
@@ -157,7 +157,7 @@ describe('AddBookmarkCommand', () => {
         });
         command = new AddBookmarkCommand(
           mockParser,
-          DEFAULT_DELIMITERS,
+          () => DEFAULT_DELIMITERS,
           mockAdapter,
           mockBookmarkService,
           mockLogger,
@@ -197,7 +197,7 @@ describe('AddBookmarkCommand', () => {
         });
         command = new AddBookmarkCommand(
           mockParser,
-          DEFAULT_DELIMITERS,
+          () => DEFAULT_DELIMITERS,
           mockAdapter,
           mockBookmarkService,
           mockLogger,
@@ -276,7 +276,7 @@ describe('AddBookmarkCommand', () => {
         });
         command = new AddBookmarkCommand(
           mockParser,
-          DEFAULT_DELIMITERS,
+          () => DEFAULT_DELIMITERS,
           mockAdapter,
           mockBookmarkService,
           mockLogger,
@@ -323,7 +323,7 @@ describe('AddBookmarkCommand', () => {
         });
         command = new AddBookmarkCommand(
           mockParser,
-          DEFAULT_DELIMITERS,
+          () => DEFAULT_DELIMITERS,
           mockAdapter,
           mockBookmarkService,
           mockLogger,
@@ -368,7 +368,7 @@ describe('AddBookmarkCommand', () => {
         });
         command = new AddBookmarkCommand(
           mockParser,
-          DEFAULT_DELIMITERS,
+          () => DEFAULT_DELIMITERS,
           mockAdapter,
           mockBookmarkService,
           mockLogger,
@@ -394,7 +394,7 @@ describe('AddBookmarkCommand', () => {
         });
         command = new AddBookmarkCommand(
           mockParser,
-          DEFAULT_DELIMITERS,
+          () => DEFAULT_DELIMITERS,
           mockAdapter,
           mockBookmarkService,
           mockLogger,
@@ -423,7 +423,7 @@ describe('AddBookmarkCommand', () => {
         });
         command = new AddBookmarkCommand(
           mockParser,
-          DEFAULT_DELIMITERS,
+          () => DEFAULT_DELIMITERS,
           mockAdapter,
           mockBookmarkService,
           mockLogger,
@@ -461,7 +461,7 @@ describe('AddBookmarkCommand', () => {
         mockBookmarkService.addBookmark.mockResolvedValue(ExtensionResult.err(storageError));
         command = new AddBookmarkCommand(
           mockParser,
-          DEFAULT_DELIMITERS,
+          () => DEFAULT_DELIMITERS,
           mockAdapter,
           mockBookmarkService,
           mockLogger,
@@ -490,7 +490,7 @@ describe('AddBookmarkCommand', () => {
         });
         command = new AddBookmarkCommand(
           mockParser,
-          DEFAULT_DELIMITERS,
+          () => DEFAULT_DELIMITERS,
           mockAdapter,
           mockBookmarkService,
           mockLogger,
@@ -518,7 +518,7 @@ describe('AddBookmarkCommand', () => {
         });
         command = new AddBookmarkCommand(
           mockParser,
-          DEFAULT_DELIMITERS,
+          () => DEFAULT_DELIMITERS,
           mockAdapter,
           mockBookmarkService,
           mockLogger,
@@ -550,7 +550,7 @@ describe('AddBookmarkCommand', () => {
         });
         command = new AddBookmarkCommand(
           mockParser,
-          DEFAULT_DELIMITERS,
+          () => DEFAULT_DELIMITERS,
           mockAdapter,
           mockBookmarkService,
           mockLogger,
@@ -575,7 +575,7 @@ describe('AddBookmarkCommand', () => {
         });
         command = new AddBookmarkCommand(
           mockParser,
-          DEFAULT_DELIMITERS,
+          () => DEFAULT_DELIMITERS,
           mockAdapter,
           mockBookmarkService,
           mockLogger,

--- a/packages/rangelink-vscode-extension/src/commands/AddBookmarkCommand.ts
+++ b/packages/rangelink-vscode-extension/src/commands/AddBookmarkCommand.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 
 import type { Logger } from 'barebone-logger';
-import { DelimiterConfig, LinkType, ParsedLink } from 'rangelink-core-ts';
+import { type DelimiterConfigGetter, LinkType, type ParsedLink } from 'rangelink-core-ts';
 
 import type { BookmarkService } from '../bookmarks';
 import type { VscodeAdapter } from '../ide/vscode/VscodeAdapter';
@@ -21,7 +21,7 @@ import { formatMessage, generateLinkFromSelections } from '../utils';
 export class AddBookmarkCommand {
   constructor(
     private readonly parser: RangeLinkParser,
-    private readonly delimiters: DelimiterConfig,
+    private readonly getDelimiters: DelimiterConfigGetter,
     private readonly ideAdapter: VscodeAdapter,
     private readonly bookmarkService: BookmarkService,
     private readonly logger: Logger,
@@ -73,7 +73,7 @@ export class AddBookmarkCommand {
         referencePath: editor.document.uri.fsPath,
         document: editor.document,
         selections,
-        delimiters: this.delimiters,
+        delimiters: this.getDelimiters(),
         linkType: LinkType.Regular,
         logger: this.logger,
       });


### PR DESCRIPTION
## Summary

Delimiter config was read once at extension activation and frozen into all consumers. If a user changed delimiter settings at runtime, nothing picked up the change until extension reload. This introduces `DelimiterConfigGetter` — a factory function type (`() => DelimiterConfig`) that consumers call at usage time, so runtime changes take effect immediately.

## Changes

- Added `DelimiterConfigGetter` type to `rangelink-core-ts` types
- Changed `RangeLinkParser`, `RangeLinkService`, and `AddBookmarkCommand` constructors from `DelimiterConfig` to `DelimiterConfigGetter`
- Updated `extension.ts` wiring to create a getter closure instead of a static snapshot
- Removed cached `pattern` from `RangeLinkParser` (rebuilt per call since delimiters may change)
- Updated all test files to pass getter functions instead of static config

## Related

- Closes #336
- Supersedes #43 (closed as not planned — this is a simpler approach)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refactored delimiter configuration handling to support dynamic configuration updates and improved extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->