### PR TITLE
[issues/554] CodeRabbit Auto-Pause Fix

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,6 +11,7 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    auto_pause_after_reviewed_commits: 0
   path_instructions:
     - path: 'packages/rangelink-vscode-extension/src/**'
       instructions: |


### PR DESCRIPTION
## Summary

CodeRabbit's `auto_pause_after_reviewed_commits` defaults to 5, causing it to silently stop reviewing PRs after 5 incremental commits. Setting it to 0 disables the auto-pause so every commit is reviewed regardless of count, eliminating the need for manual `@coderabbitai review` triggers.

## Changes

- Added `auto_pause_after_reviewed_commits: 0` to `.coderabbit.yaml` under `reviews.auto_review`
- Documentation: CHANGELOG not needed (internal CI config); README not needed (no user-facing change)

## Test Plan

- [ ] No code changes — tests are unaffected
- [ ] Verify CodeRabbit reviews all commits on future PRs without pausing

## Related

- Closes https://github.com/couimet/rangeLink/issues/554

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review automation configuration settings.

---

**Note:** This release contains only internal infrastructure changes with no impact to end-user functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/rangeLink/pull/555)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->