### PR TITLE
[issues/506] Convert R-D Bind to Destination TCs to assisted mode (9 TCs)

### DIFF
--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
@@ -125,39 +125,6 @@ test_cases:
   # Section 2 — R-D Bind to Destination
   # ---------------------------------------------------------------------------
 
-  - id: bind-to-destination-001
-    feature: 'R-D Bind to Destination'
-    scenario: 'Cmd+R Cmd+D opens destination picker showing terminals, files, and AI assistants'
-    preconditions:
-      - 'Extension installed'
-      - 'At least one terminal and one file are open'
-    steps:
-      - 'Press Cmd+R Cmd+D'
-    expected_result: 'A destination picker QuickPick opens listing terminals, open text files, and AI assistants.'
-    automated: false
-
-  - id: bind-to-destination-002
-    feature: 'R-D Bind to Destination'
-    scenario: 'Ctrl+R Ctrl+D opens the destination picker'
-    preconditions:
-      - 'Extension installed'
-      - 'At least one terminal and one file are open'
-    steps:
-      - 'Press Ctrl+R Ctrl+D'
-    expected_result: 'A destination picker QuickPick opens listing terminals, open text files, and AI assistants.'
-    automated: false
-
-  - id: bind-to-destination-003
-    feature: 'R-D Bind to Destination'
-    scenario: 'RangeLink: Bind to Destination in Command Palette opens destination picker'
-    preconditions:
-      - 'Extension installed'
-    steps:
-      - 'Open Command Palette (Cmd+Shift+P / Ctrl+Shift+P)'
-      - "Type 'Bind to Destination' and select 'RangeLink: Bind to Destination'"
-    expected_result: 'Same destination picker opens as the R-D keybinding.'
-    automated: false
-
   - id: bind-to-destination-004
     feature: 'R-D Bind to Destination'
     scenario: 'Selecting a terminal destination binds it and shows success toast'
@@ -168,7 +135,7 @@ test_cases:
       - 'Open R-D picker'
       - 'Select a terminal from the list'
     expected_result: "The terminal is bound. A success toast appears (e.g., 'Bound to Terminal')."
-    automated: false
+    automated: assisted
 
   - id: bind-to-destination-005
     feature: 'R-D Bind to Destination'
@@ -180,7 +147,7 @@ test_cases:
       - 'Open R-D picker'
       - 'Select a text file from the list'
     expected_result: 'The selected file becomes the bound destination. Success toast appears.'
-    automated: false
+    automated: assisted
 
   - id: bind-to-destination-006
     feature: 'R-D Bind to Destination'
@@ -191,7 +158,7 @@ test_cases:
       - 'Open R-D picker'
       - 'Select the AI assistant entry from the list'
     expected_result: 'AI assistant is now the bound destination. Success toast appears.'
-    automated: false
+    automated: assisted
 
   - id: bind-to-destination-007
     feature: 'R-D Bind to Destination'
@@ -202,7 +169,7 @@ test_cases:
       - 'Open R-D picker'
       - 'Select a different terminal or file'
     expected_result: "A confirmation dialog appears showing the current binding name and the proposed new binding name, with 'Yes, replace' and 'No, keep current' options."
-    automated: false
+    automated: assisted
 
   - id: bind-to-destination-008
     feature: 'R-D Bind to Destination'
@@ -213,7 +180,7 @@ test_cases:
     steps:
       - "Click 'Yes, replace' (or equivalent) in the confirmation dialog"
     expected_result: 'Binding switches to the newly selected destination. Success toast confirms the new binding.'
-    automated: false
+    automated: assisted
 
   - id: bind-to-destination-009
     feature: 'R-D Bind to Destination'
@@ -224,7 +191,7 @@ test_cases:
     steps:
       - "Click 'No, keep current' (or equivalent) in the confirmation dialog"
     expected_result: 'Original binding is preserved. No binding change occurs. Neutral info notification (if any).'
-    automated: false
+    automated: assisted
 
   - id: bind-to-destination-010
     feature: 'R-D Bind to Destination'
@@ -235,7 +202,7 @@ test_cases:
       - 'Open R-D picker'
       - 'Press Escape without selecting anything'
     expected_result: 'Picker closes. Binding state is unchanged.'
-    automated: false
+    automated: assisted
 
   - id: bind-to-destination-011
     feature: 'R-D Bind to Destination'
@@ -245,17 +212,18 @@ test_cases:
     steps:
       - 'Run the same bind command again (e.g., Bind to Claude Code)'
     expected_result: 'No confirmation dialog appears. An "already bound" info notification is shown. Binding is unchanged.'
-    automated: false
+    automated: assisted
 
   - id: bind-to-destination-012
     feature: 'R-D Bind to Destination'
     scenario: 'Switching between different AI assistants shows confirmation dialog'
     preconditions:
       - 'Bound to an AI assistant (e.g., Claude Code)'
+      - 'At least two AI assistant extensions installed and active'
     steps:
       - 'Run a different AI assistant bind command (e.g., Bind to Cursor AI)'
     expected_result: 'A confirmation dialog appears with current and proposed destination names. Selecting Yes switches the binding.'
-    automated: false
+    automated: assisted
 
   - id: bind-to-destination-013
     feature: 'R-D Bind to Destination'

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/fileHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/fileHelpers.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 
 import * as vscode from 'vscode';
 
-import { getWorkspaceRoot } from './testEnv';
+import { getWorkspaceRoot, settle } from './testEnv';
 
 let fileCounter = 0;
 
@@ -16,6 +16,34 @@ export const createWorkspaceFile = (descriptor: string, content: string): vscode
   fs.writeFileSync(filePath, content, 'utf8');
   return vscode.Uri.file(filePath);
 };
