### PR TITLE
[docs] Add `CHANGELOG` entry for vocabulary alignment (#339)

### DIFF
--- a/packages/rangelink-vscode-extension/CHANGELOG.md
+++ b/packages/rangelink-vscode-extension/CHANGELOG.md
@@ -102,6 +102,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **After:** Bind any text editor; if you try to paste to the same file you're selecting from, RangeLink copies to clipboard and shows a helpful message
   - Self-paste detection prevents the "paste into yourself" problem without restricting valid workflows
   - **Tip:** When self-paste is detected for R-L, the message suggests R-C (clipboard-only) as an alternative
+- **Vocabulary alignment: "Paste Destination" → "Destination"** - Docs now use "destination" and "bind/bound" consistently (#339)
+  - The "Paste" prefix was coined in v0.3.0 when destinations only pasted links — the feature now supports bind, unbind, jump, focus, and pick
+  - Section headers, body text, and context menu descriptions updated across README and CHANGELOG
 
 ### Fixed
 


### PR DESCRIPTION
PR #341 aligned "Paste Destination" → "Destination" across all docs but forgot to add a `Changed` entry announcing the rename itself. Users scanning the changelog would miss the terminology shift.

Benefits:
- Users see the vocabulary change when reading release notes
- Documents the reasoning (feature outgrew the "paste" name)