### PR TITLE
[issues/393] Tighten coverage thresholds in rangelink-core-ts

### DIFF
--- a/packages/rangelink-core-ts/jest.config.js
+++ b/packages/rangelink-core-ts/jest.config.js
@@ -25,9 +25,9 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: 98,
+      branches: 99,
       functions: 100,
-      lines: 99,
+      lines: 100,
       statements: 99,
     },
   },


### PR DESCRIPTION
## Summary

Raises Jest coverage thresholds in rangelink-core-ts to reflect actual coverage, closing the gap between the enforced floor and reality. Branches goes from 98% to 99% (actual 99.42%) and lines from 99% to 100% (actual 100%). Statements (99%) and functions (100%) were already at or near their actuals and remain unchanged.

## Changes

- Raised `branches` threshold from 98 to 99 in packages/rangelink-core-ts/jest.config.js
- Raised `lines` threshold from 99 to 100 in packages/rangelink-core-ts/jest.config.js

## Test Plan

- [x] All 586 existing tests pass (28 suites)
- [x] Coverage with new thresholds passes: Stmts 99.8%, Branch 99.42%, Funcs 100%, Lines 100%
- [x] No new tests needed — existing coverage already exceeds new thresholds

## Related

- Closes https://github.com/couimet/rangeLink/issues/393
- Parent: https://github.com/couimet/rangeLink/issues/391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test coverage thresholds to maintain code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->