### PR TITLE
[issues/270] Document Smart Padding settings in `README` Configuration

### DIFF
--- a/packages/rangelink-vscode-extension/CHANGELOG.md
+++ b/packages/rangelink-vscode-extension/CHANGELOG.md
@@ -88,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **List Bookmarks (R-B-L)** - `Cmd+R Cmd+B Cmd+L` (Mac) / `Ctrl+R Ctrl+B Ctrl+L` (Win/Linux)
     - Select a bookmark to paste its link to bound destination (or clipboard if unbound)
     - Manage bookmarks via the gear icon action in the bookmark list
+- **Smart Padding settings documented** - All 4 `smartPadding.*` settings now in README Configuration section (#270)
 
 ### Changed
 

--- a/packages/rangelink-vscode-extension/README.md
+++ b/packages/rangelink-vscode-extension/README.md
@@ -373,6 +373,19 @@ When enabled, a dialog appears with options: "Save & Generate", "Generate Anyway
 
 When you have more terminals than this threshold, the destination picker shows a "More terminals..." option instead of listing all terminals individually.
 
+### Smart Padding Settings <sup>Unreleased</sup>
+
+| Setting                                | Default  | Description                               |
+| -------------------------------------- | -------- | ----------------------------------------- |
+| `rangelink.smartPadding.pasteLink`     | `"both"` | Padding around generated RangeLinks (R-L) |
+| `rangelink.smartPadding.pasteContent`  | `"none"` | Padding around selected text (R-V)        |
+| `rangelink.smartPadding.pasteFilePath` | `"both"` | Padding around file paths (R-F)           |
+| `rangelink.smartPadding.pasteBookmark` | `"both"` | Padding around saved bookmarks            |
+
+**Available values:** `"both"` (space before and after), `"before"` (space before only), `"after"` (space after only), `"none"` (no padding).
+
+Most paste commands default to `"both"` to prevent the pasted text from concatenating with surrounding content. The exception is `pasteContent` which defaults to `"none"` — selected text is pasted exactly as-is since it typically represents raw code or prose where extra whitespace would be unwanted.
+
 ## What's Next
 
 RangeLink is under active development. See [open issues](https://github.com/couimet/rangeLink/issues) for planned features and enhancement requests.


### PR DESCRIPTION
## Summary

Documents all 4 `smartPadding.*` settings in the README Configuration section. These settings existed in `package.json` but had no README documentation, making them discoverable only through VSCode's Settings UI.

## Changes

- Added `### Smart Padding Settings <sup>Unreleased</sup>` subsection to README Configuration with table covering `pasteLink`, `pasteContent`, `pasteFilePath`, and `pasteBookmark`
- Explanatory paragraphs describe available values (`both`, `before`, `after`, `none`) and why `pasteContent` defaults to `"none"` while others default to `"both"`
- Added keybinding hints (R-L, R-F) to table descriptions for consistency with existing R-V hint
- Added CHANGELOG entry under `[Unreleased] > Added`

## Test Plan

- [x] All existing tests pass (1451 tests, 74 suites)
- [x] Verified setting names, defaults, and enum values match `package.json`
- [x] Table format consistent with existing Configuration subsections

## Related

- Closes #270


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for Smart Padding Settings, including configuration details, default values, and usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->