### PR TITLE
[issues/509] Block 5 — Dirty Buffer Warning (5 TCs, 4 assisted + 1 automated)

### DIFF
--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0-003.yaml
@@ -1156,7 +1156,7 @@ test_cases:
       - 'Select 2-3 lines'
       - 'Press Cmd+R Cmd+L'
     expected_result: 'A warning dialog appears before the RangeLink is generated. Dialog references unsaved changes.'
-    automated: false
+    automated: assisted
 
   - id: dirty-buffer-warning-002
     feature: 'Dirty Buffer Warning'
@@ -1170,7 +1170,7 @@ test_cases:
       - 'Select 2-3 lines, press Cmd+R Cmd+L'
       - 'Observe the dialog options'
     expected_result: 'Three choices visible: Save & Generate, Generate Anyway, and dismiss/cancel.'
-    automated: false
+    automated: assisted
 
   - id: dirty-buffer-warning-003
     feature: 'Dirty Buffer Warning'
@@ -1183,7 +1183,7 @@ test_cases:
       - 'Click Save & Generate'
       - 'Observe file state and terminal'
     expected_result: 'File saved (modified indicator gone). RangeLink generated and sent to terminal. Success toast shown.'
-    automated: false
+    automated: assisted
 
   - id: dirty-buffer-warning-004
     feature: 'Dirty Buffer Warning'
@@ -1208,7 +1208,7 @@ test_cases:
       - 'Select 2-3 lines, press Cmd+R Cmd+L'
       - 'Press Escape or click X to dismiss'
     expected_result: 'No RangeLink generated. Terminal unchanged. File still dirty.'
-    automated: false
+    automated: assisted
 
   - id: dirty-buffer-warning-006
     feature: 'Dirty Buffer Warning'
@@ -1220,7 +1220,7 @@ test_cases:
       - 'Make unsaved change to a file'
       - 'Select 2-3 lines, press Cmd+R Cmd+L'
     expected_result: 'No dialog appears. RangeLink generated and sent immediately.'
-    automated: false
+    automated: true
 
   - id: dirty-buffer-warning-007
     feature: 'Dirty Buffer Warning'

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/dirtyBufferWarning.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/dirtyBufferWarning.test.ts
@@ -2,7 +2,11 @@ import assert from 'node:assert';
 
 import * as vscode from 'vscode';
 
-import { CMD_COPY_LINK_ONLY_RELATIVE, CMD_UNBIND_DESTINATION } from '../../constants/commandIds';
+import {
+  CMD_COPY_LINK_ONLY_RELATIVE,
+  CMD_COPY_LINK_RELATIVE,
+  CMD_UNBIND_DESTINATION,
+} from '../../constants/commandIds';
 import {
   activateExtension,
   assertClipboardRestored,
@@ -244,6 +248,69 @@ suite('Dirty Buffer Warning', () => {
     }
   });
 
