### PR TITLE
[issues/520] Terminal context menu: assisted tests, direct-bind, picker-on-unbound

### DIFF
--- a/packages/rangelink-vscode-extension/.vscode-test.mjs
+++ b/packages/rangelink-vscode-extension/.vscode-test.mjs
@@ -3,7 +3,11 @@ import * as path from 'node:path';
 
 import { defineConfig } from '@vscode/test-cli';
 
-const MOCHA_TIMEOUT_MS = 300_000;
+// 10 minutes per test — assisted tests block on human interaction (modal
+// verdict dialogs don't auto-dismiss), so the human needs headroom to read
+// instructions, complete UI actions, or step away for a break. Automated tests
+// never come close to this threshold.
+const MOCHA_TIMEOUT_MS = 600_000;
 const USER_DATA_DIR = path.join(os.tmpdir(), 'rl-vscode-test');
 
 export default defineConfig([

--- a/packages/rangelink-vscode-extension/CHANGELOG.md
+++ b/packages/rangelink-vscode-extension/CHANGELOG.md
@@ -78,8 +78,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - "RangeLink: Bind Here" - Bind this editor as destination (file/untitled only)
     - "RangeLink: Unbind" - Unbind current destination (when bound)
   - **Terminal** (right-click on terminal tabs or inside terminal):
+    - "RangeLink: Send Selection to Destination" - Send the selected terminal text to the bound destination (content-area menu only; opens the destination picker if nothing is bound)
     - "RangeLink: Bind Here" - Bind this terminal as destination
-    - "RangeLink: Unbind" - Unbind current destination (when bound)
+    - "RangeLink: Unbind" - Unbind current destination (content-area menu only when bound)
 - **Navigation clamping feedback** - Navigation now warns when a link points beyond file boundaries instead of silently landing at the nearest valid position
 - **Navigation toast settings** - Control which toasts appear after clicking a RangeLink (#54)
   - `rangelink.navigation.showNavigatedToast` (default: `true`) — suppress the "Navigated to …" info toast for a quieter workflow
@@ -92,7 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Also applies to Send File Path (R-F) commands — warns when the file has unsaved changes that may cause the AI tool to read stale content from disk (#513)
 - **Send Terminal Selection (R-V)** - Send terminal text to your bound destination (#331)
   - **Keyboard shortcut:** `Cmd+R Cmd+V` (Mac) / `Ctrl+R Ctrl+V` (Win/Linux) when terminal has focus
-  - Terminal context menu "Send Selection to Destination" entry when text is selected and a destination is bound
+  - Terminal context menu "Send Selection to Destination" entry when text is selected — opens the destination picker if nothing is bound
   - R-L and R-C gracefully guide users who press editor keybindings while in the terminal
 - **Go to Link Command (R-G)** - Paste or type a RangeLink to go directly to that code location
   - **Keyboard shortcut:** `Cmd+R Cmd+G` (Mac) / `Ctrl+R Ctrl+G` (Win/Linux)

--- a/packages/rangelink-vscode-extension/README.md
+++ b/packages/rangelink-vscode-extension/README.md
@@ -352,11 +352,11 @@ Positioned after VSCode's "Copy Path" / "Copy Relative Path":
 
 #### Terminal (right-click on tab or inside terminal)
 
-| Menu Item                                | Visibility              | Action                                          |
-| ---------------------------------------- | ----------------------- | ----------------------------------------------- |
-| RangeLink: Send Selection to Destination | Text selected and bound | Copy terminal selection and send to destination |
-| RangeLink: Bind Here                     | Always                  | Bind this terminal as destination               |
-| RangeLink: Unbind                        | When bound              | Unbind current destination                      |
+| Menu Item                                | Visibility                   | Action                                                                    |
+| ---------------------------------------- | ---------------------------- | ------------------------------------------------------------------------- |
+| RangeLink: Send Selection to Destination | Text selected (content-area) | Copy terminal selection and send to destination (opens picker if unbound) |
+| RangeLink: Bind Here                     | Always                       | Bind this terminal as destination                                         |
+| RangeLink: Unbind                        | When bound (content-area)    | Unbind current destination                                                |
 
 ## Configuration
 

--- a/packages/rangelink-vscode-extension/package.json
+++ b/packages/rangelink-vscode-extension/package.json
@@ -864,7 +864,7 @@
       ],
       "terminal/context": [
         {
-          "when": "terminalTextSelected && rangelink.isBound",
+          "when": "terminalTextSelected",
           "command": "rangelink.terminal.pasteSelectedTextToDestination",
           "group": "2_edit@10"
         },

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
@@ -1052,7 +1052,7 @@ test_cases:
       - 'Right-click the terminal tab in the terminal panel tab bar'
       - "Select 'RangeLink: Bind Here'"
     expected_result: 'That terminal is bound as the destination. Success toast appears.'
-    automated: false
+    automated: assisted
 
   - id: context-menus-terminal-002
     feature: 'Context Menus — Terminal'
@@ -1064,18 +1064,44 @@ test_cases:
       - 'Right-click inside the terminal output area'
       - "Select 'RangeLink: Bind Here'"
     expected_result: 'Same result as context-menus-terminal-001 — the terminal is bound. Success toast.'
-    automated: false
+    automated: assisted
 
   - id: context-menus-terminal-003
     feature: 'Context Menus — Terminal'
-    scenario: 'Terminal: RangeLink: Unbind is visible when a destination is bound'
+    scenario: 'Terminal content-area: RangeLink: Unbind is visible when bound and unbinds on click'
     preconditions:
       - 'A destination is currently bound'
     steps:
-      - 'Right-click in a terminal (tab or content area)'
-      - 'Observe the context menu'
-    expected_result: "'RangeLink: Unbind' is visible in the terminal context menu."
-    automated: false
+      - 'Right-click INSIDE the terminal content area (the tab menu does not render Unbind)'
+      - "Select 'RangeLink: Unbind'"
+    expected_result: "'RangeLink: Unbind' is visible in the content-area menu and selecting it unbinds the destination. Confirmation notification."
+    automated: assisted
+
+  - id: context-menus-terminal-004
+    feature: 'Context Menus — Terminal'
+    scenario: 'Terminal tab right-click binds THAT specific terminal (multi-terminal disambiguation)'
+    preconditions:
+      - 'Extension installed'
+      - 'Two or more terminals are open with distinct names'
+    steps:
+      - 'Identify a specific TARGET terminal'
+      - "Right-click the TARGET terminal's TAB in the terminal panel's tab bar"
+      - "Select 'RangeLink: Bind Here'"
+    expected_result: 'The TARGET terminal is bound (status bar confirms the TARGET name, not the other terminal). No picker is shown.'
+    automated: assisted
+
+  - id: context-menus-terminal-005
+    feature: 'Context Menus — Terminal'
+    scenario: 'Terminal content-area right-click binds THAT specific terminal (multi-terminal disambiguation)'
+    preconditions:
+      - 'Extension installed'
+      - 'Two or more terminals are open with distinct names'
+    steps:
+      - 'Focus a specific TARGET terminal'
+      - "Right-click INSIDE the TARGET terminal's content area"
+      - "Select 'RangeLink: Bind Here'"
+    expected_result: 'The TARGET terminal is bound (status bar confirms the TARGET name, not the other terminal). No picker is shown.'
+    automated: assisted
 
   # ---------------------------------------------------------------------------
   # Section 8 — Dirty Buffer Warning
@@ -1435,15 +1461,15 @@ test_cases:
 
   - id: send-terminal-selection-005
     feature: 'R-V Send Terminal Selection'
-    scenario: 'Terminal context menu Send Selection to Destination when text selected and bound'
+    scenario: 'Terminal content-area context menu Send Selection to Destination when text selected and bound'
     preconditions:
       - 'Terminal focused, text selected in terminal, destination bound'
     steps:
       - 'Select text in terminal'
-      - 'Right-click in terminal'
+      - 'Right-click INSIDE the terminal content area (not the tab)'
       - 'Click RangeLink: Send Selection to Destination'
     expected_result: 'Selected text sent to bound destination. Same behavior as R-V keybinding.'
-    automated: false
+    automated: assisted
 
   - id: send-terminal-selection-006
     feature: 'R-V Send Terminal Selection'
@@ -1466,6 +1492,79 @@ test_cases:
       - 'Press Cmd+R Cmd+C'
     expected_result: 'Notification guides user to use R-V instead. No clipboard write for invalid terminal context.'
     automated: true
+
+  - id: send-terminal-selection-008
+    feature: 'R-V Send Terminal Selection'
+    scenario: 'Cross-terminal: content-area "Send Selection" routes selection from source terminal to bound terminal and shifts focus'
+    preconditions:
+      - 'Two terminals exist (SOURCE and BOUND)'
+      - 'BOUND terminal is bound as destination'
+      - 'Text is selected in SOURCE terminal'
+    steps:
+      - 'Right-click INSIDE the SOURCE terminal content area'
+      - "Select 'RangeLink: Send Selection to Destination'"
+    expected_result: 'Selected text is pasted into the BOUND terminal, and focus shifts to BOUND. Status bar confirms "sent to Terminal (BOUND)".'
+    automated: assisted
+
+  - id: send-terminal-selection-009
+    feature: 'R-V Send Terminal Selection'
+    scenario: 'Terminal TAB context menu does NOT include "Send Selection to Destination"'
+    preconditions:
+      - 'Terminal bound, text selected in terminal'
+    steps:
+      - 'Right-click the terminal TAB (not the content area)'
+      - 'Observe the context menu'
+    expected_result: '"RangeLink: Send Selection to Destination" is NOT present in the tab menu (the command is only registered for the content-area menu).'
+    automated: assisted
+
+  - id: send-terminal-selection-010
+    feature: 'R-V Send Terminal Selection'
+    scenario: 'Self-paste: bound terminal sends its own selection to itself (no self-paste guard)'
+    preconditions:
+      - 'A terminal is bound as destination'
+      - 'Text is selected in THAT SAME terminal'
+    steps:
+      - 'Right-click INSIDE the bound terminal content area'
+      - "Select 'RangeLink: Send Selection to Destination'"
+    expected_result: 'Selected text is pasted back into the same terminal (documents current behavior; a terminal-specific self-paste guard is a potential future improvement).'
+    automated: assisted
+
+  - id: send-terminal-selection-011
+    feature: 'R-V Send Terminal Selection'
+    scenario: 'Unbound: "Send Selection to Destination" is visible; clicking opens destination picker and delivers to picked destination'
+    preconditions:
+      - 'No destination is bound'
+      - 'Two terminals exist — SOURCE (with selected text) and DEST (empty)'
+    steps:
+      - 'Right-click INSIDE the SOURCE terminal content area'
+      - "Select 'RangeLink: Send Selection to Destination'"
+      - 'Pick the DEST terminal from the destination picker that opens'
+    expected_result: 'The item is visible (parity with editor family — no isBound gate). The destination picker opens, and after picking DEST, the selection is delivered to DEST and DEST becomes the bound destination.'
+    automated: assisted
+
+  - id: send-terminal-selection-012
+    feature: 'R-V Send Terminal Selection'
+    scenario: '"Send Selection to Destination" is hidden when no terminal text is selected'
+    preconditions:
+      - 'A destination is bound'
+      - 'No text is selected in the terminal'
+    steps:
+      - 'Right-click INSIDE the terminal content area without selecting anything'
+      - 'Observe the context menu'
+    expected_result: '"RangeLink: Send Selection to Destination" is NOT present (`when` clause requires `terminalTextSelected`).'
+    automated: assisted
+
+  - id: send-terminal-selection-013
+    feature: 'R-V Send Terminal Selection'
+    scenario: 'Terminal content-area "Send Selection" delivers selected text to a bound AI-assistant destination'
+    preconditions:
+      - 'Dummy AI (Tier 1) is bound as destination (via R-D)'
+      - 'Text is selected in a terminal'
+    steps:
+      - 'Right-click INSIDE the terminal content area'
+      - "Select 'RangeLink: Send Selection to Destination'"
+    expected_result: 'The selected text is delivered to the Dummy AI extension via Tier 1 direct insert; the dummy textarea contains the selection.'
+    automated: assisted
 
   # ---------------------------------------------------------------------------
   # Section 10 — R-G Go to Link

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/assistedTestHelper.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/assistedTestHelper.ts
@@ -69,8 +69,14 @@ export const waitForHuman = async (
  */
 export type HumanVerdict = 'pass' | 'fail';
 
-const VERDICT_PASS_COMMAND = 'rangelink._test.verdict.pass';
-const VERDICT_FAIL_COMMAND = 'rangelink._test.verdict.fail';
+const VERDICT_PASS_COMMAND_PREFIX = 'rangelink._test.verdict.pass';
+const VERDICT_FAIL_COMMAND_PREFIX = 'rangelink._test.verdict.fail';
+
+// Per-invocation counter: suffixes the verdict command IDs so concurrent or
+// nested `waitForHumanVerdict` calls never collide on `registerCommand`. Tests
+// today run sequentially, but future parallelism or accidental missed-await
+// patterns would otherwise throw `command '...' already exists`.
+let verdictInvocationCounter = 0;
 
 /**
  * Pauses the test until the human clicks Pass or Fail in the status bar.
@@ -121,6 +127,10 @@ export const waitForHumanVerdict = async (
   nodeConsole.log('Click the PASS or FAIL button in the status bar (bottom-left) when done.');
   nodeConsole.log(SECTION_LINE);
 
+  const invocationId = ++verdictInvocationCounter;
+  const passCommand = `${VERDICT_PASS_COMMAND_PREFIX}.${invocationId}`;
+  const failCommand = `${VERDICT_FAIL_COMMAND_PREFIX}.${invocationId}`;
+
   return vscode.window.withProgress(
     {
       location: vscode.ProgressLocation.Notification,
@@ -144,23 +154,23 @@ export const waitForHumanVerdict = async (
         };
 
         disposables.push(
-          vscode.commands.registerCommand(VERDICT_PASS_COMMAND, () => settleWith('pass')),
-          vscode.commands.registerCommand(VERDICT_FAIL_COMMAND, () => settleWith('fail')),
+          vscode.commands.registerCommand(passCommand, () => settleWith('pass')),
+          vscode.commands.registerCommand(failCommand, () => settleWith('fail')),
         );
 
         const passItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10000);
         passItem.text = `$(check) PASS [${tcId}]`;
         passItem.tooltip = `Click if the expected behavior was observed for ${tcId}`;
-        passItem.command = VERDICT_PASS_COMMAND;
-        passItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
+        passItem.command = passCommand;
+        passItem.color = new vscode.ThemeColor('testing.iconPassed');
         passItem.show();
         disposables.push(passItem);
 
         const failItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 9999);
         failItem.text = `$(x) FAIL [${tcId}]`;
         failItem.tooltip = `Click if the expected behavior was NOT observed for ${tcId}`;
-        failItem.command = VERDICT_FAIL_COMMAND;
-        failItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
+        failItem.command = failCommand;
+        failItem.color = new vscode.ThemeColor('testing.iconFailed');
         failItem.show();
         disposables.push(failItem);
       });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/assistedTestHelper.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/assistedTestHelper.ts
@@ -59,3 +59,111 @@ export const waitForHuman = async (
       }),
   );
 };
+
+/**
+ * Verdict returned by the human driver for visibility/absence tests.
+ *
+ * - `'pass'` — the described behavior was observed (e.g., menu item was
+ *   correctly hidden or visible).
+ * - `'fail'` — the described behavior was NOT observed. The test should fail.
+ */
+export type HumanVerdict = 'pass' | 'fail';
+
+const VERDICT_PASS_COMMAND = 'rangelink._test.verdict.pass';
+const VERDICT_FAIL_COMMAND = 'rangelink._test.verdict.fail';
+
+/**
+ * Pauses the test until the human clicks Pass or Fail in the status bar.
+ *
+ * Use this instead of `waitForHuman` when the test is pure visual verification
+ * (e.g., "menu item is/isn't visible", "dialog has/hasn't appeared") and the
+ * only machine-verifiable signal is a weak state-invariant check. The explicit
+ * Pass/Fail choice forces the driver to confirm the outcome — no "just hit
+ * Cancel without looking" passes.
+ *
+ * Implementation: wraps everything in `vscode.window.withProgress` so the
+ * action prompt appears as a persistent notification in the bottom-right
+ * corner. In parallel, two status bar items (PASS / FAIL) are created on the
+ * bottom-left with ephemeral commands. When the human clicks one, the
+ * underlying promise resolves, the status bar items dispose, AND the progress
+ * notification dismisses automatically — all from the same promise settlement.
+ *
+ * Why this combination:
+ * - Modal dialogs (`{ modal: true }`) are blocked by VS Code's test host.
+ * - QuickPick verdicts conflict with scenarios that themselves open
+ *   QuickPicks (R-D, R-M menus).
+ * - Plain notifications (info/warning/error) can auto-collapse depending on
+ *   `workbench.notifications.*` user settings, even with action buttons.
+ * - Status bar items never auto-dismiss — they persist until disposed.
+ * - `withProgress` notifications are tied to a promise's lifetime — they
+ *   stay visible as long as the task is running.
+ * - Combining the two gives us persistent instructions (progress title) AND
+ *   persistent buttons (status bar), with a single promise resolving both.
+ *
+ * Mocha's per-test timeout (currently 10 min in `.vscode-test.mjs`) bounds
+ * the maximum wait.
+ *
+ * @param tcId - Test case ID shown as the notification title prefix
+ * @param action - Short prompt describing what to verify
+ * @param consoleSteps - Optional bulleted steps (shown in the terminal console)
+ * @returns `'pass'` if the human clicked the Pass status bar item, `'fail'` otherwise
+ */
+export const waitForHumanVerdict = async (
+  tcId: string,
+  action: string,
+  consoleSteps?: string[],
+): Promise<HumanVerdict> => {
+  nodeConsole.log(`\n${SECTION_LINE}`);
+  nodeConsole.log(`[${tcId}] ${action}`);
+  if (consoleSteps !== undefined) {
+    consoleSteps.forEach((line) => nodeConsole.log(`  ${line}`));
+  }
+  nodeConsole.log('Click the PASS or FAIL button in the status bar (bottom-left) when done.');
+  nodeConsole.log(SECTION_LINE);
+
+  return vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: `🧪 ${tcId}: ${action}`,
+      cancellable: false,
+    },
+    (progress) => {
+      progress.report({ message: 'Click PASS or FAIL in the bottom-left status bar' });
+
+      return new Promise<HumanVerdict>((resolve) => {
+        const disposables: vscode.Disposable[] = [];
+        let settled = false;
+
+        const settleWith = (verdict: HumanVerdict): void => {
+          if (settled) return;
+          settled = true;
+          for (const d of disposables) {
+            d.dispose();
+          }
+          resolve(verdict);
+        };
+
+        disposables.push(
+          vscode.commands.registerCommand(VERDICT_PASS_COMMAND, () => settleWith('pass')),
+          vscode.commands.registerCommand(VERDICT_FAIL_COMMAND, () => settleWith('fail')),
+        );
+
+        const passItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10000);
+        passItem.text = `$(check) PASS [${tcId}]`;
+        passItem.tooltip = `Click if the expected behavior was observed for ${tcId}`;
+        passItem.command = VERDICT_PASS_COMMAND;
+        passItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
+        passItem.show();
+        disposables.push(passItem);
+
+        const failItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 9999);
+        failItem.text = `$(x) FAIL [${tcId}]`;
+        failItem.tooltip = `Click if the expected behavior was NOT observed for ${tcId}`;
+        failItem.command = VERDICT_FAIL_COMMAND;
+        failItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
+        failItem.show();
+        disposables.push(failItem);
+      });
+    },
+  );
+};

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/index.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/index.ts
@@ -1,4 +1,9 @@
-export { printAssistedBanner, waitForHuman } from './assistedTestHelper';
+export {
+  type HumanVerdict,
+  printAssistedBanner,
+  waitForHuman,
+  waitForHumanVerdict,
+} from './assistedTestHelper';
 export {
   assertTerminalBufferContains,
   assertTerminalBufferEquals,

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
@@ -20,6 +20,7 @@ import {
   printAssistedBanner,
   settle,
   waitForHuman,
+  waitForHumanVerdict,
 } from '../helpers';
 
 suite('R-D Bind to Destination', () => {
@@ -290,13 +291,15 @@ suite('R-D Bind to Destination', () => {
     const logCapture = getLogCapture();
     logCapture.mark('before-btd-009');
 
-    await waitForHuman(
+    const verdict = await waitForHumanVerdict(
       'bind-to-destination-009',
-      'Cmd+R Cmd+D → select "rl-btd-009-b" → click "No, keep current binding"',
+      'Cmd+R Cmd+D → select "rl-btd-009-b" → click "No, keep current binding" — did the original binding ("rl-btd-009-a") survive?',
       [
         '1. Press Cmd+R Cmd+D',
         '2. Select Terminal ("rl-btd-009-b") from the list',
         '3. When the confirmation dialog appears, click "No, keep current binding"',
+        '4. Click Pass if the original binding to "rl-btd-009-a" was kept (no rebind, no status-bar change).',
+        '   Click Fail if "rl-btd-009-b" ended up bound or you saw a rebind toast.',
       ],
     );
 
@@ -308,8 +311,13 @@ suite('R-D Bind to Destination', () => {
     assertNoStatusBarMsgLogged(lines, {
       message: '✓ RangeLink bound to Terminal ("rl-btd-009-b")',
     });
+    assert.strictEqual(
+      verdict,
+      'pass',
+      'Human reported the original binding was NOT preserved when clicking "No, keep current binding"',
+    );
 
-    log('✓ No rebind toast — original binding preserved');
+    log('✓ No rebind toast — original binding preserved (human verdict + state invariant)');
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuExplorer.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuExplorer.test.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert';
 import * as path from 'node:path';
 
 import * as vscode from 'vscode';

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuExplorer.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuExplorer.test.ts
@@ -21,6 +21,7 @@ import {
   printAssistedBanner,
   settle,
   waitForHuman,
+  waitForHumanVerdict,
 } from '../helpers';
 
 const FILE_CONTENT = 'explorer context-menu test file\n';
@@ -218,23 +219,28 @@ suite('Context Menus — Explorer', () => {
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-exp-005');
 
-    await waitForHuman(
+    const verdict = await waitForHumanVerdict(
       'context-menus-explorer-005',
-      `Right-click "${fn}" in Explorer and verify "RangeLink: Unbind" is HIDDEN`,
+      `Right-click "${fn}" in Explorer — is "RangeLink: Unbind" ABSENT from the menu?`,
       [
         `1. Locate "${fn}" in the Explorer panel`,
         '2. Right-click it',
-        '3. Verify "RangeLink: Unbind" is NOT in the menu (the when-clause is rangelink.isBound)',
-        '4. Dismiss the menu (Escape), then Cancel this notification',
+        '3. Click Pass if "RangeLink: Unbind" is NOT in the menu (the `when: rangelink.isBound` clause should hide it).',
+        '   Click Fail if it IS present (that would be a bug).',
       ],
     );
 
     const lines = logCapture.getLinesSince('before-ctxmenu-exp-005');
 
     assertNoSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
+    assert.strictEqual(
+      verdict,
+      'pass',
+      'Human reported "RangeLink: Unbind" WAS visible in Explorer when unbound — the `when: rangelink.isBound` clause is not working',
+    );
 
     log(
-      '✓ State invariant held (no bind during observation); human confirmed "Unbind" entry hidden',
+      '✓ Unbound state: "Unbind" absent from Explorer context menu (human verdict + state invariant)',
     );
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
@@ -1,0 +1,681 @@
+import assert from 'node:assert';
+import * as path from 'node:path';
+
+import * as vscode from 'vscode';
+
+import {
+  CMD_BIND_TO_TERMINAL_HERE,
+  CMD_CONTEXT_EDITOR_CONTENT_BIND,
+  CMD_UNBIND_DESTINATION,
+} from '../../constants/commandIds';
+import {
+  activateExtension,
+  assertSetContextLogged,
+  assertStatusBarMsgLogged,
+  cleanupFiles,
+  closeAllEditors,
+  createAndOpenFile,
+  createLogger,
+  createTerminal,
+  getLogCapture,
+  printAssistedBanner,
+  settle,
+  TERMINAL_READY_MS,
+  waitForHuman,
+  waitForHumanVerdict,
+} from '../helpers';
+
+const CONTEXT_IS_BOUND_KEY = 'rangelink.isBound';
+
+suite('Context Menus — Terminal', () => {
+  const log = createLogger('contextMenuTerminal');
+  const terminals: vscode.Terminal[] = [];
+  const tmpFileUris: vscode.Uri[] = [];
+
+  suiteSetup(async () => {
+    await activateExtension();
+    printAssistedBanner();
+  });
+
+  teardown(async () => {
+    await vscode.commands.executeCommand(CMD_UNBIND_DESTINATION);
+    for (const t of terminals) {
+      t.dispose();
+    }
+    terminals.length = 0;
+    await closeAllEditors();
+    cleanupFiles(tmpFileUris);
+    tmpFileUris.length = 0;
+    await settle();
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC context-menus-terminal-001
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-terminal-001: Terminal tab "Bind Here" binds that terminal', async () => {
+    const terminalName = 'rl-ctxmenu-term-001';
+    await createTerminal(terminalName, terminals);
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-ctxmenu-term-001');
+
+    await waitForHuman(
+      'context-menus-terminal-001',
+      `Right-click the "${terminalName}" terminal TAB → "RangeLink: Bind Here"`,
+      [
+        `1. Locate the "${terminalName}" tab in the terminal panel's tab bar`,
+        '2. Right-click the tab (NOT the terminal content area)',
+        '3. Select "RangeLink: Bind Here"',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-ctxmenu-term-001');
+
+    assertStatusBarMsgLogged(lines, {
+      message: `✓ RangeLink bound to Terminal ("${terminalName}")`,
+    });
+
+    assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
+
+    log('✓ Terminal-tab context menu bound the terminal destination');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC context-menus-terminal-002
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-terminal-002: Terminal content-area "Bind Here" binds that terminal', async () => {
+    const terminalName = 'rl-ctxmenu-term-002';
+    await createTerminal(terminalName, terminals);
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-ctxmenu-term-002');
+
+    await waitForHuman(
+      'context-menus-terminal-002',
+      `Right-click INSIDE the "${terminalName}" terminal content area → "RangeLink: Bind Here"`,
+      [
+        `1. Focus the "${terminalName}" terminal`,
+        '2. Right-click INSIDE the terminal output area (NOT the tab)',
+        '3. Select "RangeLink: Bind Here"',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-ctxmenu-term-002');
+
+    assertStatusBarMsgLogged(lines, {
+      message: `✓ RangeLink bound to Terminal ("${terminalName}")`,
+    });
+
+    assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
+
+    log('✓ Terminal content-area context menu bound the terminal destination');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC context-menus-terminal-003
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-terminal-003: Terminal content-area "Unbind" is visible when bound and unbinds on click', async () => {
+    const terminalName = 'rl-ctxmenu-term-003';
+    await createTerminal(terminalName, terminals);
+    await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-ctxmenu-term-003');
+
+    await waitForHuman(
+      'context-menus-terminal-003',
+      `Right-click INSIDE the "${terminalName}" terminal content area → "RangeLink: Unbind"`,
+      [
+        `1. Focus the "${terminalName}" terminal`,
+        '2. Right-click INSIDE the terminal CONTENT AREA (not the tab — the tab menu does not render Unbind on VSCode)',
+        '3. Verify "RangeLink: Unbind" IS present in the menu (clicking it proves visibility)',
+        '4. Select "RangeLink: Unbind"',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-ctxmenu-term-003');
+
+    assertStatusBarMsgLogged(lines, {
+      message: `✓ RangeLink unbound from Terminal ("${terminalName}")`,
+    });
+
+    assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: false });
+
+    log('✓ Terminal content-area "Unbind" was visible (clicked it) and fired the unbind path');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC context-menus-terminal-004
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-terminal-004: Right-clicking a specific terminal TAB binds THAT terminal (multi-terminal disambiguation)', async () => {
+    const targetName = 'rl-ctxmenu-term-004-TARGET';
+    const otherName = 'rl-ctxmenu-term-004-OTHER';
+    await createTerminal(otherName, terminals);
+    await createTerminal(targetName, terminals);
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-ctxmenu-term-004');
+
+    await waitForHuman(
+      'context-menus-terminal-004',
+      `Right-click the "${targetName}" TAB → "RangeLink: Bind Here" (NOT the "${otherName}" tab)`,
+      [
+        `Two terminals exist: "${otherName}" and "${targetName}"`,
+        `1. In the terminal panel's tab bar, locate the "${targetName}" tab specifically`,
+        '2. Right-click THAT tab (not the other one)',
+        '3. Select "RangeLink: Bind Here"',
+        'The TARGET terminal should bind — not the OTHER one.',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-ctxmenu-term-004');
+
+    assertStatusBarMsgLogged(lines, {
+      message: `✓ RangeLink bound to Terminal ("${targetName}")`,
+    });
+    assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
+
+    const directBindLogged = lines.some(
+      (line) =>
+        line.includes('"fn":"BindToTerminalCommand.execute"') &&
+        line.includes('"source":"context-menu"') &&
+        line.includes(`"terminalName":"${targetName}"`),
+    );
+    assert.ok(
+      directBindLogged,
+      `Expected direct-bind log for "${targetName}" from context-menu source`,
+    );
+
+    log('✓ Right-clicked TAB bound the target terminal directly (picker bypassed)');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC context-menus-terminal-005
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-terminal-005: Right-clicking a specific terminal CONTENT AREA binds THAT terminal (multi-terminal disambiguation)', async () => {
+    const targetName = 'rl-ctxmenu-term-005-TARGET';
+    const otherName = 'rl-ctxmenu-term-005-OTHER';
+    await createTerminal(otherName, terminals);
+    await createTerminal(targetName, terminals);
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-ctxmenu-term-005');
+
+    await waitForHuman(
+      'context-menus-terminal-005',
+      `Right-click INSIDE the "${targetName}" CONTENT AREA → "RangeLink: Bind Here" (NOT the "${otherName}" terminal)`,
+      [
+        `Two terminals exist: "${otherName}" and "${targetName}"`,
+        `1. Click to focus the "${targetName}" terminal`,
+        '2. Right-click INSIDE its content area (not the tab, not the other terminal)',
+        '3. Select "RangeLink: Bind Here"',
+        'The TARGET terminal should bind — not the OTHER one.',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-ctxmenu-term-005');
+
+    assertStatusBarMsgLogged(lines, {
+      message: `✓ RangeLink bound to Terminal ("${targetName}")`,
+    });
+    assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
+
+    const directBindLogged = lines.some(
+      (line) =>
+        line.includes('"fn":"BindToTerminalCommand.execute"') &&
+        line.includes('"source":"context-menu"') &&
+        line.includes(`"terminalName":"${targetName}"`),
+    );
+    assert.ok(
+      directBindLogged,
+      `Expected direct-bind log for "${targetName}" from context-menu source`,
+    );
+
+    log('✓ Right-clicked CONTENT AREA bound the target terminal directly (picker bypassed)');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC send-terminal-selection-005 (lives here because the scenario is
+  // specifically the terminal-context-menu path into R-V; the test file's slug
+  // naturally fits this scenario even though the TC ID is in Section 9 of the
+  // QA journal.)
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] send-terminal-selection-005: Terminal content-area "Send Selection to Destination" sends selected text to bound editor', async () => {
+    const editorUri = await createAndOpenFile(
+      'ctxmenu-term-sts-005',
+      'destination file — terminal selection arrives here\n',
+      undefined,
+      tmpFileUris,
+    );
+    const editorFn = path.basename(editorUri.fsPath);
+
+    await vscode.commands.executeCommand(CMD_CONTEXT_EDITOR_CONTENT_BIND, editorUri);
+    await settle();
+
+    const terminalName = 'rl-ctxmenu-term-sts-005';
+    const terminal = vscode.window.createTerminal({ name: terminalName });
+    terminals.push(terminal);
+    terminal.show(true);
+    await settle(TERMINAL_READY_MS);
+
+    const markerText = 'STS_005_MARKER_TEXT';
+    terminal.sendText(`echo ${markerText}`, true);
+    await settle(TERMINAL_READY_MS);
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-sts-005');
+
+    await waitForHuman(
+      'send-terminal-selection-005',
+      `Select "${markerText}" in terminal "${terminalName}" → right-click → "RangeLink: Send Selection to Destination"`,
+      [
+        `A Text Editor "${editorFn}" is currently bound as the destination.`,
+        `The terminal "${terminalName}" has "${markerText}" in its output.`,
+        `1. Select the "${markerText}" text in the terminal content area`,
+        '2. Right-click INSIDE the terminal content area (not the tab)',
+        '3. Verify "RangeLink: Send Selection to Destination" is present',
+        '4. Select "RangeLink: Send Selection to Destination"',
+        `The selected text should appear in the "${editorFn}" editor.`,
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-sts-005');
+
+    const pasteStarted = lines.some((line) =>
+      line.includes('"fn":"TerminalSelectionService.pasteTerminalSelectionToDestination"'),
+    );
+    assert.ok(
+      pasteStarted,
+      'Expected TerminalSelectionService.pasteTerminalSelectionToDestination log (terminal selection was read)',
+    );
+
+    assertStatusBarMsgLogged(lines, {
+      message: `✓ Selected text copied to clipboard & sent to Text Editor ("${editorFn}")`,
+    });
+
+    log('✓ Terminal context-menu "Send Selection to Destination" routed selection to bound editor');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC send-terminal-selection-008 (cross-terminal: selection in SOURCE → paste
+  // into BOUND, focus shifts to BOUND)
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] send-terminal-selection-008: Cross-terminal "Send Selection" pastes into bound terminal and shifts focus', async () => {
+    const boundName = 'rl-sts-008-BOUND';
+    const sourceName = 'rl-sts-008-SOURCE';
+
+    const boundTerminal = vscode.window.createTerminal({ name: boundName });
+    terminals.push(boundTerminal);
+    boundTerminal.show(true);
+    await settle(TERMINAL_READY_MS);
+    await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
+    await settle();
+
+    const sourceTerminal = vscode.window.createTerminal({ name: sourceName });
+    terminals.push(sourceTerminal);
+    sourceTerminal.show(true);
+    await settle(TERMINAL_READY_MS);
+    const markerText = 'STS_008_CROSS_TERMINAL_MARKER';
+    sourceTerminal.sendText(`echo ${markerText}`, true);
+    await settle(TERMINAL_READY_MS);
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-sts-008');
+
+    await waitForHuman(
+      'send-terminal-selection-008',
+      `Select "${markerText}" in SOURCE terminal "${sourceName}" → right-click → "Send Selection to Destination"`,
+      [
+        `Destination: Terminal "${boundName}" is bound.`,
+        `Source: Terminal "${sourceName}" contains "${markerText}".`,
+        `1. Click the "${sourceName}" terminal to focus it`,
+        `2. Select the "${markerText}" text in its output`,
+        '3. Right-click INSIDE the source terminal content area (not the tab)',
+        '4. Select "RangeLink: Send Selection to Destination"',
+        `The selection should paste into "${boundName}" and focus should shift there.`,
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-sts-008');
+
+    const readLogged = lines.some((line) =>
+      line.includes('"fn":"TerminalSelectionService.pasteTerminalSelectionToDestination"'),
+    );
+    assert.ok(readLogged, 'Expected TerminalSelectionService log (selection was read)');
+
+    assertStatusBarMsgLogged(lines, {
+      message: `✓ Selected text copied to clipboard & sent to Terminal ("${boundName}")`,
+    });
+
+    const focusLogged = lines.some(
+      (line) =>
+        line.includes('Terminal focused via showTerminal()') &&
+        line.includes(`"terminalName":"${boundName}"`),
+    );
+    assert.ok(focusLogged, `Expected "Terminal focused via showTerminal()" log for "${boundName}"`);
+
+    const pasteSucceeded = lines.some(
+      (line) =>
+        line.includes('"fn":"TerminalInsertFactory.insert"') &&
+        line.includes(`"terminalName":"${boundName}"`) &&
+        line.includes('Terminal paste succeeded'),
+    );
+    assert.ok(
+      pasteSucceeded,
+      `Expected "Terminal paste succeeded" log for terminalName="${boundName}"`,
+    );
+
+    log('✓ Cross-terminal send: source selection routed to bound terminal with focus shift');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC send-terminal-selection-009 (TAB menu does NOT include "Send Selection")
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] send-terminal-selection-009: "Send Selection to Destination" is NOT in the terminal TAB menu', async () => {
+    const terminalName = 'rl-sts-009';
+    const terminal = vscode.window.createTerminal({ name: terminalName });
+    terminals.push(terminal);
+    terminal.show(true);
+    await settle(TERMINAL_READY_MS);
+    await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
+    await settle();
+    terminal.sendText(`echo STS_009_MARKER_TEXT`, true);
+    await settle(TERMINAL_READY_MS);
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-sts-009');
+
+    const verdict = await waitForHumanVerdict(
+      'send-terminal-selection-009',
+      `Select text in "${terminalName}" → right-click the TAB → is "Send Selection to Destination" ABSENT from the menu?`,
+      [
+        `The terminal "${terminalName}" is bound to itself (self-bind for this contract test).`,
+        `1. Click the "${terminalName}" terminal and select "STS_009_MARKER_TEXT" in its output`,
+        '2. Right-click the terminal TAB (not the content area)',
+        '3. Click Pass if "RangeLink: Send Selection to Destination" is NOT in the menu.',
+        '   Click Fail if it IS present (that would be a bug).',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-sts-009');
+
+    const pasteFired = lines.some((line) =>
+      line.includes('"fn":"TerminalSelectionService.pasteTerminalSelectionToDestination"'),
+    );
+    assert.ok(
+      !pasteFired,
+      'Expected no TerminalSelectionService log — nothing should have triggered a paste during observation',
+    );
+    assert.strictEqual(
+      verdict,
+      'pass',
+      'Human reported "Send Selection to Destination" WAS visible in the tab menu — this is a bug',
+    );
+
+    log('✓ Tab menu did NOT offer "Send Selection" (human verdict + no paste log)');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC send-terminal-selection-010 (SELF-paste: bound terminal sends its own
+  // selection to itself — documents current behavior; no self-paste guard
+  // exists for terminal destinations)
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] send-terminal-selection-010: Self-paste — bound terminal selection is sent back to itself (current behavior, no guard)', async () => {
+    const terminalName = 'rl-sts-010';
+    const terminal = vscode.window.createTerminal({ name: terminalName });
+    terminals.push(terminal);
+    terminal.show(true);
+    await settle(TERMINAL_READY_MS);
+    await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
+    await settle();
+    const markerText = 'STS_010_SELF_PASTE_MARKER';
+    terminal.sendText(`echo ${markerText}`, true);
+    await settle(TERMINAL_READY_MS);
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-sts-010');
+
+    await waitForHuman(
+      'send-terminal-selection-010',
+      `Select "${markerText}" in "${terminalName}" → right-click content area → "Send Selection to Destination"`,
+      [
+        `Destination: Terminal "${terminalName}" is bound (the SAME terminal we'll select from).`,
+        `1. Select "${markerText}" in "${terminalName}"`,
+        '2. Right-click INSIDE the content area',
+        '3. Select "RangeLink: Send Selection to Destination"',
+        'The selection will be pasted BACK into the same terminal (this documents current behavior; a self-paste guard for terminals is worth filing as a follow-up).',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-sts-010');
+
+    assertStatusBarMsgLogged(lines, {
+      message: `✓ Selected text copied to clipboard & sent to Terminal ("${terminalName}")`,
+    });
+
+    const pasteSucceeded = lines.some(
+      (line) =>
+        line.includes('"fn":"TerminalInsertFactory.insert"') &&
+        line.includes(`"terminalName":"${terminalName}"`) &&
+        line.includes('Terminal paste succeeded'),
+    );
+    assert.ok(
+      pasteSucceeded,
+      `Expected "Terminal paste succeeded" log for self-paste to "${terminalName}"`,
+    );
+
+    log(
+      '✓ Self-paste is not currently guarded — selection echoed back into bound terminal (follow-up issue worth filing)',
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC send-terminal-selection-011 ("Send Selection" visible when unbound;
+  // clicking opens destination picker and delivers to picked destination —
+  // parity with the editor family, which never gates on rangelink.isBound)
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] send-terminal-selection-011: "Send Selection" (unbound) opens destination picker and delivers to picked terminal', async () => {
+    await vscode.commands.executeCommand(CMD_UNBIND_DESTINATION);
+    await settle();
+
+    const sourceName = 'rl-sts-011-SOURCE';
+    const destName = 'rl-sts-011-DEST';
+
+    const destTerminal = vscode.window.createTerminal({ name: destName });
+    terminals.push(destTerminal);
+    destTerminal.show(true);
+    await settle(TERMINAL_READY_MS);
+
+    const sourceTerminal = vscode.window.createTerminal({ name: sourceName });
+    terminals.push(sourceTerminal);
+    sourceTerminal.show(true);
+    await settle(TERMINAL_READY_MS);
+    const markerText = 'STS_011_MARKER_TEXT';
+    sourceTerminal.sendText(`echo ${markerText}`, true);
+    await settle(TERMINAL_READY_MS);
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-sts-011');
+
+    await waitForHuman(
+      'send-terminal-selection-011',
+      `Select "${markerText}" in "${sourceName}" → right-click content area → "Send Selection to Destination" → pick Terminal ("${destName}")`,
+      [
+        `No destination is currently bound. Two terminals exist: "${sourceName}" (with marker text) and "${destName}" (empty destination).`,
+        `1. Click the "${sourceName}" terminal and select "${markerText}"`,
+        '2. Right-click INSIDE the content area (NOT the tab)',
+        '3. Select "RangeLink: Send Selection to Destination"',
+        `4. In the destination picker that opens, pick Terminal ("${destName}")`,
+        `The selection should be delivered to "${destName}" and "${destName}" should become the bound destination.`,
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-sts-011');
+
+    const readLogged = lines.some((line) =>
+      line.includes('"fn":"TerminalSelectionService.pasteTerminalSelectionToDestination"'),
+    );
+    assert.ok(readLogged, 'Expected TerminalSelectionService log (selection was read)');
+
+    const pickerShown = lines.some(
+      (line) => line.includes('VscodeAdapter.showQuickPick') && line.includes('"items"'),
+    );
+    assert.ok(
+      pickerShown,
+      'Expected showQuickPick log with items — destination picker should have opened because nothing was bound',
+    );
+
+    assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
+
+    assertStatusBarMsgLogged(lines, {
+      message: `✓ Selected text copied to clipboard & sent to Terminal ("${destName}")`,
+    });
+
+    const destPasteSucceeded = lines.some(
+      (line) =>
+        line.includes('"fn":"TerminalInsertFactory.insert"') &&
+        line.includes(`"terminalName":"${destName}"`) &&
+        line.includes('Terminal paste succeeded'),
+    );
+    assert.ok(
+      destPasteSucceeded,
+      `Expected "Terminal paste succeeded" log for destination terminal "${destName}"`,
+    );
+
+    log(
+      '✓ Unbound state: menu item shown; click opened picker; selection delivered to picked destination',
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC send-terminal-selection-012 ("Send Selection" hidden when no text is
+  // selected — `when: terminalTextSelected`)
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] send-terminal-selection-012: "Send Selection" is hidden when no terminal text is selected', async () => {
+    const terminalName = 'rl-sts-012';
+    const terminal = vscode.window.createTerminal({ name: terminalName });
+    terminals.push(terminal);
+    terminal.show(true);
+    await settle(TERMINAL_READY_MS);
+    await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
+    await settle();
+    terminal.sendText(`echo STS_012_MARKER_TEXT`, true);
+    await settle(TERMINAL_READY_MS);
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-sts-012');
+
+    const verdict = await waitForHumanVerdict(
+      'send-terminal-selection-012',
+      `Right-click inside "${terminalName}" WITHOUT selecting → is "Send Selection to Destination" ABSENT from the menu?`,
+      [
+        `The terminal "${terminalName}" is bound to itself.`,
+        '1. Do NOT click-drag or double-click to create a text selection',
+        `2. Right-click INSIDE the "${terminalName}" content area on an empty region`,
+        '3. Click Pass if "RangeLink: Send Selection to Destination" is NOT in the menu (the `when: terminalTextSelected` clause should hide it).',
+        '   Click Fail if it IS present (that would be a bug).',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-sts-012');
+
+    const pasteFired = lines.some((line) =>
+      line.includes('"fn":"TerminalSelectionService.pasteTerminalSelectionToDestination"'),
+    );
+    assert.ok(
+      !pasteFired,
+      'Expected no paste log — nothing should have triggered a paste during observation',
+    );
+    assert.strictEqual(
+      verdict,
+      'pass',
+      'Human reported "Send Selection" WAS visible with no text selected — the `when: terminalTextSelected` clause is not working',
+    );
+
+    log('✓ No-selection state: "Send Selection" absent (human verdict + no paste log)');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC send-terminal-selection-013 (terminal content-area "Send Selection"
+  // delivers to a bound AI-assistant destination — Dummy AI Tier 1)
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] send-terminal-selection-013: Terminal content-area "Send Selection" delivers selected text to bound AI-assistant destination', async () => {
+    await waitForHuman(
+      'send-terminal-selection-013-bind',
+      'Cmd+R Cmd+D → select "Dummy AI (Tier 1)"',
+      [
+        'Setup: bind the Dummy AI test extension as the destination.',
+        '1. Press Cmd+R Cmd+D',
+        '2. Select "Dummy AI (Tier 1)" from the destination picker',
+      ],
+    );
+
+    const terminalName = 'rl-sts-013';
+    const terminal = vscode.window.createTerminal({ name: terminalName });
+    terminals.push(terminal);
+    terminal.show(true);
+    await settle(TERMINAL_READY_MS);
+    const markerText = 'STS_013_AI_DELIVERY_MARKER';
+    terminal.sendText(`echo ${markerText}`, true);
+    await settle(TERMINAL_READY_MS);
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-sts-013');
+
+    await waitForHuman(
+      'send-terminal-selection-013',
+      `Select "${markerText}" in "${terminalName}" → right-click content area → "Send Selection to Destination"`,
+      [
+        'Destination: Dummy AI (Tier 1) is bound.',
+        `Source: "${terminalName}" has "${markerText}" in its output.`,
+        `1. Click the "${terminalName}" terminal to focus it`,
+        `2. Select "${markerText}" in its output`,
+        '3. Right-click INSIDE the terminal content area (not the tab)',
+        '4. Select "RangeLink: Send Selection to Destination"',
+        'The selection should be delivered to the Dummy AI extension via direct insert.',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-sts-013');
+
+    const readLogged = lines.some((line) =>
+      line.includes('"fn":"TerminalSelectionService.pasteTerminalSelectionToDestination"'),
+    );
+    assert.ok(readLogged, 'Expected TerminalSelectionService log (selection was read)');
+
+    const directInsertLog = lines.some(
+      (line) =>
+        line.includes('DirectInsertFactory.insert') && line.includes('Direct insert succeeded'),
+    );
+    assert.ok(
+      directInsertLog,
+      'Expected DirectInsertFactory.insert success log — Dummy AI Tier 1 uses direct insert',
+    );
+
+    const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as
+      | { tier1: string; tier2: string }
+      | undefined;
+    assert.ok(textResult, 'Expected dummyAi.getText to return a result');
+    assert.ok(
+      textResult!.tier1.includes(markerText),
+      `Expected Dummy AI tier1 textarea to contain "${markerText}" but got: ${textResult!.tier1}`,
+    );
+
+    log(
+      '✓ Terminal context-menu "Send Selection" delivered selection to Dummy AI via Tier 1 direct insert',
+    );
+  });
+});

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
@@ -12,9 +12,12 @@ import {
   activateExtension,
   assertSetContextLogged,
   assertStatusBarMsgLogged,
+  assertTerminalBufferContains,
   cleanupFiles,
   closeAllEditors,
+  createAndBindCapturingTerminal,
   createAndOpenFile,
+  createCapturingTerminal,
   createLogger,
   createTerminal,
   getLogCapture,
@@ -312,12 +315,7 @@ suite('Context Menus — Terminal', () => {
     const boundName = 'rl-sts-008-BOUND';
     const sourceName = 'rl-sts-008-SOURCE';
 
-    const boundTerminal = vscode.window.createTerminal({ name: boundName });
-    terminals.push(boundTerminal);
-    boundTerminal.show(true);
-    await settle(TERMINAL_READY_MS);
-    await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
-    await settle();
+    const capturingBound = await createAndBindCapturingTerminal(boundName, terminals);
 
     const sourceTerminal = vscode.window.createTerminal({ name: sourceName });
     terminals.push(sourceTerminal);
@@ -329,12 +327,13 @@ suite('Context Menus — Terminal', () => {
 
     const logCapture = getLogCapture();
     logCapture.mark('before-sts-008');
+    capturingBound.clearCaptured();
 
     await waitForHuman(
       'send-terminal-selection-008',
       `Select "${markerText}" in SOURCE terminal "${sourceName}" → right-click → "Send Selection to Destination"`,
       [
-        `Destination: Terminal "${boundName}" is bound.`,
+        `Destination: Terminal "${boundName}" is bound (pty-captured — the test reads its buffer to verify content).`,
         `Source: Terminal "${sourceName}" contains "${markerText}".`,
         `1. Click the "${sourceName}" terminal to focus it`,
         `2. Select the "${markerText}" text in its output`,
@@ -362,18 +361,11 @@ suite('Context Menus — Terminal', () => {
     );
     assert.ok(focusLogged, `Expected "Terminal focused via showTerminal()" log for "${boundName}"`);
 
-    const pasteSucceeded = lines.some(
-      (line) =>
-        line.includes('"fn":"TerminalInsertFactory.insert"') &&
-        line.includes(`"terminalName":"${boundName}"`) &&
-        line.includes('Terminal paste succeeded'),
-    );
-    assert.ok(
-      pasteSucceeded,
-      `Expected "Terminal paste succeeded" log for terminalName="${boundName}"`,
-    );
+    assertTerminalBufferContains(capturingBound.getCapturedText(), markerText);
 
-    log('✓ Cross-terminal send: source selection routed to bound terminal with focus shift');
+    log(
+      '✓ Cross-terminal send: source selection landed in bound terminal buffer (pty-captured) with focus shift',
+    );
   });
 
   // ---------------------------------------------------------------------------
@@ -432,25 +424,21 @@ suite('Context Menus — Terminal', () => {
 
   test('[assisted] send-terminal-selection-010: Self-paste — bound terminal selection is sent back to itself (current behavior, no guard)', async () => {
     const terminalName = 'rl-sts-010';
-    const terminal = vscode.window.createTerminal({ name: terminalName });
-    terminals.push(terminal);
-    terminal.show(true);
-    await settle(TERMINAL_READY_MS);
-    await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
-    await settle();
+    const capturing = await createAndBindCapturingTerminal(terminalName, terminals);
     const markerText = 'STS_010_SELF_PASTE_MARKER';
-    terminal.sendText(`echo ${markerText}`, true);
+    capturing.terminal.sendText(markerText, false);
     await settle(TERMINAL_READY_MS);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-sts-010');
+    capturing.clearCaptured();
 
     await waitForHuman(
       'send-terminal-selection-010',
       `Select "${markerText}" in "${terminalName}" → right-click content area → "Send Selection to Destination"`,
       [
         `Destination: Terminal "${terminalName}" is bound (the SAME terminal we'll select from).`,
-        `1. Select "${markerText}" in "${terminalName}"`,
+        `1. Select "${markerText}" in "${terminalName}" (the marker text is visible in the buffer)`,
         '2. Right-click INSIDE the content area',
         '3. Select "RangeLink: Send Selection to Destination"',
         'The selection will be pasted BACK into the same terminal (this documents current behavior; a self-paste guard for terminals is worth filing as a follow-up).',
@@ -463,19 +451,10 @@ suite('Context Menus — Terminal', () => {
       message: `✓ Selected text copied to clipboard & sent to Terminal ("${terminalName}")`,
     });
 
-    const pasteSucceeded = lines.some(
-      (line) =>
-        line.includes('"fn":"TerminalInsertFactory.insert"') &&
-        line.includes(`"terminalName":"${terminalName}"`) &&
-        line.includes('Terminal paste succeeded'),
-    );
-    assert.ok(
-      pasteSucceeded,
-      `Expected "Terminal paste succeeded" log for self-paste to "${terminalName}"`,
-    );
+    assertTerminalBufferContains(capturing.getCapturedText(), markerText);
 
     log(
-      '✓ Self-paste is not currently guarded — selection echoed back into bound terminal (follow-up issue worth filing)',
+      '✓ Self-paste: selection echoed back into bound terminal buffer (pty-captured; follow-up issue worth filing for guard)',
     );
   });
 
@@ -492,10 +471,7 @@ suite('Context Menus — Terminal', () => {
     const sourceName = 'rl-sts-011-SOURCE';
     const destName = 'rl-sts-011-DEST';
 
-    const destTerminal = vscode.window.createTerminal({ name: destName });
-    terminals.push(destTerminal);
-    destTerminal.show(true);
-    await settle(TERMINAL_READY_MS);
+    const capturingDest = await createCapturingTerminal(destName, terminals);
 
     const sourceTerminal = vscode.window.createTerminal({ name: sourceName });
     terminals.push(sourceTerminal);
@@ -507,6 +483,7 @@ suite('Context Menus — Terminal', () => {
 
     const logCapture = getLogCapture();
     logCapture.mark('before-sts-011');
+    capturingDest.clearCaptured();
 
     await waitForHuman(
       'send-terminal-selection-011',
@@ -542,19 +519,10 @@ suite('Context Menus — Terminal', () => {
       message: `✓ Selected text copied to clipboard & sent to Terminal ("${destName}")`,
     });
 
-    const destPasteSucceeded = lines.some(
-      (line) =>
-        line.includes('"fn":"TerminalInsertFactory.insert"') &&
-        line.includes(`"terminalName":"${destName}"`) &&
-        line.includes('Terminal paste succeeded'),
-    );
-    assert.ok(
-      destPasteSucceeded,
-      `Expected "Terminal paste succeeded" log for destination terminal "${destName}"`,
-    );
+    assertTerminalBufferContains(capturingDest.getCapturedText(), markerText);
 
     log(
-      '✓ Unbound state: menu item shown; click opened picker; selection delivered to picked destination',
+      '✓ Unbound state: menu item shown; click opened picker; selection landed in picked destination buffer (pty-captured)',
     );
   });
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
@@ -20,6 +20,7 @@ import {
   createCapturingTerminal,
   createLogger,
   createTerminal,
+  extractQuickPickItemsLogged,
   getLogCapture,
   printAssistedBanner,
   settle,
@@ -505,12 +506,15 @@ suite('Context Menus — Terminal', () => {
     );
     assert.ok(readLogged, 'Expected TerminalSelectionService log (selection was read)');
 
-    const pickerShown = lines.some(
-      (line) => line.includes('VscodeAdapter.showQuickPick') && line.includes('"items"'),
-    );
+    const pickerItems = extractQuickPickItemsLogged(lines);
     assert.ok(
-      pickerShown,
+      pickerItems,
       'Expected showQuickPick log with items — destination picker should have opened because nothing was bound',
+    );
+    const destLabel = `Terminal ("${destName}")`;
+    assert.ok(
+      pickerItems!.some((item) => item.label === destLabel),
+      `Expected destination picker to offer "${destLabel}" as a pickable item`,
     );
 
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
@@ -264,10 +264,7 @@ suite('Context Menus — Terminal', () => {
     await settle();
 
     const terminalName = 'rl-ctxmenu-term-sts-005';
-    const terminal = vscode.window.createTerminal({ name: terminalName });
-    terminals.push(terminal);
-    terminal.show(true);
-    await settle(TERMINAL_READY_MS);
+    const terminal = await createTerminal(terminalName, terminals);
 
     const markerText = 'STS_005_MARKER_TEXT';
     terminal.sendText(`echo ${markerText}`, true);
@@ -318,10 +315,7 @@ suite('Context Menus — Terminal', () => {
 
     const capturingBound = await createAndBindCapturingTerminal(boundName, terminals);
 
-    const sourceTerminal = vscode.window.createTerminal({ name: sourceName });
-    terminals.push(sourceTerminal);
-    sourceTerminal.show(true);
-    await settle(TERMINAL_READY_MS);
+    const sourceTerminal = await createTerminal(sourceName, terminals);
     const markerText = 'STS_008_CROSS_TERMINAL_MARKER';
     sourceTerminal.sendText(`echo ${markerText}`, true);
     await settle(TERMINAL_READY_MS);
@@ -375,10 +369,7 @@ suite('Context Menus — Terminal', () => {
 
   test('[assisted] send-terminal-selection-009: "Send Selection to Destination" is NOT in the terminal TAB menu', async () => {
     const terminalName = 'rl-sts-009';
-    const terminal = vscode.window.createTerminal({ name: terminalName });
-    terminals.push(terminal);
-    terminal.show(true);
-    await settle(TERMINAL_READY_MS);
+    const terminal = await createTerminal(terminalName, terminals);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await settle();
     terminal.sendText(`echo STS_009_MARKER_TEXT`, true);
@@ -401,17 +392,17 @@ suite('Context Menus — Terminal', () => {
 
     const lines = logCapture.getLinesSince('before-sts-009');
 
+    assert.strictEqual(
+      verdict,
+      'pass',
+      'Human reported "Send Selection to Destination" WAS visible in the tab menu — this is a bug',
+    );
     const pasteFired = lines.some((line) =>
       line.includes('"fn":"TerminalSelectionService.pasteTerminalSelectionToDestination"'),
     );
     assert.ok(
       !pasteFired,
       'Expected no TerminalSelectionService log — nothing should have triggered a paste during observation',
-    );
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'Human reported "Send Selection to Destination" WAS visible in the tab menu — this is a bug',
     );
 
     log('✓ Tab menu did NOT offer "Send Selection" (human verdict + no paste log)');
@@ -474,10 +465,7 @@ suite('Context Menus — Terminal', () => {
 
     const capturingDest = await createCapturingTerminal(destName, terminals);
 
-    const sourceTerminal = vscode.window.createTerminal({ name: sourceName });
-    terminals.push(sourceTerminal);
-    sourceTerminal.show(true);
-    await settle(TERMINAL_READY_MS);
+    const sourceTerminal = await createTerminal(sourceName, terminals);
     const markerText = 'STS_011_MARKER_TEXT';
     sourceTerminal.sendText(`echo ${markerText}`, true);
     await settle(TERMINAL_READY_MS);
@@ -537,10 +525,7 @@ suite('Context Menus — Terminal', () => {
 
   test('[assisted] send-terminal-selection-012: "Send Selection" is hidden when no terminal text is selected', async () => {
     const terminalName = 'rl-sts-012';
-    const terminal = vscode.window.createTerminal({ name: terminalName });
-    terminals.push(terminal);
-    terminal.show(true);
-    await settle(TERMINAL_READY_MS);
+    const terminal = await createTerminal(terminalName, terminals);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await settle();
     terminal.sendText(`echo STS_012_MARKER_TEXT`, true);
@@ -563,17 +548,17 @@ suite('Context Menus — Terminal', () => {
 
     const lines = logCapture.getLinesSince('before-sts-012');
 
+    assert.strictEqual(
+      verdict,
+      'pass',
+      'Human reported "Send Selection" WAS visible with no text selected — the `when: terminalTextSelected` clause is not working',
+    );
     const pasteFired = lines.some((line) =>
       line.includes('"fn":"TerminalSelectionService.pasteTerminalSelectionToDestination"'),
     );
     assert.ok(
       !pasteFired,
       'Expected no paste log — nothing should have triggered a paste during observation',
-    );
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'Human reported "Send Selection" WAS visible with no text selected — the `when: terminalTextSelected` clause is not working',
     );
 
     log('✓ No-selection state: "Send Selection" absent (human verdict + no paste log)');
@@ -596,10 +581,7 @@ suite('Context Menus — Terminal', () => {
     );
 
     const terminalName = 'rl-sts-013';
-    const terminal = vscode.window.createTerminal({ name: terminalName });
-    terminals.push(terminal);
-    terminal.show(true);
-    await settle(TERMINAL_READY_MS);
+    const terminal = await createTerminal(terminalName, terminals);
     const markerText = 'STS_013_AI_DELIVERY_MARKER';
     terminal.sendText(`echo ${markerText}`, true);
     await settle(TERMINAL_READY_MS);

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/BindToTerminalCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/BindToTerminalCommand.test.ts
@@ -287,5 +287,98 @@ describe('BindToTerminalCommand', () => {
         );
       });
     });
+
+    describe('preferredTerminal (context-menu direct bind)', () => {
+      it('binds the provided terminal directly without querying available terminals', async () => {
+        const terminal = createMockTerminal({ name: 'Right-Clicked Terminal' });
+        mockAdapter = createMockVscodeAdapter();
+        (mockDestinationManager.bind as jest.Mock).mockResolvedValue(
+          Result.ok({
+            destinationName: 'Right-Clicked Terminal',
+            destinationKind: 'terminal',
+          }),
+        );
+        command = new BindToTerminalCommand(
+          mockAdapter,
+          mockAvailabilityService,
+          mockDestinationManager,
+          mockLogger,
+        );
+
+        const result = await command.execute(terminal);
+
+        expect(result).toStrictEqual({
+          outcome: 'bound',
+          bindInfo: {
+            destinationName: 'Right-Clicked Terminal',
+            destinationKind: 'terminal',
+          },
+        });
+        expect(mockAvailabilityService.getTerminalItems).not.toHaveBeenCalled();
+        expect(showTerminalPickerSpy).not.toHaveBeenCalled();
+        expect(mockDestinationManager.bind).toHaveBeenCalledWith({
+          kind: 'terminal',
+          terminal,
+        });
+        expect(mockLogger.debug).toHaveBeenCalledWith(
+          {
+            fn: 'BindToTerminalCommand.execute',
+            terminalName: 'Right-Clicked Terminal',
+            source: 'context-menu',
+          },
+          'Direct bind to terminal "Right-Clicked Terminal" from context menu',
+        );
+      });
+
+      it('returns bind-failed when the direct bind fails', async () => {
+        const terminal = createMockTerminal({ name: 'Right-Clicked Terminal' });
+        const bindError = new RangeLinkExtensionError({
+          code: RangeLinkExtensionErrorCodes.DESTINATION_BIND_FAILED,
+          message: 'Cannot bind',
+          functionName: 'PasteDestinationManager.bind',
+        });
+        mockAdapter = createMockVscodeAdapter();
+        (mockDestinationManager.bind as jest.Mock).mockResolvedValue(
+          Result.err(bindError) as ExtensionResult<BindSuccessInfo>,
+        );
+        command = new BindToTerminalCommand(
+          mockAdapter,
+          mockAvailabilityService,
+          mockDestinationManager,
+          mockLogger,
+        );
+
+        const result = await command.execute(terminal);
+
+        expect(result).toStrictEqual({ outcome: 'bind-failed', error: bindError });
+        expect(mockAvailabilityService.getTerminalItems).not.toHaveBeenCalled();
+        expect(showTerminalPickerSpy).not.toHaveBeenCalled();
+      });
+
+      it('falls through to picker-flow logic when preferredTerminal is omitted', async () => {
+        const terminal = createMockTerminal({ name: 'Only Terminal' });
+        mockAdapter = createMockVscodeAdapter();
+        mockAvailabilityService.getTerminalItems.mockResolvedValue([
+          createMockTerminalQuickPickItem(terminal),
+        ]);
+        (mockDestinationManager.bind as jest.Mock).mockResolvedValue(
+          Result.ok({ destinationName: 'Only Terminal', destinationKind: 'terminal' }),
+        );
+        command = new BindToTerminalCommand(
+          mockAdapter,
+          mockAvailabilityService,
+          mockDestinationManager,
+          mockLogger,
+        );
+
+        await command.execute();
+
+        expect(mockAvailabilityService.getTerminalItems).toHaveBeenCalledWith(Infinity, undefined);
+        expect(mockLogger.debug).toHaveBeenCalledWith(
+          { fn: 'BindToTerminalCommand.execute', terminalName: 'Only Terminal' },
+          'Single terminal, auto-binding',
+        );
+      });
+    });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
@@ -1309,9 +1309,9 @@ describe('package.json contributions', () => {
         expect(terminalContextMenu).toHaveLength(3);
       });
 
-      it('pasteSelectedTextToDestination in edit group when text selected and bound', () => {
+      it('pasteSelectedTextToDestination in edit group when text selected (matches editor family — no isBound gate)', () => {
         expect(terminalContextMenu[0]).toStrictEqual({
-          when: 'terminalTextSelected && rangelink.isBound',
+          when: 'terminalTextSelected',
           command: 'rangelink.terminal.pasteSelectedTextToDestination',
           group: '2_edit@10',
         });

--- a/packages/rangelink-vscode-extension/src/commands/BindToTerminalCommand.ts
+++ b/packages/rangelink-vscode-extension/src/commands/BindToTerminalCommand.ts
@@ -1,4 +1,5 @@
 import type { Logger } from 'barebone-logger';
+import type * as vscode from 'vscode';
 
 import type {
   BindSuccessInfo,
@@ -11,12 +12,15 @@ import { type ExtensionResult, MessageCode, type QuickPickBindResult } from '../
 import { formatMessage } from '../utils';
 
 /**
- * Command handler for binding to a terminal via picker.
+ * Command handler for binding to a terminal.
  *
- * Orchestrates the terminal selection flow:
- * - 0 terminals: Shows error message, returns 'no-resource'
- * - 1 terminal: Auto-binds to it (no picker shown)
- * - 2+ terminals: Shows picker, binds to selected terminal
+ * Two entry points:
+ * - With `preferredTerminal` (terminal context menu "Bind Here"): binds that
+ *   terminal directly, no picker. Mirrors BindToTextEditorCommand's
+ *   executeWithUri path.
+ * - Without `preferredTerminal` (palette, keybinding): falls through to the
+ *   picker flow — 0 terminals shows error, 1 auto-binds, 2+ shows the terminal
+ *   picker.
  *
  * Success feedback is handled by PasteDestinationManager.bind().
  */
@@ -33,8 +37,18 @@ export class BindToTerminalCommand {
     );
   }
 
-  async execute(): Promise<QuickPickBindResult> {
+  async execute(preferredTerminal?: vscode.Terminal): Promise<QuickPickBindResult> {
     const logCtx = { fn: 'BindToTerminalCommand.execute' };
+
+    if (preferredTerminal) {
+      this.logger.debug(
+        { ...logCtx, terminalName: preferredTerminal.name, source: 'context-menu' },
+        `Direct bind to terminal "${preferredTerminal.name}" from context menu`,
+      );
+      return this.mapBindResult(
+        await this.destinationManager.bind({ kind: 'terminal', terminal: preferredTerminal }),
+      );
+    }
 
     const boundTerminalProcessId = await resolveBoundTerminalProcessId(this.destinationManager);
     const terminalItems = await this.availabilityService.getTerminalItems(

--- a/packages/rangelink-vscode-extension/src/wireSubscriptions.ts
+++ b/packages/rangelink-vscode-extension/src/wireSubscriptions.ts
@@ -91,8 +91,8 @@ export const wireSubscriptions = (
     delimiterCache,
   } = services;
 
-  const bindToTerminalHandler = async () => {
-    await bindToTerminalCommand.execute();
+  const bindToTerminalHandler = async (terminal?: unknown) => {
+    await bindToTerminalCommand.execute(terminal as vscode.Terminal | undefined);
   };
   const bindToTextEditorHandler = async (uri?: unknown) => {
     await bindToTextEditorCommand.execute(uri as vscode.Uri | undefined);


### PR DESCRIPTION
## Summary

Converts the Terminal context-menu TCs to assisted mode (Category B of the 507 epic) and ships three product improvements surfaced while driving the new tests: right-click "Bind Here" now binds the targeted terminal directly (picker-bypass parity with Explorer / editor-tab), `pasteSelectedTextToDestination` no longer hides when unbound (matches the editor family — opens the destination picker if nothing is bound), and a new `waitForHumanVerdict` helper hardens visibility tests with an explicit Pass/Fail status-bar verdict that can't be silently dismissed.

## Changes

### Production

- `src/commands/BindToTerminalCommand.ts` — `execute()` now accepts optional `preferredTerminal?: vscode.Terminal`. When provided, skips the terminal picker and binds directly. Palette / keybinding invocations (no arg) still hit the existing picker path unchanged.
- `src/wireSubscriptions.ts` — `bindToTerminalHandler` accepts and forwards VS Code's context-provided terminal arg, mirroring `bindToTextEditorHandler`'s existing `uri?` pattern.
- `package.json` — dropped `&& rangelink.isBound` from the `terminal/context` `when` clause on `pasteSelectedTextToDestination`. The menu item now behaves like its editor-family peers: always shown when text is selected, opens the destination picker if no destination is bound. Contract test in `packageJsonContracts.test.ts` updated to match.

### Tests (13 `[assisted]` tests in new `src/__integration-tests__/suite/contextMenuTerminal.test.ts`)

- **001 / 002** — Bind Here from terminal tab / content area (single terminal)
- **003** — Content-area Unbind visible when bound, unbinds on click (content-area only — VS Code doesn't render Unbind in the terminal tab menu)
- **004 / 005** — Multi-terminal disambiguation: right-click the target terminal's tab / content area binds THAT terminal (proves the direct-bind enhancement preserves right-click context)
- **`send-terminal-selection-005, 008, 010, 011, 013`** — Cross-destination delivery from terminal context menu: text editor, cross-terminal with pty content assertion, self-paste with pty content assertion, unbound-picker-then-deliver with pty content assertion, and AI-assistant Tier 1 direct insert (verified end-to-end via `dummyAi.getText`)
- **`send-terminal-selection-009, 012`** — Menu visibility contracts (tab-menu absence, no-selection hidden) using `waitForHumanVerdict` + state-invariant log check

### Test infrastructure

- New `waitForHumanVerdict` helper in `src/__integration-tests__/helpers/assistedTestHelper.ts` — shows a persistent `withProgress` notification alongside two status-bar buttons (PASS / FAIL). Status bar items never auto-dismiss the way notifications can, and the combination coexists with any QuickPick or context menu the scenario opens. Modal dialogs (`{ modal: true }`) are blocked by VS Code's test host; plain notifications auto-collapse; QuickPick verdicts conflict with R-D-style scenarios — status bar sidesteps all three failure modes.
- Mocha per-test timeout bumped from 5 → 10 min in `.vscode-test.mjs` so human drivers have headroom to step away mid-suite.
- Four existing assisted tests migrated to the new helper: `context-menus-explorer-005`, `bind-to-destination-009`, `send-terminal-selection-009`, `send-terminal-selection-012`. Each still keeps its log-based state-invariant check as belt-and-suspenders.
- Three new TCs adopted PR 522's `createCapturingTerminal` / `createAndBindCapturingTerminal` + `assertTerminalBufferContains` helpers (landed on main after this branch was cut): `send-terminal-selection-008`, `-010`, `-011` now assert on actual terminal pty content, not just "Terminal paste succeeded" log lines.
- `BindToTerminalCommand.test.ts` extended with 3 unit tests for the direct-bind path.

### Docs

- `CHANGELOG.md` — under the existing `[Unreleased]` / `### Added` section: added "RangeLink: Send Selection to Destination" to the Terminal sub-section of "Context Menu Integrations" for symmetry with the other surfaces, and updated the "Send Terminal Selection (R-V)" bullet to describe the final (post-fix) visibility behavior ("opens the destination picker if nothing is bound"). No `### Changed` entry — this is an unreleased feature, so its final shape is what users will see.
- `README.md` — Terminal context-menu table: visibility column on "Send Selection to Destination" updated to "Text selected (content-area)", with a consolidated footnote covering both Send Selection and Unbind's tab-vs-content-area asymmetry on macOS VS Code.

## Key Discoveries

- **Right-click context was being discarded for terminal binds.** `bindToTextEditorHandler` captured its `uri?` arg but `bindToTerminalHandler` took zero args — the context-menu surface provided the terminal reference and the extension dropped it on the floor. With multiple terminals open, "Bind Here" fell through to the terminal picker instead of binding the clicked one. The fix closes the last parity gap between terminal and non-terminal context menus.
- **The `rangelink.isBound` gate on terminal "Send Selection" was over-restrictive.** The handler already delegated to `clipboardRouter.resolveDestinationBehavior` which opens the picker when unbound — the `when` clause was hiding a functional entry and forcing users to discover R-D before they could send terminal text. Dropping it matches the editor context menu's behavior (where Send/Paste items always show when text is selected, regardless of bind state).
- **VS Code's terminal tab context menu does not render Unbind OR Send Selection** even when the relevant `when` clauses are satisfied. Both items are surfaced exclusively via the content-area menu. TC 003 and 009 codify this; CHANGELOG and README reflect the asymmetry.
- **Notification dismissal is not under the extension's control.** Info/warning/error notifications can auto-collapse at any level depending on user settings and focus events; QuickPick verdicts conflict with scenarios that themselves open pickers; modal dialogs are blocked in the test host. Status bar items paired with a persistent `withProgress` notification is the only combination that's both persistent and non-conflicting.

## Test Plan

- [x] TypeScript type-check passes (`npx tsc --noEmit --project tsconfig.integration.json`)
- [x] ESLint clean; Prettier clean
- [x] All 1856 unit tests pass (`pnpm --filter rangelink-vscode-extension test`) — +3 BindToTerminalCommand unit tests
- [x] QA coverage validator passes (69 automated / 87 assisted / 72 false)
- [x] Manual drive — `pnpm test:release:grep "context-menus-terminal"` — 5/5 passing
- [x] Manual drive — `pnpm test:release:grep "send-terminal-selection"` — 6 new assisted TCs + existing, all passing
- [x] Manual drive — `pnpm test:release:grep "context-menus-explorer-005|bind-to-destination-009"` — verdict migrations passing
- [x] Manual drive — `pnpm test:release:grep "send-terminal-selection-(008|010|011)"` — pty-capture content assertions passing

## Documentation

- [x] CHANGELOG: Added-section entries updated (no standalone Changed entry — feature is unreleased)
- [x] README: Terminal context-menu table + tab-vs-content asymmetry footnote

## Related

- Closes https://github.com/couimet/rangeLink/issues/520
- Parent: https://github.com/couimet/rangeLink/issues/507
- Grandparent: https://github.com/couimet/rangeLink/issues/504
- Adopts helpers from https://github.com/couimet/rangeLink/pull/522 (issues/519 landed on main mid-branch): `createCapturingTerminal`, `assertTerminalBufferContains`
- Siblings merged: https://github.com/couimet/rangeLink/pull/521 (Explorer), https://github.com/couimet/rangeLink/pull/522 (Editor Tab / pty-capture infrastructure)
- Last sibling pending: https://github.com/couimet/rangeLink/issues/517 (Editor Content, 11 TCs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Send Selection to Destination" in the terminal now opens the destination picker when no destination is bound.

* **Improvements**
  * "Unbind" is shown only in the terminal content area when a destination is bound.
  * Terminal bind flows improved: direct bind from tab or content area and clearer multi-terminal disambiguation for selecting the correct terminal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->