### PR TITLE
[issues/263] Remove CONFIG_UNKNOWN deprecated catch-all error code

### DIFF
--- a/packages/rangelink-core-ts/src/errors/RangeLinkErrorCodes.ts
+++ b/packages/rangelink-core-ts/src/errors/RangeLinkErrorCodes.ts
@@ -28,12 +28,6 @@ export enum RangeLinkSpecificCodes {
   CONFIG_DELIMITER_SUBSTRING_CONFLICT = 'CONFIG_DELIMITER_SUBSTRING_CONFLICT',
   CONFIG_DELIMITER_WHITESPACE = 'CONFIG_DELIMITER_WHITESPACE',
   CONFIG_HASH_NOT_SINGLE_CHAR = 'CONFIG_HASH_NOT_SINGLE_CHAR',
-  /**
-   * @deprecated Tech debt: Catch-all error code defeats descriptive error handling.
-   * See #263 for elimination plan.
-   * TODO: Replace with specific error codes for each failure scenario.
-   */
-  CONFIG_UNKNOWN = 'CONFIG_UNKNOWN',
 
   //
   // BYOD parsing errors


### PR DESCRIPTION
## Summary

Removes the `CONFIG_UNKNOWN` enum value from `RangeLinkSpecificCodes` in `rangelink-core-ts`. The value was marked `@deprecated` and was never referenced anywhere in source — it existed only in its own definition. Eliminating it closes the last catch-all escape hatch in the error code system, making the error handling contract fully explicit.

## Changes

- Deleted `CONFIG_UNKNOWN = 'CONFIG_UNKNOWN'` and its JSDoc block from packages/rangelink-core-ts/src/errors/RangeLinkErrorCodes.ts

## Related

- Closes https://github.com/couimet/rangeLink/issues/263


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a deprecated error code from configuration error handling. This cleanup eliminates an unused catch-all error classification, streamlining error reporting and improving consistency across the framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->