### PR TITLE
[issues/517] Context menus — editor content: 11 TCs to assisted mode

### DIFF
--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
@@ -1020,13 +1020,14 @@ test_cases:
 
   - id: context-menus-editor-content-010
     feature: 'Context Menus — Editor Content'
-    scenario: 'Editor content: RangeLink: Unbind visible when bound'
+    scenario: 'Editor content: RangeLink: Unbind visible when bound and unbinds on click'
     preconditions:
       - 'A destination is bound'
     steps:
       - 'Right-click inside any editor'
-      - "Observe for 'RangeLink: Unbind'"
-    expected_result: "'RangeLink: Unbind' is visible in the editor context menu."
+      - "Verify 'RangeLink: Unbind' is visible"
+      - "Select 'RangeLink: Unbind'"
+    expected_result: "'RangeLink: Unbind' is visible in the editor context menu. Selecting it unbinds the destination and shows the unbind confirmation."
     automated: assisted
 
   - id: context-menus-editor-content-011

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
@@ -1035,6 +1035,7 @@ test_cases:
     scenario: 'Selection-dependent items hidden when no text is selected'
     preconditions:
       - 'Editor open'
+      - 'A destination is bound'
       - 'No text selected (cursor only)'
     steps:
       - 'Click in the editor to place cursor (no selection)'

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
@@ -924,7 +924,7 @@ test_cases:
       - 'Right-click in the editor'
       - "Select 'RangeLink: Send RangeLink'"
     expected_result: 'Terminal receives the RangeLink (same as R-L keybinding). Success toast.'
-    automated: false
+    automated: assisted
 
   - id: context-menus-editor-content-002
     feature: 'Context Menus — Editor Content'
@@ -935,7 +935,7 @@ test_cases:
     steps:
       - "Select text, right-click, select 'RangeLink: Send RangeLink (Absolute)'"
     expected_result: 'Terminal receives the RangeLink with an absolute file path (e.g., /full/path/to/file.ts#L3-L5).'
-    automated: false
+    automated: assisted
 
   - id: context-menus-editor-content-003
     feature: 'Context Menus — Editor Content'
@@ -946,7 +946,7 @@ test_cases:
     steps:
       - "Select text, right-click, select 'RangeLink: Send Portable Link'"
     expected_result: 'Terminal receives the portable link format (GitHub-style URL with blob path and line anchor).'
-    automated: false
+    automated: assisted
 
   - id: context-menus-editor-content-004
     feature: 'Context Menus — Editor Content'
@@ -957,7 +957,7 @@ test_cases:
     steps:
       - "Select text, right-click, select 'RangeLink: Send Portable Link (Absolute)'"
     expected_result: 'Terminal receives the portable link with an absolute file path variant.'
-    automated: false
+    automated: assisted
 
   - id: context-menus-editor-content-005
     feature: 'Context Menus — Editor Content'
@@ -968,7 +968,7 @@ test_cases:
     steps:
       - "Select 2-3 lines, right-click, select 'RangeLink: Send Selected Text'"
     expected_result: 'Terminal receives the raw selected text (not a link format). Success toast.'
-    automated: false
+    automated: assisted
 
   - id: context-menus-editor-content-006
     feature: 'Context Menus — Editor Content'
@@ -980,7 +980,7 @@ test_cases:
       - 'Right-click inside the editor (with or without selection)'
       - 'Observe the context menu structure'
     expected_result: 'A visual separator line is visible between the RangeLink commands and the rest of the VS Code context menu items.'
-    automated: false
+    automated: assisted
 
   - id: context-menus-editor-content-007
     feature: 'Context Menus — Editor Content'
@@ -992,7 +992,7 @@ test_cases:
       - 'Right-click inside the editor (no selection needed)'
       - "Select 'RangeLink: Send This File's Path'"
     expected_result: 'Terminal receives the absolute path of the current file.'
-    automated: false
+    automated: assisted
 
   - id: context-menus-editor-content-008
     feature: 'Context Menus — Editor Content'
