### PR TITLE
[issues/509] Block 10 — Link Generation, Filename Fallback & Custom AI Picker (6 TCs, 2 automated + 4 assisted)

### DIFF
--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
@@ -1962,7 +1962,7 @@ test_cases:
       - 'Add the text: https://example.com/path/file.ts#L10'
       - 'Hover over it to inspect the link tooltip (if any)'
     expected_result: 'RangeLink does not provide a document link for this text. No RangeLink navigation offered.'
-    automated: false
+    automated: assisted
 
   - id: stale-viewcolumn-001
     feature: 'Text Editor Destination — Stale viewColumn'
@@ -2012,7 +2012,7 @@ test_cases:
       - 'Hover over the link in the editor'
       - 'Observe the tooltip that appears'
     expected_result: 'The tooltip shows clean human-readable text (e.g., file path and line number). It does NOT show raw JSON, a command: URI, or internal command parameters.'
-    automated: false
+    automated: assisted
 
   - id: full-line-selection-validation-001
     feature: 'Link Generation — Full-Line Selection Validation'
@@ -2666,7 +2666,7 @@ test_cases:
     steps:
       - 'Click a RangeLink using only the ambiguous filename (e.g., index.ts#L1)'
     expected_result: 'A warning toast is shown: "RangeLink: Multiple files match: index.ts". No navigation occurs.'
-    automated: false
+    automated: true
 
   - id: filename-fallback-navigation-003
     feature: 'Filename-Only Navigation Fallback'
@@ -2677,7 +2677,7 @@ test_cases:
     steps:
       - 'Click a RangeLink using a nonexistent bare filename (e.g., nonexistent-file.ts#L1)'
     expected_result: 'A warning toast is shown: "RangeLink: Cannot find file: nonexistent-file.ts". No navigation occurs.'
-    automated: false
+    automated: true
 
   - id: filename-fallback-navigation-004
     feature: 'Filename-Only Navigation Fallback'
@@ -2727,7 +2727,7 @@ test_cases:
       - 'Press Cmd+R Cmd+D to open destination picker'
       - 'Observe the picker items'
     expected_result: 'The custom AI assistant appears in the picker with its configured extensionName, after the built-in destinations'
-    automated: false
+    automated: assisted
 
   - id: custom-ai-assistant-004
     feature: 'Custom AI Assistants — Command Detection'
@@ -2771,7 +2771,7 @@ test_cases:
       - 'Press Cmd+R Cmd+D to open destination picker'
       - 'Observe order of custom AI assistants in the picker'
     expected_result: 'Custom AI assistants appear after built-in destinations, in the same order as defined in settings.json'
