### PR TITLE
[issues/509] Block 9 — Text Editor Destination Edge Cases (5 TCs, all automated)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ packages/*/icon_large.png
 
 # Temp files created by integration test suites (cleaned up on normal exit; guard for CI kills)
 packages/rangelink-vscode-extension/__rl-test-*.ts
+packages/rangelink-vscode-extension/__rl-test-*.txt
 packages/rangelink-vscode-extension/.vscode/
 
 # Generated QA output (not committed)

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
@@ -1975,7 +1975,7 @@ test_cases:
       - 'Select text in another file'
       - 'Press Cmd+R Cmd+L'
     expected_result: 'The RangeLink is inserted into src/utils/helper.ts in tab group 2. Paste did not fail due to stale tab group reference.'
-    automated: false
+    automated: true
 
   - id: hidden-tab-paste-001
     feature: 'Text Editor Destination — Hidden Tab Paste'
@@ -2399,7 +2399,7 @@ test_cases:
       - 'Drag the src/utils/helper.ts tab to a second tab group (or right-click the tab → Split Right/Down)'
       - 'Observe the notification area immediately after the split'
     expected_result: 'A warning toast appears: "RangeLink: Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed." No paste was attempted — the warning fires on tab change, not on paste.'
-    automated: false
+    automated: true
 
   - id: duplicate-tab-group-002
     feature: 'Text Editor Destination — Multi-Group Guard (No Re-warn)'
@@ -2411,7 +2411,7 @@ test_cases:
       - 'Open src/utils/helper.ts in a third tab group (or trigger another tab change that keeps 2+ instances visible)'
       - 'Observe the notification area'
     expected_result: 'No second warning toast appears. The warning is shown only once per entry into the duplicate state, not on every subsequent tab change while duplicates exist.'
-    automated: false
+    automated: true
 
   - id: duplicate-tab-group-003
     feature: 'Text Editor Destination — Multi-Group Guard (Reactive Paste Error)'
@@ -2423,7 +2423,7 @@ test_cases:
       - 'Select any text in a different file'
       - 'Press Cmd+R Cmd+L (or any bound-destination send command: R-V, R-L, Send File Path)'
     expected_result: 'Paste does not occur. An error toast appears: "RangeLink: Bound editor is open in multiple tab groups. Close the duplicate tab and try again." No text is inserted into either instance of src/utils/helper.ts.'
-    automated: false
+    automated: true
 
   - id: duplicate-tab-group-004
     feature: 'Text Editor Destination — Multi-Group Guard (State Clears on Resolve)'
@@ -2437,7 +2437,7 @@ test_cases:
       - 'Open src/utils/helper.ts again in a second tab group (re-enter the duplicate state)'
       - 'Observe the notification area again'
     expected_result: 'Step 2: No toast appears when the duplicate is closed. Step 4: A fresh warning toast appears — "RangeLink: Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed." — confirming the flag was reset and re-entry into the duplicate state is correctly detected.'
-    automated: false
+    automated: true
 
   # ---------------------------------------------------------------------------
   # Section — Text Editor Destination: Language-Mode Binding Resilience (#472)

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/textEditorDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/textEditorDestination.test.ts
@@ -2,9 +2,14 @@ import assert from 'node:assert';
 
 import * as vscode from 'vscode';
 
-import { CMD_BIND_TO_TEXT_EDITOR_HERE, CMD_UNBIND_DESTINATION } from '../../constants/commandIds';
+import {
+  CMD_BIND_TO_TEXT_EDITOR_HERE,
+  CMD_COPY_LINK_RELATIVE,
+  CMD_UNBIND_DESTINATION,
+} from '../../constants/commandIds';
 import {
   activateExtension,
+  assertNoToastLogged,
   assertToastLogged,
   cleanupFiles,
   closeAllEditors,
@@ -198,5 +203,290 @@ suite('Text Editor Destination', () => {
     );
 
     log('✓ Bound editor brought to foreground and received selected text');
+  });
+
+  const WARN_DUPLICATE_TAB_GROUPS =
+    'RangeLink: Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed.';
+
+  test('duplicate-tab-group-001: warning toast fires when bound file is opened in a second editor group', async () => {
+    const destUri = createWorkspaceFile('dtg-001-dest', 'destination file\n');
+    const triggerUri = createWorkspaceFile('dtg-001-trigger', '');
+    tmpFileUris.push(destUri, triggerUri);
+
+    const destDoc = await vscode.workspace.openTextDocument(destUri);
+    await vscode.window.showTextDocument(destDoc, {
+      viewColumn: vscode.ViewColumn.One,
+      preview: false,
+    });
+    await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
+    await settle();
+
+    // Open same file in col 2 so both instances are visible. onDidChangeTabs fires
+    // during this call but visibleTextEditors may not include col 2 yet.
+    await vscode.window.showTextDocument(destDoc, {
+      viewColumn: vscode.ViewColumn.Two,
+      preview: false,
+    });
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-dtg-001');
+
+    // Open a dummy file in col 3 to force another onDidChangeTabs. At this point
+    // visibleTextEditors already contains both dest instances (col 1 and col 2),
+    // so the listener sees length > 1 and fires the warning.
+    await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(triggerUri), {
+      viewColumn: vscode.ViewColumn.Three,
+      preview: false,
+    });
+    await settle();
+
+    assertToastLogged(logCapture.getLinesSince('before-dtg-001'), {
+      type: 'warning',
+      message: WARN_DUPLICATE_TAB_GROUPS,
+    });
+
+    log('✓ Warning toast fired when bound file open in multiple editor groups');
+  });
+
+  test('duplicate-tab-group-002: warning is not repeated when duplicate state is already active', async () => {
+    const destUri = createWorkspaceFile('dtg-002-dest', 'destination file\n');
+    const trigger1Uri = createWorkspaceFile('dtg-002-trigger1', '');
+    const trigger2Uri = createWorkspaceFile('dtg-002-trigger2', '');
+    tmpFileUris.push(destUri, trigger1Uri, trigger2Uri);
+
+    const destDoc = await vscode.workspace.openTextDocument(destUri);
+    await vscode.window.showTextDocument(destDoc, {
+      viewColumn: vscode.ViewColumn.One,
+      preview: false,
+    });
+    await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
+    await settle();
+
+    await vscode.window.showTextDocument(destDoc, {
+      viewColumn: vscode.ViewColumn.Two,
+      preview: false,
+    });
+    await settle();
+
+    // Open trigger1 in col 3 — fires onDidChangeTabs with both dest instances visible → first warning.
+    await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(trigger1Uri), {
+      viewColumn: vscode.ViewColumn.Three,
+      preview: false,
+    });
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-dtg-002');
+
+    // Open trigger2 while both dest instances remain visible — isInDuplicateTabState is already
+    // true so the listener must NOT fire a second warning.
+    await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(trigger2Uri), {
+      viewColumn: vscode.ViewColumn.Four,
+      preview: false,
+    });
+    await settle();
+
+    assertNoToastLogged(logCapture.getLinesSince('before-dtg-002'), {
+      type: 'warning',
+      message: WARN_DUPLICATE_TAB_GROUPS,
+    });
+
+    log('✓ No second warning fired while already in duplicate tab state');
+  });
+
+  test('duplicate-tab-group-003: paste is blocked with error when bound file is visible in multiple tab groups', async () => {
+    const SOURCE_TEXT = 'dtg-003-source-text';
+    const destUri = createWorkspaceFile('dtg-003-dest', 'ANCHOR\n');
+    const sourceUri = createWorkspaceFile('dtg-003-source', `${SOURCE_TEXT}\n`);
+    tmpFileUris.push(destUri, sourceUri);
+
+    const destDoc = await vscode.workspace.openTextDocument(destUri);
+
+    // Bind dest in col 2.
+    await vscode.window.showTextDocument(destDoc, {
+      viewColumn: vscode.ViewColumn.Two,
+      preview: false,
+    });
+    await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
+    await settle();
+
+    // Open dest in col 3 as well (both instances now visible).
+    await vscode.window.showTextDocument(destDoc, {
+      viewColumn: vscode.ViewColumn.Three,
+      preview: false,
+    });
+    await settle();
+
+    // Focus source in col 1 with selection.
+    const sourceEditor = await vscode.window.showTextDocument(
+      await vscode.workspace.openTextDocument(sourceUri),
+      { viewColumn: vscode.ViewColumn.One, preview: false },
+    );
+    sourceEditor.selection = new vscode.Selection(
+      new vscode.Position(0, 0),
+      new vscode.Position(0, SOURCE_TEXT.length),
+    );
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-dtg-003');
+
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
+    await settle();
+
+    assertToastLogged(logCapture.getLinesSince('before-dtg-003'), {
+      type: 'error',
+      message:
+        'RangeLink: Bound editor is open in multiple tab groups. Close the duplicate tab and try again.',
+    });
+
+    log('✓ Paste blocked with ambiguous-columns error when dest is in multiple tab groups');
+  });
+
+  test('duplicate-tab-group-004: duplicate state clears when conflict resolves and re-entry triggers a fresh warning', async () => {
+    const destUri = createWorkspaceFile('dtg-004-dest', 'destination file\n');
+    const trigger1Uri = createWorkspaceFile('dtg-004-trigger1', '');
+    const trigger2Uri = createWorkspaceFile('dtg-004-trigger2', '');
+    const trigger3Uri = createWorkspaceFile('dtg-004-trigger3', '');
+    tmpFileUris.push(destUri, trigger1Uri, trigger2Uri, trigger3Uri);
+
+    const destDoc = await vscode.workspace.openTextDocument(destUri);
+    await vscode.window.showTextDocument(destDoc, {
+      viewColumn: vscode.ViewColumn.One,
+      preview: false,
+    });
+    await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
+    await settle();
+
+    await vscode.window.showTextDocument(destDoc, {
+      viewColumn: vscode.ViewColumn.Two,
+      preview: false,
+    });
+    await settle();
+
+    // Open trigger1 in col 3 → first warning fires, isInDuplicateTabState becomes true.
+    await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(trigger1Uri), {
+      viewColumn: vscode.ViewColumn.Three,
+      preview: false,
+    });
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-dtg-004-close');
+
+    // Close col 2 dest: focus it first, then close the active editor.
+    await vscode.window.showTextDocument(destDoc, { viewColumn: vscode.ViewColumn.Two });
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+    await settle();
+
+    // Open trigger2 in col 2 to force onDidChangeTabs — visibleTextEditors now has only
+    // one dest instance (col 1), so the listener clears the duplicate state.
+    await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(trigger2Uri), {
+      viewColumn: vscode.ViewColumn.Two,
+      preview: false,
+    });
+    await settle();
+
+    const linesSinceClose = logCapture.getLinesSince('before-dtg-004-close');
+    const stateCleared = linesSinceClose.some((l) =>
+      l.includes('Bound file no longer in multiple editor groups — duplicate state cleared'),
+    );
+    assert.ok(stateCleared, 'Expected state-cleared log after closing the duplicate tab');
+
+    // Re-open dest in col 2 to re-enter duplicate state.
+    await vscode.window.showTextDocument(destDoc, {
+      viewColumn: vscode.ViewColumn.Two,
+      preview: false,
+    });
+    await settle();
+
+    logCapture.mark('before-dtg-004-rewarn');
+
+    // Open trigger3 → onDidChangeTabs fires with both dest instances visible → fresh warning.
+    await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(trigger3Uri), {
+      viewColumn: vscode.ViewColumn.Three,
+      preview: false,
+    });
+    await settle();
+
+    assertToastLogged(logCapture.getLinesSince('before-dtg-004-rewarn'), {
+      type: 'warning',
+      message: WARN_DUPLICATE_TAB_GROUPS,
+    });
+
+    log('✓ Duplicate state cleared on resolve; re-entry triggered a fresh warning');
+  });
+
+  test('stale-viewcolumn-001: paste targets the correct new column after bound editor is moved', async () => {
+    const SOURCE_TEXT = 'stale-vc-001-source-text';
+    const destUri = createWorkspaceFile('svc-001-dest', 'ANCHOR\n');
+    const sourceUri = createWorkspaceFile('svc-001-source', `${SOURCE_TEXT}\n`);
+    const dummyUri = createWorkspaceFile('svc-001-dummy', '');
+    tmpFileUris.push(destUri, sourceUri, dummyUri);
+
+    const destDoc = await vscode.workspace.openTextDocument(destUri);
+    const sourceDoc = await vscode.workspace.openTextDocument(sourceUri);
+
+    // Open dest in col 2, bind (boundViewColumn = 2).
+    const destEditor = await vscode.window.showTextDocument(destDoc, {
+      viewColumn: vscode.ViewColumn.Two,
+      preview: false,
+    });
+    destEditor.selection = new vscode.Selection(
+      new vscode.Position(1, 0),
+      new vscode.Position(1, 0),
+    );
+    await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
+    await settle();
+
+    // Open dest in col 3 — dest is now visible in col 2 AND col 3.
+    await vscode.window.showTextDocument(destDoc, {
+      viewColumn: vscode.ViewColumn.Three,
+      preview: false,
+    });
+    await settle();
+
+    // Open dummy in col 2 (active) — dest in col 2 is now HIDDEN behind dummy.
+    // After this: col 2 shows dummy (visible), dest (hidden). Col 3 shows dest (visible).
+    // findVisibleEditorsByUri(destUri) returns only the col 3 instance (length = 1).
+    // hasVisibleEditorAt(destUri, 2) returns false — triggers the stale-viewColumn path.
+    await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(dummyUri), {
+      viewColumn: vscode.ViewColumn.Two,
+      preview: false,
+    });
+    await settle();
+
+    // Focus source in col 1 with a text selection.
+    const sourceEditor = await vscode.window.showTextDocument(sourceDoc, {
+      viewColumn: vscode.ViewColumn.One,
+      preview: false,
+    });
+    sourceEditor.selection = new vscode.Selection(
+      new vscode.Position(0, 0),
+      new vscode.Position(0, SOURCE_TEXT.length),
+    );
+    await settle();
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-svc-001');
+
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
+    await settle();
+
+    const lines = logCapture.getLinesSince('before-svc-001');
+    const movedLog = lines.some((l) =>
+      l.includes('Editor moved to different viewColumn, following it'),
+    );
+    assert.ok(movedLog, 'Expected "Editor moved to different viewColumn" log but none found');
+
+    const destContent = (await vscode.workspace.openTextDocument(destUri)).getText();
+    const relativeSourcePath = vscode.workspace.asRelativePath(sourceUri);
+    assert.ok(
+      destContent.includes(relativeSourcePath),
+      `Expected RangeLink referencing "${relativeSourcePath}" in dest, got: "${destContent}"`,
+    );
+
+    log('✓ Paste followed bound editor to new view column');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/textEditorDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/textEditorDestination.test.ts
@@ -341,6 +341,13 @@ suite('Text Editor Destination', () => {
         'RangeLink: Bound editor is open in multiple tab groups. Close the duplicate tab and try again.',
     });
 
+    const destContentAfter = (await vscode.workspace.openTextDocument(destUri)).getText();
+    assert.strictEqual(
+      destContentAfter,
+      'ANCHOR\n',
+      `Expected destination to remain unchanged when duplicate-tab guard blocks paste, got: "${destContentAfter}"`,
+    );
+
     log('✓ Paste blocked with ambiguous-columns error when dest is in multiple tab groups');
   });
 


### PR DESCRIPTION
## Summary

Converts the five remaining `automated: false` Text Editor Destination edge-case TCs to fully automated integration tests. All five cover multi-column guard behavior (proactive warning, no-repeat, reactive paste block, state-clear-on-resolve) and stale-viewColumn following — the last scenarios that required manual tab manipulation in the issue comment's original plan.

## Changes

- 5 new integration tests in `textEditorDestination.test.ts`: `duplicate-tab-group-001` through `004` (multi-column guard) and `stale-viewcolumn-001` (paste follows bound editor to its new column)
- QA YAML: `automated: false → true` for all 5 TCs (`stale-viewcolumn-001`, `duplicate-tab-group-001` through `004`)
- Root `.gitignore`: add `__rl-test-*.txt` pattern (stale-viewcolumn tests create `.txt` workspace files; only `.ts` was previously covered)
- Documentation: CHANGELOG not needed — internal test infrastructure only; README not needed

## Key Discoveries

- `onDidChangeTabs` fires before `visibleTextEditors` is updated in the VS Code test host. A "trigger" file opened in a new column forces the listener to re-evaluate once both dest instances are already in `visibleTextEditors`.
- `workbench.action.moveEditorToNextGroup` and `closeActiveEditor` both fire `onDidCloseTextDocument` with `isClosed=true` in the test host, triggering auto-unbind even when the document is still open elsewhere. Avoided by never physically moving or closing the bound document: hide it behind a dummy tab in its original column and open a second copy visibly in another column instead.
- `stale-viewcolumn-001` exploits the distinction between `hasVisibleEditorAt` (checks active tab at a given column) and `findVisibleEditorsByUri` (scans all visible editors). Opening dest in col 2 and col 3, then hiding the col 2 instance behind a dummy, leaves dest exclusively visible in col 3 — satisfying the stale-viewColumn condition without any close/move.

## Test Plan

- [x] All existing tests pass (1862 Jest tests)
- [x] New tests added for: `stale-viewcolumn-001`, `duplicate-tab-group-001` through `004`
- [x] Integration suite: `pnpm test:release:grep "hidden-tab-paste-001|duplicate-tab-group|stale-viewcolumn-001"` — 6 passing (5 automated, 1 assisted)

## Related

- Part of https://github.com/couimet/rangeLink/issues/509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integration test coverage for editor destination scenarios, including validation of duplicate state detection, warning notifications, and paste behavior under various conditions.
  * Enhanced automation of QA test cases to improve testing efficiency.

* **Chores**
  * Updated artifact exclusion patterns to prevent generated test files from being tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->