@@ -1004,7 +1004,7 @@ test_cases:
       - 'Right-click inside the editor'
       - "Select 'RangeLink: Send This File's Relative Path'"
     expected_result: 'Terminal receives the workspace-relative path of the current file.'
-    automated: false
+    automated: assisted
 
   - id: context-menus-editor-content-009
     feature: 'Context Menus — Editor Content'
@@ -1016,7 +1016,7 @@ test_cases:
       - 'Right-click inside the editor'
       - "Select 'RangeLink: Bind Here'"
     expected_result: 'The current file is bound as the text editor destination. Success toast appears.'
-    automated: false
+    automated: assisted
 
   - id: context-menus-editor-content-010
     feature: 'Context Menus — Editor Content'
@@ -1027,7 +1027,7 @@ test_cases:
       - 'Right-click inside any editor'
       - "Observe for 'RangeLink: Unbind'"
     expected_result: "'RangeLink: Unbind' is visible in the editor context menu."
-    automated: false
+    automated: assisted
 
   - id: context-menus-editor-content-011
     feature: 'Context Menus — Editor Content'
@@ -1040,7 +1040,7 @@ test_cases:
       - 'Right-click inside the editor'
       - 'Observe which RangeLink items are present'
     expected_result: "'Send RangeLink', 'Send RangeLink (Absolute)', 'Send Portable Link', 'Send Portable Link (Absolute)', and 'Send Selected Text' are NOT visible. File-path and Bind/Unbind items remain visible."