-    automated: false
+    automated: assisted
 
   - id: custom-ai-assistant-008
     feature: 'Custom AI Assistants — Configuration'

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/customAiAssistants.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/customAiAssistants.test.ts
@@ -11,6 +11,7 @@ import {
   closeAllEditors,
   createAndOpenFile,
   createLogger,
+  extractQuickPickItemsLogged,
   getLogCapture,
   printAssistedBanner,
   settle,
@@ -205,6 +206,86 @@ suite('Custom AI Assistants', () => {
     assert.ok(
       parseLog.includes('rangelink.dummy-ai-extension'),
       `Expected loaded assistant to include rangelink.dummy-ai-extension but got: ${parseLog}`,
+    );
+  });
+});
+
+suite('Custom AI Assistants — Destination Picker (Assisted)', () => {
+  const log = createLogger('customAiPicker');
+
+  suiteSetup(async () => {
+    await activateExtension();
+    printAssistedBanner();
+  });
+
+  test('[assisted] custom-ai-assistant-003: custom AI assistant appears in R-D destination picker with configured display name', async () => {
+    const logCapture = getLogCapture();
+    logCapture.mark('before-003');
+
+    await waitForHuman(
+      'custom-ai-assistant-003',
+      'Open R-D picker (Cmd+R Cmd+D), observe that Dummy AI entries appear, then press Escape',
+      [
+        '1. Press Cmd+R Cmd+D to open the destination picker',
+        '2. Observe the list — confirm "Dummy AI (Tier 1)" appears',
+        '3. Press Escape to close without selecting',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-003');
+    const items = extractQuickPickItemsLogged(lines);
+    assert.ok(items, 'Expected showQuickPick log entry — was the picker opened?');
+
+    const tier1 = items!.find((item) => item.displayName === 'Dummy AI (Tier 1)');
+    assert.ok(tier1, 'Expected "Dummy AI (Tier 1)" in the destination picker items');
+    assert.strictEqual(tier1!.itemKind, 'bindable');
+
+    log('✓ custom-ai-assistant-003 — log confirms "Dummy AI (Tier 1)" appears in R-D picker');
+  });
+
+  test('[assisted] custom-ai-assistant-007: multiple custom AI assistants listed in user-defined order', async () => {
+    const logCapture = getLogCapture();
+    logCapture.mark('before-007');
+
+    await waitForHuman(
+      'custom-ai-assistant-007',
+      'Open R-D picker (Cmd+R Cmd+D), observe Dummy AI order (Tier 1 → Tier 2 → Tier 3 → Template → Fallback), then press Escape',
+      [
+        '1. Press Cmd+R Cmd+D to open the destination picker',
+        '2. Observe custom AI assistants appear in order: Tier 1, Tier 2, Tier 3, Template, Fallback',
+        '3. Press Escape to close without selecting',
+      ],
+    );
+
+    const lines = logCapture.getLinesSince('before-007');
+    const items = extractQuickPickItemsLogged(lines);
+    assert.ok(items, 'Expected showQuickPick log entry — was the picker opened?');
+
+    const EXPECTED_ORDER = [
+      'Dummy AI (Tier 1)',
+      'Dummy AI (Tier 2)',
+      'Dummy AI (Tier 3)',
+      'Dummy AI (Template)',
+      'Dummy AI (Fallback)',
+    ];
+
+    const indices = EXPECTED_ORDER.map((name) =>
+      items!.findIndex((item) => item.displayName === name),
+    );
+
+    for (const [i, name] of EXPECTED_ORDER.entries()) {
+      assert.notStrictEqual(indices[i], -1, `Expected "${name}" in the destination picker items`);
+    }
+
+    for (let i = 0; i < indices.length - 1; i++) {
+      assert.ok(
+        indices[i]! < indices[i + 1]!,
+        `Expected "${EXPECTED_ORDER[i]}" (index ${indices[i]}) before "${EXPECTED_ORDER[i + 1]}" (index ${indices[i + 1]})`,
+      );
+    }
+
+    log(
+      '✓ custom-ai-assistant-007 — log confirms custom AI assistants appear in settings.json order',
     );
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filenameOnlyNavigation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filenameOnlyNavigation.test.ts
@@ -3,7 +3,9 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { parseLink, DEFAULT_DELIMITERS } from 'rangelink-core-ts';
+import * as vscode from 'vscode';
 
+import { CMD_HANDLE_DOCUMENT_LINK_CLICK } from '../../constants/commandIds';
 import {
   activateExtension,
   assertToastLogged,
@@ -12,12 +14,19 @@ import {
   getLogCapture,
   getWorkspaceRoot,
   navigateViaHandleLinkClick,
+  settle,
 } from '../helpers';
+
+const DUPLICATE_FILE_CONTENT = 'duplicate file content\n';
 
 suite('Filename-Only Navigation Fallback', () => {
   let uniqueFilename: string;
   let uniqueFilePath: string;
   let relativeFilePath: string;
+
+  let duplicateFilename: string;
+  let duplicateFilePath1: string;
+  let duplicateFilePath2: string;
 
   suiteSetup(async () => {
     await activateExtension();
@@ -31,6 +40,18 @@ suite('Filename-Only Navigation Fallback', () => {
     fs.writeFileSync(uniqueFilePath, lines.join('\n') + '\n', 'utf8');
 
     relativeFilePath = path.relative(getWorkspaceRoot(), uniqueFilePath);
+
+    // Place duplicate files outside src/ to avoid triggering the TypeScript watcher,
+    // which can block vscode.workspace.findFiles while the TS server re-initializes.
+    duplicateFilename = `__rl-test-dup-${Date.now()}.ts`;
+    const dupDir1 = path.join(getWorkspaceRoot(), '__rl-test-dup-a');
+    const dupDir2 = path.join(getWorkspaceRoot(), '__rl-test-dup-b');
+    fs.mkdirSync(dupDir1, { recursive: true });
+    fs.mkdirSync(dupDir2, { recursive: true });
+    duplicateFilePath1 = path.join(dupDir1, duplicateFilename);
+    duplicateFilePath2 = path.join(dupDir2, duplicateFilename);
+    fs.writeFileSync(duplicateFilePath1, DUPLICATE_FILE_CONTENT, 'utf8');
+    fs.writeFileSync(duplicateFilePath2, DUPLICATE_FILE_CONTENT, 'utf8');
   });
 
   suiteTeardown(async () => {
@@ -39,6 +60,14 @@ suite('Filename-Only Navigation Fallback', () => {
       fs.unlinkSync(uniqueFilePath);
     } catch {
       // best-effort — subdirectory file, not managed by cleanupFiles
+    }
+    for (const p of [duplicateFilePath1, duplicateFilePath2]) {
+      try {
+        fs.unlinkSync(p);
+        fs.rmdirSync(path.dirname(p));
+      } catch {
+        // best-effort
+      }
     }
   });
 
@@ -72,6 +101,54 @@ suite('Filename-Only Navigation Fallback', () => {
     assertToastLogged(lines, {
       type: 'info',
       message: `RangeLink: Navigated to ${uniqueFilename} @ 5`,
+    });
+  });
+
+  test('filename-fallback-navigation-002: bare filename with multiple matches shows ambiguity warning', async () => {
+    const linkText = `${duplicateFilename}#L1`;
+    const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
+    assert.ok(parseResult.success, `Expected parseLink to succeed for: ${linkText}`);
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-fallback-002');
+
+    // VscodeAdapter logs the message before awaiting showWarningMessage. The notification
+    // itself never auto-dismisses in the test host, so we fire-and-forget the command and
+    // settle before asserting — the log is already captured by then.
+    void vscode.commands.executeCommand(CMD_HANDLE_DOCUMENT_LINK_CLICK, {
+      linkText,
+      parsed: parseResult.value,
+    });
+    await settle();
+
+    const lines = logCapture.getLinesSince('before-fallback-002');
+    assertToastLogged(lines, {
+      type: 'warning',
+      message: `RangeLink: Multiple files match: ${duplicateFilename}`,
+    });
+  });
+
+  test('filename-fallback-navigation-003: bare filename with no matches shows file-not-found warning', async () => {
+    const missingFilename = `__rl-nonexistent-${Date.now()}.ts`;
+    const linkText = `${missingFilename}#L1`;
+    const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
+    assert.ok(parseResult.success, `Expected parseLink to succeed for: ${linkText}`);
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-fallback-003');
+
+    // Same fire-and-forget pattern as TC-002 — the warning log is written before
+    // showWarningMessage is awaited, so settle() is sufficient.
+    void vscode.commands.executeCommand(CMD_HANDLE_DOCUMENT_LINK_CLICK, {
+      linkText,
+      parsed: parseResult.value,
+    });
+    await settle();
+
+    const lines = logCapture.getLinesSince('before-fallback-003');
+    assertToastLogged(lines, {
+      type: 'warning',
+      message: `RangeLink: Cannot find file: ${missingFilename}`,
     });
   });
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/linkGeneration.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/linkGeneration.test.ts
@@ -1,15 +1,20 @@
 import assert from 'node:assert';
 
 import { NoOpLogger } from 'barebone-logger';
-import { findLinksInText, DEFAULT_DELIMITERS } from 'rangelink-core-ts';
+import { DEFAULT_DELIMITERS, findLinksInText } from 'rangelink-core-ts';
 import * as vscode from 'vscode';
 
 import {
   activateExtension,
   cleanupFiles,
   closeAllEditors,
+  createAndOpenFile,
+  createLogger,
   createWorkspaceFile,
   openEditor,
+  printAssistedBanner,
+  settle,
+  waitForHumanVerdict,
 } from '../helpers';
 
 const LOGGER = new NoOpLogger();
@@ -156,5 +161,73 @@ suite('Link Generation', () => {
       0,
       `Expected 0 RangeLinks for HTTP URL but got ${links.length}: ${links.map((l) => l.linkText).join(', ')}`,
     );
+  });
+});
+
+suite('Link Generation — Clickable Links (Assisted)', () => {
+  const log = createLogger('linkGenerationAssisted');
+  const tmpFileUris: vscode.Uri[] = [];
+
+  suiteSetup(async () => {
+    await activateExtension();
+    printAssistedBanner();
+  });
+
+  teardown(async () => {
+    await closeAllEditors();
+    cleanupFiles(tmpFileUris);
+    tmpFileUris.length = 0;
+    await settle();
+  });
+
+  test('[assisted] url-exclusion-002: https:// URL in document does not receive a RangeLink document link', async () => {
+    const uri = await createAndOpenFile(
+      '__rl-test-url-exclusion',
+      'Some text\nhttps://example.com/path/file.ts#L10\nMore text\n',
+    );
+    tmpFileUris.push(uri);
+    await settle();
+
+    const verdict = await waitForHumanVerdict(
+      'url-exclusion-002',
+      'Hover over https://example.com/path/file.ts#L10 in the editor',
+      [
+        '1. Look at the line: https://example.com/path/file.ts#L10',
+        '2. Hover your cursor over any part of that URL',
+        '3. PASS if: no RangeLink tooltip or clickable underline appears',
+        '4. A browser-style VS Code link tooltip is OK — only RangeLink must NOT add its own',
+        '5. FAIL if: a RangeLink tooltip or clickable underline appears',
+      ],
+    );
+
+    assert.strictEqual(
+      verdict,
+      'pass',
+      'Human reported FAIL: RangeLink document link appeared on https:// URL',
+    );
+    log('✓ url-exclusion-002 — no RangeLink document link on https:// URL (human verified)');
+  });
+
+  test('[assisted] document-link-tooltip-001: hovering a clickable RangeLink shows clean tooltip', async () => {
+    const uri = await createAndOpenFile(
+      '__rl-test-doc-link-tooltip',
+      'See code at src/utils/helper.ts#L5 for details\n',
+    );
+    tmpFileUris.push(uri);
+    await settle();
+
+    const verdict = await waitForHumanVerdict(
+      'document-link-tooltip-001',
+      'Hover over src/utils/helper.ts#L5 in the editor',
+      [
+        '1. Look at the line: See code at src/utils/helper.ts#L5 for details',
+        '2. Hover your cursor over the link text (it should be underlined/clickable)',
+        '3. PASS if: the tooltip shows clean human-readable text (file path and line number)',
+        '4. FAIL if: the tooltip shows raw JSON, a command: URI, or internal parameters',
+      ],
+    );
+
+    assert.strictEqual(verdict, 'pass', 'Human reported FAIL: document link tooltip was not clean');
+    log('✓ document-link-tooltip-001 — clean tooltip on RangeLink document link (human verified)');
   });
 });


### PR DESCRIPTION
## Summary

Adds integration test coverage for 6 QA test cases across three feature areas: URL exclusion in link generation, filename-only navigation fallback (multiple-match and not-found error paths), and custom AI assistant appearance in the destination picker. Two TCs are fully automated (log-capture assertions); four are assisted (human-in-the-loop with pass/fail verdict).

## Changes

- `src/__integration-tests__/suite/linkGeneration.test.ts` — new `'Link Generation — Clickable Links (Assisted)'` suite: `url-exclusion-002` (asserts no RangeLink document link on https:// URLs via `waitForHumanVerdict`) and `document-link-tooltip-001` (asserts clean tooltip via `waitForHumanVerdict`)
- `src/__integration-tests__/suite/filenameOnlyNavigation.test.ts` — new automated TCs: `filename-fallback-navigation-002` (fire-and-forget + `assertToastLogged` for "Multiple files match") and `filename-fallback-navigation-003` (same pattern for "Cannot find file"); duplicate fixture files placed in `__rl-test-dup-a/` / `__rl-test-dup-b/` at workspace root (not `src/`) to avoid triggering the TypeScript watcher which blocks `vscode.workspace.findFiles`
- `src/__integration-tests__/suite/customAiAssistants.test.ts` — new `'Custom AI Assistants — Destination Picker (Assisted)'` suite: `custom-ai-assistant-003` (asserts "Dummy AI" entry exists in picker via `extractQuickPickItemsLogged`) and `custom-ai-assistant-007` (asserts 5 custom AI entries appear in user-defined order via index comparison)
- `qa/qa-test-cases-v1.1.0-003.yaml` — updated `automated` field: `filename-fallback-navigation-002` and `-003` to `true`; `url-exclusion-002`, `document-link-tooltip-001`, `custom-ai-assistant-003`, `custom-ai-assistant-007` to `assisted`

## Key Discoveries

- Duplicate fixture files must be placed outside `src/` because the TypeScript watcher recompiles when new `.ts` files appear in the `src/` include path, which blocks `vscode.workspace.findFiles` and stalls the test.
- `extractQuickPickItemsLogged` enables log-based assertion on picker content without human visual verification — VscodeAdapter logs all picker items before blocking on `showQuickPick`.
- Hover tooltip tests (`url-exclusion-002`, `document-link-tooltip-001`) genuinely require `waitForHumanVerdict` since there is no log to capture hover behavior.
- Commands whose handlers call `showWarningMessage` (without buttons) must use fire-and-forget (`void vscode.commands.executeCommand(...)`) + `await settle()` rather than `await executeCommand(...)`, to avoid stalling.

## Test Plan

- [x] All existing unit tests pass (1862 passing)
- [x] New integration tests pass: all 6 TCs verified via `pnpm test:release:grep "filename-fallback-navigation-00[23]|url-exclusion-002|document-link-tooltip-001|custom-ai-assistant-00[37]"` (exit code 0, 6 passing)
- [x] QA validator passes: 83 automated + 137 assisted, all matched

## Related

- Part of https://github.com/couimet/rangeLink/issues/509