### PR TITLE
[issues/492] Silence stale `baseline-browser-mapping` warning during `eslint` runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@eslint/js": "^9.10.0",
     "@typescript-eslint/eslint-plugin": "^8.8.0",
     "@typescript-eslint/parser": "^8.8.0",
-    "baseline-browser-mapping": "latest",
+    "baseline-browser-mapping": "^2.10.10",
     "eslint": "^9.10.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^3.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: ^8.8.0
         version: 8.46.2(eslint@9.38.0)(typescript@5.9.3)
       baseline-browser-mapping:
-        specifier: latest
+        specifier: ^2.10.10
         version: 2.10.10
       eslint:
         specifier: ^9.10.0


### PR DESCRIPTION
## Summary

Adds `baseline-browser-mapping@latest` as a direct root devDependency to override the stale transitive version pinned by `eslint-plugin-unicorn → core-js-compat → browserslist`. This eliminates the noisy "data is over two months old" warning on every `eslint` / `eslint --fix` run.

## Changes

- Added `baseline-browser-mapping: latest` to root `package.json` devDependencies
- Updated `pnpm-lock.yaml` (auto-generated)

## Related

- Closes https://github.com/couimet/rangeLink/issues/492

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to include `baseline-browser-mapping`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->