### PR TITLE
[issues/509] Block 8 — Core Send Commands + R-V Terminal Selection (8 TCs, 2 automated)

### DIFF
--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
@@ -1457,7 +1457,7 @@ test_cases:
       - 'Press Cmd+R Cmd+V'
       - 'Observe bound destination'
     expected_result: 'Bound destination receives selected terminal text. Success toast appears.'
-    automated: false
+    automated: assisted
 
   - id: send-terminal-selection-002
     feature: 'R-V Send Terminal Selection'
@@ -1482,7 +1482,7 @@ test_cases:
       - 'Click in terminal (no selection)'
       - 'Press Cmd+R Cmd+V'
     expected_result: 'Error notification: No text selected in the terminal. Select text and try again. Nothing sent to destination.'
-    automated: false
+    automated: true
 
   - id: send-terminal-selection-004
     feature: 'R-V Send Terminal Selection'
@@ -1495,7 +1495,7 @@ test_cases:
       - 'Select text in terminal'
       - 'Press Cmd+R Cmd+V'
     expected_result: 'Destination picker opens. On selection: text sent to new destination. On Escape: nothing sent.'
-    automated: false
+    automated: assisted
 
   - id: send-terminal-selection-005
     feature: 'R-V Send Terminal Selection'
@@ -2057,7 +2057,7 @@ test_cases:
       - 'Press Cmd+R Cmd+L'
       - 'Observe file B'
     expected_result: 'RangeLink text inserted at cursor in file B. Success toast confirms send.'
-    automated: false
+    automated: assisted
 
   - id: core-send-commands-r-l-003
     feature: 'Core Send Commands — R-L'
@@ -2071,7 +2071,7 @@ test_cases:
       - 'Press Cmd+R Cmd+L'
       - 'Observe AI chat input area'
     expected_result: 'RangeLink appears in AI chat input. Success toast confirms send.'
-    automated: false
+    automated: assisted
 
   - id: core-send-commands-r-c-001
     feature: 'Core Send Commands — R-C'
@@ -2085,7 +2085,7 @@ test_cases:
       - 'Observe terminal — nothing should arrive'
       - 'Press Cmd+V in any text field'
     expected_result: 'Clipboard contains the RangeLink. Terminal received nothing. No destination picker shown.'
-    automated: false
+    automated: true
 
   - id: core-send-commands-r-l-004
     feature: 'Core Send Commands — R-L'
@@ -2098,7 +2098,7 @@ test_cases:
       - 'Type Send RangeLink and press Enter on RangeLink: Send RangeLink'
       - 'Observe terminal'
     expected_result: 'Terminal receives the RangeLink. Identical to R-L keybinding.'
-    automated: false
+    automated: assisted
 
   - id: core-send-commands-r-c-002
     feature: 'Core Send Commands — R-C'
@@ -2112,7 +2112,7 @@ test_cases:
       - 'Observe terminal — nothing should arrive'
       - 'Press Cmd+V in any text field'
     expected_result: 'Terminal received nothing. Clipboard contains the RangeLink.'
