### PR TITLE
[issues/392] Consolidate test scope + raise coverage thresholds

### DIFF
--- a/packages/rangelink-vscode-extension/jest.config.js
+++ b/packages/rangelink-vscode-extension/jest.config.js
@@ -21,10 +21,10 @@ module.exports = {
   coverageReporters: ['text', 'text-summary', 'html', 'lcov'],
   coverageThreshold: {
     global: {
-      branches: 65,
-      functions: 43,
-      lines: 58,
-      statements: 60,
+      branches: 88,
+      functions: 80,
+      lines: 92,
+      statements: 92,
     },
   },
   moduleNameMapper: {

--- a/packages/rangelink-vscode-extension/src/__tests__/RangeLinkService.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/RangeLinkService.test.ts
@@ -152,78 +152,78 @@ describe('RangeLinkService', () => {
       );
     });
 
-      it('delegates to ClipboardPreserver for BoundDestination behavior', async () => {
-        const boundService = new RangeLinkService(
-          getDelimiters,
-          mockVscodeAdapter,
-          createMockDestinationManager({
-            isBound: true,
-            boundDestination: createMockTerminalPasteDestination({ displayName: 'Terminal' }),
-          }),
-          mockPickerCommand,
-          mockConfigReader,
-          mockClipboardPreserver,
-          mockLogger,
-        );
-        const executeSpy = jest
-          .spyOn(boundService as any, 'executeCopyAndSend')
-          .mockResolvedValue(undefined);
-        const sendFn = jest.fn();
-        const isEligibleFn = jest.fn();
+    it('delegates to ClipboardPreserver for BoundDestination behavior', async () => {
+      const boundService = new RangeLinkService(
+        getDelimiters,
+        mockVscodeAdapter,
+        createMockDestinationManager({
+          isBound: true,
+          boundDestination: createMockTerminalPasteDestination({ displayName: 'Terminal' }),
+        }),
+        mockPickerCommand,
+        mockConfigReader,
+        mockClipboardPreserver,
+        mockLogger,
+      );
+      const executeSpy = jest
+        .spyOn(boundService as any, 'executeCopyAndSend')
+        .mockResolvedValue(undefined);
+      const sendFn = jest.fn();
+      const isEligibleFn = jest.fn();
 
-        await (boundService as any).copyAndSendToDestination({
-          control: {
-            contentType: PasteContentType.Link,
-            destinationBehavior: DestinationBehavior.BoundDestination,
-          },
-          content: { clipboard: 'src/file.ts#L1', send: 'src/file.ts#L1' },
-          strategies: { sendFn, isEligibleFn },
-          contentName: 'RangeLink',
-          fnName: 'test',
-        });
-
-        expect(mockClipboardPreserver.preserve).toHaveBeenCalledTimes(1);
-        expect(executeSpy).toHaveBeenCalledWith({
-          control: { contentType: 'Link', destinationBehavior: 'bound-destination' },
-          content: { clipboard: 'src/file.ts#L1', send: 'src/file.ts#L1' },
-          strategies: { sendFn, isEligibleFn },
-          contentName: 'RangeLink',
-          fnName: 'test',
-        });
+      await (boundService as any).copyAndSendToDestination({
+        control: {
+          contentType: PasteContentType.Link,
+          destinationBehavior: DestinationBehavior.BoundDestination,
+        },
+        content: { clipboard: 'src/file.ts#L1', send: 'src/file.ts#L1' },
+        strategies: { sendFn, isEligibleFn },
+        contentName: 'RangeLink',
+        fnName: 'test',
       });
 
-      it('does not preserve when no destination is bound', async () => {
-        await (service as any).copyAndSendToDestination({
-          control: {
-            contentType: PasteContentType.Link,
-            destinationBehavior: DestinationBehavior.BoundDestination,
-          },
-          content: { clipboard: 'src/file.ts#L1', send: 'src/file.ts#L1' },
-          strategies: { sendFn: jest.fn(), isEligibleFn: jest.fn() },
-          contentName: 'RangeLink',
-          fnName: 'test',
-        });
+      expect(mockClipboardPreserver.preserve).toHaveBeenCalledTimes(1);
+      expect(executeSpy).toHaveBeenCalledWith({
+        control: { contentType: 'Link', destinationBehavior: 'bound-destination' },
+        content: { clipboard: 'src/file.ts#L1', send: 'src/file.ts#L1' },
+        strategies: { sendFn, isEligibleFn },
+        contentName: 'RangeLink',
+        fnName: 'test',
+      });
+    });
 
-        expect(mockClipboardPreserver.preserve).not.toHaveBeenCalled();
-        expect(mockClipboard.writeText).toHaveBeenCalledWith('src/file.ts#L1');
+    it('does not preserve when no destination is bound', async () => {
+      await (service as any).copyAndSendToDestination({
+        control: {
+          contentType: PasteContentType.Link,
+          destinationBehavior: DestinationBehavior.BoundDestination,
+        },
+        content: { clipboard: 'src/file.ts#L1', send: 'src/file.ts#L1' },
+        strategies: { sendFn: jest.fn(), isEligibleFn: jest.fn() },
+        contentName: 'RangeLink',
+        fnName: 'test',
       });
 
-      it('does not delegate to ClipboardPreserver for ClipboardOnly behavior', async () => {
-        await (service as any).copyAndSendToDestination({
-          control: {
-            contentType: PasteContentType.Link,
-            destinationBehavior: DestinationBehavior.ClipboardOnly,
-          },
-          content: { clipboard: 'src/file.ts#L1', send: 'src/file.ts#L1' },
-          strategies: { sendFn: jest.fn(), isEligibleFn: jest.fn() },
-          contentName: 'RangeLink',
-          fnName: 'test',
-        });
+      expect(mockClipboardPreserver.preserve).not.toHaveBeenCalled();
+      expect(mockClipboard.writeText).toHaveBeenCalledWith('src/file.ts#L1');
+    });
 
-        expect(mockClipboardPreserver.preserve).not.toHaveBeenCalled();
-        expect(mockClipboard.writeText).toHaveBeenCalledWith('src/file.ts#L1');
-        expect(mockClipboard.readText).not.toHaveBeenCalled();
+    it('does not delegate to ClipboardPreserver for ClipboardOnly behavior', async () => {
+      await (service as any).copyAndSendToDestination({
+        control: {
+          contentType: PasteContentType.Link,
+          destinationBehavior: DestinationBehavior.ClipboardOnly,
+        },
+        content: { clipboard: 'src/file.ts#L1', send: 'src/file.ts#L1' },
+        strategies: { sendFn: jest.fn(), isEligibleFn: jest.fn() },
+        contentName: 'RangeLink',
+        fnName: 'test',
       });
+
+      expect(mockClipboardPreserver.preserve).not.toHaveBeenCalled();
+      expect(mockClipboard.writeText).toHaveBeenCalledWith('src/file.ts#L1');
+      expect(mockClipboard.readText).not.toHaveBeenCalled();
+    });
   });
 
   describe('pasteSelectedTextToDestination', () => {


### PR DESCRIPTION
## Summary

RangeLinkService.test.ts had 4 test scope problems: mass-duplicated test groups (3-6 identical tests per scenario), private method testing via `(service as any)`, duplicated diagnostic log payload assertions across entry points, and redundant private method coverage. This PR consolidates the test file from 133 to 101 tests (3,846 → 3,167 lines) with near-zero coverage loss, then raises the stale coverage thresholds from 60/65/43/58% to 92/88/80/92% to match actual coverage.

## Changes

- **Collapsed mass-duplicated test groups** — 5 describe blocks where 3-6 tests shared identical setup and identical assertions. Each group collapsed to 1-2 tests with descriptive names. (-12 tests, -305 lines)
- **Removed `copyToClipboardAndDestination` private method tests** — 13 tests testing a private method via `(service as any)` already covered through public API tests (createLink, createPortableLink, pasteSelectedTextToDestination). Kept only the 3 clipboard preservation delegation tests. (-13 tests, -220 lines)
- **Deduplicated `validateSelectionsAndShowError` diagnostic assertions** — Full log payload now asserted once (pasteSelectedTextToDestination). createLink's "no active editor" simplified to assert only observable behavior. (-1 test)
- **Removed `getReferencePath` and `pasteCurrentFilePath` private method tests** — 6 tests duplicating coverage already exercised through public API. (-6 tests, -121 lines)
- **Raised coverage thresholds** — statements 60→92%, branches 65→88%, functions 43→80%, lines 58→92%. Actual: 94.89/91.09/83.91/94.83%.

## Test Plan

- [x] All tests pass (1651 tests, 91 suites)
- [x] Coverage exceeds all new thresholds: statements 94.89% > 92%, branches 91.09% > 88%, functions 83.91% > 80%, lines 94.83% > 92%
- [x] Coverage delta from baseline: -0.09% statements, -0.14% branches (3 private method edge case statements no longer reached through public API)
- [x] No test uses `(service as any).copyToClipboardAndDestination()` anymore (except 3 clipboard preservation tests)

## Documentation

- [x] CHANGELOG: not needed — internal test cleanup + threshold change
- [x] README: not needed

## Related

- Closes https://github.com/couimet/rangeLink/issues/392
- Parent: https://github.com/couimet/rangeLink/issues/391 (raise thresholds across all packages)
- Follow-up: https://github.com/couimet/rangeLink/issues/485 (extract RangeLinkService into single-responsibility modules)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Raised test coverage benchmarks and streamlined test structure for improved code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->