### PR TITLE
[side-quest] Add "RangeLink:" prefix and message string contracts to all picker flows

### DIFF
--- a/packages/rangelink-vscode-extension/src/__tests__/RangeLinkService.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/RangeLinkService.test.ts
@@ -90,6 +90,20 @@ const mockSelection = (
   });
 };
 
+describe('RangeLinkService paste picker message contracts', () => {
+  it('placeholder message identifies RangeLink and describes the action', () => {
+    expect(messagesEn[MessageCode.INFO_PASTE_CONTENT_QUICK_PICK_DESTINATIONS_CHOOSE_BELOW]).toBe(
+      'RangeLink: No bound destination. Choose below to bind and paste',
+    );
+  });
+
+  it('no-destinations message explains how to resolve the situation', () => {
+    expect(messagesEn[MessageCode.INFO_PASTE_CONTENT_NO_DESTINATIONS_AVAILABLE]).toBe(
+      'No destinations available. Open a terminal, split editor, or install an AI assistant extension.',
+    );
+  });
+});
+
 describe('RangeLinkService', () => {
   beforeEach(() => {
     mockLogger = createMockLogger();
@@ -912,7 +926,10 @@ describe('RangeLinkService', () => {
 
           await service.pasteSelectedTextToDestination();
 
-          expect(mockPickerCommand.pick).toHaveBeenCalledTimes(1);
+          expect(mockPickerCommand.pick).toHaveBeenCalledWith({
+            noDestinationsMessageCode: 'INFO_PASTE_CONTENT_NO_DESTINATIONS_AVAILABLE',
+            placeholderMessageCode: 'INFO_PASTE_CONTENT_QUICK_PICK_DESTINATIONS_CHOOSE_BELOW',
+          });
           expect(mockSetStatusBarMessage).not.toHaveBeenCalled();
         });
 

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/JumpToDestinationCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/JumpToDestinationCommand.test.ts
@@ -4,9 +4,24 @@ import { JumpToDestinationCommand } from '../../commands';
 import type { DestinationPicker } from '../../destinations';
 import type { FocusSuccessInfo, PasteDestinationManager } from '../../destinations';
 import { RangeLinkExtensionError, RangeLinkExtensionErrorCodes } from '../../errors';
+import { messagesEn } from '../../i18n';
 import type { BindOptions, DestinationPickerResult } from '../../types';
-import { ExtensionResult } from '../../types';
+import { ExtensionResult, MessageCode } from '../../types';
 import { createMockDestinationManager, createMockDestinationPicker } from '../helpers';
+
+describe('JumpToDestinationCommand message contracts', () => {
+  it('placeholder message identifies RangeLink and describes the action', () => {
+    expect(messagesEn[MessageCode.INFO_JUMP_QUICK_PICK_PLACEHOLDER]).toBe(
+      'RangeLink: No destination bound. Choose destination to jump to',
+    );
+  });
+
+  it('no-destinations message explains how to resolve the situation', () => {
+    expect(messagesEn[MessageCode.INFO_JUMP_NO_DESTINATIONS_AVAILABLE]).toBe(
+      'No destinations available. Open a terminal, split editor, or install an AI assistant extension.',
+    );
+  });
+});
 
 describe('JumpToDestinationCommand', () => {
   let mockDestinationManager: jest.Mocked<PasteDestinationManager>;
@@ -118,6 +133,10 @@ describe('JumpToDestinationCommand', () => {
       const result = await command.execute();
 
       expect(result).toStrictEqual({ outcome: 'no-resource' });
+      expect(mockPickerCommand.pick).toHaveBeenCalledWith({
+        noDestinationsMessageCode: 'INFO_JUMP_NO_DESTINATIONS_AVAILABLE',
+        placeholderMessageCode: 'INFO_JUMP_QUICK_PICK_PLACEHOLDER',
+      });
       expect(mockDestinationManager.bindAndFocus).not.toHaveBeenCalled();
       expect(mockLogger.debug).toHaveBeenCalledWith(
         { fn: 'JumpToDestinationCommand.execute' },
@@ -137,6 +156,10 @@ describe('JumpToDestinationCommand', () => {
       const result = await command.execute();
 
       expect(result).toStrictEqual({ outcome: 'cancelled' });
+      expect(mockPickerCommand.pick).toHaveBeenCalledWith({
+        noDestinationsMessageCode: 'INFO_JUMP_NO_DESTINATIONS_AVAILABLE',
+        placeholderMessageCode: 'INFO_JUMP_QUICK_PICK_PLACEHOLDER',
+      });
       expect(mockDestinationManager.bindAndFocus).not.toHaveBeenCalled();
       expect(mockLogger.debug).toHaveBeenCalledWith(
         { fn: 'JumpToDestinationCommand.execute' },
@@ -162,6 +185,10 @@ describe('JumpToDestinationCommand', () => {
       const result = await command.execute();
 
       expect(result).toStrictEqual({ outcome: 'focus-failed', error: bindError });
+      expect(mockPickerCommand.pick).toHaveBeenCalledWith({
+        noDestinationsMessageCode: 'INFO_JUMP_NO_DESTINATIONS_AVAILABLE',
+        placeholderMessageCode: 'INFO_JUMP_QUICK_PICK_PLACEHOLDER',
+      });
       expect(mockLogger.debug).toHaveBeenCalledWith(
         { fn: 'JumpToDestinationCommand.execute' },
         'Bind and focus failed',

--- a/packages/rangelink-vscode-extension/src/i18n/messages.en.ts
+++ b/packages/rangelink-vscode-extension/src/i18n/messages.en.ts
@@ -100,7 +100,7 @@ export const messagesEn: Record<MessageCode, string> = {
   [MessageCode.INFO_JUMP_NO_DESTINATIONS_AVAILABLE]:
     'No destinations available. Open a terminal, split editor, or install an AI assistant extension.',
   [MessageCode.INFO_JUMP_QUICK_PICK_PLACEHOLDER]:
-    'No destination bound. Choose destination to jump to:',
+    'RangeLink: No destination bound. Choose destination to jump to',
   [MessageCode.INFO_NAVIGATION_EMPTY_INPUT]: 'RangeLink: Please enter a link to navigate',
   [MessageCode.INFO_NAVIGATION_INPUT_BOX_PLACEHOLDER]: 'recipes/baking/chickenpie.ts#L3C14-L15C9',
   [MessageCode.INFO_NAVIGATION_INPUT_BOX_PROMPT]: 'Enter RangeLink to navigate',
@@ -109,7 +109,7 @@ export const messagesEn: Record<MessageCode, string> = {
   [MessageCode.INFO_PASTE_CONTENT_NO_DESTINATIONS_AVAILABLE]:
     'No destinations available. Open a terminal, split editor, or install an AI assistant extension.',
   [MessageCode.INFO_PASTE_CONTENT_QUICK_PICK_DESTINATIONS_CHOOSE_BELOW]:
-    'No bound destination. Choose below to bind and paste:',
+    'RangeLink: No bound destination. Choose below to bind and paste',
   [MessageCode.INFO_SELF_PASTE_CONTENT_SKIPPED]:
     'Selected text copied to clipboard. Cannot paste to same file.',
   [MessageCode.INFO_SELF_PASTE_LINK_SKIPPED]:


### PR DESCRIPTION
## Summary

Adds the "RangeLink:" prefix to the Jump and Paste quickpick placeholders so users can immediately identify which extension launched the picker, and adds message string contract tests that freeze the user-facing text for all three picker flows. Discovered while working on #330 — the Bind placeholder string was changed and zero tests broke.

## Changes

- Fix Jump placeholder: `'No destination bound. Choose destination to jump to:'` -> `'RangeLink: No destination bound. Choose destination to jump to'`
- Fix Paste placeholder: `'No bound destination. Choose below to bind and paste:'` -> `'RangeLink: No bound destination. Choose below to bind and paste'`
- Add message string contract tests to `JumpToDestinationCommand.test.ts` (placeholder + no-destinations)
- Add message string contract tests to `RangeLinkService.test.ts` (placeholder + no-destinations)
- Add picker call assertions to all non-success paths in `JumpToDestinationCommand.test.ts` (no-resource, cancelled, focus-failed)
- Upgrade paste picker test from `toHaveBeenCalledTimes(1)` to `toHaveBeenCalledWith(...)` with exact message codes

## Test Plan

- [x] All 1378 tests pass
- [x] 4 new message contract tests (2 Jump, 2 Paste)
- [x] 3 new picker call assertions on Jump non-success paths
- [x] 1 upgraded paste picker assertion (call count -> exact args)

## Related

- Follow-up to #330 (which added the same pattern for Bind)