-    automated: false
+    automated: assisted
 
   - id: core-send-commands-r-l-005
     feature: 'Core Send Commands — R-L'

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
@@ -49,10 +49,6 @@ suite('R-D Bind to Destination', () => {
   const findFileItems = (items: Record<string, unknown>[]): Record<string, unknown>[] =>
     findTestItemsByPrefix(items, '__rl-test-btd-');
 
-  // ---------------------------------------------------------------------------
-  // TC bind-to-destination-004
-  // ---------------------------------------------------------------------------
-
   test('[assisted] bind-to-destination-004: selecting a terminal destination binds it and shows success toast', async () => {
     await createTerminal('rl-btd-004', terminals);
 
@@ -101,10 +97,6 @@ suite('R-D Bind to Destination', () => {
 
     log('✓ Picker showed unbound terminal; bind succeeded with correct status bar toast');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC bind-to-destination-005
-  // ---------------------------------------------------------------------------
 
   test('[assisted] bind-to-destination-005: selecting a text editor destination binds it and shows success toast', async () => {
     await createAndOpenFile('btd-005-a', 'line 1\n', undefined, tmpFileUris);
@@ -155,10 +147,6 @@ suite('R-D Bind to Destination', () => {
     log('✓ Picker showed unbound file; bind succeeded with correct status bar toast');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC bind-to-destination-006
-  // ---------------------------------------------------------------------------
-
   test('[assisted] bind-to-destination-006: selecting an AI assistant destination binds it and shows success toast', async () => {
     const logCapture = getLogCapture();
     logCapture.mark('before-btd-006');
@@ -185,10 +173,6 @@ suite('R-D Bind to Destination', () => {
 
     log('✓ AI assistant bind success toast logged');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC bind-to-destination-007
-  // ---------------------------------------------------------------------------
 
   test('[assisted] bind-to-destination-007: when already bound, destination picker shows smart-bind confirmation dialog', async () => {
     await createTerminal('rl-btd-007-a', terminals);
@@ -243,10 +227,6 @@ suite('R-D Bind to Destination', () => {
     log('✓ Confirmation dialog items validated; no bind/rebind toast after Escape');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC bind-to-destination-008
-  // ---------------------------------------------------------------------------
-
   test('[assisted] bind-to-destination-008: smart-bind confirmation Yes replaces the binding', async () => {
     await createTerminal('rl-btd-008-a', terminals);
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
@@ -278,10 +258,6 @@ suite('R-D Bind to Destination', () => {
 
     log('✓ Replacement binding toast logged; old binding not re-confirmed');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC bind-to-destination-009
-  // ---------------------------------------------------------------------------
 
   test('[assisted] bind-to-destination-009: smart-bind confirmation No keeps existing binding', async () => {
     await createTerminal('rl-btd-009-a', terminals);
@@ -321,10 +297,6 @@ suite('R-D Bind to Destination', () => {
     log('✓ No rebind toast — original binding preserved (human verdict + state invariant)');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC bind-to-destination-010
-  // ---------------------------------------------------------------------------
-
   test('[assisted] bind-to-destination-010: Escape from destination picker dismisses without changing binding', async () => {
     await createTerminal('rl-btd-010', terminals);
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
@@ -349,10 +321,6 @@ suite('R-D Bind to Destination', () => {
 
     log('✓ No bind or unbind toast after Escape — binding state unchanged');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC bind-to-destination-011
-  // ---------------------------------------------------------------------------
 
   test('[assisted] bind-to-destination-011: re-binding same AI assistant shows already-bound message', async () => {
     const logCapture = getLogCapture();
@@ -394,10 +362,6 @@ suite('R-D Bind to Destination', () => {
 
     log('✓ Already-bound info toast logged; no confirmation dialog shown');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC bind-to-destination-012
-  // ---------------------------------------------------------------------------
 
   test('[assisted] bind-to-destination-012: switching between different AI assistants shows confirmation dialog', async () => {
     const logCapture = getLogCapture();
@@ -441,10 +405,6 @@ suite('R-D Bind to Destination', () => {
     log('✓ Confirmation dialog shown; rebind toast logged after "Yes, replace"');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC bind-to-destination-014
-  // ---------------------------------------------------------------------------
-
   test('[assisted] bind-to-destination-014: Jump to Bound Destination with no bound destination opens picker', async () => {
     const verdict = await waitForHumanVerdict(
       'bind-to-destination-014',
@@ -465,10 +425,6 @@ suite('R-D Bind to Destination', () => {
     );
     log('✓ Jump to Bound Destination with no destination opens picker (human verdict)');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC bind-to-destination-015
-  // ---------------------------------------------------------------------------
 
   test('[assisted] bind-to-destination-015: binding a text editor with a single tab group succeeds', async () => {
     await closeAllEditors();

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
@@ -144,10 +144,6 @@ suite('Clipboard Preservation — Assisted', () => {
     await settle();
   });
 
-  // ---------------------------------------------------------------------------
-  // TC clipboard-preservation-001
-  // ---------------------------------------------------------------------------
-
   test('[assisted] clipboard-preservation-001: always mode — R-L to terminal restores clipboard', async () => {
     await loadSettingsProfile('default', log);
 
@@ -178,10 +174,6 @@ suite('Clipboard Preservation — Assisted', () => {
     assertTerminalBufferContains(capturing.getCapturedText(), '#L');
     log('✓ Clipboard restored to sentinel after R-L; terminal received link');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC clipboard-preservation-002
-  // ---------------------------------------------------------------------------
 
   test('clipboard-preservation-002: always mode — R-V from terminal restores clipboard', async () => {
     const PHRASE = 'hello world cbp-002';
@@ -219,10 +211,6 @@ suite('Clipboard Preservation — Assisted', () => {
     await assertClipboardRestored('clipboard-preservation-002: always + R-V');
     log('✓ Clipboard restored to sentinel and phrase landed in destination file after R-V');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC clipboard-preservation-004
-  // ---------------------------------------------------------------------------
 
   test('[assisted] clipboard-preservation-004: always mode — AI assistant paste restores clipboard', async () => {
     await loadSettingsProfile('default', log);
@@ -264,10 +252,6 @@ suite('Clipboard Preservation — Assisted', () => {
     log('✓ Clipboard restored to sentinel and link landed in Dummy AI after R-L');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC clipboard-preservation-005
-  // ---------------------------------------------------------------------------
-
   test('[assisted] clipboard-preservation-005: always mode — terminal paste (fresh bind) restores clipboard', async () => {
     await loadSettingsProfile('default', log);
 
@@ -298,10 +282,6 @@ suite('Clipboard Preservation — Assisted', () => {
     assertTerminalBufferContains(capturing.getCapturedText(), '#L');
     log('✓ Clipboard restored to sentinel after terminal paste (preserve=always)');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC clipboard-preservation-007
-  // ---------------------------------------------------------------------------
 
   test('clipboard-preservation-007: never mode — R-V from terminal overwrites clipboard', async () => {
     const PHRASE = 'test phrase cbp-007';
@@ -339,10 +319,6 @@ suite('Clipboard Preservation — Assisted', () => {
     await assertClipboardChanged('clipboard-preservation-007: never + R-V');
     log('✓ Clipboard changed from sentinel and phrase landed in destination file after R-V');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC clipboard-preservation-009
-  // ---------------------------------------------------------------------------
 
   test('[assisted] clipboard-preservation-009: always mode — dismissed picker leaves clipboard unchanged', async () => {
     await loadSettingsProfile('default', log);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
@@ -73,10 +73,6 @@ suite('Context Menus — Editor Content', () => {
     await settle();
   });
 
-  // ---------------------------------------------------------------------------
-  // TC context-menus-editor-content-001: "Send RangeLink"
-  // ---------------------------------------------------------------------------
-
   test('[assisted] context-menus-editor-content-001: Editor content "Send RangeLink" sends workspace-relative link to bound terminal', async () => {
     const uri = await createAndOpenFile('ctxmenu-ed-001', FILE_CONTENT, undefined, tmpFileUris);
     const fn = path.basename(uri.fsPath);
@@ -116,10 +112,6 @@ suite('Context Menus — Editor Content', () => {
     log('✓ Editor-content "Send RangeLink" delivered workspace-relative link to bound terminal');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC context-menus-editor-content-002: "Send RangeLink (Absolute)"
-  // ---------------------------------------------------------------------------
-
   test('[assisted] context-menus-editor-content-002: Editor content "Send RangeLink (Absolute)" sends absolute link to bound terminal', async () => {
     const uri = await createAndOpenFile('ctxmenu-ed-002', FILE_CONTENT, undefined, tmpFileUris);
     const fn = path.basename(uri.fsPath);
@@ -156,10 +148,6 @@ suite('Context Menus — Editor Content', () => {
 
     log('✓ Editor-content "Send RangeLink (Absolute)" delivered absolute link to bound terminal');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC context-menus-editor-content-003: "Send Portable Link"
-  // ---------------------------------------------------------------------------
 
   test('[assisted] context-menus-editor-content-003: Editor content "Send Portable Link" sends portable link with workspace-relative path', async () => {
     const uri = await createAndOpenFile('ctxmenu-ed-003', FILE_CONTENT, undefined, tmpFileUris);
@@ -199,10 +187,6 @@ suite('Context Menus — Editor Content', () => {
     log('✓ Editor-content "Send Portable Link" delivered portable link to bound terminal');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC context-menus-editor-content-004: "Send Portable Link (Absolute)"
-  // ---------------------------------------------------------------------------
-
   test('[assisted] context-menus-editor-content-004: Editor content "Send Portable Link (Absolute)" sends portable link with absolute path', async () => {
     const uri = await createAndOpenFile('ctxmenu-ed-004', FILE_CONTENT, undefined, tmpFileUris);
     const fn = path.basename(uri.fsPath);
@@ -241,10 +225,6 @@ suite('Context Menus — Editor Content', () => {
       '✓ Editor-content "Send Portable Link (Absolute)" delivered portable link with absolute path',
     );
   });
-
-  // ---------------------------------------------------------------------------
-  // TC context-menus-editor-content-005: "Send Selected Text"
-  // ---------------------------------------------------------------------------
 
   test('[assisted] context-menus-editor-content-005: Editor content "Send Selected Text" sends raw selected text to bound terminal', async () => {
     const uri = await createAndOpenFile('ctxmenu-ed-005', FILE_CONTENT, undefined, tmpFileUris);
@@ -293,10 +273,6 @@ suite('Context Menus — Editor Content', () => {
     log('✓ Editor-content "Send Selected Text" delivered raw selected text to bound terminal');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC context-menus-editor-content-006: visual separator in editor content menu
-  // ---------------------------------------------------------------------------
-
   test('[assisted] context-menus-editor-content-006: Visual separator is visible between RangeLink commands and other menu items', async () => {
     const uri = await createAndOpenFile('ctxmenu-ed-006', FILE_CONTENT, undefined, tmpFileUris);
     const fn = path.basename(uri.fsPath);
@@ -320,10 +296,6 @@ suite('Context Menus — Editor Content', () => {
 
     log('✓ Editor-content context menu renders a visual separator for the RangeLink block');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC context-menus-editor-content-007: "Send This File's Path" (absolute)
-  // ---------------------------------------------------------------------------
 
   test('[assisted] context-menus-editor-content-007: Editor content "Send This File\'s Path" sends absolute path to bound terminal', async () => {
     const uri = await createAndOpenFile('ctxmenu-ed-007', FILE_CONTENT, undefined, tmpFileUris);
@@ -360,10 +332,6 @@ suite('Context Menus — Editor Content', () => {
 
     log('✓ Editor-content "Send This File\'s Path" delivered absolute path to bound terminal');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC context-menus-editor-content-008: "Send This File's Relative Path"
-  // ---------------------------------------------------------------------------
 
   test('[assisted] context-menus-editor-content-008: Editor content "Send This File\'s Relative Path" sends workspace-relative path to bound terminal', async () => {
     const uri = await createAndOpenFile('ctxmenu-ed-008', FILE_CONTENT, undefined, tmpFileUris);
@@ -404,10 +372,6 @@ suite('Context Menus — Editor Content', () => {
     );
   });
 
-  // ---------------------------------------------------------------------------
-  // TC context-menus-editor-content-009: "Bind Here" binds current file as text editor
-  // ---------------------------------------------------------------------------
-
   test('[assisted] context-menus-editor-content-009: Editor content "Bind Here" binds the current file as the text editor destination', async () => {
     const uri = await createAndOpenFile('ctxmenu-ed-009', FILE_CONTENT, undefined, tmpFileUris);
     const fn = path.basename(uri.fsPath);
@@ -434,10 +398,6 @@ suite('Context Menus — Editor Content', () => {
 
     log('✓ Editor-content "Bind Here" committed a text-editor binding for the current file');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC context-menus-editor-content-010: Unbind visible when bound + click fires unbind
-  // ---------------------------------------------------------------------------
 
   test('[assisted] context-menus-editor-content-010: Editor content "Unbind" is visible when bound and unbinds on click', async () => {
     const uri = await createAndOpenFile('ctxmenu-ed-010', FILE_CONTENT, undefined, tmpFileUris);
@@ -479,10 +439,6 @@ suite('Context Menus — Editor Content', () => {
 
     log('✓ Editor-content "Unbind" was visible (clicked it) and fired the unbind path');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC context-menus-editor-content-011: selection-dependent items hidden when no selection
-  // ---------------------------------------------------------------------------
 
   test('[assisted] context-menus-editor-content-011: Selection-dependent RangeLink items are hidden when no text is selected', async () => {
     const uri = await createAndOpenFile('ctxmenu-ed-011', FILE_CONTENT, undefined, tmpFileUris);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorTab.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorTab.test.ts
@@ -47,10 +47,6 @@ suite('Context Menus — Editor Tab', () => {
     await settle();
   });
 
-  // ---------------------------------------------------------------------------
-  // TC context-menus-editor-tab-001
-  // ---------------------------------------------------------------------------
-
   test('[assisted] context-menus-editor-tab-001: Editor tab "Send File Path" sends absolute path to bound terminal', async () => {
     const uri = await createAndOpenFile('ctxmenu-tab-001', FILE_CONTENT, undefined, tmpFileUris);
     const fn = path.basename(uri.fsPath);
@@ -88,10 +84,6 @@ suite('Context Menus — Editor Tab', () => {
       '✓ Editor-tab absolute path landed in bound terminal buffer (pty capture verified content)',
     );
   });
-
-  // ---------------------------------------------------------------------------
-  // TC context-menus-editor-tab-002
-  // ---------------------------------------------------------------------------
 
   test('[assisted] context-menus-editor-tab-002: Editor tab "Send Relative File Path" sends relative path to bound terminal', async () => {
     const uri = await createAndOpenFile('ctxmenu-tab-002', FILE_CONTENT, undefined, tmpFileUris);
@@ -132,10 +124,6 @@ suite('Context Menus — Editor Tab', () => {
     );
   });
 
-  // ---------------------------------------------------------------------------
-  // TC context-menus-editor-tab-003
-  // ---------------------------------------------------------------------------
-
   test('[assisted] context-menus-editor-tab-003: Editor tab "Bind Here" binds that editor as text editor destination', async () => {
     const uri = await createAndOpenFile('ctxmenu-tab-003', FILE_CONTENT, undefined, tmpFileUris);
     const fn = path.basename(uri.fsPath);
@@ -165,10 +153,6 @@ suite('Context Menus — Editor Tab', () => {
 
     log('✓ Editor-tab "Bind Here" committed a text-editor binding with correct displayName');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC context-menus-editor-tab-004
-  // ---------------------------------------------------------------------------
 
   test('[assisted] context-menus-editor-tab-004: Editor tab "Unbind" is visible when bound and unbinds on click', async () => {
     const uri = await createAndOpenFile('ctxmenu-tab-004', FILE_CONTENT, undefined, tmpFileUris);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuExplorer.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuExplorer.test.ts
@@ -50,10 +50,6 @@ suite('Context Menus — Explorer', () => {
     await settle();
   });
 
-  // ---------------------------------------------------------------------------
-  // TC context-menus-explorer-001
-  // ---------------------------------------------------------------------------
-
   test('[assisted] context-menus-explorer-001: Explorer "Send File Path" sends absolute path to bound terminal', async () => {
     const uri = await createAndOpenFile('ctxmenu-exp-001', FILE_CONTENT, undefined, tmpFileUris);
     const fn = path.basename(uri.fsPath);
@@ -89,10 +85,6 @@ suite('Context Menus — Explorer', () => {
 
     log('✓ Absolute path landed in bound terminal buffer (pty capture verified content)');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC context-menus-explorer-002
-  // ---------------------------------------------------------------------------
 
   test('[assisted] context-menus-explorer-002: Explorer "Send Relative File Path" sends relative path to bound terminal', async () => {
     const uri = await createAndOpenFile('ctxmenu-exp-002', FILE_CONTENT, undefined, tmpFileUris);
@@ -131,10 +123,6 @@ suite('Context Menus — Explorer', () => {
     log('✓ Workspace-relative path landed in bound terminal buffer (pty capture verified content)');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC context-menus-explorer-003
-  // ---------------------------------------------------------------------------
-
   test('[assisted] context-menus-explorer-003: Explorer "Bind Here" opens the file and binds it as text editor destination', async () => {
     const uri = await createAndOpenFile('ctxmenu-exp-003', FILE_CONTENT, undefined, tmpFileUris);
     const fn = path.basename(uri.fsPath);
@@ -164,10 +152,6 @@ suite('Context Menus — Explorer', () => {
 
     log('✓ Explorer "Bind Here" committed a text-editor binding with correct displayName');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC context-menus-explorer-004
-  // ---------------------------------------------------------------------------
 
   test('[assisted] context-menus-explorer-004: Explorer "Unbind" is visible when bound and unbinds on click', async () => {
     const uri = await createAndOpenFile('ctxmenu-exp-004', FILE_CONTENT, undefined, tmpFileUris);
@@ -205,10 +189,6 @@ suite('Context Menus — Explorer', () => {
 
     log('✓ Explorer "Unbind" fired the unbind path; context key flipped to false');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC context-menus-explorer-005
-  // ---------------------------------------------------------------------------
 
   test('[assisted] context-menus-explorer-005: Explorer "Unbind" is hidden when no destination is bound', async () => {
     const uri = await createAndOpenFile('ctxmenu-exp-005', FILE_CONTENT, undefined, tmpFileUris);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
@@ -9,6 +9,7 @@ import {
   CMD_UNBIND_DESTINATION,
 } from '../../constants/commandIds';
 import {
+  TERMINAL_READY_MS,
   activateExtension,
   assertSetContextLogged,
   assertStatusBarMsgLogged,
@@ -24,7 +25,6 @@ import {
   getLogCapture,
   printAssistedBanner,
   settle,
-  TERMINAL_READY_MS,
   waitForHuman,
   waitForHumanVerdict,
 } from '../helpers';
@@ -52,10 +52,6 @@ suite('Context Menus — Terminal', () => {
     tmpFileUris.length = 0;
     await settle();
   });
-
-  // ---------------------------------------------------------------------------
-  // TC context-menus-terminal-001
-  // ---------------------------------------------------------------------------
 
   test('[assisted] context-menus-terminal-001: Terminal tab "Bind Here" binds that terminal', async () => {
     const terminalName = 'rl-ctxmenu-term-001';
@@ -85,10 +81,6 @@ suite('Context Menus — Terminal', () => {
     log('✓ Terminal-tab context menu bound the terminal destination');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC context-menus-terminal-002
-  // ---------------------------------------------------------------------------
-
   test('[assisted] context-menus-terminal-002: Terminal content-area "Bind Here" binds that terminal', async () => {
     const terminalName = 'rl-ctxmenu-term-002';
     await createTerminal(terminalName, terminals);
@@ -116,10 +108,6 @@ suite('Context Menus — Terminal', () => {
 
     log('✓ Terminal content-area context menu bound the terminal destination');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC context-menus-terminal-003
-  // ---------------------------------------------------------------------------
 
   test('[assisted] context-menus-terminal-003: Terminal content-area "Unbind" is visible when bound and unbinds on click', async () => {
     const terminalName = 'rl-ctxmenu-term-003';
@@ -151,10 +139,6 @@ suite('Context Menus — Terminal', () => {
 
     log('✓ Terminal content-area "Unbind" was visible (clicked it) and fired the unbind path');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC context-menus-terminal-004
-  // ---------------------------------------------------------------------------
 
   test('[assisted] context-menus-terminal-004: Right-clicking a specific terminal TAB binds THAT terminal (multi-terminal disambiguation)', async () => {
     const targetName = 'rl-ctxmenu-term-004-TARGET';
@@ -197,10 +181,6 @@ suite('Context Menus — Terminal', () => {
 
     log('✓ Right-clicked TAB bound the target terminal directly (picker bypassed)');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC context-menus-terminal-005
-  // ---------------------------------------------------------------------------
 
   test('[assisted] context-menus-terminal-005: Right-clicking a specific terminal CONTENT AREA binds THAT terminal (multi-terminal disambiguation)', async () => {
     const targetName = 'rl-ctxmenu-term-005-TARGET';
@@ -362,10 +342,6 @@ suite('Context Menus — Terminal', () => {
       '✓ Cross-terminal send: source selection landed in bound terminal buffer (pty-captured) with focus shift',
     );
   });
-
-  // ---------------------------------------------------------------------------
-  // TC send-terminal-selection-009 (TAB menu does NOT include "Send Selection")
-  // ---------------------------------------------------------------------------
 
   test('[assisted] send-terminal-selection-009: "Send Selection to Destination" is NOT in the terminal TAB menu', async () => {
     const terminalName = 'rl-sts-009';

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
@@ -1,22 +1,43 @@
 import assert from 'node:assert';
+import path from 'node:path';
 
 import * as vscode from 'vscode';
 
-import { CMD_UNBIND_DESTINATION } from '../../constants/commandIds';
+import {
+  CMD_BIND_TO_TEXT_EDITOR_HERE,
+  CMD_COPY_LINK_ONLY_RELATIVE,
+  CMD_TERMINAL_PASTE_SELECTED_TEXT,
+  CMD_UNBIND_DESTINATION,
+} from '../../constants/commandIds';
 import {
   activateExtension,
+  assertClipboardChanged,
+  assertStatusBarMsgLogged,
+  assertTerminalBufferContains,
+  assertToastLogged,
+  type CapturingTerminal,
   cleanupFiles,
   closeAllEditors,
+  createAndBindCapturingTerminal,
   createLogger,
   createWorkspaceFile,
+  extractQuickPickItemsLogged,
+  getLogCapture,
+  openEditor,
   printAssistedBanner,
   settle,
-  waitForHumanVerdict,
+  TERMINAL_READY_MS,
+  waitForHuman,
+  writeClipboardSentinel,
 } from '../helpers';
+
+const NO_TERMINAL_SELECTION_MSG =
+  'RangeLink: No text selected in the terminal. Select text and try again.';
 
 suite('Core Send Commands', () => {
   const log = createLogger('coreSendCommands');
   const tmpFileUris: vscode.Uri[] = [];
+  const tmpTerminals: vscode.Terminal[] = [];
 
   suiteSetup(async () => {
     await activateExtension();
@@ -25,9 +46,334 @@ suite('Core Send Commands', () => {
 
   teardown(async () => {
     await vscode.commands.executeCommand(CMD_UNBIND_DESTINATION);
+    await vscode.commands.executeCommand('dummyAi.clearAll');
+    for (const t of tmpTerminals.splice(0)) t.dispose();
     await closeAllEditors();
     cleanupFiles(tmpFileUris);
+    tmpFileUris.splice(0);
     await settle();
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC core-send-commands-r-l-002
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] core-send-commands-r-l-002: R-L sends RangeLink to bound text editor destination', async () => {
+    const srcUri = createWorkspaceFile(
+      'csc-r-l-002-src',
+      'line 1\nline 2\nline 3\nline 4\nline 5\n',
+    );
+    const destUri = createWorkspaceFile('csc-r-l-002-dest', '');
+    tmpFileUris.push(srcUri, destUri);
+
+    const destDoc = await vscode.workspace.openTextDocument(destUri);
+    await vscode.window.showTextDocument(destDoc, vscode.ViewColumn.Two);
+    await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
+    await settle();
+
+    const srcDoc = await vscode.workspace.openTextDocument(srcUri);
+    const srcEditor = await vscode.window.showTextDocument(srcDoc, vscode.ViewColumn.One);
+    srcEditor.selection = new vscode.Selection(
+      new vscode.Position(1, 0),
+      new vscode.Position(3, 0),
+    );
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-r-l-002');
+
+    await waitForHuman(
+      'core-send-commands-r-l-002',
+      'Lines 2-3 selected in "csc-r-l-002-src". "csc-r-l-002-dest" is bound as text editor destination.',
+      ['1. Press Cmd+R Cmd+L'],
+    );
+
+    const updatedDestDoc = await vscode.workspace.openTextDocument(destUri);
+    const destText = updatedDestDoc.getText();
+    assert.ok(
+      destText.includes('#L'),
+      `Expected RangeLink inserted into dest editor, got: ${JSON.stringify(destText)}`,
+    );
+
+    const lines = logCapture.getLinesSince('before-r-l-002');
+    const destBasename = path.basename(destUri.fsPath);
+    assertStatusBarMsgLogged(lines, {
+      message: `✓ RangeLink copied to clipboard & sent to Text Editor ("${destBasename}")`,
+    });
+    log('✓ R-L inserted RangeLink into bound text editor destination');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC core-send-commands-r-l-003
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] core-send-commands-r-l-003: R-L sends RangeLink to bound AI assistant destination', async () => {
+    const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1} content`);
+    const fileUri = createWorkspaceFile('csc-r-l-003', lines.join('\n') + '\n');
+    tmpFileUris.push(fileUri);
+
+    const relPath = vscode.workspace.asRelativePath(fileUri);
+    const expectedLink = `${relPath}#L1-L3`;
+
+    await openEditor(fileUri);
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-r-l-003');
+
+    await waitForHuman(
+      'core-send-commands-r-l-003',
+      `Bind Dummy AI Tier 1 via Cmd+R Cmd+D, select lines 1-3 in ${relPath}, press Cmd+R Cmd+L.`,
+      [
+        '1. Press Cmd+R Cmd+D → select "Dummy AI (Tier 1)"',
+        `2. Click into ${relPath}, select lines 1-3`,
+        '3. Press Cmd+R Cmd+L',
+      ],
+    );
+
+    await settle();
+    const dummyText = (await vscode.commands.executeCommand('dummyAi.getText')) as {
+      tier1: string;
+      tier2: string;
+    };
+    assert.strictEqual(
+      dummyText.tier1.trim(),
+      expectedLink,
+      `Expected Dummy AI tier1="${expectedLink}", got: ${JSON.stringify(dummyText.tier1)}`,
+    );
+
+    assert.ok(
+      logCapture.getLinesSince('before-r-l-003').some((l) => l.includes('sent to')),
+      'Expected "sent to" log line after R-L to AI destination',
+    );
+    log('✓ R-L sent RangeLink to Dummy AI (Tier 1) destination');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC core-send-commands-r-c-001
+  // ---------------------------------------------------------------------------
+
+  test('core-send-commands-r-c-001: R-C copies RangeLink to clipboard and does NOT send to terminal', async () => {
+    const fileUri = createWorkspaceFile('csc-r-c-001', 'line 1\nline 2\nline 3\n');
+    tmpFileUris.push(fileUri);
+
+    const capturing: CapturingTerminal = await createAndBindCapturingTerminal(
+      'csc-r-c-001-dest',
+      tmpTerminals,
+    );
+
+    const editor = await openEditor(fileUri);
+    editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(2, 0));
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-r-c-001');
+
+    await writeClipboardSentinel();
+    await vscode.commands.executeCommand(CMD_COPY_LINK_ONLY_RELATIVE);
+    await settle();
+
+    const clipboard = await assertClipboardChanged('R-C should write link to clipboard');
+    assert.ok(
+      clipboard.includes('#L'),
+      `Expected line-range link in clipboard, got: ${JSON.stringify(clipboard)}`,
+    );
+
+    assert.strictEqual(
+      capturing.getCapturedText(),
+      '',
+      'Terminal should not have received anything from R-C',
+    );
+
+    assertStatusBarMsgLogged(logCapture.getLinesSince('before-r-c-001'), {
+      message: '✓ RangeLink copied to clipboard',
+    });
+    log('✓ R-C wrote link to clipboard; terminal received nothing');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC core-send-commands-r-l-004
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] core-send-commands-r-l-004: Command Palette "Send RangeLink" behaves identically to R-L keybinding', async () => {
+    const fileUri = createWorkspaceFile('csc-r-l-004', 'line 1\nline 2\nline 3\n');
+    tmpFileUris.push(fileUri);
+
+    const capturing: CapturingTerminal = await createAndBindCapturingTerminal(
+      'csc-r-l-004-dest',
+      tmpTerminals,
+    );
+
+    const editor = await openEditor(fileUri);
+    editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(2, 0));
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-r-l-004');
+
+    await waitForHuman(
+      'core-send-commands-r-l-004',
+      '"csc-r-l-004-dest" is bound. Lines 1-2 selected.',
+      ['1. Press Cmd+Shift+P → "RangeLink: Send RangeLink"'],
+    );
+
+    assertTerminalBufferContains(capturing.getCapturedText(), '#L');
+
+    assertStatusBarMsgLogged(logCapture.getLinesSince('before-r-l-004'), {
+      message: '✓ RangeLink copied to clipboard & sent to Terminal ("csc-r-l-004-dest")',
+    });
+    log('✓ Command Palette "Send RangeLink" delivered link to bound terminal destination');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC core-send-commands-r-c-002
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] core-send-commands-r-c-002: Command Palette "Copy RangeLink" behaves identically to R-C keybinding', async () => {
+    const fileUri = createWorkspaceFile('csc-r-c-002', 'line 1\nline 2\nline 3\n');
+    tmpFileUris.push(fileUri);
+
+    const capturing: CapturingTerminal = await createAndBindCapturingTerminal(
+      'csc-r-c-002-dest',
+      tmpTerminals,
+    );
+
+    const editor = await openEditor(fileUri);
+    editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(2, 0));
+    await settle();
+
+    await writeClipboardSentinel();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-r-c-002');
+
+    await waitForHuman(
+      'core-send-commands-r-c-002',
+      '"csc-r-c-002-dest" is bound but should NOT receive anything. Lines 1-2 selected.',
+      ['1. Press Cmd+Shift+P → "RangeLink: Copy RangeLink"'],
+    );
+
+    const clipboard = await assertClipboardChanged('R-C palette should write link to clipboard');
+    assert.ok(
+      clipboard.includes('#L'),
+      `Expected line-range link in clipboard, got: ${JSON.stringify(clipboard)}`,
+    );
+
+    assert.strictEqual(
+      capturing.getCapturedText(),
+      '',
+      'Terminal should not have received anything from "Copy RangeLink"',
+    );
+    assertStatusBarMsgLogged(logCapture.getLinesSince('before-r-c-002'), {
+      message: '✓ RangeLink copied to clipboard',
+    });
+    log('✓ Command Palette "Copy RangeLink" wrote link to clipboard; terminal received nothing');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC send-terminal-selection-001
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] send-terminal-selection-001: Cmd+R Cmd+V with terminal text selected sends to bound destination', async () => {
+    const MARKER = 'rl-sts-001-marker';
+
+    const capturing: CapturingTerminal = await createAndBindCapturingTerminal(
+      'csc-sts-001-dest',
+      tmpTerminals,
+    );
+    await settle();
+
+    const srcTerminal = vscode.window.createTerminal({ name: 'csc-sts-001-src' });
+    srcTerminal.show(true);
+    tmpTerminals.push(srcTerminal);
+    await settle(TERMINAL_READY_MS);
+
+    srcTerminal.sendText(`echo "${MARKER}"`, true);
+    await settle(TERMINAL_READY_MS);
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-sts-001');
+
+    await waitForHuman(
+      'send-terminal-selection-001',
+      `In "csc-sts-001-src", select "${MARKER}" and press Cmd+R Cmd+V.`,
+      [`1. Click into "csc-sts-001-src", drag-select "${MARKER}"`, '2. Press Cmd+R Cmd+V'],
+    );
+
+    assertTerminalBufferContains(capturing.getCapturedText(), MARKER);
+
+    assertStatusBarMsgLogged(logCapture.getLinesSince('before-sts-001'), {
+      message: '✓ Selected text copied to clipboard & sent to Terminal ("csc-sts-001-dest")',
+    });
+    log('✓ R-V sent selected terminal text to bound destination');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC send-terminal-selection-003
+  // ---------------------------------------------------------------------------
+
+  test('send-terminal-selection-003: R-V with no text selected in terminal shows error message', async () => {
+    const terminal = vscode.window.createTerminal({ name: 'csc-sts-003' });
+    terminal.show(true);
+    tmpTerminals.push(terminal);
+    await settle(TERMINAL_READY_MS);
+
+    // On macOS, terminal.copySelection leaves the clipboard unchanged when nothing
+    // is selected — so we prime the clipboard to empty so the preserve/read roundtrip
+    // returns "" and triggers the no-text-selected error path.
+    await vscode.env.clipboard.writeText('');
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-sts-003');
+
+    await vscode.commands.executeCommand(CMD_TERMINAL_PASTE_SELECTED_TEXT);
+    await settle();
+
+    assertToastLogged(logCapture.getLinesSince('before-sts-003'), {
+      type: 'error',
+      message: NO_TERMINAL_SELECTION_MSG,
+    });
+    log('✓ R-V with no selection shows "no text selected" error toast');
+  });
+
+  // ---------------------------------------------------------------------------
+  // TC send-terminal-selection-004
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] send-terminal-selection-004: R-V with no bound destination opens destination picker', async () => {
+    const MARKER = 'rl-sts-004-marker';
+
+    await vscode.commands.executeCommand(CMD_UNBIND_DESTINATION);
+    await settle();
+
+    const srcTerminal = vscode.window.createTerminal({ name: 'csc-sts-004-src' });
+    srcTerminal.show(true);
+    tmpTerminals.push(srcTerminal);
+    await settle(TERMINAL_READY_MS);
+
+    srcTerminal.sendText(`echo "${MARKER}"`, true);
+    await settle(TERMINAL_READY_MS);
+
+    const logCapture004 = getLogCapture();
+    logCapture004.mark('before-sts-004');
+
+    await waitForHuman(
+      'send-terminal-selection-004',
+      `No destination bound. In "csc-sts-004-src", select "${MARKER}" and press Cmd+R Cmd+V.`,
+      [
+        `1. Click into "csc-sts-004-src", drag-select "${MARKER}"`,
+        '2. Press Cmd+R Cmd+V — the RangeLink destination picker opens',
+        '3. Press Escape to dismiss the picker, then click Cancel',
+      ],
+    );
+
+    const items004 = extractQuickPickItemsLogged(logCapture004.getLinesSince('before-sts-004'));
+    assert.ok(
+      items004 !== undefined,
+      'Expected destination picker to open (no showQuickPick log entry found)',
+    );
+    assert.ok(items004.length > 0, 'Expected destination picker to contain at least one item');
+    log('✓ R-V with no bound destination opens picker (log-based)');
   });
 
   // ---------------------------------------------------------------------------
@@ -42,21 +388,25 @@ suite('Core Send Commands', () => {
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 4));
     await settle();
 
-    const verdict = await waitForHumanVerdict(
+    const logCaptureRl005 = getLogCapture();
+    logCaptureRl005.mark('before-r-l-005');
+
+    await waitForHuman(
       'core-send-commands-r-l-005',
-      'No destination is bound. Press Cmd+R Cmd+L — verify destination picker opens (not silent clipboard fallback). Escape to dismiss.',
+      'No destination bound. "test" is already selected.',
       [
-        '1. Text "test" is already selected',
-        '2. Confirm no destination is bound',
-        '3. Press Cmd+R Cmd+L',
-        '4. Verify destination picker appears (NOT a clipboard copy with no UI)',
-        '5. Press Escape to dismiss',
-        '   Click Pass if picker appeared, Fail if link was silently copied without a picker',
+        'Press Cmd+R Cmd+L — the RangeLink destination picker opens',
+        'Press Escape to dismiss the picker, then click Cancel',
       ],
     );
 
-    assert.strictEqual(verdict, 'pass', 'R-L with no destination did not open picker');
-    log('✓ R-L with no destination opens picker (human verdict)');
+    const itemsRl005 = extractQuickPickItemsLogged(logCaptureRl005.getLinesSince('before-r-l-005'));
+    assert.ok(
+      itemsRl005 !== undefined,
+      'Expected destination picker to open (no showQuickPick log entry found)',
+    );
+    assert.ok(itemsRl005.length > 0, 'Expected destination picker to contain at least one item');
+    log('✓ R-L with no destination opens picker (log-based)');
   });
 
   // ---------------------------------------------------------------------------
@@ -71,25 +421,25 @@ suite('Core Send Commands', () => {
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 4));
     await settle();
 
-    const verdict = await waitForHumanVerdict(
+    const logCaptureRp001 = getLogCapture();
+    logCaptureRp001.mark('before-r-p-001');
+
+    await waitForHuman(
       'core-send-commands-r-p-001',
-      'No destination is bound. From Command Palette, run "Send Portable Link" — verify destination picker opens. Escape.',
+      'No destination bound. "test" is already selected.',
       [
-        '1. Text "test" is already selected',
-        '2. Confirm no destination is bound',
-        '3. Press Cmd+Shift+P → type "Send Portable Link" → select "RangeLink: Send Portable Link"',
-        '4. Verify destination picker appears',
-        '5. Press Escape to dismiss',
-        '   Click Pass if picker appeared, Fail if link was silently copied without a picker',
+        'Press Cmd+Shift+P → "RangeLink: Send Portable Link" — the RangeLink destination picker opens',
+        'Press Escape to dismiss the picker, then click Cancel',
       ],
     );
 
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'Send Portable Link with no destination did not open picker',
+    const itemsRp001 = extractQuickPickItemsLogged(logCaptureRp001.getLinesSince('before-r-p-001'));
+    assert.ok(
+      itemsRp001 !== undefined,
+      'Expected destination picker to open (no showQuickPick log entry found)',
     );
-    log('✓ Send Portable Link with no destination opens picker (human verdict)');
+    assert.ok(itemsRp001.length > 0, 'Expected destination picker to contain at least one item');
+    log('✓ Send Portable Link with no destination opens picker (log-based)');
   });
 
   // ---------------------------------------------------------------------------
@@ -104,24 +454,24 @@ suite('Core Send Commands', () => {
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 4));
     await settle();
 
-    const verdict = await waitForHumanVerdict(
+    const logCaptureRv001 = getLogCapture();
+    logCaptureRv001.mark('before-r-v-001');
+
+    await waitForHuman(
       'core-send-commands-r-v-001',
-      'No destination is bound. From Command Palette, run "Send Selected Text" — verify destination picker opens. Escape.',
+      'No destination bound. "test" is already selected.',
       [
-        '1. Text "test" is already selected',
-        '2. Confirm no destination is bound',
-        '3. Press Cmd+Shift+P → type "Send Selected Text" → select "RangeLink: Send Selected Text"',
-        '4. Verify destination picker appears',
-        '5. Press Escape to dismiss',
-        '   Click Pass if picker appeared, Fail if text was silently copied without a picker',
+        'Press Cmd+Shift+P → "RangeLink: Send Selected Text" — the RangeLink destination picker opens',
+        'Press Escape to dismiss the picker, then click Cancel',
       ],
     );
 
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'Send Selected Text with no destination did not open picker',
+    const itemsRv001 = extractQuickPickItemsLogged(logCaptureRv001.getLinesSince('before-r-v-001'));
+    assert.ok(
+      itemsRv001 !== undefined,
+      'Expected destination picker to open (no showQuickPick log entry found)',
     );
-    log('✓ Send Selected Text with no destination opens picker (human verdict)');
+    assert.ok(itemsRv001.length > 0, 'Expected destination picker to contain at least one item');
+    log('✓ Send Selected Text with no destination opens picker (log-based)');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
@@ -54,10 +54,6 @@ suite('Core Send Commands', () => {
     await settle();
   });
 
-  // ---------------------------------------------------------------------------
-  // TC core-send-commands-r-l-002
-  // ---------------------------------------------------------------------------
-
   test('[assisted] core-send-commands-r-l-002: R-L sends RangeLink to bound text editor destination', async () => {
     const srcUri = createWorkspaceFile(
       'csc-r-l-002-src',
@@ -103,10 +99,6 @@ suite('Core Send Commands', () => {
     log('✓ R-L inserted RangeLink into bound text editor destination');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC core-send-commands-r-l-003
-  // ---------------------------------------------------------------------------
-
   test('[assisted] core-send-commands-r-l-003: R-L sends RangeLink to bound AI assistant destination', async () => {
     const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1} content`);
     const fileUri = createWorkspaceFile('csc-r-l-003', lines.join('\n') + '\n');
@@ -149,10 +141,6 @@ suite('Core Send Commands', () => {
     log('✓ R-L sent RangeLink to Dummy AI (Tier 1) destination');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC core-send-commands-r-c-001
-  // ---------------------------------------------------------------------------
-
   test('core-send-commands-r-c-001: R-C copies RangeLink to clipboard and does NOT send to terminal', async () => {
     const fileUri = createWorkspaceFile('csc-r-c-001', 'line 1\nline 2\nline 3\n');
     tmpFileUris.push(fileUri);
@@ -191,10 +179,6 @@ suite('Core Send Commands', () => {
     log('✓ R-C wrote link to clipboard; terminal received nothing');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC core-send-commands-r-l-004
-  // ---------------------------------------------------------------------------
-
   test('[assisted] core-send-commands-r-l-004: Command Palette "Send RangeLink" behaves identically to R-L keybinding', async () => {
     const fileUri = createWorkspaceFile('csc-r-l-004', 'line 1\nline 2\nline 3\n');
     tmpFileUris.push(fileUri);
@@ -224,10 +208,6 @@ suite('Core Send Commands', () => {
     });
     log('✓ Command Palette "Send RangeLink" delivered link to bound terminal destination');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC core-send-commands-r-c-002
-  // ---------------------------------------------------------------------------
 
   test('[assisted] core-send-commands-r-c-002: Command Palette "Copy RangeLink" behaves identically to R-C keybinding', async () => {
     const fileUri = createWorkspaceFile('csc-r-c-002', 'line 1\nline 2\nline 3\n');
@@ -270,10 +250,6 @@ suite('Core Send Commands', () => {
     log('✓ Command Palette "Copy RangeLink" wrote link to clipboard; terminal received nothing');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC send-terminal-selection-001
-  // ---------------------------------------------------------------------------
-
   test('[assisted] send-terminal-selection-001: Cmd+R Cmd+V with terminal text selected sends to bound destination', async () => {
     const MARKER = 'rl-sts-001-marker';
 
@@ -308,10 +284,6 @@ suite('Core Send Commands', () => {
     log('✓ R-V sent selected terminal text to bound destination');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC send-terminal-selection-003
-  // ---------------------------------------------------------------------------
-
   test('send-terminal-selection-003: R-V with no text selected in terminal shows error message', async () => {
     const terminal = vscode.window.createTerminal({ name: 'csc-sts-003' });
     terminal.show(true);
@@ -335,10 +307,6 @@ suite('Core Send Commands', () => {
     });
     log('✓ R-V with no selection shows "no text selected" error toast');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC send-terminal-selection-004
-  // ---------------------------------------------------------------------------
 
   test('[assisted] send-terminal-selection-004: R-V with no bound destination opens destination picker', async () => {
     const MARKER = 'rl-sts-004-marker';
@@ -376,10 +344,6 @@ suite('Core Send Commands', () => {
     log('✓ R-V with no bound destination opens picker (log-based)');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC core-send-commands-r-l-005
-  // ---------------------------------------------------------------------------
-
   test('[assisted] core-send-commands-r-l-005: R-L with no bound destination opens picker', async () => {
     const fileUri = createWorkspaceFile('csc-r-l-005', 'test content\n');
     tmpFileUris.push(fileUri);
@@ -409,10 +373,6 @@ suite('Core Send Commands', () => {
     log('✓ R-L with no destination opens picker (log-based)');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC core-send-commands-r-p-001
-  // ---------------------------------------------------------------------------
-
   test('[assisted] core-send-commands-r-p-001: Send Portable Link with no bound destination opens picker', async () => {
     const fileUri = createWorkspaceFile('csc-r-p-001', 'test content\n');
     tmpFileUris.push(fileUri);
@@ -441,10 +401,6 @@ suite('Core Send Commands', () => {
     assert.ok(itemsRp001.length > 0, 'Expected destination picker to contain at least one item');
     log('✓ Send Portable Link with no destination opens picker (log-based)');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC core-send-commands-r-v-001
-  // ---------------------------------------------------------------------------
 
   test('[assisted] core-send-commands-r-v-001: Send Selected Text with no bound destination opens picker', async () => {
     const fileUri = createWorkspaceFile('csc-r-v-001', 'test content\n');

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/editorBindingValidation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/editorBindingValidation.test.ts
@@ -37,10 +37,6 @@ suite('Editor Binding Validation', () => {
     await settle();
   });
 
-  // ---------------------------------------------------------------------------
-  // TC editor-binding-validation-001
-  // ---------------------------------------------------------------------------
-
   test('[assisted] editor-binding-validation-001: search editor content hides link and bind commands', async () => {
     const verdict = await waitForHumanVerdict(
       'editor-binding-validation-001',
@@ -61,10 +57,6 @@ suite('Editor Binding Validation', () => {
     );
     log('✓ Search editor content hides link/bind commands (human verdict)');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC editor-binding-validation-002
-  // ---------------------------------------------------------------------------
 
   test('[assisted] editor-binding-validation-002: output panel hides file path and bind commands', async () => {
     const verdict = await waitForHumanVerdict(
@@ -88,10 +80,6 @@ suite('Editor Binding Validation', () => {
     log('✓ Output panel hides file path/bind commands (human verdict)');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC editor-binding-validation-003
-  // ---------------------------------------------------------------------------
-
   test('[assisted] editor-binding-validation-003: Settings UI hides file path and bind commands', async () => {
     const verdict = await waitForHumanVerdict(
       'editor-binding-validation-003',
@@ -111,10 +99,6 @@ suite('Editor Binding Validation', () => {
     assert.strictEqual(verdict, 'pass', 'File path or bind commands appeared for the Settings UI');
     log('✓ Settings UI hides file path/bind commands (human verdict)');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC editor-binding-validation-004
-  // ---------------------------------------------------------------------------
 
   test('[assisted] editor-binding-validation-004: binary .png file is excluded from R-D destination picker', async () => {
     // Minimal PNG magic bytes — enough for VSCode to detect as binary
@@ -174,10 +158,6 @@ suite('Editor Binding Validation', () => {
 
     log('✓ Binary .png excluded from R-D picker; .txt control file present (log verified)');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC editor-binding-validation-005
-  // ---------------------------------------------------------------------------
 
   test('[assisted] editor-binding-validation-005: search editor TAB hides file path commands', async () => {
     const verdict = await waitForHumanVerdict(

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/goToRangeLink.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/goToRangeLink.test.ts
@@ -54,10 +54,6 @@ suite('R-G Go to Link', () => {
     await settle();
   });
 
-  // ---------------------------------------------------------------------------
-  // TC go-to-link-001
-  // ---------------------------------------------------------------------------
-
   test('[assisted] go-to-link-001: Cmd+R Cmd+G opens the Go to Link input box', async () => {
     const logCapture = getLogCapture();
     logCapture.mark('before-gtl-001');
@@ -71,10 +67,6 @@ suite('R-G Go to Link', () => {
 
     log('✓ Input box opened with correct prompt/placeholder; cancellation logged');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC go-to-link-003
-  // ---------------------------------------------------------------------------
 
   test('[assisted] go-to-link-003: valid link navigates to file and selects the range', async () => {
     const uri = await createAndOpenFile(
@@ -126,10 +118,6 @@ suite('R-G Go to Link', () => {
     log('✓ Navigation toast logged; editor selection spans lines 3-7 of the target file');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC go-to-link-004
-  // ---------------------------------------------------------------------------
-
   test('[assisted] go-to-link-004: character-level precision link selects the exact column range', async () => {
     const uri = await createAndOpenFile(
       'gtl-004',
@@ -179,10 +167,6 @@ suite('R-G Go to Link', () => {
     log('✓ Character-precision navigation logged; selection spans col 5 to col 20 on line 3');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC go-to-link-005
-  // ---------------------------------------------------------------------------
-
   test('[assisted] go-to-link-005: invalid link format shows error toast', async () => {
     const invalidInput = 'not-a-valid-link-format';
     const uriBefore = vscode.window.activeTextEditor?.document.uri.toString();
@@ -222,10 +206,6 @@ suite('R-G Go to Link', () => {
     log('✓ Invalid input produced error toast with exact message; no navigation occurred');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC go-to-link-006
-  // ---------------------------------------------------------------------------
-
   test('[assisted] go-to-link-006: empty input shows error toast', async () => {
     const uriBefore = vscode.window.activeTextEditor?.document.uri.toString();
 
@@ -264,10 +244,6 @@ suite('R-G Go to Link', () => {
     log('✓ Empty input produced the empty-input error toast; no parse attempted');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC go-to-link-007
-  // ---------------------------------------------------------------------------
-
   test('[assisted] go-to-link-007: nonexistent file path shows warning toast', async () => {
     const missingPath = 'src/nonexistent/file.ts';
     const linkText = `${missingPath}#L1`;
@@ -299,10 +275,6 @@ suite('R-G Go to Link', () => {
     log('✓ Nonexistent file produced the file-not-found warning toast with exact path');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC go-to-link-008
-  // ---------------------------------------------------------------------------
-
   test('[assisted] go-to-link-008: Command Palette "RangeLink: Go to Link" opens the same input box', async () => {
     const logCapture = getLogCapture();
     logCapture.mark('before-gtl-008');
@@ -325,10 +297,6 @@ suite('R-G Go to Link', () => {
 
     log('✓ Command Palette entry opened the same Go to Link input box');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC go-to-link-009
-  // ---------------------------------------------------------------------------
 
   test('[assisted] go-to-link-009: R-M menu "Go to Link" item opens the same input box', async () => {
     const logCapture = getLogCapture();

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/sendFilePath.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/sendFilePath.test.ts
@@ -55,10 +55,6 @@ suite('Send File Path', () => {
     await settle();
   });
 
-  // ---------------------------------------------------------------------------
-  // TC send-file-path-001
-  // ---------------------------------------------------------------------------
-
   test('send-file-path-001: R-F sends workspace-relative path to bound terminal', async () => {
     const capturing = await createAndBindCapturingTerminal('sfp-test');
     tmpTerminals.push(capturing.terminal);
@@ -88,10 +84,6 @@ suite('Send File Path', () => {
     });
     log('✓ R-F sends workspace-relative path to terminal');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC send-file-path-002
-  // ---------------------------------------------------------------------------
 
   test('[assisted] send-file-path-002: Cmd+R Cmd+Shift+F sends absolute path to bound terminal', async () => {
     const capturing = await createAndBindCapturingTerminal('sfp-test');
@@ -128,10 +120,6 @@ suite('Send File Path', () => {
     assertTerminalBufferContains(capturing.getCapturedText(), absolutePath);
     log('✓ Cmd+R Cmd+Shift+F sends absolute path to terminal');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC send-file-path-004
-  // ---------------------------------------------------------------------------
 
   test('[assisted] send-file-path-004: terminal destination — path with spaces is auto-quoted in single quotes', async () => {
     const capturing = await createAndBindCapturingTerminal('sfp-test');
@@ -170,10 +158,6 @@ suite('Send File Path', () => {
     log('✓ Path with spaces auto-quoted for terminal destination');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC send-file-path-005
-  // ---------------------------------------------------------------------------
-
   test('[assisted] send-file-path-005: terminal destination — path with parentheses is auto-quoted in single quotes', async () => {
     const capturing = await createAndBindCapturingTerminal('sfp-test');
     tmpTerminals.push(capturing.terminal);
@@ -210,10 +194,6 @@ suite('Send File Path', () => {
     assertTerminalBufferContains(capturing.getCapturedText(), `'${relativePath}'`);
     log('✓ Path with parentheses auto-quoted for terminal destination');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC send-file-path-006
-  // ---------------------------------------------------------------------------
 
   test('send-file-path-006: text editor destination — path with spaces is auto-quoted', async () => {
     const ANCHOR_START = 'ANCHOR_START';
@@ -263,10 +243,6 @@ suite('Send File Path', () => {
     log('✓ Text editor destination receives auto-quoted path (spaces → single quotes)');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC send-file-path-007
-  // ---------------------------------------------------------------------------
-
   test('send-file-path-007: clipboard write uses unquoted path even when terminal receives quoted version', async () => {
     await vscode.workspace
       .getConfiguration('rangelink')
@@ -311,10 +287,6 @@ suite('Send File Path', () => {
     log('✓ Log shows path was quoted for terminal; terminal and clipboard both contain the path');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC send-file-path-008
-  // ---------------------------------------------------------------------------
-
   test('send-file-path-008: self-paste shows info notification and copies path to clipboard without modifying file', async () => {
     await vscode.workspace
       .getConfiguration('rangelink')
@@ -350,10 +322,6 @@ suite('Send File Path', () => {
     assert.ok(!doc.isDirty, 'Expected file to remain unmodified after self-paste');
     log('✓ Self-paste: info notification shown, path on clipboard, file unchanged');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC send-file-path-009
-  // ---------------------------------------------------------------------------
 
   test('[assisted] send-file-path-009: unbound — R-F opens destination picker before sending', async () => {
     const capturing = await createCapturingTerminal('sfp-picker-test');
@@ -394,10 +362,6 @@ suite('Send File Path', () => {
     log('✓ Unbound R-F opens picker; path sent after selection');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC send-file-path-010
-  // ---------------------------------------------------------------------------
-
   test('[assisted] send-file-path-010: Command Palette "Send Current File Path" sends workspace-relative path', async () => {
     const capturing = await createAndBindCapturingTerminal('sfp-test');
     tmpTerminals.push(capturing.terminal);
@@ -435,10 +399,6 @@ suite('Send File Path', () => {
     log('✓ Command Palette "Send Current File Path" sends workspace-relative path');
   });
 
-  // ---------------------------------------------------------------------------
-  // TC send-file-path-011
-  // ---------------------------------------------------------------------------
-
   test('[assisted] send-file-path-011: Command Palette "Send Current File Path (Absolute)" sends absolute path', async () => {
     const capturing = await createAndBindCapturingTerminal('sfp-test');
     tmpTerminals.push(capturing.terminal);
@@ -475,10 +435,6 @@ suite('Send File Path', () => {
     assertTerminalBufferContains(capturing.getCapturedText(), absolutePath);
     log('✓ Command Palette "Send Current File Path (Absolute)" sends absolute path');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC send-file-path-012
-  // ---------------------------------------------------------------------------
 
   test('[assisted] send-file-path-012: bound text editor hidden behind another tab — paste still lands in bound editor', async () => {
     const ANCHOR_START = 'ANCHOR_START';

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/textEditorDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/textEditorDestination.test.ts
@@ -32,10 +32,6 @@ suite('Text Editor Destination', () => {
     await settle();
   });
 
-  // ---------------------------------------------------------------------------
-  // TC text-editor-destination-001
-  // ---------------------------------------------------------------------------
-
   test('[assisted] text-editor-destination-001: self-paste R-L copies to clipboard and shows info message', async () => {
     const fileUri = createWorkspaceFile('ted-001', 'self-paste test\n');
     tmpFileUris.push(fileUri);
@@ -74,10 +70,6 @@ suite('Text Editor Destination', () => {
 
     log('✓ Self-paste R-L: info toast shown, file unchanged (log verified)');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC hidden-tab-paste-001
-  // ---------------------------------------------------------------------------
 
   test('[assisted] hidden-tab-paste-001: R-L with bound editor hidden behind another tab — paste still lands in bound editor', async () => {
     const ANCHOR_START = 'ANCHOR_START';
@@ -145,10 +137,6 @@ suite('Text Editor Destination', () => {
 
     log('✓ Bound editor brought to foreground and received RangeLink');
   });
-
-  // ---------------------------------------------------------------------------
-  // TC hidden-tab-paste-002
-  // ---------------------------------------------------------------------------
 
   test('[assisted] hidden-tab-paste-002: R-V with bound editor hidden behind another tab — paste still lands in bound editor', async () => {
     const ANCHOR_START = 'ANCHOR_START';


### PR DESCRIPTION
## Summary

Converts 8 `automated: false` QA test cases to `automated: assisted` or `automated: true` integration tests, continuing the Phase 2 sweep. Covers the Core Send Commands feature area (R-L to text-editor/AI/palette, R-C clipboard-only/palette) and three R-V Send Terminal Selection cases (happy path, no-selection error, unbound picker). QA counts advance to 76 automated / 133 assisted / 20 false.

## Changes

- **Block 8 — Core Send Commands + R-V Terminal Selection** (`coreSendCommands.test.ts`): 8 new tests covering TCs r-l-002, r-l-003, r-c-001, r-l-004, r-c-002, send-terminal-selection-001, 003, 004. Two tests are fully automated (r-c-001 and send-terminal-selection-003); the remaining six are `[assisted]`.
- **QA YAML** (`qa-test-cases-v1.1.0-003.yaml`): 8 TCs updated from `automated: false` to `automated: assisted` or `automated: true` (status-only update, permitted by QA002 exception).
- Got rid of all banner comments in integration tests

## Test Plan

- [ ] All 1862 unit tests pass (`pnpm test`)
- [ ] QA validator passes: 76 automated, 133 assisted, 20 false
- [ ] Block 8 drive passes: `pnpm test:release:grep "core-send-commands|send-terminal-selection-(001|003|004)"`
- [ ] r-c-001 and send-terminal-selection-003 pass unattended (fully automated)

Part of https://github.com/couimet/rangeLink/issues/509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integration test coverage for core send/copy commands, including text-editor, AI assistant, clipboard, and terminal destinations.
  * Updated test case automation classifications in QA suite.

* **Chores**
  * Removed internal test case comment headers across multiple test suites for code cleanliness.
  * Refactored test imports for improved module organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->