### PR TITLE
[issues/543] Simplify `CLAUDE.md` E001 shell setup — remove `source` and `nvm use`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,58 +280,9 @@
 
 <rule id="E001" priority="critical">
   <title>Shell environment setup</title>
-  <when>Before running pnpm, npm, node, or any JS tooling commands</when>
-
-  <prerequisites>
-    1. Ensure working directory is project root (where pnpm-workspace.yaml lives)
-    2. Shell config must have nvm configured (Claude Code runs non-interactive shells that don't auto-source config files)
-  </prerequisites>
-
-  <setup-sequence>
-    Run this sequence to initialize the environment:
-    ```
-    For zsh:  source ~/.zshrc && nvm use && npm run enable-pnpm
-    For bash: source ~/.bashrc && nvm use && npm run enable-pnpm
-    ```
-  </setup-sequence>
-
-  <verification>
-    After setup, verify tools are available:
-    ```bash
-    node --version && pnpm --version
-    ```
-    Both commands should return version numbers.
-  </verification>
-
-  <troubleshooting>
-    <problem symptom="nvm: command not found">
-      <cause>Shell config not sourced - nvm function not loaded</cause>
-      <fix>Run: `source ~/.zshrc` (zsh) or `source ~/.bashrc` (bash)</fix>
-    </problem>
-
-    <problem symptom="N/A: version 'N/A' not found" or ".nvmrc not found">
-      <cause>Node version not installed via nvm</cause>
-      <fix>Run: `nvm install` (installs version from .nvmrc)</fix>
-    </problem>
-
-    <problem symptom="command not found: node">
-      <cause>nvm not loaded OR node not installed</cause>
-      <fix>Run: `source ~/.zshrc && nvm install && nvm use` (zsh) or `source ~/.bashrc && nvm install && nvm use` (bash)</fix>
-    </problem>
-
-    <problem symptom="command not found: pnpm">
-      <cause>corepack/pnpm not enabled</cause>
-      <fix>Run: `npm run enable-pnpm` from the root of the project</fix>
-    </problem>
-
-    <problem symptom="ENOENT pnpm-workspace.yaml">
-      <cause>Not in project root directory</cause>
-      <fix>Navigate to project root before running commands</fix>
-    </problem>
-
-  </troubleshooting>
-
-<rationale>Claude Code runs non-interactive shells; node/pnpm not in PATH by default</rationale>
+  <when>Before the first pnpm, npm, or node command in a session</when>
+  <do>Verify `node --version && pnpm --version`; if either fails, tell the user to run `./setup.sh`</do>
+  <rationale>`./setup.sh` runs `corepack enable` once — it persists across terminals and reboots</rationale>
 </rule>
 
 <rule id="A001" priority="critical">


### PR DESCRIPTION
## Summary

Replaced the 55-line E001 shell environment rule in CLAUDE.md with a 6-line version. The old rule forced `source ~/.zshrc && nvm use && npm run enable-pnpm` before every JS tooling command, triggering permission prompts because `source` evaluates arguments as shell code. Node and pnpm are already available in the user's environment — `./setup.sh` runs `corepack enable` once, and it persists across terminals and reboots.

## Changes

- CLAUDE.md E001 rule: replaced multi-step setup sequence and nvm troubleshooting matrix with a single verification (`node --version && pnpm --version`) that runs once per session, falling back to `./setup.sh` if tools are missing
- Documentation: CHANGELOG not needed (internal tooling); README not needed (no user-facing changes)

Closes https://github.com/couimet/rangeLink/issues/543

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified shell environment setup instructions for faster project initialization and clearer troubleshooting. Users can now quickly verify their development environment with streamlined version checks, with automatic guidance to run the setup script if adjustments are needed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/rangeLink/pull/544)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->