### PR TITLE
[issues/571] Condition unbind command palette visibility on `rangelink.isBound`

### DIFF
--- a/packages/rangelink-vscode-extension/CHANGELOG.md
+++ b/packages/rangelink-vscode-extension/CHANGELOG.md
@@ -179,6 +179,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Before:** "RangeLink: Bind RangeLink to Terminal Destination"
   - **After:** "RangeLink: Bind to Terminal"
   - Category "RangeLink" already provides the namespace; titles now focus on the action
+- **Unbind hidden when nothing bound** - "RangeLink: Unbind" now hides from the command palette when no destination is bound (via `when: rangelink.isBound`) instead of showing grayed out (#571)
+  - **Before:** Unbind always appeared in the command palette, grayed out when unbound
+  - **After:** Unbind only appears when a destination is bound, matching the existing menu and keybinding behavior
 
 ### Fixed
 

--- a/packages/rangelink-vscode-extension/package.json
+++ b/packages/rangelink-vscode-extension/package.json
@@ -702,6 +702,10 @@
           "when": "false"
         },
         {
+          "command": "rangelink.unbindDestination",
+          "when": "rangelink.isBound"
+        },
+        {
           "command": "rangelink.editorTab.pasteFilePath",
           "when": "false"
         },

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
@@ -1858,6 +1858,28 @@ test_cases:
     expected_result: 'Same behavior as R-U keybinding — destination is unbound with confirmation notification.'
     automated: true
 
+  - id: unbind-005
+    feature: 'R-U Unbind'
+    scenario: 'RangeLink: Unbind Destination is hidden in the Command Palette when no destination is bound'
+    preconditions:
+      - 'No destination is currently bound'
+    steps:
+      - 'Open Command Palette (Cmd+Shift+P / Ctrl+Shift+P)'
+      - "Type 'RangeLink: Unbind'"
+    expected_result: "'RangeLink: Unbind' is NOT visible in the command palette. The when: rangelink.isBound clause hides it when no destination is bound."
+    automated: assisted
+
+  - id: unbind-006
+    feature: 'R-U Unbind'
+    scenario: 'RangeLink: Unbind Destination is visible in the Command Palette when a destination is bound'
+    preconditions:
+      - 'A destination is currently bound'
+    steps:
+      - 'Open Command Palette (Cmd+Shift+P / Ctrl+Shift+P)'
+      - "Type 'RangeLink: Unbind'"
+    expected_result: "'RangeLink: Unbind' IS visible in the command palette and can be selected. The when: rangelink.isBound clause shows it when a destination is bound."
+    automated: assisted
+
   # ---------------------------------------------------------------------------
   # Section — Editor Binding Validation
   # ---------------------------------------------------------------------------

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/index.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/index.ts
@@ -50,7 +50,12 @@ export { createLogger } from './logHelpers';
 export { navigateViaHandleLinkClick } from './navigationHelpers';
 export { loadSettingsProfile, resetRangelinkSettings } from './settingsHelpers';
 export { standardSuite } from './standardSuite';
