### PR TITLE
[chore] Enforce lint strictly in CI — no more soft failures

### DIFF
--- a/.github/actions/check-formatting/action.yml
+++ b/.github/actions/check-formatting/action.yml
@@ -14,26 +14,6 @@ inputs:
     description: 'Skip type checking'
     required: false
     default: 'false'
-  allow-format-failure:
-    description: 'Allow format check to fail without blocking CI'
-    required: false
-    default: 'false'
-  allow-lint-failure:
-    description: 'Allow linting to fail without blocking CI'
-    required: false
-    default: 'false'
-  lint-changed-only:
-    description: 'Only lint files changed in the PR (strict mode on changed files)'
-    required: false
-    default: 'false'
-  base-ref:
-    description: 'Base branch for changed file comparison (default: main)'
-    required: false
-    default: 'main'
-  allow-types-failure:
-    description: 'Allow type checking to fail without blocking CI'
-    required: false
-    default: 'false'
 
 runs:
   using: 'composite'
@@ -43,52 +23,18 @@ runs:
       shell: bash
       run: |
         echo "Running format check..."
-        if ! pnpm format; then
-          if [ "${{ inputs.allow-format-failure }}" = "true" ]; then
-            echo "::warning::Format check found issues (allowed to fail)"
-          else
-            exit 1
-          fi
-        fi
+        pnpm format
 
-    - name: Run ESLint (changed files only)
-      if: inputs.skip-lint != 'true' && inputs.lint-changed-only == 'true'
-      shell: bash
-      env:
-        BASE_REF: ${{ inputs.base-ref }}
-      run: |
-        echo "Running linter on changed files only (strict mode)..."
-        CHANGED_FILES=$(git diff --name-only --diff-filter=d origin/${BASE_REF}...HEAD -- '*.ts' '*.tsx' || true)
-        if [ -z "$CHANGED_FILES" ]; then
-          echo "No TypeScript files changed - skipping lint"
-        else
-          echo "Linting changed files:"
-          echo "$CHANGED_FILES"
-          echo "$CHANGED_FILES" | xargs pnpm eslint
-        fi
-
-    - name: Run ESLint (all files)
-      if: inputs.skip-lint != 'true' && inputs.lint-changed-only != 'true'
+    - name: Run ESLint
+      if: inputs.skip-lint != 'true'
       shell: bash
       run: |
         echo "Running linter on all files..."
-        if ! pnpm lint; then
-          if [ "${{ inputs.allow-lint-failure }}" = "true" ]; then
-            echo "::warning::Linting found issues (allowed to fail)"
-          else
-            exit 1
-          fi
-        fi
+        pnpm lint
 
     - name: Type check with TypeScript
       if: inputs.skip-types != 'true'
       shell: bash
       run: |
         echo "Running type check..."
-        if ! pnpm compile; then
-          if [ "${{ inputs.allow-types-failure }}" = "true" ]; then
-            echo "::warning::Type checking found issues (allowed to fail)"
-          else
-            exit 1
-          fi
-        fi
+        pnpm compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,6 @@ jobs:
 
       - name: Check formatting and linting
         uses: ./.github/actions/check-formatting
-        with:
-          # For PRs: strict lint on changed files only
-          # For pushes to main: informational lint on all files
-          lint-changed-only: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
-          base-ref: ${{ github.base_ref || 'main' }}
-          allow-lint-failure: ${{ github.event_name != 'pull_request' && 'true' || 'false' }}
 
       - name: Run tests with coverage
         uses: ./.github/actions/run-tests

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "install-local:vscode-extension:cursor": "pnpm --filter rangelink-vscode-extension install-local:cursor",
     "install-local:vscode-extension:vscode": "pnpm --filter rangelink-vscode-extension install-local:vscode",
     "lint": "eslint .",
-    "lint:changed": "git diff --name-only --diff-filter=d origin/${BASE_REF:-main}...HEAD -- '*.ts' '*.tsx' | xargs -r eslint",
     "lint:fix": "eslint . --fix",
     "package:prepare": "pnpm clean:all && pnpm install",
     "package:vscode-extension": "pnpm --filter rangelink-vscode-extension clean && pnpm --filter rangelink-vscode-extension compile && pnpm --filter rangelink-vscode-extension test && pnpm --filter rangelink-vscode-extension package",


### PR DESCRIPTION
With 0 lint errors across the monorepo, the temporary allow-failure scaffolding is no longer needed. CI now lints all files strictly on both PRs and pushes to main.

Removed the allow-lint-failure, allow-format-failure, allow-types-failure inputs and the lint-changed-only machinery from the check-formatting action. Also removed the lint:changed script from package.json — CI lints everything, every time.

Benefits:
- Lint violations now block ALL CI runs (PRs and main pushes)
- Simpler CI config — no conditional soft/strict modes
- 95 lines of scaffolding removed (action went from 95 to 41 lines)

Closes #254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified internal CI/CD processes and build scripts for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->