+  test('dirty-buffer-warning-006: warnOnDirtyBuffer=false — R-L sends link to bound destination without dialog', async () => {
+    const capturing = await createAndBindCapturingTerminal('dirty-buffer-test');
+
+    try {
+      const editor = await openEditor(testFileUri);
+
+      await editor.edit((editBuilder) => {
+        editBuilder.insert(new vscode.Position(0, 0), '// dirty-006\n');
+      });
+      assert.ok(editor.document.isDirty, 'Expected document to be dirty after edit');
+
+      editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 8));
+
+      await vscode.workspace
+        .getConfiguration('rangelink')
+        .update('warnOnDirtyBuffer', false, vscode.ConfigurationTarget.Workspace);
+
+      await writeClipboardSentinel();
+
+      const logCapture = getLogCapture();
+      logCapture.mark('before-006');
+      capturing.clearCaptured();
+
+      await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
+      await settle();
+
+      const lines = logCapture.getLinesSince('before-006');
+      const disabledLog = lines.find(
+        (l) =>
+          l.includes('handleDirtyBufferWarning') &&
+          l.includes('Document has unsaved changes but warning is disabled by setting'),
+      );
+      assert.ok(
+        disabledLog,
+        'Expected "disabled by setting" log — warnOnDirtyBuffer=false must short-circuit the dialog',
+      );
+
+      const dialogLog = lines.find(
+        (l) =>
+          l.includes('handleDirtyBufferWarning') &&
+          l.includes('Document has unsaved changes, showing warning'),
+      );
+      assert.strictEqual(
+        dialogLog,
+        undefined,
+        'Expected no dialog log — setting should bypass dialog',
+      );
+
+      assertTerminalBufferContains(capturing.getCapturedText(), '#L');
+
+      assert.ok(
+        editor.document.isDirty,
+        'Expected document to remain dirty — bypass must not trigger save',
+      );
+
+      await assertClipboardRestored(
+        'R-L warnOnDirtyBuffer=false: clipboard should be restored after send',
+      );
+    } finally {
+      capturing.terminal.dispose();
+    }
+  });
+
   test('dirty-buffer-warning-019: R-C on clean file generates link without warning dialog', async () => {
     const cleanUri = createWorkspaceFile('clean-rc', 'clean rc content\n');
 
@@ -308,6 +375,234 @@ suite('Dirty Buffer Warning — Dialog Interaction', () => {
       .update('warnOnDirtyBuffer', undefined, vscode.ConfigurationTarget.Workspace);
     await closeAllEditors();
     await settle();
+  });
+
+  test('[assisted] dirty-buffer-warning-001: warnOnDirtyBuffer=true — R-L on dirty file shows warning dialog', async () => {
+    const capturing = await createAndBindCapturingTerminal('dirty-buffer-test');
+
+    try {
+      const editor = await openEditor(testFileUri);
+
+      await editor.edit((editBuilder) => {
+        editBuilder.insert(new vscode.Position(0, 0), '// dirty-001\n');
+      });
+      assert.ok(editor.document.isDirty, 'Expected document to be dirty');
+
+      editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 8));
+
+      await writeClipboardSentinel();
+
+      const logCapture = getLogCapture();
+      logCapture.mark('before-001');
+      capturing.clearCaptured();
+
+      await waitForHuman(
+        'dirty-buffer-warning-001',
+        'R-L on dirty file → confirm dialog appears, then dismiss',
+        [
+          'Click in the editor and ensure some text is selected.',
+          'Press Cmd+R Cmd+L — the dirty buffer warning dialog should appear.',
+          'Press Escape or click X to dismiss.',
+        ],
+      );
+
+      await settle();
+
+      const lines = logCapture.getLinesSince('before-001');
+      const showingWarningLog = lines.find(
+        (l) =>
+          l.includes('handleDirtyBufferWarning') &&
+          l.includes('Document has unsaved changes, showing warning'),
+      );
+      assert.ok(
+        showingWarningLog,
+        'Expected "showing warning" log — dialog must fire when file is dirty',
+      );
+
+      assertTerminalBufferEquals(capturing.getCapturedText(), '');
+
+      log('✓ Warning dialog appeared when R-L on dirty file (default warnOnDirtyBuffer=true)');
+    } finally {
+      capturing.terminal.dispose();
+    }
+  });
+
+  test('[assisted] dirty-buffer-warning-002: dirty buffer dialog shows Save & Generate, Generate Anyway, and dismiss options', async () => {
+    const capturing = await createAndBindCapturingTerminal('dirty-buffer-test');
+
+    try {
+      const editor = await openEditor(testFileUri);
+
+      await editor.edit((editBuilder) => {
+        editBuilder.insert(new vscode.Position(0, 0), '// dirty-002\n');
+      });
+      assert.ok(editor.document.isDirty, 'Expected document to be dirty');
+
+      editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 8));
+
+      await writeClipboardSentinel();
+
+      const logCapture = getLogCapture();
+      logCapture.mark('before-002');
+      capturing.clearCaptured();
+
+      await waitForHuman(
+        'dirty-buffer-warning-002',
+        'R-L on dirty file → verify 3 dialog options are visible, then dismiss',
+        [
+          'Click in the editor and ensure some text is selected.',
+          'Press Cmd+R Cmd+L — the dirty buffer warning dialog should appear.',
+          'Confirm the dialog shows exactly 3 choices: "Save & Generate", "Generate Anyway", and an X/dismiss button.',
+          'Press Escape or click X to dismiss.',
+        ],
+      );
+
+      await settle();
+
+      const lines = logCapture.getLinesSince('before-002');
+      const showingWarningLog = lines.find(
+        (l) =>
+          l.includes('handleDirtyBufferWarning') &&
+          l.includes('Document has unsaved changes, showing warning'),
+      );
+      assert.ok(
+        showingWarningLog,
+        'Expected "showing warning" log — dialog must fire for option verification',
+      );
+
+      const dismissLog = lines.find(
+        (l) =>
+          l.includes('handleDirtyBufferWarning') && l.includes('User dismissed warning, aborting'),
+      );
+      assert.ok(
+        dismissLog,
+        'Expected "User dismissed warning, aborting" log — confirms user saw and dismissed dialog',
+      );
+
+      assertTerminalBufferEquals(capturing.getCapturedText(), '');
+
+      log('✓ Dialog showed 3 options: Save & Generate, Generate Anyway, and dismiss');
+    } finally {
+      capturing.terminal.dispose();
+    }
+  });
+
+  test('[assisted] dirty-buffer-warning-003: R-L Save & Generate saves file and sends link to bound destination', async () => {
+    const capturing = await createAndBindCapturingTerminal('dirty-buffer-test');
+
+    try {
+      const editor = await openEditor(testFileUri);
+
+      await editor.edit((editBuilder) => {
+        editBuilder.insert(new vscode.Position(0, 0), '// dirty-003\n');
+      });
+      assert.ok(editor.document.isDirty, 'Expected document to be dirty');
+
+      editor.selection = new vscode.Selection(
+        new vscode.Position(0, 0),
+        new vscode.Position(0, 10),
+      );
+
+      await writeClipboardSentinel();
+
+      const logCapture = getLogCapture();
+      logCapture.mark('before-003');
+      capturing.clearCaptured();
+
+      await waitForHuman(
+        'dirty-buffer-warning-003',
+        'R-L on dirty file → click "Save & Generate"',
+        [
+          'Click in the editor and select some text (the first word is fine).',
+          'Press Cmd+R Cmd+L — the dirty buffer dialog should appear.',
+          'Click "Save & Generate".',
+        ],
+      );
+
+      await settle();
+
+      const lines = logCapture.getLinesSince('before-003');
+      const showingWarningLog = lines.find(
+        (l) =>
+          l.includes('handleDirtyBufferWarning') &&
+          l.includes('Document has unsaved changes, showing warning'),
+      );
+      assert.ok(showingWarningLog, 'Expected "showing warning" log — dialog must fire');
+
+      const saveLog = lines.find(
+        (l) =>
+          l.includes('handleDirtyBufferWarning') && l.includes('User chose to save and continue'),
+      );
+      assert.ok(saveLog, 'Expected "User chose to save and continue" log');
+
+      assert.ok(!editor.document.isDirty, 'Expected document to be saved after Save & Generate');
+
+      assertTerminalBufferContains(capturing.getCapturedText(), 'dirty');
+
+      await assertClipboardRestored('R-L Save & Generate: clipboard should be restored after send');
+
+      log('✓ R-L Save & Generate: file saved, link sent to terminal');
+    } finally {
+      capturing.terminal.dispose();
+    }
+  });
+
+  test('[assisted] dirty-buffer-warning-005: R-L dismiss aborts link generation, terminal unchanged', async () => {
+    const capturing = await createAndBindCapturingTerminal('dirty-buffer-test');
+
+    try {
+      const editor = await openEditor(testFileUri);
+
+      await editor.edit((editBuilder) => {
+        editBuilder.insert(new vscode.Position(0, 0), '// dirty-005\n');
+      });
+      assert.ok(editor.document.isDirty, 'Expected document to be dirty');
+
+      editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 8));
+
+      await writeClipboardSentinel();
+
+      const logCapture = getLogCapture();
+      logCapture.mark('before-005');
+      capturing.clearCaptured();
+
+      await waitForHuman(
+        'dirty-buffer-warning-005',
+        'R-L on dirty file → dismiss the dialog (press Escape or click X)',
+        [
+          'Click in the editor and ensure some text is selected.',
+          'Press Cmd+R Cmd+L — the dirty buffer dialog should appear.',
+          'Press Escape or click the X to dismiss.',
+        ],
+      );
+
+      await settle();
+
+      const lines = logCapture.getLinesSince('before-005');
+      const showingWarningLog = lines.find(
+        (l) =>
+          l.includes('handleDirtyBufferWarning') &&
+          l.includes('Document has unsaved changes, showing warning'),
+      );
+      assert.ok(showingWarningLog, 'Expected "showing warning" log — dialog must fire');
+
+      const dismissLog = lines.find(
+        (l) =>
+          l.includes('handleDirtyBufferWarning') && l.includes('User dismissed warning, aborting'),
+      );
+      assert.ok(dismissLog, 'Expected "User dismissed warning, aborting" log');
+
+      assertTerminalBufferEquals(capturing.getCapturedText(), '');
+      assert.ok(editor.document.isDirty, 'Expected document to remain dirty after dismiss');
+
+      await assertClipboardRestored(
+        'R-L dismiss: clipboard should still have sentinel (no send occurred)',
+      );
+
+      log('✓ R-L dismiss: terminal unchanged, file still dirty');
+    } finally {
+      capturing.terminal.dispose();
+    }
   });
 
   test('[assisted] dirty-buffer-warning-010: R-C Save & Generate saves file and generates link', async () => {

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/dirtyBufferWarning.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/dirtyBufferWarning.test.ts
@@ -23,6 +23,7 @@ import {
   printAssistedBanner,
   settle,
   waitForHuman,
+  waitForHumanVerdict,
   writeClipboardSentinel,
 } from '../helpers';
 
@@ -396,14 +397,20 @@ suite('Dirty Buffer Warning — Dialog Interaction', () => {
       logCapture.mark('before-001');
       capturing.clearCaptured();
 
-      await waitForHuman(
+      const verdict = await waitForHumanVerdict(
         'dirty-buffer-warning-001',
-        'R-L on dirty file → confirm dialog appears, then dismiss',
+        'Select text, press Cmd+R Cmd+L → PASS if warning dialog appears (then dismiss it), FAIL if not',
         [
-          'Click in the editor and ensure some text is selected.',
-          'Press Cmd+R Cmd+L — the dirty buffer warning dialog should appear.',
-          'Press Escape or click X to dismiss.',
+          'Click in the editor and ensure text is selected.',
+          'Press Cmd+R Cmd+L.',
+          'If the dirty buffer warning dialog appears → click PASS, then dismiss it (Escape or X).',
+          'If no dialog appears → click FAIL.',
         ],
+      );
+      assert.strictEqual(
+        verdict,
+        'pass',
+        'Human confirmed: warning dialog did NOT appear when R-L on dirty file',
       );
 
       await settle();
@@ -446,15 +453,20 @@ suite('Dirty Buffer Warning — Dialog Interaction', () => {
       logCapture.mark('before-002');
       capturing.clearCaptured();
 
-      await waitForHuman(
+      const verdict = await waitForHumanVerdict(
         'dirty-buffer-warning-002',
-        'R-L on dirty file → verify 3 dialog options are visible, then dismiss',
+        'Press Cmd+R Cmd+L → PASS if dialog shows "Save & Generate" + "Generate Anyway" + X, FAIL if not',
         [
-          'Click in the editor and ensure some text is selected.',
-          'Press Cmd+R Cmd+L — the dirty buffer warning dialog should appear.',
+          'Press Cmd+R Cmd+L — the dirty buffer dialog should appear.',
           'Confirm the dialog shows exactly 3 choices: "Save & Generate", "Generate Anyway", and an X/dismiss button.',
-          'Press Escape or click X to dismiss.',
+          'If all 3 options are present → click PASS, then dismiss the dialog (Escape or X).',
+          'If any option is missing or the dialog did not appear → click FAIL.',
         ],
+      );
+      assert.strictEqual(
+        verdict,
+        'pass',
+        'Human confirmed: dialog options did not match expected (Save & Generate / Generate Anyway / dismiss)',
       );
 
       await settle();
@@ -476,7 +488,7 @@ suite('Dirty Buffer Warning — Dialog Interaction', () => {
       );
       assert.ok(
         dismissLog,
-        'Expected "User dismissed warning, aborting" log — confirms user saw and dismissed dialog',
+        'Expected "User dismissed warning, aborting" log — confirms dialog was dismissed after verdict',
       );
 
       assertTerminalBufferEquals(capturing.getCapturedText(), '');


### PR DESCRIPTION
## Summary

Converts the five remaining `automated: false` Dirty Buffer Warning TCs to assisted or fully automated integration tests. All five cover the core R-L dialog flow (warning fires, dialog shows 3 options, Save & Generate, Dismiss aborts) and the `warnOnDirtyBuffer=false` bypass. Tests were added to the existing `dirtyBufferWarning.test.ts` alongside all other dirty-buffer coverage.

## Changes

- 4 new `[assisted]` integration tests in `dirtyBufferWarning.test.ts`: `dirty-buffer-warning-001` (dialog fires on R-L), `dirty-buffer-warning-002` (dialog shows 3 options), `dirty-buffer-warning-003` (Save & Generate saves file + sends link), `dirty-buffer-warning-005` (Dismiss aborts, terminal unchanged)
- 1 new fully automated integration test: `dirty-buffer-warning-006` (warnOnDirtyBuffer=false skips dialog, R-L sends link immediately via bound terminal)
- QA YAML (`qa-test-cases-v1.1.0-003.yaml`): `automated: false → assisted` for 001, 002, 003, 005; `false → true` for 006
- Documentation: CHANGELOG not needed — internal test infrastructure only; README not needed

## Test Plan

- [ ] All existing tests pass (1874 Jest tests)
- [ ] New tests added for: `dirty-buffer-warning-001`, `dirty-buffer-warning-002`, `dirty-buffer-warning-003`, `dirty-buffer-warning-005`, `dirty-buffer-warning-006`
- [ ] Integration suite (assisted drive): `pnpm test:release:grep "dirty-buffer-warning-(001|002|003|005|006)"`

## Related

- Part of https://github.com/couimet/rangeLink/issues/509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated test coverage for the dirty buffer warning feature, including validation of dialog interactions, save operations, dismissal behavior, and disabled state scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->