-    automated: false
+    automated: assisted
 
   - id: context-menus-terminal-001
     feature: 'Context Menus — Terminal'

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
@@ -32,16 +32,33 @@ suite('Context Menus — Editor Content', () => {
   const log = createLogger('contextMenuEditorContent');
   const terminals: vscode.Terminal[] = [];
   const tmpFileUris: vscode.Uri[] = [];
+  let originalMultiLinePasteWarning: unknown;
 
   suiteSetup(async () => {
     await activateExtension();
     // Multi-line "Send Selected Text" triggers VS Code's terminal
     // multi-line-paste warning dialog by default; set to 'never' so
     // TC 005's selection delivers deterministically in the test host.
+    const terminalConfig = vscode.workspace.getConfiguration('terminal.integrated');
+    originalMultiLinePasteWarning = terminalConfig.inspect(
+      'enableMultiLinePasteWarning',
+    )?.globalValue;
+    await terminalConfig.update(
+      'enableMultiLinePasteWarning',
+      'never',
+      vscode.ConfigurationTarget.Global,
+    );
+    printAssistedBanner();
+  });
+
+  suiteTeardown(async () => {
     await vscode.workspace
       .getConfiguration('terminal.integrated')
-      .update('enableMultiLinePasteWarning', 'never', vscode.ConfigurationTarget.Global);
-    printAssistedBanner();
+      .update(
+        'enableMultiLinePasteWarning',
+        originalMultiLinePasteWarning,
+        vscode.ConfigurationTarget.Global,
+      );
   });
 
   teardown(async () => {
@@ -435,15 +452,22 @@ suite('Context Menus — Editor Content', () => {
     const logCapture = getLogCapture();
     logCapture.mark('before-ed-010');
 
-    await waitForHuman(
+    const verdict = await waitForHumanVerdict(
       'context-menus-editor-content-010',
-      `Right-click in "${fn}" → "RangeLink: Unbind"`,
+      `Right-click in "${fn}" → verify "RangeLink: Unbind" is visible, then click it`,
       [
         `A Terminal "${terminalName}" is bound as the current destination.`,
         '1. Right-click anywhere inside the editor',
-        '2. Verify "RangeLink: Unbind" IS present in the menu (clicking it proves visibility)',
+        '2. Verify "RangeLink: Unbind" IS present in the menu',
         '3. Select "RangeLink: Unbind"',
+        '4. Click Pass if the item was visible and clicked. Click Fail if it was absent or could not be selected.',
       ],
+    );
+
+    assert.strictEqual(
+      verdict,
+      'pass',
+      'Human reported RangeLink: Unbind was absent or could not be selected while bound',
     );
 
     const lines = logCapture.getLinesSince('before-ed-010');

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
@@ -1,0 +1,512 @@
+import assert from 'node:assert';
+import * as path from 'node:path';
+
+import * as vscode from 'vscode';
+
+import { CMD_UNBIND_DESTINATION } from '../../constants/commandIds';
+import {
+  activateExtension,
+  assertClipboardWriteLogged,
+  assertFilePathLogged,
+  assertFnLogged,
+  assertSetContextLogged,
+  assertStatusBarMsgLogged,
+  assertTerminalBufferContains,
+  cleanupFiles,
+  closeAllEditors,
+  createAndBindCapturingTerminal,
+  createAndOpenFile,
+  createLogger,
+  getLogCapture,
+  openEditor,
+  printAssistedBanner,
+  settle,
+  waitForHuman,
+  waitForHumanVerdict,
+} from '../helpers';
+
+const FILE_CONTENT = 'line 1\nline 2\nline 3\nline 4\n';
+const CONTEXT_IS_BOUND_KEY = 'rangelink.isBound';
+
+suite('Context Menus — Editor Content', () => {
+  const log = createLogger('contextMenuEditorContent');
+  const terminals: vscode.Terminal[] = [];
+  const tmpFileUris: vscode.Uri[] = [];
+
+  suiteSetup(async () => {
+    await activateExtension();
+    // Multi-line "Send Selected Text" triggers VS Code's terminal
+    // multi-line-paste warning dialog by default; set to 'never' so
+    // TC 005's selection delivers deterministically in the test host.
+    await vscode.workspace
+      .getConfiguration('terminal.integrated')
+      .update('enableMultiLinePasteWarning', 'never', vscode.ConfigurationTarget.Global);
+    printAssistedBanner();
+  });
+
+  teardown(async () => {
+    await vscode.commands.executeCommand(CMD_UNBIND_DESTINATION);
+    for (const t of terminals) {
+      t.dispose();
+    }
+    terminals.length = 0;
+    await closeAllEditors();
+    cleanupFiles(tmpFileUris);
+    tmpFileUris.length = 0;
+    await settle();
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC context-menus-editor-content-001: "Send RangeLink"
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-editor-content-001: Editor content "Send RangeLink" sends workspace-relative link to bound terminal', async () => {
+    const uri = await createAndOpenFile('ctxmenu-ed-001', FILE_CONTENT, undefined, tmpFileUris);
+    const fn = path.basename(uri.fsPath);
+    const relativePath = vscode.workspace.asRelativePath(uri, false);
+
+    const terminalName = 'rl-ctxmenu-ed-001';
+    const capturing = await createAndBindCapturingTerminal(terminalName, terminals);
+
+    const editor = await openEditor(uri);
+    editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(1, 6));
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-ed-001');
+    capturing.clearCaptured();
+
+    await waitForHuman(
+      'context-menus-editor-content-001',
+      `Right-click INSIDE the selected text in "${fn}" → "RangeLink: Send RangeLink"`,
+      [
+        `The file "${fn}" has lines 1–2 already selected for you.`,
+        `A Terminal "${terminalName}" is bound as the destination.`,
+        '1. Right-click INSIDE the highlighted selection',
+        '2. Select "RangeLink: Send RangeLink"',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-ed-001');
+
+    assertFnLogged(lines, { fn: 'LinkGenerator.copyToClipboardAndDestination' });
+    assertTerminalBufferContains(capturing.getCapturedText(), relativePath);
+    assertTerminalBufferContains(capturing.getCapturedText(), '#L1-L2');
+    assertStatusBarMsgLogged(lines, {
+      message: `✓ RangeLink copied to clipboard & sent to Terminal ("${terminalName}")`,
+    });
+
+    log('✓ Editor-content "Send RangeLink" delivered workspace-relative link to bound terminal');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC context-menus-editor-content-002: "Send RangeLink (Absolute)"
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-editor-content-002: Editor content "Send RangeLink (Absolute)" sends absolute link to bound terminal', async () => {
+    const uri = await createAndOpenFile('ctxmenu-ed-002', FILE_CONTENT, undefined, tmpFileUris);
+    const fn = path.basename(uri.fsPath);
+
+    const terminalName = 'rl-ctxmenu-ed-002';
+    const capturing = await createAndBindCapturingTerminal(terminalName, terminals);
+
+    const editor = await openEditor(uri);
+    editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(1, 6));
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-ed-002');
+    capturing.clearCaptured();
+
+    await waitForHuman(
+      'context-menus-editor-content-002',
+      `Right-click INSIDE the selected text in "${fn}" → "RangeLink: Send RangeLink (Absolute)"`,
+      [
+        `The file "${fn}" has lines 1–2 already selected for you.`,
+        '1. Right-click INSIDE the highlighted selection',
+        '2. Select "RangeLink: Send RangeLink (Absolute)"',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-ed-002');
+
+    assertFnLogged(lines, { fn: 'LinkGenerator.copyToClipboardAndDestination' });
+    assertTerminalBufferContains(capturing.getCapturedText(), uri.fsPath);
+    assertTerminalBufferContains(capturing.getCapturedText(), '#L1-L2');
+    assertStatusBarMsgLogged(lines, {
+      message: `✓ RangeLink copied to clipboard & sent to Terminal ("${terminalName}")`,
+    });
+
+    log('✓ Editor-content "Send RangeLink (Absolute)" delivered absolute link to bound terminal');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC context-menus-editor-content-003: "Send Portable Link"
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-editor-content-003: Editor content "Send Portable Link" sends portable link with workspace-relative path', async () => {
+    const uri = await createAndOpenFile('ctxmenu-ed-003', FILE_CONTENT, undefined, tmpFileUris);
+    const fn = path.basename(uri.fsPath);
+    const relativePath = vscode.workspace.asRelativePath(uri, false);
+
+    const terminalName = 'rl-ctxmenu-ed-003';
+    const capturing = await createAndBindCapturingTerminal(terminalName, terminals);
+
+    const editor = await openEditor(uri);
+    editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(1, 6));
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-ed-003');
+    capturing.clearCaptured();
+
+    await waitForHuman(
+      'context-menus-editor-content-003',
+      `Right-click INSIDE the selected text in "${fn}" → "RangeLink: Send Portable Link"`,
+      [
+        `The file "${fn}" has lines 1–2 already selected for you.`,
+        '1. Right-click INSIDE the highlighted selection',
+        '2. Select "RangeLink: Send Portable Link"',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-ed-003');
+
+    assertFnLogged(lines, { fn: 'LinkGenerator.copyToClipboardAndDestination' });
+    assertTerminalBufferContains(capturing.getCapturedText(), relativePath);
+    assertTerminalBufferContains(capturing.getCapturedText(), '#L1-L2');
+    assertStatusBarMsgLogged(lines, {
+      message: `✓ Portable RangeLink copied to clipboard & sent to Terminal ("${terminalName}")`,
+    });
+
+    log('✓ Editor-content "Send Portable Link" delivered portable link to bound terminal');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC context-menus-editor-content-004: "Send Portable Link (Absolute)"
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-editor-content-004: Editor content "Send Portable Link (Absolute)" sends portable link with absolute path', async () => {
+    const uri = await createAndOpenFile('ctxmenu-ed-004', FILE_CONTENT, undefined, tmpFileUris);
+    const fn = path.basename(uri.fsPath);
+
+    const terminalName = 'rl-ctxmenu-ed-004';
+    const capturing = await createAndBindCapturingTerminal(terminalName, terminals);
+
+    const editor = await openEditor(uri);
+    editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(1, 6));
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-ed-004');
+    capturing.clearCaptured();
+
+    await waitForHuman(
+      'context-menus-editor-content-004',
+      `Right-click INSIDE the selected text in "${fn}" → "RangeLink: Send Portable Link (Absolute)"`,
+      [
+        `The file "${fn}" has lines 1–2 already selected for you.`,
+        '1. Right-click INSIDE the highlighted selection',
+        '2. Select "RangeLink: Send Portable Link (Absolute)"',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-ed-004');
+
+    assertFnLogged(lines, { fn: 'LinkGenerator.copyToClipboardAndDestination' });
+    assertTerminalBufferContains(capturing.getCapturedText(), uri.fsPath);
+    assertTerminalBufferContains(capturing.getCapturedText(), '#L1-L2');
+    assertStatusBarMsgLogged(lines, {
+      message: `✓ Portable RangeLink copied to clipboard & sent to Terminal ("${terminalName}")`,
+    });
+
+    log(
+      '✓ Editor-content "Send Portable Link (Absolute)" delivered portable link with absolute path',
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC context-menus-editor-content-005: "Send Selected Text"
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-editor-content-005: Editor content "Send Selected Text" sends raw selected text to bound terminal', async () => {
+    const uri = await createAndOpenFile('ctxmenu-ed-005', FILE_CONTENT, undefined, tmpFileUris);
+    const fn = path.basename(uri.fsPath);
+
+    const terminalName = 'rl-ctxmenu-ed-005';
+    const capturing = await createAndBindCapturingTerminal(terminalName, terminals);
+
+    const editor = await openEditor(uri);
+    editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(2, 6));
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-ed-005');
+    capturing.clearCaptured();
+
+    await waitForHuman(
+      'context-menus-editor-content-005',
+      `Right-click INSIDE the selected text in "${fn}" → "RangeLink: Send Selected Text"`,
+      [
+        `The file "${fn}" has lines 1–3 already selected for you.`,
+        '1. Right-click INSIDE the highlighted selection',
+        '2. Select "RangeLink: Send Selected Text"',
+        'Visual note: the test terminal will LOOK like it only shows "line 3" — that is correct.',
+        'VS Code\'s terminal paste converts newlines to carriage returns so each line',
+        'would execute separately in a real shell. Our capturing pty has no shell, so',
+        'successive `\\r`s overwrite the same screen row. All three lines ARE delivered',
+        '(the test reads the raw captured buffer, not the rendered display).',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-ed-005');
+
+    assertFnLogged(lines, { fn: 'TextSelectionPaster.pasteSelectedTextToDestination' });
+    // Normalize both `\r\n` and lone `\r` to `\n` so the contiguous-substring
+    // check passes regardless of VS Code's line-ending choice. `workbench.action.terminal.paste`
+    // sends `\r` between lines so a real shell treats each line as Enter-terminated;
+    // our capturing pty preserves exactly what was sent.
+    const normalizedCapture = capturing.getCapturedText().replace(/\r\n|\r/g, '\n');
+    log(`TC 005 captured (normalized): ${JSON.stringify(normalizedCapture)}`);
+    assertTerminalBufferContains(normalizedCapture, 'line 1\nline 2\nline 3');
+    assertStatusBarMsgLogged(lines, {
+      message: `✓ Selected text copied to clipboard & sent to Terminal ("${terminalName}")`,
+    });
+
+    log('✓ Editor-content "Send Selected Text" delivered raw selected text to bound terminal');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC context-menus-editor-content-006: visual separator in editor content menu
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-editor-content-006: Visual separator is visible between RangeLink commands and other menu items', async () => {
+    const uri = await createAndOpenFile('ctxmenu-ed-006', FILE_CONTENT, undefined, tmpFileUris);
+    const fn = path.basename(uri.fsPath);
+
+    const verdict = await waitForHumanVerdict(
+      'context-menus-editor-content-006',
+      `Right-click in "${fn}" — is there a visual separator line between the RangeLink block and the rest of the menu?`,
+      [
+        '1. Right-click anywhere inside the editor',
+        '2. Look at the RangeLink commands as a group (grouped together in the menu)',
+        '3. Click Pass if a visual separator line sits between the RangeLink block and the adjacent VS Code menu items.',
+        '   Click Fail if there is no separator (the RangeLink commands blend into the rest of the menu).',
+      ],
+    );
+
+    assert.strictEqual(
+      verdict,
+      'pass',
+      'Human reported the RangeLink block has no visual separator — group prefixes in package.json may have drifted',
+    );
+
+    log('✓ Editor-content context menu renders a visual separator for the RangeLink block');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC context-menus-editor-content-007: "Send This File's Path" (absolute)
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-editor-content-007: Editor content "Send This File\'s Path" sends absolute path to bound terminal', async () => {
+    const uri = await createAndOpenFile('ctxmenu-ed-007', FILE_CONTENT, undefined, tmpFileUris);
+    const fn = path.basename(uri.fsPath);
+
+    const terminalName = 'rl-ctxmenu-ed-007';
+    const capturing = await createAndBindCapturingTerminal(terminalName, terminals);
+
+    await openEditor(uri);
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-ed-007');
+    capturing.clearCaptured();
+
+    await waitForHuman(
+      'context-menus-editor-content-007',
+      `Right-click in "${fn}" → "RangeLink: Send This File's Path"`,
+      [
+        '1. Right-click anywhere inside the editor (no selection needed)',
+        '2. Select "RangeLink: Send This File\'s Path"',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-ed-007');
+
+    assertFilePathLogged(lines, {
+      pathFormat: 'absolute',
+      uriSource: 'context-menu',
+      filePath: uri.fsPath,
+    });
+    assertClipboardWriteLogged(lines, { textLength: uri.fsPath.length });
+    assertTerminalBufferContains(capturing.getCapturedText(), uri.fsPath);
+
+    log('✓ Editor-content "Send This File\'s Path" delivered absolute path to bound terminal');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC context-menus-editor-content-008: "Send This File's Relative Path"
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-editor-content-008: Editor content "Send This File\'s Relative Path" sends workspace-relative path to bound terminal', async () => {
+    const uri = await createAndOpenFile('ctxmenu-ed-008', FILE_CONTENT, undefined, tmpFileUris);
+    const fn = path.basename(uri.fsPath);
+    const relativePath = vscode.workspace.asRelativePath(uri, false);
+
+    const terminalName = 'rl-ctxmenu-ed-008';
+    const capturing = await createAndBindCapturingTerminal(terminalName, terminals);
+
+    await openEditor(uri);
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-ed-008');
+    capturing.clearCaptured();
+
+    await waitForHuman(
+      'context-menus-editor-content-008',
+      `Right-click in "${fn}" → "RangeLink: Send This File's Relative Path"`,
+      [
+        '1. Right-click anywhere inside the editor (no selection needed)',
+        '2. Select "RangeLink: Send This File\'s Relative Path"',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-ed-008');
+
+    assertFilePathLogged(lines, {
+      pathFormat: 'workspace-relative',
+      uriSource: 'context-menu',
+      filePath: relativePath,
+    });
+    assertClipboardWriteLogged(lines, { textLength: relativePath.length });
+    assertTerminalBufferContains(capturing.getCapturedText(), relativePath);
+
+    log(
+      '✓ Editor-content "Send This File\'s Relative Path" delivered relative path to bound terminal',
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC context-menus-editor-content-009: "Bind Here" binds current file as text editor
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-editor-content-009: Editor content "Bind Here" binds the current file as the text editor destination', async () => {
+    const uri = await createAndOpenFile('ctxmenu-ed-009', FILE_CONTENT, undefined, tmpFileUris);
+    const fn = path.basename(uri.fsPath);
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-ed-009');
+
+    await waitForHuman(
+      'context-menus-editor-content-009',
+      `Right-click in "${fn}" → "RangeLink: Bind Here"`,
+      [
+        '1. Right-click anywhere inside the editor (no selection needed)',
+        '2. Select "RangeLink: Bind Here"',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-ed-009');
+
+    assertFnLogged(lines, { fn: 'BindToTextEditorCommand.executeWithUri' });
+    assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
+    assertStatusBarMsgLogged(lines, {
+      message: `✓ RangeLink bound to Text Editor ("${fn}")`,
+    });
+
+    log('✓ Editor-content "Bind Here" committed a text-editor binding for the current file');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC context-menus-editor-content-010: Unbind visible when bound + click fires unbind
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-editor-content-010: Editor content "Unbind" is visible when bound and unbinds on click', async () => {
+    const uri = await createAndOpenFile('ctxmenu-ed-010', FILE_CONTENT, undefined, tmpFileUris);
+    const fn = path.basename(uri.fsPath);
+
+    const terminalName = 'rl-ctxmenu-ed-010';
+    await createAndBindCapturingTerminal(terminalName, terminals);
+
+    await openEditor(uri);
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-ed-010');
+
+    await waitForHuman(
+      'context-menus-editor-content-010',
+      `Right-click in "${fn}" → "RangeLink: Unbind"`,
+      [
+        `A Terminal "${terminalName}" is bound as the current destination.`,
+        '1. Right-click anywhere inside the editor',
+        '2. Verify "RangeLink: Unbind" IS present in the menu (clicking it proves visibility)',
+        '3. Select "RangeLink: Unbind"',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-ed-010');
+
+    assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: false });
+    assertStatusBarMsgLogged(lines, {
+      message: `✓ RangeLink unbound from Terminal ("${terminalName}")`,
+    });
+
+    log('✓ Editor-content "Unbind" was visible (clicked it) and fired the unbind path');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC context-menus-editor-content-011: selection-dependent items hidden when no selection
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-editor-content-011: Selection-dependent RangeLink items are hidden when no text is selected', async () => {
+    const uri = await createAndOpenFile('ctxmenu-ed-011', FILE_CONTENT, undefined, tmpFileUris);
+    const fn = path.basename(uri.fsPath);
+
+    const terminalName = 'rl-ctxmenu-ed-011';
+    await createAndBindCapturingTerminal(terminalName, terminals);
+
+    const editor = await openEditor(uri);
+    editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0));
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-ed-011');
+
+    const verdict = await waitForHumanVerdict(
+      'context-menus-editor-content-011',
+      `Right-click in "${fn}" WITHOUT selecting — are the 5 selection-dependent items ABSENT from the menu?`,
+      [
+        `A Terminal "${terminalName}" is bound so Unbind should remain visible.`,
+        '1. Do NOT click-drag or double-click to create a text selection — cursor only',
+        '2. Right-click anywhere inside the editor',
+        '3. Click Pass if ALL FIVE of these items are NOT visible: "Send RangeLink", "Send RangeLink (Absolute)", "Send Portable Link", "Send Portable Link (Absolute)", "Send Selected Text"',
+        '   (File-path items and Bind/Unbind should remain visible — that is correct.)',
+        '   Click Fail if any of the five selection-dependent items appear despite no selection.',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-ed-011');
+
+    assert.strictEqual(
+      verdict,
+      'pass',
+      'Human reported selection-dependent items WERE visible without a selection — the `when: editorHasSelection` clause is not working',
+    );
+    const linkFired = lines.some((line) => line.includes('"fn":"LinkGenerator.createLinkCore"'));
+    const pasteFired = lines.some((line) =>
+      line.includes('"fn":"VscodeAdapter.writeTextToClipboard"'),
+    );
+    assert.ok(
+      !linkFired,
+      'Expected no LinkGenerator.createLinkCore log — no selection-dependent send should have fired during observation',
+    );
+    assert.ok(
+      !pasteFired,
+      'Expected no clipboard write log — nothing should have been sent during observation',
+    );
+
+    log('✓ No-selection state: selection-dependent items hidden (human verdict + state invariant)');
+  });
+});

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
@@ -252,7 +252,7 @@ suite('Context Menus — Editor Content', () => {
         '1. Right-click INSIDE the highlighted selection',
         '2. Select "RangeLink: Send Selected Text"',
         'Visual note: the test terminal will LOOK like it only shows "line 3" — that is correct.',
-        'VS Code\'s terminal paste converts newlines to carriage returns so each line',
+        "VS Code's terminal paste converts newlines to carriage returns so each line",
         'would execute separately in a real shell. Our capturing pty has no shell, so',
         'successive `\\r`s overwrite the same screen row. All three lines ARE delivered',
         '(the test reads the raw captured buffer, not the rendered display).',


### PR DESCRIPTION
## Summary

Last Category-B sibling of the 507 epic. Converts all 11 Context Menus — Editor Content QA test cases from `automated: false` to `automated: assisted` by adding a new integration-test suite at `contextMenuEditorContent.test.ts`. Covers link sends (regular + absolute + portable + portable-absolute + raw selected text), file-path sends (absolute + relative), bind/unbind, and three visibility contracts (visual separator, Unbind-when-bound, no-selection-hides-5-items).

## Changes

- **New integration tests** — 11 `[assisted]`-tagged TCs in `src/__integration-tests__/suite/contextMenuEditorContent.test.ts`. Delivery-path TCs (001–005, 007–008) use `createAndBindCapturingTerminal` + `assertTerminalBufferContains` for content-level verification of what landed in the bound terminal. Visibility-contract TCs (006, 010, 011) use `waitForHumanVerdict` for the human signal; 010 and 011 pair the verdict with a state-invariant log check (belt-and-suspenders, parity with the terminal/editor-tab/explorer patterns), 006 is verdict-only (pure visual contract, no state invariant possible).
- **QA YAML** — flipped `automated: false` → `automated: assisted` on all 11 `context-menus-editor-content-*` TCs in `qa/qa-test-cases-v1.1.0-003.yaml`. In-place edit (QA002 exception for `automated` field updates); no journal copy needed.
- **TC 010 scope expansion** — converted from the YAML's observe-only scope to click-and-verify, mirroring how terminal-003 was converted under #523. The test now both proves visibility (menu item present → human could click it) and asserts the click path (setContext false + unbind status-bar message).

## Test Plan

- [x] TypeScript type-check passes (`npx tsc --noEmit --project tsconfig.integration.json`)
- [x] ESLint clean (`pnpm lint:fix`)
- [x] Prettier clean (`pnpm format:fix`)
- [x] All 1856 unit tests pass (`pnpm test`)
- [x] QA coverage validator passes: 69 automated / 98 assisted / 67 false (was 87 assisted / 78 false before this PR; `scripts/validate-qa-coverage.sh` reports matching integration-test IDs for every assisted marker)
- [x] Manual drive: `pnpm test:release:grep "context-menus-editor-content"` — 11 TCs require a human driver for the right-click gestures and PASS/FAIL verdicts. Drive locally before marking PR ready.

## Documentation

- [ ] CHANGELOG: not needed — internal test-coverage improvement, no user-facing change. Matches the pattern set by the three sibling PRs (#521 explorer, #522 editor-tab, #523 terminal).
- [ ] README: not needed — no new command, setting, or feature.

## Related

- Closes https://github.com/couimet/rangeLink/issues/517
- Parent: https://github.com/couimet/rangeLink/issues/507
- Grandparent: https://github.com/couimet/rangeLink/issues/504
- Adopts helpers from https://github.com/couimet/rangeLink/pull/522 (pty-capture infrastructure) and https://github.com/couimet/rangeLink/pull/523 (`waitForHumanVerdict` + assertion-order convention: verdict first, state-invariant second)
- Siblings merged: https://github.com/couimet/rangeLink/pull/521, https://github.com/couimet/rangeLink/pull/522, https://github.com/couimet/rangeLink/pull/523

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration test suite covering editor context-menu behaviors: bind/unbind flows, send-to-destination actions, selection-dependent menu visibility, clipboard/path handling, terminal output formats, and status-bar messages; includes human-assisted verification steps and deterministic setup/teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->