### PR TITLE
[issues/509-block7] Block 7 — Status Bar Menu (5 TCs) + PR feedback fixes

### DIFF
--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
@@ -31,7 +31,7 @@ test_cases:
       - 'Locate the RangeLink item'
       - 'Hover over it to see the tooltip'
     expected_result: "Status bar shows $(link) RangeLink. Tooltip reads 'RangeLink Menu'."
-    automated: false
+    automated: assisted
 
   - id: status-bar-menu-002
     feature: 'R-M Status Bar Menu'
@@ -86,7 +86,7 @@ test_cases:
       - 'Open the R-M menu'
       - 'Observe the first item'
     expected_result: "Menu shows a bind item that opens the destination picker. 'Jump to Bound Destination' is absent."
-    automated: false
+    automated: assisted
 
   - id: status-bar-menu-007
     feature: 'R-M Status Bar Menu'
@@ -97,7 +97,7 @@ test_cases:
       - 'Open the R-M menu'
       - "Select 'Unbind Destination'"
     expected_result: "The destination is unbound. A notification confirms. R-M menu no longer shows 'Jump to Bound Destination' next time."
-    automated: false
+    automated: assisted
 
   - id: status-bar-menu-008
     feature: 'R-M Status Bar Menu'
@@ -108,7 +108,7 @@ test_cases:
       - 'Open the R-M menu'
       - "Select 'Go to Link'"
     expected_result: 'R-G input box opens, ready to accept a RangeLink for navigation.'
-    automated: false
+    automated: assisted
 
   - id: status-bar-menu-009
     feature: 'R-M Status Bar Menu'
@@ -119,7 +119,7 @@ test_cases:
       - 'Open the R-M menu'
       - "Select 'Show Version Info'"
     expected_result: 'A notification or info message shows the extension version, short commit SHA, branch name, and build date.'
-    automated: false
+    automated: assisted
 
   # ---------------------------------------------------------------------------
   # Section 2 — R-D Bind to Destination

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/statusBarMenu.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/statusBarMenu.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 
 import * as vscode from 'vscode';
 