-export { createAndBindTerminal, createTerminal, findTerminalItems } from './terminalHelpers';
+export {
+  createAndBindTerminal,
+  createTerminal,
+  disposeAllTerminals,
+  findTerminalItems,
+} from './terminalHelpers';
 export {
   activateExtension,
   getExtensionVersion,

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/standardSuite.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/standardSuite.ts
@@ -8,6 +8,7 @@ import { closeAllEditors } from './fileHelpers';
 import { getLogCapture } from './getLogCapture';
 import { createLogger } from './logHelpers';
 import { resetRangelinkSettings } from './settingsHelpers';
+import { disposeAllTerminals } from './terminalHelpers';
 import { activateExtension, settle } from './testEnv';
 
 export const standardSuite = (name: string, fn: (log: (msg: string) => void) => void): void => {
@@ -26,6 +27,7 @@ export const standardSuite = (name: string, fn: (log: (msg: string) => void) => 
       await resetRangelinkSettings(log);
       await vscode.commands.executeCommand(CMD_UNBIND_DESTINATION);
       await closeAllEditors();
+      disposeAllTerminals();
       await settle();
     });
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/terminalHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/terminalHelpers.ts
@@ -2,6 +2,12 @@ import * as vscode from 'vscode';
 
 import { settle, TERMINAL_READY_MS } from './testEnv';
 
+export const disposeAllTerminals = (): void => {
+  for (const t of vscode.window.terminals) {
+    t.dispose();
+  }
+};
+
 export const createTerminal = async (
   name: string,
   trackingArray?: vscode.Terminal[],

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
@@ -25,14 +25,9 @@ import {
 } from '../helpers';
 
 standardSuite('R-D Bind to Destination', (log) => {
-  const terminals: vscode.Terminal[] = [];
   const tmpFileUris: vscode.Uri[] = [];
 
   teardown(async () => {
-    for (const t of terminals) {
-      t.dispose();
-    }
-    terminals.length = 0;
     cleanupFiles(tmpFileUris);
     tmpFileUris.length = 0;
     await settle();
@@ -42,7 +37,7 @@ standardSuite('R-D Bind to Destination', (log) => {
     findTestItemsByPrefix(items, '__rl-test-btd-');
 
   test('[assisted] bind-to-destination-004: selecting a terminal destination binds it and shows success toast', async () => {
-    await createTerminal('rl-btd-004', terminals);
+    await createTerminal('rl-btd-004');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-btd-004');
@@ -167,10 +162,10 @@ standardSuite('R-D Bind to Destination', (log) => {
   });
 
   test('[assisted] bind-to-destination-007: when already bound, destination picker shows smart-bind confirmation dialog', async () => {
-    await createTerminal('rl-btd-007-a', terminals);
+    await createTerminal('rl-btd-007-a');
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
     await settle();
-    await createTerminal('rl-btd-007-b', terminals);
+    await createTerminal('rl-btd-007-b');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-btd-007');
@@ -220,10 +215,10 @@ standardSuite('R-D Bind to Destination', (log) => {
   });
 
   test('[assisted] bind-to-destination-008: smart-bind confirmation Yes replaces the binding', async () => {
-    await createTerminal('rl-btd-008-a', terminals);
+    await createTerminal('rl-btd-008-a');
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
     await settle();
-    await createTerminal('rl-btd-008-b', terminals);
+    await createTerminal('rl-btd-008-b');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-btd-008');
@@ -252,10 +247,10 @@ standardSuite('R-D Bind to Destination', (log) => {
   });
 
   test('[assisted] bind-to-destination-009: smart-bind confirmation No keeps existing binding', async () => {
-    await createTerminal('rl-btd-009-a', terminals);
+    await createTerminal('rl-btd-009-a');
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
     await settle();
-    await createTerminal('rl-btd-009-b', terminals);
+    await createTerminal('rl-btd-009-b');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-btd-009');
@@ -290,7 +285,7 @@ standardSuite('R-D Bind to Destination', (log) => {
   });
 
   test('bind-to-destination-010: Escape from destination picker dismisses without changing binding', async () => {
-    await createTerminal('rl-btd-010', terminals);
+    await createTerminal('rl-btd-010');
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
     await settle();
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
@@ -4,7 +4,6 @@ import * as vscode from 'vscode';
 
 import {
   CMD_BIND_TO_TEXT_EDITOR_HERE,
-  CMD_BIND_TO_TERMINAL_HERE,
   CMD_COPY_LINK_RELATIVE,
   CMD_PASTE_CURRENT_FILE_PATH_RELATIVE,
   CMD_TERMINAL_PASTE_SELECTED_TEXT,
@@ -38,10 +37,6 @@ standardSuite('Clipboard Preservation', (_log) => {
   suiteSetup(async () => {
     const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1} content`);
     testFileUri = createWorkspaceFile('clipboard', lines.join('\n') + '\n');
-
-    editor = await openEditor(testFileUri);
-
-    capturing = await createAndBindCapturingTerminal('rl-clipboard-test');
     editor = await openEditor(testFileUri);
   });
 
@@ -50,8 +45,7 @@ standardSuite('Clipboard Preservation', (_log) => {
   });
 
   setup(async () => {
-    capturing.terminal.show(true);
-    await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
+    capturing = await createAndBindCapturingTerminal('rl-clipboard-test');
     await settle();
     editor = await vscode.window.showTextDocument(editor.document);
     await writeClipboardSentinel();

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
@@ -46,7 +46,6 @@ standardSuite('Clipboard Preservation', (_log) => {
   });
 
   suiteTeardown(async () => {
-    capturing.terminal.dispose();
     cleanupFiles([testFileUri]);
   });
 
@@ -116,11 +115,9 @@ standardSuite('Clipboard Preservation', (_log) => {
 
 standardSuite('Clipboard Preservation — Assisted', (log) => {
   const tmpFileUris: vscode.Uri[] = [];
-  const tmpTerminals: vscode.Terminal[] = [];
 
   teardown(async () => {
     await vscode.commands.executeCommand('dummyAi.clearAll');
-    for (const t of tmpTerminals.splice(0)) t.dispose();
     cleanupFiles(tmpFileUris);
     tmpFileUris.splice(0);
     await settle();
@@ -131,10 +128,7 @@ standardSuite('Clipboard Preservation — Assisted', (log) => {
     const fileUri = createWorkspaceFile('cbp-001', lines.join('\n') + '\n');
     tmpFileUris.push(fileUri);
 
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal(
-      'cbp-001-dest',
-      tmpTerminals,
-    );
+    const capturing: CapturingTerminal = await createAndBindCapturingTerminal('cbp-001-dest');
 
     await openEditor(fileUri);
     await writeClipboardSentinel();
@@ -165,7 +159,7 @@ standardSuite('Clipboard Preservation — Assisted', (log) => {
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
     await settle();
 
-    const srcTerminal = await createTerminal('cbp-002-src', tmpTerminals);
+    const srcTerminal = await createTerminal('cbp-002-src');
     srcTerminal.show(true);
     await settle();
 
@@ -233,10 +227,7 @@ standardSuite('Clipboard Preservation — Assisted', (log) => {
     const fileUri = createWorkspaceFile('cbp-005', lines.join('\n') + '\n');
     tmpFileUris.push(fileUri);
 
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal(
-      'cbp-005-dest',
-      tmpTerminals,
-    );
+    const capturing: CapturingTerminal = await createAndBindCapturingTerminal('cbp-005-dest');
 
     await openEditor(fileUri);
     await writeClipboardSentinel();
@@ -269,7 +260,7 @@ standardSuite('Clipboard Preservation — Assisted', (log) => {
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
     await settle();
 
-    const srcTerminal = await createTerminal('cbp-007-src', tmpTerminals);
+    const srcTerminal = await createTerminal('cbp-007-src');
     srcTerminal.show(true);
     await settle();
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
@@ -25,7 +25,6 @@ const FILE_CONTENT = 'line 1\nline 2\nline 3\nline 4\n';
 const CONTEXT_IS_BOUND_KEY = 'rangelink.isBound';
 
 standardSuite('Context Menus — Editor Content', (log) => {
-  const terminals: vscode.Terminal[] = [];
   const tmpFileUris: vscode.Uri[] = [];
   let originalMultiLinePasteWarning: unknown;
 
@@ -55,10 +54,6 @@ standardSuite('Context Menus — Editor Content', (log) => {
   });
 
   teardown(async () => {
-    for (const t of terminals) {
-      t.dispose();
-    }
-    terminals.length = 0;
     cleanupFiles(tmpFileUris);
     tmpFileUris.length = 0;
     await settle();
@@ -70,7 +65,7 @@ standardSuite('Context Menus — Editor Content', (log) => {
     const relativePath = vscode.workspace.asRelativePath(uri, false);
 
     const terminalName = 'rl-ctxmenu-ed-001';
-    const capturing = await createAndBindCapturingTerminal(terminalName, terminals);
+    const capturing = await createAndBindCapturingTerminal(terminalName);
 
     const editor = await openEditor(uri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(1, 6));
@@ -108,7 +103,7 @@ standardSuite('Context Menus — Editor Content', (log) => {
     const fn = path.basename(uri.fsPath);
 
     const terminalName = 'rl-ctxmenu-ed-002';
-    const capturing = await createAndBindCapturingTerminal(terminalName, terminals);
+    const capturing = await createAndBindCapturingTerminal(terminalName);
 
     const editor = await openEditor(uri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(1, 6));
@@ -146,7 +141,7 @@ standardSuite('Context Menus — Editor Content', (log) => {
     const relativePath = vscode.workspace.asRelativePath(uri, false);
 
     const terminalName = 'rl-ctxmenu-ed-003';
-    const capturing = await createAndBindCapturingTerminal(terminalName, terminals);
+    const capturing = await createAndBindCapturingTerminal(terminalName);
 
     const editor = await openEditor(uri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(1, 6));
@@ -183,7 +178,7 @@ standardSuite('Context Menus — Editor Content', (log) => {
     const fn = path.basename(uri.fsPath);
 
     const terminalName = 'rl-ctxmenu-ed-004';
-    const capturing = await createAndBindCapturingTerminal(terminalName, terminals);
+    const capturing = await createAndBindCapturingTerminal(terminalName);
 
     const editor = await openEditor(uri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(1, 6));
@@ -222,7 +217,7 @@ standardSuite('Context Menus — Editor Content', (log) => {
     const fn = path.basename(uri.fsPath);
 
     const terminalName = 'rl-ctxmenu-ed-005';
-    const capturing = await createAndBindCapturingTerminal(terminalName, terminals);
+    const capturing = await createAndBindCapturingTerminal(terminalName);
 
     const editor = await openEditor(uri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(2, 6));
@@ -293,7 +288,7 @@ standardSuite('Context Menus — Editor Content', (log) => {
     const fn = path.basename(uri.fsPath);
 
     const terminalName = 'rl-ctxmenu-ed-007';
-    const capturing = await createAndBindCapturingTerminal(terminalName, terminals);
+    const capturing = await createAndBindCapturingTerminal(terminalName);
 
     await openEditor(uri);
     await settle();
@@ -330,7 +325,7 @@ standardSuite('Context Menus — Editor Content', (log) => {
     const relativePath = vscode.workspace.asRelativePath(uri, false);
 
     const terminalName = 'rl-ctxmenu-ed-008';
-    const capturing = await createAndBindCapturingTerminal(terminalName, terminals);
+    const capturing = await createAndBindCapturingTerminal(terminalName);
 
     await openEditor(uri);
     await settle();
@@ -395,7 +390,7 @@ standardSuite('Context Menus — Editor Content', (log) => {
     const fn = path.basename(uri.fsPath);
 
     const terminalName = 'rl-ctxmenu-ed-010';
-    await createAndBindCapturingTerminal(terminalName, terminals);
+    await createAndBindCapturingTerminal(terminalName);
 
     await openEditor(uri);
     await settle();
@@ -436,7 +431,7 @@ standardSuite('Context Menus — Editor Content', (log) => {
     const fn = path.basename(uri.fsPath);
 
     const terminalName = 'rl-ctxmenu-ed-011';
-    await createAndBindCapturingTerminal(terminalName, terminals);
+    await createAndBindCapturingTerminal(terminalName);
 
     const editor = await openEditor(uri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0));

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorTab.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorTab.test.ts
@@ -23,14 +23,9 @@ const FILE_CONTENT = 'editor-tab context-menu test file\n';
 const CONTEXT_IS_BOUND_KEY = 'rangelink.isBound';
 
 standardSuite('Context Menus — Editor Tab', (log) => {
-  const terminals: vscode.Terminal[] = [];
   const tmpFileUris: vscode.Uri[] = [];
 
   teardown(async () => {
-    for (const t of terminals) {
-      t.dispose();
-    }
-    terminals.length = 0;
     cleanupFiles(tmpFileUris);
     tmpFileUris.length = 0;
     await settle();
@@ -41,7 +36,7 @@ standardSuite('Context Menus — Editor Tab', (log) => {
     const fn = path.basename(uri.fsPath);
 
     const terminalName = 'rl-ctxmenu-tab-001';
-    const capturing = await createCapturingTerminal(terminalName, terminals);
+    const capturing = await createCapturingTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await settle();
 
@@ -80,7 +75,7 @@ standardSuite('Context Menus — Editor Tab', (log) => {
     const relativePath = vscode.workspace.asRelativePath(uri, false);
 
     const terminalName = 'rl-ctxmenu-tab-002';
-    const capturing = await createCapturingTerminal(terminalName, terminals);
+    const capturing = await createCapturingTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await settle();
 
@@ -149,7 +144,7 @@ standardSuite('Context Menus — Editor Tab', (log) => {
 
     const terminalName = 'rl-ctxmenu-tab-004';
     const terminal = vscode.window.createTerminal({ name: terminalName });
-    terminals.push(terminal);
+
     terminal.show(true);
     await settle();
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuExplorer.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuExplorer.test.ts
@@ -26,14 +26,9 @@ const FILE_CONTENT = 'explorer context-menu test file\n';
 const CONTEXT_IS_BOUND_KEY = 'rangelink.isBound';
 
 standardSuite('Context Menus — Explorer', (log) => {
-  const terminals: vscode.Terminal[] = [];
   const tmpFileUris: vscode.Uri[] = [];
 
   teardown(async () => {
-    for (const t of terminals) {
-      t.dispose();
-    }
-    terminals.length = 0;
     cleanupFiles(tmpFileUris);
     tmpFileUris.length = 0;
     await settle();
@@ -44,7 +39,7 @@ standardSuite('Context Menus — Explorer', (log) => {
     const fn = path.basename(uri.fsPath);
 
     const terminalName = 'rl-ctxmenu-exp-001';
-    const capturing = await createCapturingTerminal(terminalName, terminals);
+    const capturing = await createCapturingTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await settle();
 
@@ -81,7 +76,7 @@ standardSuite('Context Menus — Explorer', (log) => {
     const relativePath = vscode.workspace.asRelativePath(uri, false);
 
     const terminalName = 'rl-ctxmenu-exp-002';
-    const capturing = await createCapturingTerminal(terminalName, terminals);
+    const capturing = await createCapturingTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await settle();
 
@@ -148,7 +143,7 @@ standardSuite('Context Menus — Explorer', (log) => {
 
     const terminalName = 'rl-ctxmenu-exp-004';
     const terminal = vscode.window.createTerminal({ name: terminalName });
-    terminals.push(terminal);
+
     terminal.show(true);
     await settle();
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
@@ -28,14 +28,9 @@ import {
 const CONTEXT_IS_BOUND_KEY = 'rangelink.isBound';
 
 standardSuite('Context Menus — Terminal', (log) => {
-  const terminals: vscode.Terminal[] = [];
   const tmpFileUris: vscode.Uri[] = [];
 
   teardown(async () => {
-    for (const t of terminals) {
-      t.dispose();
-    }
-    terminals.length = 0;
     cleanupFiles(tmpFileUris);
     tmpFileUris.length = 0;
     await settle();
@@ -43,7 +38,7 @@ standardSuite('Context Menus — Terminal', (log) => {
 
   test('[assisted] context-menus-terminal-001: Terminal tab "Bind Here" binds that terminal', async () => {
     const terminalName = 'rl-ctxmenu-term-001';
-    await createTerminal(terminalName, terminals);
+    await createTerminal(terminalName);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-term-001');
@@ -71,7 +66,7 @@ standardSuite('Context Menus — Terminal', (log) => {
 
   test('[assisted] context-menus-terminal-002: Terminal content-area "Bind Here" binds that terminal', async () => {
     const terminalName = 'rl-ctxmenu-term-002';
-    await createTerminal(terminalName, terminals);
+    await createTerminal(terminalName);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-term-002');
@@ -99,7 +94,7 @@ standardSuite('Context Menus — Terminal', (log) => {
 
   test('[assisted] context-menus-terminal-003: Terminal content-area "Unbind" is visible when bound and unbinds on click', async () => {
     const terminalName = 'rl-ctxmenu-term-003';
-    await createTerminal(terminalName, terminals);
+    await createTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await settle();
 
@@ -131,8 +126,8 @@ standardSuite('Context Menus — Terminal', (log) => {
   test('[assisted] context-menus-terminal-004: Right-clicking a specific terminal TAB binds THAT terminal (multi-terminal disambiguation)', async () => {
     const targetName = 'rl-ctxmenu-term-004-TARGET';
     const otherName = 'rl-ctxmenu-term-004-OTHER';
-    await createTerminal(otherName, terminals);
-    await createTerminal(targetName, terminals);
+    await createTerminal(otherName);
+    await createTerminal(targetName);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-term-004');
@@ -173,8 +168,8 @@ standardSuite('Context Menus — Terminal', (log) => {
   test('[assisted] context-menus-terminal-005: Right-clicking a specific terminal CONTENT AREA binds THAT terminal (multi-terminal disambiguation)', async () => {
     const targetName = 'rl-ctxmenu-term-005-TARGET';
     const otherName = 'rl-ctxmenu-term-005-OTHER';
-    await createTerminal(otherName, terminals);
-    await createTerminal(targetName, terminals);
+    await createTerminal(otherName);
+    await createTerminal(targetName);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-term-005');
@@ -232,7 +227,7 @@ standardSuite('Context Menus — Terminal', (log) => {
     await settle();
 
     const terminalName = 'rl-ctxmenu-term-sts-005';
-    const terminal = await createTerminal(terminalName, terminals);
+    const terminal = await createTerminal(terminalName);
 
     const markerText = 'STS_005_MARKER_TEXT';
     terminal.sendText(`echo ${markerText}`, true);
@@ -281,9 +276,9 @@ standardSuite('Context Menus — Terminal', (log) => {
     const boundName = 'rl-sts-008-BOUND';
     const sourceName = 'rl-sts-008-SOURCE';
 
-    const capturingBound = await createAndBindCapturingTerminal(boundName, terminals);
+    const capturingBound = await createAndBindCapturingTerminal(boundName);
 
-    const sourceTerminal = await createTerminal(sourceName, terminals);
+    const sourceTerminal = await createTerminal(sourceName);
     const markerText = 'STS_008_CROSS_TERMINAL_MARKER';
     sourceTerminal.sendText(`echo ${markerText}`, true);
     await settle(TERMINAL_READY_MS);
@@ -333,7 +328,7 @@ standardSuite('Context Menus — Terminal', (log) => {
 
   test('[assisted] send-terminal-selection-009: "Send Selection to Destination" is NOT in the terminal TAB menu', async () => {
     const terminalName = 'rl-sts-009';
-    const terminal = await createTerminal(terminalName, terminals);
+    const terminal = await createTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await settle();
     terminal.sendText(`echo STS_009_MARKER_TEXT`, true);
@@ -380,7 +375,7 @@ standardSuite('Context Menus — Terminal', (log) => {
 
   test('[assisted] send-terminal-selection-010: Self-paste — bound terminal selection is sent back to itself (current behavior, no guard)', async () => {
     const terminalName = 'rl-sts-010';
-    const capturing = await createAndBindCapturingTerminal(terminalName, terminals);
+    const capturing = await createAndBindCapturingTerminal(terminalName);
     const markerText = 'STS_010_SELF_PASTE_MARKER';
     capturing.terminal.sendText(markerText, false);
     await settle(TERMINAL_READY_MS);
@@ -424,9 +419,9 @@ standardSuite('Context Menus — Terminal', (log) => {
     const sourceName = 'rl-sts-011-SOURCE';
     const destName = 'rl-sts-011-DEST';
 
-    const capturingDest = await createCapturingTerminal(destName, terminals);
+    const capturingDest = await createCapturingTerminal(destName);
 
-    const sourceTerminal = await createTerminal(sourceName, terminals);
+    const sourceTerminal = await createTerminal(sourceName);
     const markerText = 'STS_011_MARKER_TEXT';
     sourceTerminal.sendText(`echo ${markerText}`, true);
     await settle(TERMINAL_READY_MS);
@@ -486,7 +481,7 @@ standardSuite('Context Menus — Terminal', (log) => {
 
   test('[assisted] send-terminal-selection-012: "Send Selection" is hidden when no terminal text is selected', async () => {
     const terminalName = 'rl-sts-012';
-    const terminal = await createTerminal(terminalName, terminals);
+    const terminal = await createTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await settle();
     terminal.sendText(`echo STS_012_MARKER_TEXT`, true);
@@ -542,7 +537,7 @@ standardSuite('Context Menus — Terminal', (log) => {
     );
 
     const terminalName = 'rl-sts-013';
-    const terminal = await createTerminal(terminalName, terminals);
+    const terminal = await createTerminal(terminalName);
     const markerText = 'STS_013_AI_DELIVERY_MARKER';
     terminal.sendText(`echo ${markerText}`, true);
     await settle(TERMINAL_READY_MS);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
@@ -38,11 +38,9 @@ const NO_TERMINAL_SELECTION_MSG =
 
 standardSuite('Core Send Commands', (log) => {
   const tmpFileUris: vscode.Uri[] = [];
-  const tmpTerminals: vscode.Terminal[] = [];
 
   teardown(async () => {
     await vscode.commands.executeCommand('dummyAi.clearAll');
-    for (const t of tmpTerminals.splice(0)) t.dispose();
     cleanupFiles(tmpFileUris);
     tmpFileUris.splice(0);
     await settle();
@@ -139,10 +137,7 @@ standardSuite('Core Send Commands', (log) => {
     const fileUri = createWorkspaceFile('csc-r-c-001', 'line 1\nline 2\nline 3\n');
     tmpFileUris.push(fileUri);
 
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal(
-      'csc-r-c-001-dest',
-      tmpTerminals,
-    );
+    const capturing: CapturingTerminal = await createAndBindCapturingTerminal('csc-r-c-001-dest');
 
     const editor = await openEditor(fileUri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(2, 0));
@@ -177,10 +172,7 @@ standardSuite('Core Send Commands', (log) => {
     const fileUri = createWorkspaceFile('csc-r-l-004', 'line 1\nline 2\nline 3\n');
     tmpFileUris.push(fileUri);
 
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal(
-      'csc-r-l-004-dest',
-      tmpTerminals,
-    );
+    const capturing: CapturingTerminal = await createAndBindCapturingTerminal('csc-r-l-004-dest');
 
     const editor = await openEditor(fileUri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(2, 0));
@@ -207,10 +199,7 @@ standardSuite('Core Send Commands', (log) => {
     const fileUri = createWorkspaceFile('csc-r-c-002', 'line 1\nline 2\nline 3\n');
     tmpFileUris.push(fileUri);
 
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal(
-      'csc-r-c-002-dest',
-      tmpTerminals,
-    );
+    const capturing: CapturingTerminal = await createAndBindCapturingTerminal('csc-r-c-002-dest');
 
     const editor = await openEditor(fileUri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(2, 0));
@@ -247,15 +236,12 @@ standardSuite('Core Send Commands', (log) => {
   test('[assisted] send-terminal-selection-001: Cmd+R Cmd+V with terminal text selected sends to bound destination', async () => {
     const MARKER = 'rl-sts-001-marker';
 
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal(
-      'csc-sts-001-dest',
-      tmpTerminals,
-    );
+    const capturing: CapturingTerminal = await createAndBindCapturingTerminal('csc-sts-001-dest');
     await settle();
 
     const srcTerminal = vscode.window.createTerminal({ name: 'csc-sts-001-src' });
     srcTerminal.show(true);
-    tmpTerminals.push(srcTerminal);
+
     await settle(TERMINAL_READY_MS);
 
     srcTerminal.sendText(`echo "${MARKER}"`, true);
@@ -281,7 +267,7 @@ standardSuite('Core Send Commands', (log) => {
   test('send-terminal-selection-003: R-V with no text selected in terminal shows error message', async () => {
     const terminal = vscode.window.createTerminal({ name: 'csc-sts-003' });
     terminal.show(true);
-    tmpTerminals.push(terminal);
+
     await settle(TERMINAL_READY_MS);
 
     // On macOS, terminal.copySelection leaves the clipboard unchanged when nothing
@@ -307,7 +293,7 @@ standardSuite('Core Send Commands', (log) => {
 
     const srcTerminal = vscode.window.createTerminal({ name: 'csc-sts-004-src' });
     srcTerminal.show(true);
-    tmpTerminals.push(srcTerminal);
+
     await settle(TERMINAL_READY_MS);
 
     srcTerminal.sendText(`echo "${MARKER}"`, true);
@@ -402,10 +388,7 @@ standardSuite('Core Send Commands', (log) => {
   });
 
   test('send-terminal-selection-006: R-L with terminal focus shows no-active-editor error', async () => {
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal(
-      'csc-sts-006-dest',
-      tmpTerminals,
-    );
+    const capturing: CapturingTerminal = await createAndBindCapturingTerminal('csc-sts-006-dest');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-sts-006');
@@ -431,10 +414,7 @@ standardSuite('Core Send Commands', (log) => {
   });
 
   test('send-terminal-selection-007: R-C with terminal focus shows no-active-editor error', async () => {
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal(
-      'csc-sts-007-dest',
-      tmpTerminals,
-    );
+    const capturing: CapturingTerminal = await createAndBindCapturingTerminal('csc-sts-007-dest');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-sts-007');
@@ -457,10 +437,7 @@ standardSuite('Core Send Commands', (log) => {
   });
 
   test('core-send-commands-r-l-001: R-L sends RangeLink to bound terminal', async () => {
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal(
-      'csc-r-l-001-dest',
-      tmpTerminals,
-    );
+    const capturing: CapturingTerminal = await createAndBindCapturingTerminal('csc-r-l-001-dest');
 
     const fileUri = createWorkspaceFile('csc-r-l-001', 'line 1\nline 2\nline 3\nline 4\nline 5\n');
     tmpFileUris.push(fileUri);
@@ -489,10 +466,8 @@ standardSuite('Core Send Commands', (log) => {
   });
 
   test('full-line-selection-validation-001: R-L after expandLineSelection generates link without error', async () => {
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal(
-      'csc-fullline-001-dest',
-      tmpTerminals,
-    );
+    const capturing: CapturingTerminal =
+      await createAndBindCapturingTerminal('csc-fullline-001-dest');
 
     const fileUri = createWorkspaceFile('csc-fullline-001', 'line 1\nline 2\nline 3\n');
     tmpFileUris.push(fileUri);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/sendFilePath.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/sendFilePath.test.ts
@@ -28,17 +28,14 @@ import {
 
 standardSuite('Send File Path', (log) => {
   const tmpFileUris: vscode.Uri[] = [];
-  const tmpTerminals: vscode.Terminal[] = [];
 
   teardown(async () => {
-    for (const t of tmpTerminals.splice(0)) t.dispose();
     cleanupFiles(tmpFileUris.splice(0));
     await settle();
   });
 
   test('send-file-path-001: R-F sends workspace-relative path to bound terminal', async () => {
     const capturing = await createAndBindCapturingTerminal('sfp-test');
-    tmpTerminals.push(capturing.terminal);
 
     const fileUri = createWorkspaceFile('sfp-001', 'content\n');
     tmpFileUris.push(fileUri);
@@ -68,7 +65,6 @@ standardSuite('Send File Path', (log) => {
 
   test('[assisted] send-file-path-002: Cmd+R Cmd+Shift+F sends absolute path to bound terminal', async () => {
     const capturing = await createAndBindCapturingTerminal('sfp-test');
-    tmpTerminals.push(capturing.terminal);
 
     const fileUri = createWorkspaceFile('sfp-002', 'content\n');
     tmpFileUris.push(fileUri);
@@ -104,7 +100,6 @@ standardSuite('Send File Path', (log) => {
 
   test('[assisted] send-file-path-004: terminal destination — path with spaces is auto-quoted in single quotes', async () => {
     const capturing = await createAndBindCapturingTerminal('sfp-test');
-    tmpTerminals.push(capturing.terminal);
 
     const fileUri = createFileAt('__rl-test-my folder.ts', 'content\n');
     tmpFileUris.push(fileUri);
@@ -141,7 +136,6 @@ standardSuite('Send File Path', (log) => {
 
   test('[assisted] send-file-path-005: terminal destination — path with parentheses is auto-quoted in single quotes', async () => {
     const capturing = await createAndBindCapturingTerminal('sfp-test');
-    tmpTerminals.push(capturing.terminal);
 
     const fileUri = createFileAt('__rl-test-utils (v2).ts', 'content\n');
     tmpFileUris.push(fileUri);
@@ -230,7 +224,6 @@ standardSuite('Send File Path', (log) => {
       .update('clipboard.preserve', 'never', vscode.ConfigurationTarget.Global);
 
     const capturing = await createAndBindCapturingTerminal('sfp-test');
-    tmpTerminals.push(capturing.terminal);
 
     const fileUri = createFileAt('__rl-test-clipboard check.ts', 'content\n');
     tmpFileUris.push(fileUri);
@@ -310,7 +303,6 @@ standardSuite('Send File Path', (log) => {
 
   test('[assisted] send-file-path-009: unbound — R-F opens destination picker before sending', async () => {
     const capturing = await createCapturingTerminal('sfp-picker-test');
-    tmpTerminals.push(capturing.terminal);
 
     const fileUri = createWorkspaceFile('sfp-009', 'content\n');
     tmpFileUris.push(fileUri);
@@ -349,7 +341,6 @@ standardSuite('Send File Path', (log) => {
 
   test('[assisted] send-file-path-010: Command Palette "Send Current File Path" sends workspace-relative path', async () => {
     const capturing = await createAndBindCapturingTerminal('sfp-test');
-    tmpTerminals.push(capturing.terminal);
 
     const fileUri = createWorkspaceFile('sfp-010', 'content\n');
     tmpFileUris.push(fileUri);
@@ -386,7 +377,6 @@ standardSuite('Send File Path', (log) => {
 
   test('[assisted] send-file-path-011: Command Palette "Send Current File Path (Absolute)" sends absolute path', async () => {
     const capturing = await createAndBindCapturingTerminal('sfp-test');
-    tmpTerminals.push(capturing.terminal);
 
     const fileUri = createWorkspaceFile('sfp-011', 'content\n');
     tmpFileUris.push(fileUri);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/statusBarMenu.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/statusBarMenu.test.ts
@@ -108,29 +108,25 @@ standardSuite('R-M Status Bar Menu', (log) => {
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
     await settle();
 
-    try {
-      const logCapture = getLogCapture();
-      logCapture.mark('before-menu-005');
+    const logCapture = getLogCapture();
+    logCapture.mark('before-menu-005');
 
-      await openAndDismiss(CMD_OPEN_STATUS_BAR_MENU);
+    await openAndDismiss(CMD_OPEN_STATUS_BAR_MENU);
 
-      const lines = logCapture.getLinesSince('before-menu-005');
-      assertQuickPickItemsLogged(lines, [
-        {
-          label: '$(arrow-right) Jump to Bound Destination',
-          description: '→ Terminal ("rl-menu-test")',
-          itemKind: 'command',
-        },
-        { label: '$(close) Unbind Destination', itemKind: 'command' },
-        { label: '', kind: SEPARATOR_KIND },
-        { label: '$(link-external) Go to Link', itemKind: 'command' },
-        { label: '$(info) Show Version Info', itemKind: 'command' },
-      ]);
+    const lines = logCapture.getLinesSince('before-menu-005');
+    assertQuickPickItemsLogged(lines, [
+      {
+        label: '$(arrow-right) Jump to Bound Destination',
+        description: '→ Terminal ("rl-menu-test")',
+        itemKind: 'command',
+      },
+      { label: '$(close) Unbind Destination', itemKind: 'command' },
+      { label: '', kind: SEPARATOR_KIND },
+      { label: '$(link-external) Go to Link', itemKind: 'command' },
+      { label: '$(info) Show Version Info', itemKind: 'command' },
+    ]);
 
-      log('✓ Bound-state menu items validated via log capture');
-    } finally {
-      terminal.dispose();
-    }
+    log('✓ Bound-state menu items validated via log capture');
   });
 
   test('[assisted] status-bar-menu-001: status bar item visible with correct text and tooltip', async () => {
@@ -176,63 +172,59 @@ standardSuite('R-M Status Bar Menu', (log) => {
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await settle();
 
-    try {
-      const logCapture = getLogCapture();
-      logCapture.mark('before-007');
+    const logCapture = getLogCapture();
+    logCapture.mark('before-007');
 
-      await waitForHuman(
-        'status-bar-menu-007',
-        'Destination is bound to "rl-sbm-007". Open the R-M menu (Cmd+R Cmd+M), verify Jump and Unbind are present, select "$(close) Unbind Destination", then click Cancel.',
-        [
-          '1. Press Cmd+R Cmd+M to open the R-M menu',
-          '2. Confirm "$(arrow-right) Jump to Bound Destination" shows "rl-sbm-007"',
-          '3. Confirm "$(close) Unbind Destination" is visible',
-          '4. Select "$(close) Unbind Destination"',
-          '5. Click Cancel on this notification',
-        ],
-      );
+    await waitForHuman(
+      'status-bar-menu-007',
+      'Destination is bound to "rl-sbm-007". Open the R-M menu (Cmd+R Cmd+M), verify Jump and Unbind are present, select "$(close) Unbind Destination", then click Cancel.',
+      [
+        '1. Press Cmd+R Cmd+M to open the R-M menu',
+        '2. Confirm "$(arrow-right) Jump to Bound Destination" shows "rl-sbm-007"',
+        '3. Confirm "$(close) Unbind Destination" is visible',
+        '4. Select "$(close) Unbind Destination"',
+        '5. Click Cancel on this notification',
+      ],
+    );
 
-      const lines = logCapture.getLinesSince('before-007');
-      const items = extractQuickPickItemsLogged(lines);
-      assert.ok(items, 'Expected showQuickPick log entry with items');
-      assert.ok(
-        items!.find((i) => i.label === '$(arrow-right) Jump to Bound Destination'),
-        'Expected Jump item present in bound state',
-      );
-      assert.ok(
-        items!.find((i) => i.label === '$(close) Unbind Destination'),
-        'Expected Unbind item present in bound state',
-      );
-      const commandSelectedLog = lines.find(
-        (l) => l.includes('Command item selected') && l.includes('Unbind Destination'),
-      );
-      assert.ok(commandSelectedLog, 'Expected "Command item selected" log for Unbind Destination');
+    const lines = logCapture.getLinesSince('before-007');
+    const items = extractQuickPickItemsLogged(lines);
+    assert.ok(items, 'Expected showQuickPick log entry with items');
+    assert.ok(
+      items!.find((i) => i.label === '$(arrow-right) Jump to Bound Destination'),
+      'Expected Jump item present in bound state',
+    );
+    assert.ok(
+      items!.find((i) => i.label === '$(close) Unbind Destination'),
+      'Expected Unbind item present in bound state',
+    );
+    const commandSelectedLog = lines.find(
+      (l) => l.includes('Command item selected') && l.includes('Unbind Destination'),
+    );
+    assert.ok(commandSelectedLog, 'Expected "Command item selected" log for Unbind Destination');
 
-      logCapture.mark('after-unbind-007');
-      await waitForHuman(
-        'status-bar-menu-007',
-        'Re-open the R-M menu (Cmd+R Cmd+M), verify "Jump to Bound Destination" is gone, then press Escape and click Cancel.',
-        [
-          '1. Press Cmd+R Cmd+M to open the R-M menu',
-          '2. Confirm "$(arrow-right) Jump to Bound Destination" is NOT present',
-          '3. Press Escape to dismiss, then click Cancel',
-        ],
-      );
+    logCapture.mark('after-unbind-007');
+    await waitForHuman(
+      'status-bar-menu-007',
+      'Re-open the R-M menu (Cmd+R Cmd+M), verify "Jump to Bound Destination" is gone, then press Escape and click Cancel.',
+      [
+        '1. Press Cmd+R Cmd+M to open the R-M menu',
+        '2. Confirm "$(arrow-right) Jump to Bound Destination" is NOT present',
+        '3. Press Escape to dismiss, then click Cancel',
+      ],
+    );
 
-      const postLines = logCapture.getLinesSince('after-unbind-007');
-      const postItems = extractQuickPickItemsLogged(postLines);
-      assert.ok(postItems, 'Expected post-unbind showQuickPick log entry with items');
-      assert.strictEqual(
-        postItems!.find((i) => i.label === '$(arrow-right) Jump to Bound Destination'),
-        undefined,
-        'Expected no Jump item after unbind',
-      );
-      log(
-        '✓ Bound menu showed Jump + Unbind; human selected Unbind; post-unbind menu confirmed Jump absent',
-      );
-    } finally {
-      terminal.dispose();
-    }
+    const postLines = logCapture.getLinesSince('after-unbind-007');
+    const postItems = extractQuickPickItemsLogged(postLines);
+    assert.ok(postItems, 'Expected post-unbind showQuickPick log entry with items');
+    assert.strictEqual(
+      postItems!.find((i) => i.label === '$(arrow-right) Jump to Bound Destination'),
+      undefined,
+      'Expected no Jump item after unbind',
+    );
+    log(
+      '✓ Bound menu showed Jump + Unbind; human selected Unbind; post-unbind menu confirmed Jump absent',
+    );
   });
 
   test('[assisted] status-bar-menu-008: R-M menu Go to Link item opens the R-G input box', async () => {

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/terminalPicker.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/terminalPicker.test.ts
@@ -25,19 +25,9 @@ const MAX_INLINE_DEFAULT = 5;
 const FILE_OVERFLOW_THRESHOLD = 5;
 
 standardSuite('Terminal Picker', (log) => {
-  const terminals: vscode.Terminal[] = [];
-
-  teardown(async () => {
-    for (const t of terminals) {
-      t.dispose();
-    }
-    terminals.length = 0;
-    await settle();
-  });
-
   test('terminal-picker-001: active terminal is marked with active badge', async () => {
-    const t1 = await createTerminal('rl-tp-001-a', terminals);
-    await createTerminal('rl-tp-001-b', terminals);
+    const t1 = await createTerminal('rl-tp-001-a');
+    await createTerminal('rl-tp-001-b');
     t1.show(true);
     await settle();
 
@@ -84,10 +74,10 @@ standardSuite('Terminal Picker', (log) => {
   });
 
   test('terminal-picker-002: bound terminal is marked with bound badge', async () => {
-    await createTerminal('rl-tp-002', terminals);
+    await createTerminal('rl-tp-002');
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
     await settle();
-    const t2 = await createTerminal('rl-tp-002-other', terminals);
+    const t2 = await createTerminal('rl-tp-002-other');
     t2.show(true);
     await settle();
 
@@ -134,7 +124,7 @@ standardSuite('Terminal Picker', (log) => {
   });
 
   test('terminal-picker-003: terminal that is both active and bound shows dual badge', async () => {
-    const t = await createTerminal('rl-tp-003', terminals);
+    const t = await createTerminal('rl-tp-003');
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
     t.show(true);
     await settle();
@@ -174,10 +164,10 @@ standardSuite('Terminal Picker', (log) => {
   });
 
   test('terminal-picker-004: bound terminal always appears first in the list', async () => {
-    await createTerminal('rl-tp-004-b', terminals);
+    await createTerminal('rl-tp-004-b');
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
     await settle();
-    await createTerminal('rl-tp-004-a', terminals);
+    await createTerminal('rl-tp-004-a');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-004');
@@ -222,10 +212,10 @@ standardSuite('Terminal Picker', (log) => {
   });
 
   test('terminal-picker-005: active non-bound terminal appears second', async () => {
-    await createTerminal('rl-tp-005-a', terminals);
+    await createTerminal('rl-tp-005-a');
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
     await settle();
-    const t2 = await createTerminal('rl-tp-005-b', terminals);
+    const t2 = await createTerminal('rl-tp-005-b');
     t2.show(true);
     await settle();
 
@@ -272,7 +262,7 @@ standardSuite('Terminal Picker', (log) => {
   });
 
   test('terminal-picker-006: hidden IDE terminals are absent from the picker', async () => {
-    await createTerminal('rl-tp-006', terminals);
+    await createTerminal('rl-tp-006');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-006');
@@ -309,8 +299,8 @@ standardSuite('Terminal Picker', (log) => {
   });
 
   test('terminal-picker-007: all terminals shown inline when within maxInline limit', async () => {
-    await createTerminal('rl-tp-007-a', terminals);
-    await createTerminal('rl-tp-007-b', terminals);
+    await createTerminal('rl-tp-007-a');
+    await createTerminal('rl-tp-007-b');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-007');
@@ -362,7 +352,7 @@ standardSuite('Terminal Picker', (log) => {
 
   test('terminal-picker-008: overflow shows "More terminals..." when exceeding maxInline', async () => {
     for (let i = 1; i <= TERMINAL_OVERFLOW_COUNT; i++) {
-      await createTerminal(`rl-tp-008-${i}`, terminals);
+      await createTerminal(`rl-tp-008-${i}`);
     }
 
     const logCapture = getLogCapture();
@@ -423,7 +413,7 @@ standardSuite('Terminal Picker', (log) => {
 
   test('[assisted] terminal-picker-009: selecting "More terminals..." opens secondary full picker', async () => {
     for (let i = 1; i <= TERMINAL_OVERFLOW_COUNT; i++) {
-      await createTerminal(`rl-tp-009-${i}`, terminals);
+      await createTerminal(`rl-tp-009-${i}`);
     }
 
     const logCapture = getLogCapture();
@@ -488,7 +478,7 @@ standardSuite('Terminal Picker', (log) => {
 
   test('[assisted] terminal-picker-010: escaping secondary picker returns to parent destination picker', async () => {
     for (let i = 1; i <= TERMINAL_OVERFLOW_COUNT; i++) {
-      await createTerminal(`rl-tp-010-${i}`, terminals);
+      await createTerminal(`rl-tp-010-${i}`);
     }
 
     const logCapture = getLogCapture();
@@ -531,7 +521,7 @@ standardSuite('Terminal Picker', (log) => {
     const TC_TERMINAL_COUNT = 3;
 
     for (let i = 1; i <= TC_TERMINAL_COUNT; i++) {
-      await createTerminal(`rl-tp-011-${i}`, terminals);
+      await createTerminal(`rl-tp-011-${i}`);
     }
 
     const logCapture = getLogCapture();
@@ -587,7 +577,7 @@ standardSuite('Terminal Picker', (log) => {
   });
 
   test('terminal-picker-012: terminal picker appears inline in R-M menu when unbound', async () => {
-    await createTerminal('rl-tp-012', terminals);
+    await createTerminal('rl-tp-012');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-012');
@@ -629,7 +619,7 @@ standardSuite('Terminal Picker', (log) => {
   });
 
   test('terminal-picker-013: terminal picker appears inline in R-D destination picker', async () => {
-    await createTerminal('rl-tp-013', terminals);
+    await createTerminal('rl-tp-013');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-013');
@@ -667,7 +657,7 @@ standardSuite('Terminal Picker', (log) => {
 
   test('bind-to-destination-013: R-D picker shows both overflow items when many terminals and files are open', async () => {
     for (let i = 1; i <= TERMINAL_OVERFLOW_COUNT; i++) {
-      await createTerminal(`rl-btd-013-${i}`, terminals);
+      await createTerminal(`rl-btd-013-${i}`);
     }
 
     const tmpFileUris: vscode.Uri[] = [];

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/unbind.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/unbind.test.ts
@@ -62,8 +62,6 @@ standardSuite('Unbind Destination', (_log) => {
       clipboard.includes('#L'),
       `Expected clipboard to contain a line reference but got: ${clipboard}`,
     );
-
-    terminal.dispose();
   });
 
   test('unbind-004: RangeLink: Unbind Destination available in Command Palette', async () => {
@@ -82,8 +80,6 @@ standardSuite('Unbind Destination', (_log) => {
     assertStatusBarMsgLogged(lines, {
       message: '✓ RangeLink unbound from Terminal ("rl-unbind-004-test")',
     });
-
-    terminal.dispose();
   });
 
   test('[assisted] unbind-005: "RangeLink: Unbind" hidden in command palette when no destination is bound', async () => {
@@ -144,9 +140,6 @@ standardSuite('Unbind Destination', (_log) => {
       'pass',
       'Human reported "RangeLink: Unbind" was NOT visible in command palette when bound — the `when: rangelink.isBound` clause is not working',
     );
-
-    await vscode.commands.executeCommand('rangelink.unbindDestination');
-    terminal.dispose();
   });
 
   test('unbind-003: unbindDestination is a safe no-op when no destination is bound', async () => {

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/unbind.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/unbind.test.ts
@@ -4,12 +4,15 @@ import * as vscode from 'vscode';
 
 import {
   TERMINAL_READY_MS,
+  assertNoSetContextLogged,
+  assertSetContextLogged,
   assertStatusBarMsgLogged,
   cleanupFiles,
   createWorkspaceFile,
   getLogCapture,
   settle,
   standardSuite,
+  waitForHumanVerdict,
 } from '../helpers';
 
 standardSuite('Unbind Destination', (_log) => {
@@ -80,6 +83,69 @@ standardSuite('Unbind Destination', (_log) => {
       message: '✓ RangeLink unbound from Terminal ("rl-unbind-004-test")',
     });
 
+    terminal.dispose();
+  });
+
+  test('[assisted] unbind-005: "RangeLink: Unbind" hidden in command palette when no destination is bound', async () => {
+    const CONTEXT_IS_BOUND_KEY = 'rangelink.isBound';
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-unbind-005');
+
+    const lines = logCapture.getLinesSince('before-unbind-005');
+    assertNoSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
+
+    const verdict = await waitForHumanVerdict(
+      'unbind-005',
+      'Open Command Palette (Cmd+Shift+P), type "RangeLink: Unbind" — is "RangeLink: Unbind" ABSENT?',
+      [
+        '1. Open the Command Palette (Cmd+Shift+P / Ctrl+Shift+P)',
+        '2. Type "RangeLink: Unbind"',
+        '3. Click Pass if "RangeLink: Unbind" is NOT visible (the `when: rangelink.isBound` clause should hide it).',
+        '   Click Fail if it IS present (that would be a bug).',
+      ],
+    );
+
+    assert.strictEqual(
+      verdict,
+      'pass',
+      'Human reported "RangeLink: Unbind" WAS visible in command palette when unbound — the `when: rangelink.isBound` clause is not working',
+    );
+  });
+
+  test('[assisted] unbind-006: "RangeLink: Unbind" visible in command palette when a destination is bound', async () => {
+    const CONTEXT_IS_BOUND_KEY = 'rangelink.isBound';
+
+    const terminal = vscode.window.createTerminal({ name: 'rl-unbind-006-test' });
+    terminal.show(true);
+    await settle(TERMINAL_READY_MS);
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-unbind-006');
+
+    await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
+
+    const lines = logCapture.getLinesSince('before-unbind-006');
+    assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
+
+    const verdict = await waitForHumanVerdict(
+      'unbind-006',
+      'Open Command Palette (Cmd+Shift+P), type "RangeLink: Unbind" — is "RangeLink: Unbind" PRESENT?',
+      [
+        '1. Open the Command Palette (Cmd+Shift+P / Ctrl+Shift+P)',
+        '2. Type "RangeLink: Unbind"',
+        '3. Click Pass if "RangeLink: Unbind" IS visible (the `when: rangelink.isBound` clause should show it when bound).',
+        '   Click Fail if it is NOT present (that would be a bug).',
+      ],
+    );
+
+    assert.strictEqual(
+      verdict,
+      'pass',
+      'Human reported "RangeLink: Unbind" was NOT visible in command palette when bound — the `when: rangelink.isBound` clause is not working',
+    );
+
+    await vscode.commands.executeCommand('rangelink.unbindDestination');
     terminal.dispose();
   });
 

--- a/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
@@ -1113,201 +1113,204 @@ describe('package.json contributions', () => {
     describe('commandPalette', () => {
       const commandPalette = packageJson.contributes.menus['commandPalette'] as MenuContribution[];
 
+      const findEntry = (commandId: string): MenuContribution | undefined =>
+        commandPalette.find((entry) => entry.command === commandId);
+
       it('has the expected number of commandPalette entries', () => {
         expect(commandPalette).toHaveLength(28);
       });
 
       it('bindToTerminalHere is hidden from command palette', () => {
-        expect(commandPalette[0]).toStrictEqual({
+        expect(findEntry('rangelink.bindToTerminalHere')).toStrictEqual({
           command: 'rangelink.bindToTerminalHere',
           when: 'false',
         });
       });
 
       it('bindToTextEditorHere is hidden from command palette', () => {
-        expect(commandPalette[1]).toStrictEqual({
+        expect(findEntry('rangelink.bindToTextEditorHere')).toStrictEqual({
           command: 'rangelink.bindToTextEditorHere',
           when: 'false',
         });
       });
 
       it('pasteFileAbsolutePath is hidden from command palette', () => {
-        expect(commandPalette[2]).toStrictEqual({
+        expect(findEntry('rangelink.pasteFileAbsolutePath')).toStrictEqual({
           command: 'rangelink.pasteFileAbsolutePath',
           when: 'false',
         });
       });
 
       it('pasteFileRelativePath is hidden from command palette', () => {
-        expect(commandPalette[3]).toStrictEqual({
+        expect(findEntry('rangelink.pasteFileRelativePath')).toStrictEqual({
           command: 'rangelink.pasteFileRelativePath',
           when: 'false',
         });
       });
 
       it('explorer.bind is hidden from command palette', () => {
-        expect(commandPalette[4]).toStrictEqual({
+        expect(findEntry('rangelink.explorer.bind')).toStrictEqual({
           command: 'rangelink.explorer.bind',
           when: 'false',
         });
       });
 
       it('explorer.pasteFilePath is hidden from command palette', () => {
-        expect(commandPalette[5]).toStrictEqual({
+        expect(findEntry('rangelink.explorer.pasteFilePath')).toStrictEqual({
           command: 'rangelink.explorer.pasteFilePath',
           when: 'false',
         });
       });
 
       it('explorer.pasteRelativeFilePath is hidden from command palette', () => {
-        expect(commandPalette[6]).toStrictEqual({
+        expect(findEntry('rangelink.explorer.pasteRelativeFilePath')).toStrictEqual({
           command: 'rangelink.explorer.pasteRelativeFilePath',
           when: 'false',
         });
       });
 
       it('explorer.unbind is hidden from command palette', () => {
-        expect(commandPalette[7]).toStrictEqual({
+        expect(findEntry('rangelink.explorer.unbind')).toStrictEqual({
           command: 'rangelink.explorer.unbind',
           when: 'false',
         });
       });
 
       it('unbindDestination is conditionally gated in command palette', () => {
-        expect(commandPalette[8]).toStrictEqual({
+        expect(findEntry('rangelink.unbindDestination')).toStrictEqual({
           command: 'rangelink.unbindDestination',
           when: 'rangelink.isBound',
         });
       });
 
       it('editorTab.pasteFilePath is hidden from command palette', () => {
-        expect(commandPalette[9]).toStrictEqual({
+        expect(findEntry('rangelink.editorTab.pasteFilePath')).toStrictEqual({
           command: 'rangelink.editorTab.pasteFilePath',
           when: 'false',
         });
       });
 
       it('editorTab.pasteRelativeFilePath is hidden from command palette', () => {
-        expect(commandPalette[10]).toStrictEqual({
+        expect(findEntry('rangelink.editorTab.pasteRelativeFilePath')).toStrictEqual({
           command: 'rangelink.editorTab.pasteRelativeFilePath',
           when: 'false',
         });
       });
 
       it('editorContent.pasteFilePath is hidden from command palette', () => {
-        expect(commandPalette[11]).toStrictEqual({
+        expect(findEntry('rangelink.editorContent.pasteFilePath')).toStrictEqual({
           command: 'rangelink.editorContent.pasteFilePath',
           when: 'false',
         });
       });
 
       it('editorContent.pasteRelativeFilePath is hidden from command palette', () => {
-        expect(commandPalette[12]).toStrictEqual({
+        expect(findEntry('rangelink.editorContent.pasteRelativeFilePath')).toStrictEqual({
           command: 'rangelink.editorContent.pasteRelativeFilePath',
           when: 'false',
         });
       });
 
       it('editorContent.bind is hidden from command palette', () => {
-        expect(commandPalette[13]).toStrictEqual({
+        expect(findEntry('rangelink.editorContent.bind')).toStrictEqual({
           command: 'rangelink.editorContent.bind',
           when: 'false',
         });
       });
 
       it('editorContent.unbind is hidden from command palette', () => {
-        expect(commandPalette[14]).toStrictEqual({
+        expect(findEntry('rangelink.editorContent.unbind')).toStrictEqual({
           command: 'rangelink.editorContent.unbind',
           when: 'false',
         });
       });
 
       it('editorContext.copyLink is hidden from command palette', () => {
-        expect(commandPalette[15]).toStrictEqual({
+        expect(findEntry('rangelink.editorContext.copyLink')).toStrictEqual({
           command: 'rangelink.editorContext.copyLink',
           when: 'false',
         });
       });
 
       it('editorContext.copyLinkAbsolute is hidden from command palette', () => {
-        expect(commandPalette[16]).toStrictEqual({
+        expect(findEntry('rangelink.editorContext.copyLinkAbsolute')).toStrictEqual({
           command: 'rangelink.editorContext.copyLinkAbsolute',
           when: 'false',
         });
       });
 
       it('editorContext.copyPortableLink is hidden from command palette', () => {
-        expect(commandPalette[17]).toStrictEqual({
+        expect(findEntry('rangelink.editorContext.copyPortableLink')).toStrictEqual({
           command: 'rangelink.editorContext.copyPortableLink',
           when: 'false',
         });
       });
 
       it('editorContext.copyPortableLinkAbsolute is hidden from command palette', () => {
-        expect(commandPalette[18]).toStrictEqual({
+        expect(findEntry('rangelink.editorContext.copyPortableLinkAbsolute')).toStrictEqual({
           command: 'rangelink.editorContext.copyPortableLinkAbsolute',
           when: 'false',
         });
       });
 
       it('editorContext.pasteSelectedText is hidden from command palette', () => {
-        expect(commandPalette[19]).toStrictEqual({
+        expect(findEntry('rangelink.editorContext.pasteSelectedText')).toStrictEqual({
           command: 'rangelink.editorContext.pasteSelectedText',
           when: 'false',
         });
       });
 
       it('editorContext.saveBookmark is hidden from command palette', () => {
-        expect(commandPalette[20]).toStrictEqual({
+        expect(findEntry('rangelink.editorContext.saveBookmark')).toStrictEqual({
           command: 'rangelink.editorContext.saveBookmark',
           when: 'false',
         });
       });
 
       it('bookmark.add is gated by bookmarks feature flag in command palette', () => {
-        expect(commandPalette[21]).toStrictEqual({
+        expect(findEntry('rangelink.bookmark.add')).toStrictEqual({
           command: 'rangelink.bookmark.add',
           when: 'config.rangelink.features.bookmarks.enabled && editorHasSelection',
         });
       });
 
       it('bookmark.list is gated by bookmarks feature flag in command palette', () => {
-        expect(commandPalette[22]).toStrictEqual({
+        expect(findEntry('rangelink.bookmark.list')).toStrictEqual({
           command: 'rangelink.bookmark.list',
           when: 'config.rangelink.features.bookmarks.enabled',
         });
       });
 
       it('terminal.bind is hidden from command palette', () => {
-        expect(commandPalette[23]).toStrictEqual({
+        expect(findEntry('rangelink.terminal.bind')).toStrictEqual({
           command: 'rangelink.terminal.bind',
           when: 'false',
         });
       });
 
       it('terminal.copyLinkGuard is hidden from command palette', () => {
-        expect(commandPalette[24]).toStrictEqual({
+        expect(findEntry('rangelink.terminal.copyLinkGuard')).toStrictEqual({
           command: 'rangelink.terminal.copyLinkGuard',
           when: 'false',
         });
       });
 
       it('terminal.linkBridge is hidden from command palette', () => {
-        expect(commandPalette[25]).toStrictEqual({
+        expect(findEntry('rangelink.terminal.linkBridge')).toStrictEqual({
           command: 'rangelink.terminal.linkBridge',
           when: 'false',
         });
       });
 
       it('terminal.pasteSelectedTextToDestination is hidden from command palette', () => {
-        expect(commandPalette[26]).toStrictEqual({
+        expect(findEntry('rangelink.terminal.pasteSelectedTextToDestination')).toStrictEqual({
           command: 'rangelink.terminal.pasteSelectedTextToDestination',
           when: 'false',
         });
       });
 
       it('terminal.unbind is hidden from command palette', () => {
-        expect(commandPalette[27]).toStrictEqual({
+        expect(findEntry('rangelink.terminal.unbind')).toStrictEqual({
           command: 'rangelink.terminal.unbind',
           when: 'false',
         });

--- a/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
@@ -1114,7 +1114,7 @@ describe('package.json contributions', () => {
       const commandPalette = packageJson.contributes.menus['commandPalette'] as MenuContribution[];
 
       it('has the expected number of commandPalette entries', () => {
-        expect(commandPalette).toHaveLength(27);
+        expect(commandPalette).toHaveLength(28);
       });
 
       it('bindToTerminalHere is hidden from command palette', () => {
@@ -1173,134 +1173,141 @@ describe('package.json contributions', () => {
         });
       });
 
-      it('editorTab.pasteFilePath is hidden from command palette', () => {
+      it('unbindDestination is conditionally gated in command palette', () => {
         expect(commandPalette[8]).toStrictEqual({
+          command: 'rangelink.unbindDestination',
+          when: 'rangelink.isBound',
+        });
+      });
+
+      it('editorTab.pasteFilePath is hidden from command palette', () => {
+        expect(commandPalette[9]).toStrictEqual({
           command: 'rangelink.editorTab.pasteFilePath',
           when: 'false',
         });
       });
 
       it('editorTab.pasteRelativeFilePath is hidden from command palette', () => {
-        expect(commandPalette[9]).toStrictEqual({
+        expect(commandPalette[10]).toStrictEqual({
           command: 'rangelink.editorTab.pasteRelativeFilePath',
           when: 'false',
         });
       });
 
       it('editorContent.pasteFilePath is hidden from command palette', () => {
-        expect(commandPalette[10]).toStrictEqual({
+        expect(commandPalette[11]).toStrictEqual({
           command: 'rangelink.editorContent.pasteFilePath',
           when: 'false',
         });
       });
 
       it('editorContent.pasteRelativeFilePath is hidden from command palette', () => {
-        expect(commandPalette[11]).toStrictEqual({
+        expect(commandPalette[12]).toStrictEqual({
           command: 'rangelink.editorContent.pasteRelativeFilePath',
           when: 'false',
         });
       });
 
       it('editorContent.bind is hidden from command palette', () => {
-        expect(commandPalette[12]).toStrictEqual({
+        expect(commandPalette[13]).toStrictEqual({
           command: 'rangelink.editorContent.bind',
           when: 'false',
         });
       });
 
       it('editorContent.unbind is hidden from command palette', () => {
-        expect(commandPalette[13]).toStrictEqual({
+        expect(commandPalette[14]).toStrictEqual({
           command: 'rangelink.editorContent.unbind',
           when: 'false',
         });
       });
 
       it('editorContext.copyLink is hidden from command palette', () => {
-        expect(commandPalette[14]).toStrictEqual({
+        expect(commandPalette[15]).toStrictEqual({
           command: 'rangelink.editorContext.copyLink',
           when: 'false',
         });
       });
 
       it('editorContext.copyLinkAbsolute is hidden from command palette', () => {
-        expect(commandPalette[15]).toStrictEqual({
+        expect(commandPalette[16]).toStrictEqual({
           command: 'rangelink.editorContext.copyLinkAbsolute',
           when: 'false',
         });
       });
 
       it('editorContext.copyPortableLink is hidden from command palette', () => {
-        expect(commandPalette[16]).toStrictEqual({
+        expect(commandPalette[17]).toStrictEqual({
           command: 'rangelink.editorContext.copyPortableLink',
           when: 'false',
         });
       });
 
       it('editorContext.copyPortableLinkAbsolute is hidden from command palette', () => {
-        expect(commandPalette[17]).toStrictEqual({
+        expect(commandPalette[18]).toStrictEqual({
           command: 'rangelink.editorContext.copyPortableLinkAbsolute',
           when: 'false',
         });
       });
 
       it('editorContext.pasteSelectedText is hidden from command palette', () => {
-        expect(commandPalette[18]).toStrictEqual({
+        expect(commandPalette[19]).toStrictEqual({
           command: 'rangelink.editorContext.pasteSelectedText',
           when: 'false',
         });
       });
 
       it('editorContext.saveBookmark is hidden from command palette', () => {
-        expect(commandPalette[19]).toStrictEqual({
+        expect(commandPalette[20]).toStrictEqual({
           command: 'rangelink.editorContext.saveBookmark',
           when: 'false',
         });
       });
 
       it('bookmark.add is gated by bookmarks feature flag in command palette', () => {
-        expect(commandPalette[20]).toStrictEqual({
+        expect(commandPalette[21]).toStrictEqual({
           command: 'rangelink.bookmark.add',
           when: 'config.rangelink.features.bookmarks.enabled && editorHasSelection',
         });
       });
 
       it('bookmark.list is gated by bookmarks feature flag in command palette', () => {
-        expect(commandPalette[21]).toStrictEqual({
+        expect(commandPalette[22]).toStrictEqual({
           command: 'rangelink.bookmark.list',
           when: 'config.rangelink.features.bookmarks.enabled',
         });
       });
 
       it('terminal.bind is hidden from command palette', () => {
-        expect(commandPalette[22]).toStrictEqual({
+        expect(commandPalette[23]).toStrictEqual({
           command: 'rangelink.terminal.bind',
           when: 'false',
         });
       });
 
       it('terminal.copyLinkGuard is hidden from command palette', () => {
-        expect(commandPalette[23]).toStrictEqual({
+        expect(commandPalette[24]).toStrictEqual({
           command: 'rangelink.terminal.copyLinkGuard',
           when: 'false',
         });
       });
 
       it('terminal.linkBridge is hidden from command palette', () => {
-        expect(commandPalette[24]).toStrictEqual({
+        expect(commandPalette[25]).toStrictEqual({
           command: 'rangelink.terminal.linkBridge',
           when: 'false',
         });
       });
 
       it('terminal.pasteSelectedTextToDestination is hidden from command palette', () => {
-        expect(commandPalette[25]).toStrictEqual({
+        expect(commandPalette[26]).toStrictEqual({
           command: 'rangelink.terminal.pasteSelectedTextToDestination',
           when: 'false',
         });
       });
 
       it('terminal.unbind is hidden from command palette', () => {
-        expect(commandPalette[26]).toStrictEqual({
+        expect(commandPalette[27]).toStrictEqual({
           command: 'rangelink.terminal.unbind',
           when: 'false',
         });


### PR DESCRIPTION
## Summary

`rangelink.unbindDestination` now hides from the command palette when no destination is bound, instead of appearing grayed out. This aligns palette behavior with the existing keybinding and status bar menu, both of which already gate on `rangelink.isBound`. VS Code best practice is to hide irrelevant commands via `when` on `commandPalette` rather than showing them disabled via `enablement` alone.

## Changes

- Added `rangelink.unbindDestination` to the `commandPalette` contributions in `package.json` with `"when": "rangelink.isBound"`, inserting alphabetically after the existing `rangelink.explorer.unbind` entry
- Added `[assisted]` verdict integration tests: `unbind-005` (hidden when unbound, with `assertNoSetContextLogged` precondition) and `unbind-006` (visible when bound, with `assertSetContextLogged` precondition)
- Added QA test cases `unbind-005` and `unbind-006` with `automated: assisted`
- Updated contract test to cover the new commandPalette entry
- Documentation: CHANGELOG added (Changed); README not needed (no new command or setting)

## Test Plan

- [x] All existing tests pass (1890)
- [x] New tests added for: unbind-005 and unbind-006 `[assisted]` integration tests, unbindDestination contract test
- [x] Manual testing: verified with `test:release` — both verdict prompts confirmed correct command palette visibility behavior

## Related

- Closes https://github.com/couimet/rangeLink/issues/571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * The "RangeLink: Unbind" command is now hidden from the command palette when no destination is bound, rather than appearing disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/rangeLink/pull/573)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->