+
+export const createAndOpenFile = async (
+  descriptor: string,
+  content: string,
+  viewColumn?: vscode.ViewColumn,
+  trackingArray?: vscode.Uri[],
+): Promise<vscode.Uri> => {
+  const uri = createWorkspaceFile(descriptor, content);
+  trackingArray?.push(uri);
+  const doc = await vscode.workspace.openTextDocument(uri);
+  await vscode.window.showTextDocument(doc, {
+    viewColumn: viewColumn ?? vscode.ViewColumn.One,
+    preview: false,
+  });
+  await settle();
+  return uri;
+};
+
+export const findTestItemsByPrefix = (
+  items: Record<string, unknown>[],
+  prefix: string,
+): Record<string, unknown>[] =>
+  items.filter(
+    (item) =>
+      item.itemKind === 'bindable' &&
+      typeof item.label === 'string' &&
+      (item.label as string).includes(prefix),
+  );
 
 export const openEditor = async (
   uri: vscode.Uri,

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/index.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/index.ts
@@ -6,7 +6,14 @@ export {
   writeClipboardSentinel,
 } from './clipboardHelpers';
 export { clearEditorSelection, selectAll, waitForActiveEditor } from './editorHelpers';
-export { cleanupFiles, closeAllEditors, createWorkspaceFile, openEditor } from './fileHelpers';
+export {
+  cleanupFiles,
+  closeAllEditors,
+  createAndOpenFile,
+  createWorkspaceFile,
+  findTestItemsByPrefix,
+  openEditor,
+} from './fileHelpers';
 export { getLogCapture } from './getLogCapture';
 export {
   assertNoStatusBarMsgLogged,
@@ -21,7 +28,7 @@ export {
 export { createLogger } from './logHelpers';
 export { navigateViaHandleLinkClick } from './navigationHelpers';
 export { loadSettingsProfile, resetRangelinkSettings } from './settingsHelpers';
-export { createAndBindTerminal } from './terminalHelpers';
+export { createAndBindTerminal, createTerminal, findTerminalItems } from './terminalHelpers';
 export {
   activateExtension,
   getWorkspaceRoot,

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/terminalHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/terminalHelpers.ts
@@ -2,6 +2,25 @@ import * as vscode from 'vscode';
 
 import { settle, TERMINAL_READY_MS } from './testEnv';
 
+export const createTerminal = async (
+  name: string,
+  trackingArray?: vscode.Terminal[],
+): Promise<vscode.Terminal> => {
+  const t = vscode.window.createTerminal({ name });
+  trackingArray?.push(t);
+  t.show(true);
+  await settle(TERMINAL_READY_MS);
+  return t;
+};
+
+export const findTerminalItems = (items: Record<string, unknown>[]): Record<string, unknown>[] =>
+  items.filter(
+    (item) =>
+      item.itemKind === 'bindable' &&
+      typeof item.label === 'string' &&
+      (item.label as string).includes('Terminal ('),
+  );
+
 export const createAndBindTerminal = async (name: string): Promise<vscode.Terminal> => {
   const terminal = vscode.window.createTerminal({ name });
   terminal.show(true);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
@@ -22,6 +22,12 @@ import {
   waitForHuman,
 } from '../helpers';
 
+const AI_ASSISTANT_DISPLAY_NAMES = [
+  'Claude Code Chat',
+  'Cursor AI Assistant',
+  'GitHub Copilot Chat',
+];
+
 suite('R-D Bind to Destination', () => {
   const log = createLogger('bindToDestination');
   const terminals: vscode.Terminal[] = [];
@@ -168,11 +174,6 @@ suite('R-D Bind to Destination', () => {
 
     const lines = logCapture.getLinesSince('before-btd-006');
 
-    const AI_ASSISTANT_DISPLAY_NAMES = [
-      'Claude Code Chat',
-      'Cursor AI Assistant',
-      'GitHub Copilot Chat',
-    ];
     const boundToAny = AI_ASSISTANT_DISPLAY_NAMES.some((name) =>
       lines.some((line) => line.includes(`✓ RangeLink bound to ${name}`)),
     );
@@ -370,11 +371,6 @@ suite('R-D Bind to Destination', () => {
       `Expected exactly 2 showQuickPick entries (two destination picker opens, no confirmation dialog), got ${quickPickEntries.length}`,
     );
 
-    const AI_ASSISTANT_DISPLAY_NAMES = [
-      'Claude Code Chat',
-      'Cursor AI Assistant',
-      'GitHub Copilot Chat',
-    ];
     const alreadyBoundLogged = AI_ASSISTANT_DISPLAY_NAMES.some((name) =>
       lines.some((line) => line.includes(`RangeLink: Already bound to ${name}`)),
     );

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
@@ -1,0 +1,469 @@
+import assert from 'node:assert';
+import * as path from 'node:path';
+
+import * as vscode from 'vscode';
+
+import {
+  activateExtension,
+  assertNoStatusBarMsgLogged,
+  assertStatusBarMsgLogged,
+  cleanupFiles,
+  closeAllEditors,
+  createLogger,
+  createWorkspaceFile,
+  extractQuickPickItemsLogged,
+  getLogCapture,
+  parseQuickPickItemsFromLogLine,
+  printAssistedBanner,
+  settle,
+  TERMINAL_READY_MS,
+  waitForHuman,
+} from '../helpers';
+
+suite('R-D Bind to Destination', () => {
+  const log = createLogger('bindToDestination');
+  const terminals: vscode.Terminal[] = [];
+  const tmpFileUris: vscode.Uri[] = [];
+
+  suiteSetup(async () => {
+    await activateExtension();
+    printAssistedBanner();
+  });
+
+  teardown(async () => {
+    await vscode.commands.executeCommand('rangelink.unbindDestination');
+    for (const t of terminals) {
+      t.dispose();
+    }
+    terminals.length = 0;
+    await closeAllEditors();
+    cleanupFiles(tmpFileUris);
+    tmpFileUris.length = 0;
+    await settle();
+  });
+
+  const createTerminal = async (name: string): Promise<vscode.Terminal> => {
+    const t = vscode.window.createTerminal({ name });
+    terminals.push(t);
+    t.show(true);
+    await settle(TERMINAL_READY_MS);
+    return t;
+  };
+
+  const createAndOpenFile = async (
+    descriptor: string,
+    content: string,
+    viewColumn: vscode.ViewColumn = vscode.ViewColumn.One,
+  ): Promise<vscode.Uri> => {
+    const uri = createWorkspaceFile(descriptor, content);
+    tmpFileUris.push(uri);
+    const doc = await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(doc, { viewColumn, preview: false });
+    await settle();
+    return uri;
+  };
+
+  const findTerminalItems = (items: Record<string, unknown>[]): Record<string, unknown>[] =>
+    items.filter(
+      (item) =>
+        item.itemKind === 'bindable' &&
+        typeof item.label === 'string' &&
+        (item.label as string).includes('Terminal ('),
+    );
+
+  const findFileItems = (items: Record<string, unknown>[]): Record<string, unknown>[] =>
+    items.filter(
+      (item) =>
+        item.itemKind === 'bindable' &&
+        typeof item.label === 'string' &&
+        (item.label as string).includes('__rl-test-btd-'),
+    );
+
+  // ---------------------------------------------------------------------------
+  // TC bind-to-destination-004
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] bind-to-destination-004: selecting a terminal destination binds it and shows success toast', async () => {
+    await createTerminal('rl-btd-004');
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-btd-004');
+
+    await waitForHuman(
+      'bind-to-destination-004',
+      'Press Cmd+R Cmd+D, select Terminal ("rl-btd-004")',
+    );
+
+    const lines = logCapture.getLinesSince('before-btd-004');
+
+    const items = extractQuickPickItemsLogged(lines);
+    assert.ok(items, 'Expected showQuickPick log entry');
+
+    const termItems = findTerminalItems(items!);
+    assert.deepStrictEqual(
+      termItems.map(({ label, displayName, description, isActive, boundState, itemKind }) => ({
+        label,
+        displayName,
+        description,
+        isActive,
+        boundState,
+        itemKind,
+      })),
+      [
+        {
+          label: 'Terminal ("rl-btd-004")',
+          displayName: 'Terminal ("rl-btd-004")',
+          description: 'active',
+          isActive: true,
+          boundState: 'not-bound',
+          itemKind: 'bindable',
+        },
+      ],
+    );
+
+    assertStatusBarMsgLogged(lines, {
+      message: '✓ RangeLink bound to Terminal ("rl-btd-004")',
+    });
+
+    assertNoStatusBarMsgLogged(lines, {
+      message: 'RangeLink: No destination bound',
+    });
+
+    log('✓ Picker showed unbound terminal; bind succeeded with correct status bar toast');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC bind-to-destination-005
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] bind-to-destination-005: selecting a text editor destination binds it and shows success toast', async () => {
+    await createAndOpenFile('btd-005-a', 'line 1\n');
+    const uriB = await createAndOpenFile('btd-005-b', 'line 2\n', vscode.ViewColumn.Two);
+    const fnB = path.basename(uriB.fsPath);
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-btd-005');
+
+    await waitForHuman('bind-to-destination-005', `Press Cmd+R Cmd+D, select "${fnB}"`);
+
+    const lines = logCapture.getLinesSince('before-btd-005');
+
+    const items = extractQuickPickItemsLogged(lines);
+    assert.ok(items, 'Expected showQuickPick log entry');
+
+    const fileItems = findFileItems(items!);
+    const targetFile = fileItems.find((item) => item.label === fnB);
+    assert.ok(targetFile, `Expected file item for ${fnB}`);
+    assert.deepStrictEqual(
+      {
+        label: targetFile!.label,
+        displayName: targetFile!.displayName,
+        boundState: targetFile!.boundState,
+        itemKind: targetFile!.itemKind,
+      },
+      {
+        label: fnB,
+        displayName: fnB,
+        boundState: 'not-bound',
+        itemKind: 'bindable',
+      },
+    );
+
+    assertStatusBarMsgLogged(lines, {
+      message: `✓ RangeLink bound to Text Editor ("${fnB}")`,
+    });
+
+    assertNoStatusBarMsgLogged(lines, {
+      message: 'RangeLink: No destination bound',
+    });
+
+    log('✓ Picker showed unbound file; bind succeeded with correct status bar toast');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC bind-to-destination-006
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] bind-to-destination-006: selecting an AI assistant destination binds it and shows success toast', async () => {
+    const logCapture = getLogCapture();
+    logCapture.mark('before-btd-006');
+
+    await waitForHuman(
+      'bind-to-destination-006',
+      'Press Cmd+R Cmd+D, select any available AI assistant entry',
+    );
+
+    const lines = logCapture.getLinesSince('before-btd-006');
+
+    const AI_ASSISTANT_DISPLAY_NAMES = [
+      'Claude Code Chat',
+      'Cursor AI Assistant',
+      'GitHub Copilot Chat',
+    ];
+    const boundToAny = AI_ASSISTANT_DISPLAY_NAMES.some((name) =>
+      lines.some((line) => line.includes(`✓ RangeLink bound to ${name}`)),
+    );
+    assert.ok(
+      boundToAny,
+      `Expected status bar message "✓ RangeLink bound to <AI assistant>" for one of: ${AI_ASSISTANT_DISPLAY_NAMES.join(', ')}`,
+    );
+
+    log('✓ AI assistant bind success toast logged');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC bind-to-destination-007
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] bind-to-destination-007: when already bound, destination picker shows smart-bind confirmation dialog', async () => {
+    await createTerminal('rl-btd-007-a');
+    await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
+    await settle();
+    await createTerminal('rl-btd-007-b');
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-btd-007');
+
+    await waitForHuman(
+      'bind-to-destination-007',
+      'Cmd+R Cmd+D → select "rl-btd-007-b" → Escape the confirmation dialog',
+      [
+        '1. Press Cmd+R Cmd+D',
+        '2. Select Terminal ("rl-btd-007-b") from the picker',
+        '3. Escape the confirmation dialog that appears',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-btd-007');
+    const quickPickEntries = lines.filter(
+      (line) => line.includes('VscodeAdapter.showQuickPick') && line.includes('"items"'),
+    );
+    assert.ok(
+      quickPickEntries.length >= 2,
+      `Expected at least 2 showQuickPick entries (R-D picker + confirmation dialog), got ${quickPickEntries.length}`,
+    );
+
+    const confirmItems = parseQuickPickItemsFromLogLine(quickPickEntries[1]);
+    assert.deepStrictEqual(
+      confirmItems.map(({ label, description }) => ({ label, description })),
+      [
+        {
+          label: 'Yes, replace',
+          description: 'Switch from Terminal ("rl-btd-007-a") to Terminal ("rl-btd-007-b")',
+        },
+        {
+          label: 'No, keep current binding',
+          description: 'Stay bound to Terminal ("rl-btd-007-a")',
+        },
+      ],
+    );
+
+    assertNoStatusBarMsgLogged(lines, {
+      message: '✓ RangeLink bound to Terminal ("rl-btd-007-b")',
+    });
+    assertNoStatusBarMsgLogged(lines, {
+      message: 'Unbound Terminal ("rl-btd-007-a"), now bound to Terminal ("rl-btd-007-b")',
+    });
+
+    log('✓ Confirmation dialog items validated; no bind/rebind toast after Escape');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC bind-to-destination-008
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] bind-to-destination-008: smart-bind confirmation Yes replaces the binding', async () => {
+    await createTerminal('rl-btd-008-a');
+    await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
+    await settle();
+    await createTerminal('rl-btd-008-b');
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-btd-008');
+
+    await waitForHuman(
+      'bind-to-destination-008',
+      'Cmd+R Cmd+D → select "rl-btd-008-b" → click "Yes, replace"',
+      [
+        '1. Press Cmd+R Cmd+D',
+        '2. Select Terminal ("rl-btd-008-b") from the list',
+        '3. When the confirmation dialog appears, click "Yes, replace"',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-btd-008');
+
+    assertStatusBarMsgLogged(lines, {
+      message: 'Unbound Terminal ("rl-btd-008-a"), now bound to Terminal ("rl-btd-008-b")',
+    });
+
+    assertNoStatusBarMsgLogged(lines, {
+      message: '✓ RangeLink bound to Terminal ("rl-btd-008-a")',
+    });
+
+    log('✓ Replacement binding toast logged; old binding not re-confirmed');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC bind-to-destination-009
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] bind-to-destination-009: smart-bind confirmation No keeps existing binding', async () => {
+    await createTerminal('rl-btd-009-a');
+    await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
+    await settle();
+    await createTerminal('rl-btd-009-b');
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-btd-009');
+
+    await waitForHuman(
+      'bind-to-destination-009',
+      'Cmd+R Cmd+D → select "rl-btd-009-b" → click "No, keep current binding"',
+      [
+        '1. Press Cmd+R Cmd+D',
+        '2. Select Terminal ("rl-btd-009-b") from the list',
+        '3. When the confirmation dialog appears, click "No, keep current binding"',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-btd-009');
+
+    assertNoStatusBarMsgLogged(lines, {
+      message: 'Unbound Terminal ("rl-btd-009-a"), now bound to Terminal ("rl-btd-009-b")',
+    });
+    assertNoStatusBarMsgLogged(lines, {
+      message: '✓ RangeLink bound to Terminal ("rl-btd-009-b")',
+    });
+
+    log('✓ No rebind toast — original binding preserved');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC bind-to-destination-010
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] bind-to-destination-010: Escape from destination picker dismisses without changing binding', async () => {
+    await createTerminal('rl-btd-010');
+    await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-btd-010');
+
+    await waitForHuman('bind-to-destination-010', 'Press Cmd+R Cmd+D, then Escape');
+
+    const lines = logCapture.getLinesSince('before-btd-010');
+
+    const items = extractQuickPickItemsLogged(lines);
+    assert.ok(items, 'Expected showQuickPick log entry (picker did open)');
+
+    assertNoStatusBarMsgLogged(lines, {
+      message: '✓ RangeLink bound to Terminal ("rl-btd-010")',
+    });
+    assertNoStatusBarMsgLogged(lines, {
+      message: 'RangeLink: No destination bound',
+    });
+
+    log('✓ No bind or unbind toast after Escape — binding state unchanged');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC bind-to-destination-011
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] bind-to-destination-011: re-binding same AI assistant shows already-bound message', async () => {
+    const logCapture = getLogCapture();
+    logCapture.mark('before-btd-011');
+
+    await waitForHuman(
+      'bind-to-destination-011',
+      'Cmd+R Cmd+D → select an AI assistant → Cmd+R Cmd+D → select same AI assistant',
+      [
+        '1. Press Cmd+R Cmd+D and select any AI assistant (e.g., Claude Code Chat)',
+        '2. Press Cmd+R Cmd+D again',
+        '3. Select the same AI assistant a second time',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-btd-011');
+
+    const quickPickEntries = lines.filter(
+      (line) => line.includes('VscodeAdapter.showQuickPick') && line.includes('"items"'),
+    );
+    assert.strictEqual(
+      quickPickEntries.length,
+      2,
+      `Expected exactly 2 showQuickPick entries (two destination picker opens, no confirmation dialog), got ${quickPickEntries.length}`,
+    );
+
+    const AI_ASSISTANT_DISPLAY_NAMES = [
+      'Claude Code Chat',
+      'Cursor AI Assistant',
+      'GitHub Copilot Chat',
+    ];
+    const alreadyBoundLogged = AI_ASSISTANT_DISPLAY_NAMES.some((name) =>
+      lines.some((line) => line.includes(`RangeLink: Already bound to ${name}`)),
+    );
+    assert.ok(
+      alreadyBoundLogged,
+      `Expected "RangeLink: Already bound to <AI assistant>" info toast for one of: ${AI_ASSISTANT_DISPLAY_NAMES.join(', ')}`,
+    );
+
+    log('✓ Already-bound info toast logged; no confirmation dialog shown');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC bind-to-destination-012
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] bind-to-destination-012: switching between different AI assistants shows confirmation dialog', async () => {
+    await waitForHuman(
+      'bind-to-destination-012 (setup)',
+      'Ensure at least 2 AI assistant extensions are installed and enabled',
+      [
+        'This test requires two different AI assistants (e.g., GitHub Copilot Chat + Claude Code).',
+        'Install a second one now if needed, then dismiss this notification.',
+      ],
+    );
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-btd-012');
+
+    await waitForHuman(
+      'bind-to-destination-012',
+      'Cmd+R Cmd+D → select AI assistant A → Cmd+R Cmd+D → select different AI assistant B → click "Yes, replace"',
+      [
+        '1. Press Cmd+R Cmd+D and select one AI assistant (e.g., Claude Code Chat)',
+        '2. Press Cmd+R Cmd+D again',
+        '3. Select a different AI assistant (e.g., GitHub Copilot Chat)',
+        '4. When the confirmation dialog appears, click "Yes, replace"',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-btd-012');
+
+    const quickPickEntries = lines.filter(
+      (line) => line.includes('VscodeAdapter.showQuickPick') && line.includes('"items"'),
+    );
+    assert.ok(
+      quickPickEntries.length >= 3,
+      `Expected at least 3 showQuickPick entries (first picker, second picker, confirmation dialog), got ${quickPickEntries.length}`,
+    );
+
+    const confirmItems = parseQuickPickItemsFromLogLine(
+      quickPickEntries[quickPickEntries.length - 1],
+    );
+    assert.deepStrictEqual(
+      confirmItems.map(({ label }) => ({ label })),
+      [{ label: 'Yes, replace' }, { label: 'No, keep current binding' }],
+    );
+
+    const reboundLogged = lines.some(
+      (line) => line.includes('VscodeAdapter.setStatusBarMessage') && line.includes('now bound to'),
+    );
+    assert.ok(reboundLogged, 'Expected rebound status bar message after "Yes, replace"');
+
+    log('✓ Confirmation dialog shown; rebind toast logged after "Yes, replace"');
+  });
+});

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
@@ -9,14 +9,16 @@ import {
   assertStatusBarMsgLogged,
   cleanupFiles,
   closeAllEditors,
+  createAndOpenFile,
   createLogger,
-  createWorkspaceFile,
+  createTerminal,
   extractQuickPickItemsLogged,
+  findTerminalItems,
+  findTestItemsByPrefix,
   getLogCapture,
   parseQuickPickItemsFromLogLine,
   printAssistedBanner,
   settle,
-  TERMINAL_READY_MS,
   waitForHuman,
 } from '../helpers';
 
@@ -42,49 +44,15 @@ suite('R-D Bind to Destination', () => {
     await settle();
   });
 
-  const createTerminal = async (name: string): Promise<vscode.Terminal> => {
-    const t = vscode.window.createTerminal({ name });
-    terminals.push(t);
-    t.show(true);
-    await settle(TERMINAL_READY_MS);
-    return t;
-  };
-
-  const createAndOpenFile = async (
-    descriptor: string,
-    content: string,
-    viewColumn: vscode.ViewColumn = vscode.ViewColumn.One,
-  ): Promise<vscode.Uri> => {
-    const uri = createWorkspaceFile(descriptor, content);
-    tmpFileUris.push(uri);
-    const doc = await vscode.workspace.openTextDocument(uri);
-    await vscode.window.showTextDocument(doc, { viewColumn, preview: false });
-    await settle();
-    return uri;
-  };
-
-  const findTerminalItems = (items: Record<string, unknown>[]): Record<string, unknown>[] =>
-    items.filter(
-      (item) =>
-        item.itemKind === 'bindable' &&
-        typeof item.label === 'string' &&
-        (item.label as string).includes('Terminal ('),
-    );
-
   const findFileItems = (items: Record<string, unknown>[]): Record<string, unknown>[] =>
-    items.filter(
-      (item) =>
-        item.itemKind === 'bindable' &&
-        typeof item.label === 'string' &&
-        (item.label as string).includes('__rl-test-btd-'),
-    );
+    findTestItemsByPrefix(items, '__rl-test-btd-');
 
   // ---------------------------------------------------------------------------
   // TC bind-to-destination-004
   // ---------------------------------------------------------------------------
 
   test('[assisted] bind-to-destination-004: selecting a terminal destination binds it and shows success toast', async () => {
-    await createTerminal('rl-btd-004');
+    await createTerminal('rl-btd-004', terminals);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-btd-004');
@@ -137,8 +105,13 @@ suite('R-D Bind to Destination', () => {
   // ---------------------------------------------------------------------------
 
   test('[assisted] bind-to-destination-005: selecting a text editor destination binds it and shows success toast', async () => {
-    await createAndOpenFile('btd-005-a', 'line 1\n');
-    const uriB = await createAndOpenFile('btd-005-b', 'line 2\n', vscode.ViewColumn.Two);
+    await createAndOpenFile('btd-005-a', 'line 1\n', undefined, tmpFileUris);
+    const uriB = await createAndOpenFile(
+      'btd-005-b',
+      'line 2\n',
+      vscode.ViewColumn.Two,
+      tmpFileUris,
+    );
     const fnB = path.basename(uriB.fsPath);
 
     const logCapture = getLogCapture();
@@ -216,10 +189,10 @@ suite('R-D Bind to Destination', () => {
   // ---------------------------------------------------------------------------
 
   test('[assisted] bind-to-destination-007: when already bound, destination picker shows smart-bind confirmation dialog', async () => {
-    await createTerminal('rl-btd-007-a');
+    await createTerminal('rl-btd-007-a', terminals);
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
     await settle();
-    await createTerminal('rl-btd-007-b');
+    await createTerminal('rl-btd-007-b', terminals);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-btd-007');
@@ -273,10 +246,10 @@ suite('R-D Bind to Destination', () => {
   // ---------------------------------------------------------------------------
 
   test('[assisted] bind-to-destination-008: smart-bind confirmation Yes replaces the binding', async () => {
-    await createTerminal('rl-btd-008-a');
+    await createTerminal('rl-btd-008-a', terminals);
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
     await settle();
-    await createTerminal('rl-btd-008-b');
+    await createTerminal('rl-btd-008-b', terminals);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-btd-008');
@@ -309,10 +282,10 @@ suite('R-D Bind to Destination', () => {
   // ---------------------------------------------------------------------------
 
   test('[assisted] bind-to-destination-009: smart-bind confirmation No keeps existing binding', async () => {
-    await createTerminal('rl-btd-009-a');
+    await createTerminal('rl-btd-009-a', terminals);
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
     await settle();
-    await createTerminal('rl-btd-009-b');
+    await createTerminal('rl-btd-009-b', terminals);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-btd-009');
@@ -344,7 +317,7 @@ suite('R-D Bind to Destination', () => {
   // ---------------------------------------------------------------------------
 
   test('[assisted] bind-to-destination-010: Escape from destination picker dismisses without changing binding', async () => {
-    await createTerminal('rl-btd-010');
+    await createTerminal('rl-btd-010', terminals);
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
     await settle();
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filePicker.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filePicker.test.ts
@@ -8,12 +8,13 @@ import {
   activateExtension,
   cleanupFiles,
   closeAllEditors,
+  createAndOpenFile,
   createLogger,
-  createWorkspaceFile,
   extractQuickPickItemsLogged,
+  findTestItemsByPrefix,
   getLogCapture,
-  parseQuickPickItemsFromLogLine,
   getWorkspaceRoot,
+  parseQuickPickItemsFromLogLine,
   printAssistedBanner,
   settle,
   waitForHuman,
@@ -39,33 +40,25 @@ suite('File Picker', () => {
     await settle();
   });
 
-  const createAndOpenFile = async (
-    name: string,
-    content: string,
-    viewColumn: vscode.ViewColumn = vscode.ViewColumn.One,
-  ): Promise<vscode.Uri> => {
-    const uri = createWorkspaceFile(name, content);
-    tmpFileUris.push(uri);
-    const doc = await vscode.workspace.openTextDocument(uri);
-    await vscode.window.showTextDocument(doc, { viewColumn, preview: false });
-    await settle();
-    return uri;
-  };
-
   const findTestFileItems = (items: Record<string, unknown>[]): Record<string, unknown>[] =>
-    items.filter(
-      (item) =>
-        item.itemKind === 'bindable' &&
-        typeof item.label === 'string' &&
-        (item.label as string).includes('__rl-test-fp-'),
-    );
+    findTestItemsByPrefix(items, '__rl-test-fp-');
 
   test('[assisted] file-picker-001: bound file appears first with bound badge', async () => {
-    const uriA = await createAndOpenFile('fp-001-a', 'line 1\nline 2\n', vscode.ViewColumn.One);
+    const uriA = await createAndOpenFile(
+      'fp-001-a',
+      'line 1\nline 2\n',
+      vscode.ViewColumn.One,
+      tmpFileUris,
+    );
     const fnA = path.basename(uriA.fsPath);
     await vscode.commands.executeCommand('rangelink.bindToTextEditorHere');
     await settle();
-    const uriB = await createAndOpenFile('fp-001-b', 'other file\n', vscode.ViewColumn.Two);
+    const uriB = await createAndOpenFile(
+      'fp-001-b',
+      'other file\n',
+      vscode.ViewColumn.Two,
+      tmpFileUris,
+    );
     const fnB = path.basename(uriB.fsPath);
 
     const logCapture = getLogCapture();
@@ -108,9 +101,19 @@ suite('File Picker', () => {
   });
 
   test('[assisted] file-picker-002: active file appears before others in its group', async () => {
-    const uriA = await createAndOpenFile('fp-002-a', 'file a\n', vscode.ViewColumn.One);
+    const uriA = await createAndOpenFile(
+      'fp-002-a',
+      'file a\n',
+      vscode.ViewColumn.One,
+      tmpFileUris,
+    );
     const fnA = path.basename(uriA.fsPath);
-    const uriB = await createAndOpenFile('fp-002-b', 'file b\n', vscode.ViewColumn.Two);
+    const uriB = await createAndOpenFile(
+      'fp-002-b',
+      'file b\n',
+      vscode.ViewColumn.Two,
+      tmpFileUris,
+    );
     const fnB = path.basename(uriB.fsPath);
 
     const logCapture = getLogCapture();
@@ -230,7 +233,7 @@ suite('File Picker', () => {
   });
 
   test('[assisted] file-picker-004: open files appear as inline items in destination picker', async () => {
-    const uri = await createAndOpenFile('fp-004', 'content\n');
+    const uri = await createAndOpenFile('fp-004', 'content\n', undefined, tmpFileUris);
     const fn = path.basename(uri.fsPath);
 
     const logCapture = getLogCapture();
@@ -267,7 +270,7 @@ suite('File Picker', () => {
 
   test('[assisted] file-picker-005: overflow shows "More files..." when exceeding inline limit', async () => {
     for (let i = 1; i <= FILE_OVERFLOW_THRESHOLD; i++) {
-      await createAndOpenFile(`fp-005-${i}`, `file ${i}\n`);
+      await createAndOpenFile(`fp-005-${i}`, `file ${i}\n`, undefined, tmpFileUris);
     }
 
     const logCapture = getLogCapture();
@@ -307,7 +310,7 @@ suite('File Picker', () => {
   test('[assisted] file-picker-006: secondary picker shows Active Files section', async () => {
     const fileNames: string[] = [];
     for (let i = 1; i <= FILE_OVERFLOW_THRESHOLD; i++) {
-      const uri = await createAndOpenFile(`fp-006-${i}`, `file ${i}\n`);
+      const uri = await createAndOpenFile(`fp-006-${i}`, `file ${i}\n`, undefined, tmpFileUris);
       fileNames.push(path.basename(uri.fsPath));
     }
     const lastFileName = fileNames[fileNames.length - 1];
@@ -377,8 +380,8 @@ suite('File Picker', () => {
   });
 
   test('[assisted] file-picker-007: secondary picker shows Tab Group sections', async () => {
-    await createAndOpenFile('fp-007-g1', 'group 1\n', vscode.ViewColumn.One);
-    await createAndOpenFile('fp-007-g2', 'group 2\n', vscode.ViewColumn.Two);
+    await createAndOpenFile('fp-007-g1', 'group 1\n', vscode.ViewColumn.One, tmpFileUris);
+    await createAndOpenFile('fp-007-g2', 'group 2\n', vscode.ViewColumn.Two, tmpFileUris);
 
     const extraNames: string[] = [];
     for (let i = 1; i <= 3; i++) {
@@ -386,10 +389,11 @@ suite('File Picker', () => {
         `fp-007-extra-${i}`,
         `extra ${i}\n`,
         vscode.ViewColumn.One,
+        tmpFileUris,
       );
       extraNames.push(path.basename(uri.fsPath));
     }
-    await createAndOpenFile('fp-007-g2b', 'group 2 extra\n', vscode.ViewColumn.Two);
+    await createAndOpenFile('fp-007-g2b', 'group 2 extra\n', vscode.ViewColumn.Two, tmpFileUris);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-fp-007');
@@ -438,7 +442,7 @@ suite('File Picker', () => {
 
   test('[assisted] file-picker-008: escaping secondary file picker returns to parent', async () => {
     for (let i = 1; i <= FILE_OVERFLOW_THRESHOLD; i++) {
-      await createAndOpenFile(`fp-008-${i}`, `file ${i}\n`);
+      await createAndOpenFile(`fp-008-${i}`, `file ${i}\n`, undefined, tmpFileUris);
     }
 
     const logCapture = getLogCapture();
@@ -502,7 +506,7 @@ suite('File Picker', () => {
     await settle();
 
     for (let i = 1; i <= FILE_OVERFLOW_THRESHOLD; i++) {
-      await createAndOpenFile(`fp-010-filler-${i}`, `filler ${i}\n`);
+      await createAndOpenFile(`fp-010-filler-${i}`, `filler ${i}\n`, undefined, tmpFileUris);
     }
 
     const logCapture = getLogCapture();
@@ -637,9 +641,19 @@ suite('File Picker', () => {
   });
 
   test('[assisted] file-picker-012: unique file names have no disambiguator in description', async () => {
-    const uriA = await createAndOpenFile('fp-012-alpha', 'file a\n', vscode.ViewColumn.One);
+    const uriA = await createAndOpenFile(
+      'fp-012-alpha',
+      'file a\n',
+      vscode.ViewColumn.One,
+      tmpFileUris,
+    );
     const fnA = path.basename(uriA.fsPath);
-    const uriB = await createAndOpenFile('fp-012-beta', 'file b\n', vscode.ViewColumn.Two);
+    const uriB = await createAndOpenFile(
+      'fp-012-beta',
+      'file b\n',
+      vscode.ViewColumn.Two,
+      tmpFileUris,
+    );
     const fnB = path.basename(uriB.fsPath);
 
     const logCapture = getLogCapture();
@@ -682,7 +696,7 @@ suite('File Picker', () => {
   });
 
   test('[assisted] file-picker-009: file picker appears inline in R-M menu when unbound', async () => {
-    const uri = await createAndOpenFile('fp-009', 'content\n');
+    const uri = await createAndOpenFile('fp-009', 'content\n', undefined, tmpFileUris);
     const fn = path.basename(uri.fsPath);
 
     const logCapture = getLogCapture();

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/terminalPicker.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/terminalPicker.test.ts
@@ -7,15 +7,16 @@ import {
   cleanupFiles,
   closeAllEditors,
   createLogger,
+  createTerminal,
   createWorkspaceFile,
   extractQuickPickItemsLogged,
+  findTerminalItems,
   getLogCapture,
   loadSettingsProfile,
   parseQuickPickItemsFromLogLine,
   printAssistedBanner,
   resetRangelinkSettings,
   settle,
-  TERMINAL_READY_MS,
   waitForHuman,
 } from '../helpers';
 
@@ -43,25 +44,9 @@ suite('Terminal Picker', () => {
     await settle();
   });
 
-  const createTerminal = async (name: string): Promise<vscode.Terminal> => {
-    const t = vscode.window.createTerminal({ name });
-    terminals.push(t);
-    t.show(true);
-    await settle(TERMINAL_READY_MS);
-    return t;
-  };
-
-  const findTerminalItems = (items: Record<string, unknown>[]): Record<string, unknown>[] =>
-    items.filter(
-      (item) =>
-        item.itemKind === 'bindable' &&
-        typeof item.label === 'string' &&
-        (item.label as string).includes('Terminal ('),
-    );
-
   test('[assisted] terminal-picker-001: active terminal is marked with active badge', async () => {
-    const t1 = await createTerminal('rl-tp-001-a');
-    await createTerminal('rl-tp-001-b');
+    const t1 = await createTerminal('rl-tp-001-a', terminals);
+    await createTerminal('rl-tp-001-b', terminals);
     t1.show(true);
     await settle();
 
@@ -108,10 +93,10 @@ suite('Terminal Picker', () => {
   });
 
   test('[assisted] terminal-picker-002: bound terminal is marked with bound badge', async () => {
-    await createTerminal('rl-tp-002');
+    await createTerminal('rl-tp-002', terminals);
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
     await settle();
-    const t2 = await createTerminal('rl-tp-002-other');
+    const t2 = await createTerminal('rl-tp-002-other', terminals);
     t2.show(true);
     await settle();
 
@@ -158,7 +143,7 @@ suite('Terminal Picker', () => {
   });
 
   test('[assisted] terminal-picker-003: terminal that is both active and bound shows dual badge', async () => {
-    const t = await createTerminal('rl-tp-003');
+    const t = await createTerminal('rl-tp-003', terminals);
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
     t.show(true);
     await settle();
@@ -198,10 +183,10 @@ suite('Terminal Picker', () => {
   });
 
   test('[assisted] terminal-picker-004: bound terminal always appears first in the list', async () => {
-    await createTerminal('rl-tp-004-b');
+    await createTerminal('rl-tp-004-b', terminals);
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
     await settle();
-    await createTerminal('rl-tp-004-a');
+    await createTerminal('rl-tp-004-a', terminals);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-004');
@@ -246,10 +231,10 @@ suite('Terminal Picker', () => {
   });
 
   test('[assisted] terminal-picker-005: active non-bound terminal appears second', async () => {
-    await createTerminal('rl-tp-005-a');
+    await createTerminal('rl-tp-005-a', terminals);
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
     await settle();
-    const t2 = await createTerminal('rl-tp-005-b');
+    const t2 = await createTerminal('rl-tp-005-b', terminals);
     t2.show(true);
     await settle();
 
@@ -296,7 +281,7 @@ suite('Terminal Picker', () => {
   });
 
   test('[assisted] terminal-picker-006: hidden IDE terminals are absent from the picker', async () => {
-    await createTerminal('rl-tp-006');
+    await createTerminal('rl-tp-006', terminals);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-006');
@@ -333,8 +318,8 @@ suite('Terminal Picker', () => {
   });
 
   test('[assisted] terminal-picker-007: all terminals shown inline when within maxInline limit', async () => {
-    await createTerminal('rl-tp-007-a');
-    await createTerminal('rl-tp-007-b');
+    await createTerminal('rl-tp-007-a', terminals);
+    await createTerminal('rl-tp-007-b', terminals);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-007');
@@ -386,7 +371,7 @@ suite('Terminal Picker', () => {
 
   test('[assisted] terminal-picker-008: overflow shows "More terminals..." when exceeding maxInline', async () => {
     for (let i = 1; i <= TERMINAL_OVERFLOW_COUNT; i++) {
-      await createTerminal(`rl-tp-008-${i}`);
+      await createTerminal(`rl-tp-008-${i}`, terminals);
     }
 
     const logCapture = getLogCapture();
@@ -447,7 +432,7 @@ suite('Terminal Picker', () => {
 
   test('[assisted] terminal-picker-009: selecting "More terminals..." opens secondary full picker', async () => {
     for (let i = 1; i <= TERMINAL_OVERFLOW_COUNT; i++) {
-      await createTerminal(`rl-tp-009-${i}`);
+      await createTerminal(`rl-tp-009-${i}`, terminals);
     }
 
     const logCapture = getLogCapture();
@@ -512,7 +497,7 @@ suite('Terminal Picker', () => {
 
   test('[assisted] terminal-picker-010: escaping secondary picker returns to parent destination picker', async () => {
     for (let i = 1; i <= TERMINAL_OVERFLOW_COUNT; i++) {
-      await createTerminal(`rl-tp-010-${i}`);
+      await createTerminal(`rl-tp-010-${i}`, terminals);
     }
 
     const logCapture = getLogCapture();
@@ -556,7 +541,7 @@ suite('Terminal Picker', () => {
 
     try {
       for (let i = 1; i <= TC_TERMINAL_COUNT; i++) {
-        await createTerminal(`rl-tp-011-${i}`);
+        await createTerminal(`rl-tp-011-${i}`, terminals);
       }
 
       const logCapture = getLogCapture();
@@ -619,7 +604,7 @@ suite('Terminal Picker', () => {
   });
 
   test('[assisted] terminal-picker-012: terminal picker appears inline in R-M menu when unbound', async () => {
-    await createTerminal('rl-tp-012');
+    await createTerminal('rl-tp-012', terminals);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-012');
@@ -661,7 +646,7 @@ suite('Terminal Picker', () => {
   });
 
   test('[assisted] terminal-picker-013: terminal picker appears inline in R-D destination picker', async () => {
-    await createTerminal('rl-tp-013');
+    await createTerminal('rl-tp-013', terminals);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-013');
@@ -699,7 +684,7 @@ suite('Terminal Picker', () => {
 
   test('[assisted] bind-to-destination-013: R-D picker shows both overflow items when many terminals and files are open', async () => {
     for (let i = 1; i <= TERMINAL_OVERFLOW_COUNT; i++) {
-      await createTerminal(`rl-btd-013-${i}`);
+      await createTerminal(`rl-btd-013-${i}`, terminals);
     }
 
     const tmpFileUris: vscode.Uri[] = [];


### PR DESCRIPTION
## Summary

Adds 9 assisted integration tests for the R-D Bind to Destination flow — the multi-step pattern where the human opens the picker, selects a destination, and the test asserts toast/status bar messages via log capture. Also removes 3 duplicate TCs (001-003) that were fully covered by existing terminal/file picker tests.

## Changes

- New `bindToDestination.test.ts` with 9 `[assisted]` tests covering bind success (terminal, file, AI assistant), smart-bind confirmation dialog (items, Yes/replace, No/keep), escape handling, and AI assistant re-bind/switch scenarios
- Deleted TCs 001-003 from QA YAML — "picker opens via trigger X" was already tested by every terminal/file picker assisted test (no renumbering per QA001)
- Updated TCs 004-012 from `automated: false` to `automated: assisted`
- AI assistant TCs (006, 011, 012) are included as assisted — they require running in an IDE with the relevant extensions installed
- TC 012 (switch between AI assistants) includes a setup `waitForHuman` prompting to install a second AI extension; will be fully testable once https://github.com/couimet/rangeLink/issues/500 (custom AI assistants) lands
- Fixed smart-bind confirmation tests (007, 009) — removed incorrect "Escape again" step; the confirmation dialog is invoked after `DestinationPicker.pick()` returns (in `commitBind`), so no parent picker reopens

## Test Plan

- [x] All 1737 unit tests pass (99 suites)
- [x] QA coverage validator passes (38 assisted entries, 59 automated, 98 false)
- [x] 9/10 assisted tests pass with human interaction (`pnpm test:release:grep "bind-to-destination"`)
- [ ] TC 012 deferred — requires two AI assistant extensions in the test host (blocked on https://github.com/couimet/rangeLink/issues/500)

## Documentation

- CHANGELOG: not needed — test infrastructure, not user-facing
- README: not needed

## Related

- Closes https://github.com/couimet/rangeLink/issues/506
- Parent: https://github.com/couimet/rangeLink/issues/504
- Blocked: TC 012 depends on https://github.com/couimet/rangeLink/issues/500 for testability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed three manual bind-to-destination test cases; remaining destination-binding cases changed from "manual" to "assisted"
  * Added an end-to-end integration suite validating bind-to-destination flows (terminal, editor, AI assistant switching, confirmations, and dismissal behavior)
  * Introduced shared test helpers for creating/opening files and terminals and for locating bindable items; updated existing tests to use these helpers
  * Extended a test precondition to require at least two AI assistant extensions active
<!-- end of auto-generated comment: release notes by coderabbit.ai -->