### PR TITLE
[issues/277] Add missing Bind to Destination row to Commands Table

### DIFF
--- a/packages/rangelink-vscode-extension/README.md
+++ b/packages/rangelink-vscode-extension/README.md
@@ -273,6 +273,7 @@ Access via `Cmd+Shift+P` (Mac) or `Ctrl+Shift+P` (Windows/Linux), then type "Ran
 | Jump to Bound Destination                                | `Cmd+R Cmd+J`       | `Ctrl+R Ctrl+J`       | Focus your currently bound destination                   |
 | Go to Link <sup>Unreleased</sup>                         | `Cmd+R Cmd+G`       | `Ctrl+R Ctrl+G`       | Paste/type a RangeLink to go to that code location       |
 | Open Menu <sup>Unreleased</sup>                          | `Cmd+R Cmd+M`       | `Ctrl+R Ctrl+M`       | Open the RangeLink menu                                  |
+| Bind to Destination <sup>Unreleased</sup>                | `Cmd+R Cmd+D`       | `Ctrl+R Ctrl+D`       | Open destination picker to select and bind a target      |
 | Bind to Claude Code                                      | —                   | —                     | Auto-send links to Claude Code chat                      |
 | Bind to Cursor AI                                        | —                   | —                     | Auto-send links to Cursor AI chat                        |
 | Bind to GitHub Copilot Chat                              | —                   | —                     | Auto-send links to Copilot Chat                          |


### PR DESCRIPTION
## Summary

A full audit of all Command Palette entries against the README Commands Table revealed that `rangelink.bindToDestination` ("Bind to Destination", `Cmd+R Cmd+D`) had a keybinding and a CHANGELOG entry but was never added to the table. The primary concern in the issue — verifying that `rangelink.goToRangeLink` ("Go to Link") is documented — was already satisfied; this fills the only remaining gap.

## Changes

- Added "Bind to Destination `<sup>Unreleased</sup>`" row to the Commands Table in README.md, with `Cmd+R Cmd+D` / `Ctrl+R Ctrl+D` shortcuts, positioned before the AI-specific Bind-* rows

## Related

- Closes https://github.com/couimet/rangeLink/issues/277
- Parent: https://github.com/couimet/rangeLink/issues/275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Bind to Destination" command with keyboard shortcut Cmd+R Cmd+D / Ctrl+R Ctrl+D to open the destination picker for selecting and binding targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->