+import { CMD_BIND_TO_TERMINAL_HERE, CMD_UNBIND_DESTINATION } from '../../constants/commandIds';
 import {
   activateExtension,
   assertQuickPickItemsLogged,
@@ -15,6 +16,7 @@ import {
   settle,
   TERMINAL_READY_MS,
   waitForHuman,
+  waitForHumanVerdict,
 } from '../helpers';
 
 const SEPARATOR_KIND = -1;
@@ -139,5 +141,174 @@ suite('R-M Status Bar Menu', () => {
       await vscode.commands.executeCommand('rangelink.unbindDestination');
       terminal.dispose();
     }
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC status-bar-menu-001
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] status-bar-menu-001: status bar item visible with correct text and tooltip', async () => {
+    const verdict = await waitForHumanVerdict(
+      'status-bar-menu-001',
+      'Look at the VS Code status bar (bottom right). Does it show "$(link) RangeLink" with tooltip "RangeLink Menu" on hover?',
+      [
+        '1. Locate the RangeLink item in the bottom-right status bar',
+        '2. Hover over it to reveal the tooltip',
+        '3. Click PASS if it shows "$(link) RangeLink" with tooltip "RangeLink Menu"',
+        '   Click FAIL if the text or tooltip is wrong, or the item is missing',
+      ],
+    );
+    assert.strictEqual(verdict, 'pass', 'Human reported status bar text or tooltip was incorrect');
+    log('✓ Status bar item shows correct text and tooltip');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC status-bar-menu-006
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] status-bar-menu-006: R-M menu shows destination picker items when no destination is bound', async () => {
+    await vscode.commands.executeCommand(CMD_UNBIND_DESTINATION);
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-006');
+
+    await waitForHuman(
+      'status-bar-menu-006',
+      'No destination bound. Open the R-M menu (Cmd+R Cmd+M), observe the first item and the absence of "Jump to Bound Destination", then press Escape.',
+      [
+        '1. Press Cmd+R Cmd+M to open the R-M menu',
+        '2. Confirm the first item says "No bound destination. Choose below to bind:"',
+        '3. Confirm there is NO "Jump to Bound Destination" item',
+        '4. Press Escape to dismiss, then click Cancel',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-006');
+    const items = extractQuickPickItemsLogged(lines);
+    assert.ok(items, 'Expected showQuickPick log entry with items');
+    assert.deepStrictEqual(
+      { label: items![0].label, itemKind: items![0].itemKind },
+      { label: 'No bound destination. Choose below to bind:', itemKind: 'info' },
+    );
+    assert.strictEqual(
+      items!.find((i) => i.label === '$(arrow-right) Jump to Bound Destination'),
+      undefined,
+      'Expected no Jump item in unbound state',
+    );
+    log('✓ Unbound menu shows "choose below" info item and no Jump item');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC status-bar-menu-007
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] status-bar-menu-007: R-M menu Unbind Destination item unbinds the destination when selected', async () => {
+    const terminal = vscode.window.createTerminal({ name: 'rl-sbm-007' });
+    terminal.show(true);
+    await settle(TERMINAL_READY_MS);
+    await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
+    await settle();
+
+    try {
+      const logCapture = getLogCapture();
+      logCapture.mark('before-007');
+
+      await waitForHuman(
+        'status-bar-menu-007',
+        'Destination is bound to "rl-sbm-007". Open the R-M menu (Cmd+R Cmd+M), verify Jump and Unbind are present, select "$(close) Unbind Destination", then click Cancel.',
+        [
+          '1. Press Cmd+R Cmd+M to open the R-M menu',
+          '2. Confirm "$(arrow-right) Jump to Bound Destination" shows "rl-sbm-007"',
+          '3. Confirm "$(close) Unbind Destination" is visible',
+          '4. Select "$(close) Unbind Destination"',
+          '5. Click Cancel on this notification',
+        ],
+      );
+
+      const lines = logCapture.getLinesSince('before-007');
+      const items = extractQuickPickItemsLogged(lines);
+      assert.ok(items, 'Expected showQuickPick log entry with items');
+      assert.ok(
+        items!.find((i) => i.label === '$(arrow-right) Jump to Bound Destination'),
+        'Expected Jump item present in bound state',
+      );
+      assert.ok(
+        items!.find((i) => i.label === '$(close) Unbind Destination'),
+        'Expected Unbind item present in bound state',
+      );
+      const commandSelectedLog = lines.find(
+        (l) => l.includes('Command item selected') && l.includes('Unbind Destination'),
+      );
+      assert.ok(commandSelectedLog, 'Expected "Command item selected" log for Unbind Destination');
+      log('✓ Bound menu showed Jump + Unbind; human selected Unbind and it was dispatched');
+    } finally {
+      terminal.dispose();
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC status-bar-menu-008
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] status-bar-menu-008: R-M menu Go to Link item opens the R-G input box', async () => {
+    const logCapture = getLogCapture();
+    logCapture.mark('before-008');
+
+    await waitForHuman(
+      'status-bar-menu-008',
+      'Open the R-M menu (Cmd+R Cmd+M), select "$(link-external) Go to Link", dismiss the R-G input box (Escape), then click Cancel.',
+      [
+        '1. Press Cmd+R Cmd+M to open the R-M menu',
+        '2. Select "$(link-external) Go to Link"',
+        '3. The R-G input box opens — press Escape to dismiss it',
+        '4. Click Cancel on this notification',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-008');
+    const items = extractQuickPickItemsLogged(lines);
+    assert.ok(items, 'Expected showQuickPick log entry with items');
+    assert.ok(
+      items!.find((i) => i.label === '$(link-external) Go to Link'),
+      'Expected "Go to Link" item in menu',
+    );
+    const commandSelectedLog = lines.find(
+      (l) => l.includes('Command item selected') && l.includes('Go to Link'),
+    );
+    assert.ok(commandSelectedLog, 'Expected "Command item selected" log for Go to Link');
+    const inputBoxLog = lines.find(
+      (l) => l.includes('GoToRangeLinkCommand.execute') && l.includes('Showing input box'),
+    );
+    assert.ok(inputBoxLog, 'Expected GoToRangeLinkCommand to log input box presentation');
+    log('✓ R-M menu "Go to Link" dispatched the R-G command and input box was shown');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC status-bar-menu-009
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] status-bar-menu-009: R-M menu Show Version Info displays version, commit, branch, and build date', async () => {
+    const verdict = await waitForHumanVerdict(
+      'status-bar-menu-009',
+      'Open the R-M menu (Cmd+R Cmd+M), select "$(info) Show Version Info", read the notification. Does it show the version, a short commit SHA, a branch name, and a build date?',
+      [
+        '1. Press Cmd+R Cmd+M to open the R-M menu',
+        '2. Select "$(info) Show Version Info"',
+        '3. Read the notification — verify it contains:',
+        '   • Extension version (e.g. 1.1.0)',
+        '   • Short commit SHA (e.g. abc1234)',
+        '   • Branch name (e.g. main or issues/509-block7)',
+        '   • Build date',
+        '4. Dismiss the notification, then click PASS or FAIL',
+      ],
+    );
+
+    assert.strictEqual(
+      verdict,
+      'pass',
+      'Human reported version info notification was missing fields',
+    );
+    log('✓ Show Version Info displayed notification with all required fields (human verified)');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/statusBarMenu.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/statusBarMenu.test.ts
@@ -143,10 +143,6 @@ suite('R-M Status Bar Menu', () => {
     }
   });
 
-  // ---------------------------------------------------------------------------
-  // TC status-bar-menu-001
-  // ---------------------------------------------------------------------------
-
   test('[assisted] status-bar-menu-001: status bar item visible with correct text and tooltip', async () => {
     const verdict = await waitForHumanVerdict(
       'status-bar-menu-001',
@@ -161,10 +157,6 @@ suite('R-M Status Bar Menu', () => {
     assert.strictEqual(verdict, 'pass', 'Human reported status bar text or tooltip was incorrect');
     log('✓ Status bar item shows correct text and tooltip');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC status-bar-menu-006
-  // ---------------------------------------------------------------------------
 
   test('[assisted] status-bar-menu-006: R-M menu shows destination picker items when no destination is bound', async () => {
     await vscode.commands.executeCommand(CMD_UNBIND_DESTINATION);
@@ -198,10 +190,6 @@ suite('R-M Status Bar Menu', () => {
     );
     log('✓ Unbound menu shows "choose below" info item and no Jump item');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC status-bar-menu-007
-  // ---------------------------------------------------------------------------
 
   test('[assisted] status-bar-menu-007: R-M menu Unbind Destination item unbinds the destination when selected', async () => {
     const terminal = vscode.window.createTerminal({ name: 'rl-sbm-007' });
@@ -241,15 +229,31 @@ suite('R-M Status Bar Menu', () => {
         (l) => l.includes('Command item selected') && l.includes('Unbind Destination'),
       );
       assert.ok(commandSelectedLog, 'Expected "Command item selected" log for Unbind Destination');
-      log('✓ Bound menu showed Jump + Unbind; human selected Unbind and it was dispatched');
+
+      logCapture.mark('after-unbind-007');
+      await waitForHuman(
+        'status-bar-menu-007',
+        'Re-open the R-M menu (Cmd+R Cmd+M), verify "Jump to Bound Destination" is gone, then press Escape and click Cancel.',
+        [
+          '1. Press Cmd+R Cmd+M to open the R-M menu',
+          '2. Confirm "$(arrow-right) Jump to Bound Destination" is NOT present',
+          '3. Press Escape to dismiss, then click Cancel',
+        ],
+      );
+
+      const postLines = logCapture.getLinesSince('after-unbind-007');
+      const postItems = extractQuickPickItemsLogged(postLines);
+      assert.ok(postItems, 'Expected post-unbind showQuickPick log entry with items');
+      assert.strictEqual(
+        postItems!.find((i) => i.label === '$(arrow-right) Jump to Bound Destination'),
+        undefined,
+        'Expected no Jump item after unbind',
+      );
+      log('✓ Bound menu showed Jump + Unbind; human selected Unbind; post-unbind menu confirmed Jump absent');
     } finally {
       terminal.dispose();
     }
   });
-
-  // ---------------------------------------------------------------------------
-  // TC status-bar-menu-008
-  // ---------------------------------------------------------------------------
 
   test('[assisted] status-bar-menu-008: R-M menu Go to Link item opens the R-G input box', async () => {
     const logCapture = getLogCapture();
@@ -284,11 +288,10 @@ suite('R-M Status Bar Menu', () => {
     log('✓ R-M menu "Go to Link" dispatched the R-G command and input box was shown');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC status-bar-menu-009
-  // ---------------------------------------------------------------------------
-
   test('[assisted] status-bar-menu-009: R-M menu Show Version Info displays version, commit, branch, and build date', async () => {
+    const logCapture = getLogCapture();
+    logCapture.mark('before-009');
+
     const verdict = await waitForHumanVerdict(
       'status-bar-menu-009',
       'Open the R-M menu (Cmd+R Cmd+M), select "$(info) Show Version Info", read the notification. Does it show the version, a short commit SHA, a branch name, and a build date?',
@@ -304,11 +307,19 @@ suite('R-M Status Bar Menu', () => {
       ],
     );
 
+    const lines = logCapture.getLinesSince('before-009');
+    // "Executing command" is logged by VscodeAdapter before awaiting ShowVersionCommand.execute(),
+    // so it lands in the capture regardless of when the human dismisses the version notification.
+    const commandDispatchLog = lines.find(
+      (l) => l.includes('Executing command') && l.includes('rangelink.showVersion'),
+    );
+    assert.ok(commandDispatchLog, 'Expected command dispatch log for Show Version Info');
+
     assert.strictEqual(
       verdict,
       'pass',
       'Human reported version info notification was missing fields',
     );
-    log('✓ Show Version Info displayed notification with all required fields (human verified)');
+    log('✓ Show Version Info dispatched and notification displayed all required fields (human verified)');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/statusBarMenu.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/statusBarMenu.test.ts
@@ -249,7 +249,9 @@ suite('R-M Status Bar Menu', () => {
         undefined,
         'Expected no Jump item after unbind',
       );
-      log('✓ Bound menu showed Jump + Unbind; human selected Unbind; post-unbind menu confirmed Jump absent');
+      log(
+        '✓ Bound menu showed Jump + Unbind; human selected Unbind; post-unbind menu confirmed Jump absent',
+      );
     } finally {
       terminal.dispose();
     }
@@ -320,6 +322,8 @@ suite('R-M Status Bar Menu', () => {
       'pass',
       'Human reported version info notification was missing fields',
     );
-    log('✓ Show Version Info dispatched and notification displayed all required fields (human verified)');
+    log(
+      '✓ Show Version Info dispatched and notification displayed all required fields (human verified)',
+    );
   });
 });


### PR DESCRIPTION
Converts five status bar menu TCs from `automated: false` to `automated: assisted`, bringing the Phase 2 sweep to 127 assisted TCs total.

- **Block 7 — Status Bar Menu** (`statusBarMenu.test.ts`): 5 new `[assisted]` tests for TCs 001, 006, 007, 008, 009. TC 001 and TC 009 use `waitForHumanVerdict` (PASS/FAIL) for purely visual checks; TCs 006–008 use `waitForHuman` with `extractQuickPickItemsLogged` and log-line assertions.
- **QA YAML** (`qa-test-cases-v1.1.0-003.yaml`): TCs 001, 006, 007, 008, 009 updated from `automated: false` to `automated: assisted` (status-only update, permitted by QA002 exception).

- [ ] All 1862 unit tests pass (`pnpm test`)
- [ ] QA validator passes: 127 assisted, 74 automated, 28 false
- [ ] Block 7 drive passes: `pnpm test:release:grep "status-bar-menu-(001|006|007|008|009)"`

Part of https://github.com/couimet/rangeLink/issues/509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated QA test case metadata for Status Bar Menu scenarios from manual-only to assisted testing mode.
  * Added five new integration tests for Status Bar Menu functionality, covering menu state validation, command dispatch, and notification content verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->