### PR TITLE
[issues/572] Extract inline CI shell scripts to standalone + bats tests

### DIFF
--- a/.github/actions/post-pr-ci-summary/action.yml
+++ b/.github/actions/post-pr-ci-summary/action.yml
@@ -17,6 +17,14 @@ inputs:
     description: 'Number of integration tests passing (empty if N/A)'
     required: false
     default: ''
+  int-failed:
+    description: 'Number of integration tests failed (empty if N/A)'
+    required: false
+    default: ''
+  report-file:
+    description: 'Path to the test report file for re-run command extraction'
+    required: false
+    default: ''
   label-filter:
     description: "TC ID label filter — 'requires-extensions' for with-extensions job, empty for all automated without that label"
     required: false
@@ -44,23 +52,13 @@ runs:
 
         # Extract TC IDs exercised
         LABEL_FILTER="${{ inputs.label-filter }}"
-        TC_IDS=$(python3 -c "
-        import sys, yaml
-        label_filter = sys.argv[2] if len(sys.argv) > 2 else ''
-        with open(sys.argv[1]) as f:
-            data = yaml.safe_load(f)
-        ids = []
-        for tc in data['test_cases']:
-            if tc.get('automated') is True:
-                labels = tc.get('labels') or []
-                if label_filter:
-                    if label_filter in labels:
-                        ids.append(tc['id'])
-                else:
-                    if 'requires-extensions' not in labels:
-                        ids.append(tc['id'])
-        print(', '.join(ids))
-        " "$QA_YAML" "$LABEL_FILTER")
+        RESOLVE_ARGS=(--automated-only --yaml "$QA_YAML" --format csv)
+        if [ -n "$LABEL_FILTER" ]; then
+          RESOLVE_ARGS+=(--label "$LABEL_FILTER")
+        else
+          RESOLVE_ARGS+=(--exclude-label requires-extensions)
+        fi
+        TC_IDS=$(node packages/rangelink-vscode-extension/scripts/resolve-qa-labels.js "${RESOLVE_ARGS[@]}")
 
         # Build table
         TABLE="### ${{ inputs.title }}"
@@ -74,9 +72,21 @@ runs:
         if [ -n "${{ inputs.int-passing }}" ]; then
           TABLE="${TABLE}"$'\n'"| Integration tests passing | ${{ inputs.int-passing }} |"
         fi
+        if [ -n "${{ inputs.int-failed }}" ] && [ "${{ inputs.int-failed }}" != "0" ]; then
+          TABLE="${TABLE}"$'\n'"| Integration tests failed | ${{ inputs.int-failed }} |"
+        fi
 
         TABLE="${TABLE}"$'\n'"| QA TC IDs exercised | ${TC_IDS} |"
         TABLE="${TABLE}"$'\n'"| Report | [View run & artifacts](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) |"
 
+        # Extract re-run command from test report
+        BODY="$TABLE"
+        if [ -n "${{ inputs.report-file }}" ] && [ -f "${{ inputs.report-file }}" ]; then
+          RE_RUN=$(sed -n '/^Re-run failed tests:/,$p' "${{ inputs.report-file }}" | tail -n +2 | sed 's/^  //')
+          if [ -n "$RE_RUN" ]; then
+            BODY="${BODY}"$'\n\n'"To re-run failed tests:"$'\n'"\`\`\`"$'\n'"${RE_RUN}"$'\n'"\`\`\`"
+          fi
+        fi
+
         gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-          -f body="$TABLE"
+          -f body="$BODY"

--- a/.github/actions/run-integration-tests-with-extensions/action.yml
+++ b/.github/actions/run-integration-tests-with-extensions/action.yml
@@ -5,6 +5,9 @@ outputs:
   int-passing:
     description: 'Number of integration tests passing'
     value: ${{ steps.stats.outputs.int-passing }}
+  int-failed:
+    description: 'Number of integration tests failed'
+    value: ${{ steps.stats.outputs.int-failed }}
 
 runs:
   using: 'composite'
@@ -36,12 +39,7 @@ runs:
       if: always()
       shell: bash
       run: |
-        if [ -f /tmp/test-report-with-extensions.txt ]; then
-          INT_PASSING=$(grep -oP '\d+(?= passing)' /tmp/test-report-with-extensions.txt | tail -1 || echo "0")
-        else
-          INT_PASSING="0"
-        fi
-        echo "int-passing=${INT_PASSING}" >> "$GITHUB_OUTPUT"
+        "$GITHUB_ACTION_PATH/../../scripts/ci/extract-test-stats.sh" --mode mocha /tmp/test-report-with-extensions.txt >> "$GITHUB_OUTPUT"
 
     - name: Upload test report artifact
       if: always()

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -5,6 +5,9 @@ outputs:
   int-passing:
     description: 'Number of integration tests passing'
     value: ${{ steps.stats.outputs.int-passing }}
+  int-failed:
+    description: 'Number of integration tests failed'
+    value: ${{ steps.stats.outputs.int-failed }}
 
 runs:
   using: 'composite'
@@ -35,12 +38,7 @@ runs:
       if: always()
       shell: bash
       run: |
-        if [ -f /tmp/test-report-automated.txt ]; then
-          INT_PASSING=$(grep -oP '\d+(?= passing)' /tmp/test-report-automated.txt | tail -1 || echo "0")
-        else
-          INT_PASSING="0"
-        fi
-        echo "int-passing=${INT_PASSING}" >> "$GITHUB_OUTPUT"
+        "$GITHUB_ACTION_PATH/../../scripts/ci/extract-test-stats.sh" --mode mocha /tmp/test-report-automated.txt >> "$GITHUB_OUTPUT"
 
     - name: Upload test report artifact
       if: always()

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -39,15 +39,7 @@ runs:
       if: always()
       shell: bash
       run: |
-        if [ -f /tmp/jest-out.txt ]; then
-          UNIT_PASSED=$(grep -oP 'Tests:\s+\K\d+(?= passed)' /tmp/jest-out.txt | tail -1 || echo "0")
-          UNIT_TOTAL=$(grep -oP 'Tests:.*\s\K\d+(?= total)' /tmp/jest-out.txt | tail -1 || echo "0")
-        else
-          UNIT_PASSED="0"
-          UNIT_TOTAL="0"
-        fi
-        echo "unit-passed=${UNIT_PASSED}" >> "$GITHUB_OUTPUT"
-        echo "unit-total=${UNIT_TOTAL}" >> "$GITHUB_OUTPUT"
+        "$GITHUB_ACTION_PATH/../../scripts/ci/extract-test-stats.sh" --mode jest /tmp/jest-out.txt >> "$GITHUB_OUTPUT"
 
     - name: Generate coverage summary
       if: always()

--- a/.github/scripts/ci/extract-test-stats.sh
+++ b/.github/scripts/ci/extract-test-stats.sh
@@ -19,6 +19,10 @@ OUTPUT_FILE=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --mode)
+      if [[ $# -lt 2 || "$2" == -* ]]; then
+        echo "Error: --mode requires a value" >&2
+        usage
+      fi
       MODE="$2"
       shift 2
       ;;

--- a/.github/scripts/ci/extract-test-stats.sh
+++ b/.github/scripts/ci/extract-test-stats.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Extract test stats (passed, total, passing) from Jest or mocha output files.
+# Usage: extract-test-stats.sh --mode jest|mocha <output-file>
+# Writes KEY=VALUE lines to stdout (intended to be redirected to GITHUB_OUTPUT).
+
+usage() {
+  echo "Usage: extract-test-stats.sh --mode jest|mocha <output-file>" >&2
+  echo "" >&2
+  echo "  --mode jest    Extract 'Tests: N passed, M total' from Jest output" >&2
+  echo "  --mode mocha   Extract 'N passing' from mocha/vscode-test output" >&2
+  exit 2
+}
+
+MODE=""
+OUTPUT_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      MODE="$2"
+      shift 2
+      ;;
+    -*)
+      usage
+      ;;
+    *)
+      OUTPUT_FILE="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$MODE" || -z "$OUTPUT_FILE" ]]; then
+  usage
+fi
+
+if [[ "$MODE" != "jest" && "$MODE" != "mocha" ]]; then
+  echo "Error: --mode must be 'jest' or 'mocha', got '$MODE'" >&2
+  exit 2
+fi
+
+if [[ ! -f "$OUTPUT_FILE" ]]; then
+  echo "Error: file not found: $OUTPUT_FILE" >&2
+  exit 1
+fi
+
+case "$MODE" in
+  jest)
+    UNIT_PASSED=$(perl -nle 'print $1 if /Tests:\s+(\d+)(?= passed)/' "$OUTPUT_FILE" | tail -1)
+    UNIT_TOTAL=$(perl -nle 'print $1 if /Tests:.*\s(\d+)(?= total)/' "$OUTPUT_FILE" | tail -1)
+    UNIT_PASSED="${UNIT_PASSED:-0}"
+    UNIT_TOTAL="${UNIT_TOTAL:-0}"
+    echo "unit-passed=${UNIT_PASSED}"
+    echo "unit-total=${UNIT_TOTAL}"
+    ;;
+  mocha)
+    INT_PASSING=$(perl -nle 'print $1 if /(\d+)(?= passing)/' "$OUTPUT_FILE" | tail -1)
+    INT_PASSING="${INT_PASSING:-0}"
+    INT_FAILED=$(perl -nle 'print $1 if /(\d+)(?= failing)/' "$OUTPUT_FILE" | tail -1)
+    INT_FAILED="${INT_FAILED:-0}"
+    echo "int-passing=${INT_PASSING}"
+    echo "int-failed=${INT_FAILED}"
+    ;;
+esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
           unit-passed: ${{ steps.run-tests.outputs.unit-passed }}
           unit-total: ${{ steps.run-tests.outputs.unit-total }}
           int-passing: ${{ steps.run-integration-tests.outputs.int-passing }}
+          int-failed: ${{ steps.run-integration-tests.outputs.int-failed }}
+          report-file: '/tmp/test-report-automated.txt'
           label-filter: ''
           job-start: ${{ env.TEST_JOB_START }}
 
@@ -96,5 +98,7 @@ jobs:
           unit-passed: ''
           unit-total: ''
           int-passing: ${{ steps.run-integration-tests-with-extensions.outputs.int-passing }}
+          int-failed: ${{ steps.run-integration-tests-with-extensions.outputs.int-failed }}
+          report-file: '/tmp/test-report-with-extensions.txt'
           label-filter: 'requires-extensions'
           job-start: ${{ env.EXTENSIONS_JOB_START }}

--- a/.github/workflows/test-shell-scripts.yml
+++ b/.github/workflows/test-shell-scripts.yml
@@ -1,0 +1,23 @@
+name: Shell Script Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bats-core/bats-action@4.0.0
+        with:
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - run: bats tests/shell/

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "publish:vscode-extension:vsix": "pnpm --filter rangelink-vscode-extension publish:vsix",
     "qa:setup:vscode-extension": "pnpm --filter rangelink-vscode-extension run qa:setup",
     "test": "pnpm -r test",
+    "test:bats": "bats tests/shell/",
     "test:release": "pnpm --filter rangelink-vscode-extension test:release",
     "test:release:automated": "pnpm --filter rangelink-vscode-extension test:release:automated",
     "test:release:grep": "pnpm --filter rangelink-vscode-extension test:release:grep",

--- a/packages/rangelink-vscode-extension/scripts/resolve-qa-labels.js
+++ b/packages/rangelink-vscode-extension/scripts/resolve-qa-labels.js
@@ -10,7 +10,19 @@ const args = process.argv.slice(2);
 let labelFilter = '';
 let assistedOnly = false;
 let noAssisted = false;
+let automatedOnly = false;
+let excludeLabel = '';
+let outputFormat = 'lines';
 let yamlPath = '';
+
+const printUsage = () => {
+  process.stderr.write(
+    'Usage: resolve-qa-labels.js [--label <name>] [--assisted] [--no-assisted]\n' +
+      '                          [--automated-only] [--exclude-label <name>]\n' +
+      '                          [--format csv|lines] [--yaml <path>]\n',
+  );
+  process.exit(2);
+};
 
 for (let i = 0; i < args.length; i++) {
   switch (args[i]) {
@@ -27,6 +39,27 @@ for (let i = 0; i < args.length; i++) {
     case '--no-assisted':
       noAssisted = true;
       break;
+    case '--automated-only':
+      automatedOnly = true;
+      break;
+    case '--exclude-label':
+      if (i + 1 >= args.length || args[i + 1].startsWith('--')) {
+        process.stderr.write('Error: --exclude-label requires a value\n');
+        process.exit(1);
+      }
+      excludeLabel = args[++i];
+      break;
+    case '--format':
+      if (i + 1 >= args.length || args[i + 1].startsWith('--')) {
+        process.stderr.write('Error: --format requires a value\n');
+        process.exit(1);
+      }
+      outputFormat = args[++i];
+      if (outputFormat !== 'csv' && outputFormat !== 'lines') {
+        process.stderr.write("Error: --format must be 'csv' or 'lines'\n");
+        process.exit(1);
+      }
+      break;
     case '--yaml':
       if (i + 1 >= args.length || args[i + 1].startsWith('--')) {
         process.stderr.write('Error: --yaml requires a value\n');
@@ -34,15 +67,13 @@ for (let i = 0; i < args.length; i++) {
       }
       yamlPath = args[++i];
       break;
+    case '--help':
+      printUsage();
+      break;
     default:
       process.stderr.write(`Unknown option: ${args[i]}\n`);
       process.exit(1);
   }
-}
-
-if (!labelFilter) {
-  process.stderr.write('Error: --label is required\n');
-  process.exit(1);
 }
 
 if (assistedOnly && noAssisted) {
@@ -71,12 +102,10 @@ if (!yamlPath) {
     process.exit(1);
   }
 
-  // Sort by embedded version (extract from filename like qa-test-cases-v1.1.0.yaml)
   files.sort((a, b) => {
     const va = a.match(/v(\d+\.\d+\.\d+)/)?.[1] ?? '';
     const vb = b.match(/v(\d+\.\d+\.\d+)/)?.[1] ?? '';
     if (va !== vb) return va.localeCompare(vb, undefined, { numeric: true });
-    // If same version, no suffix wins (the base file)
     const suffixA = a.match(/v\d+\.\d+\.\d+-(.+)\.yaml$/)?.[1] ?? '';
     const suffixB = b.match(/v\d+\.\d+\.\d+-(.+)\.yaml$/)?.[1] ?? '';
     if (!suffixA && suffixB) return 1;
@@ -113,7 +142,6 @@ const finalizeCurrent = () => {
 for (const rawLine of lines) {
   const line = rawLine;
 
-  // Test case entry: "  - id: some-id"
   const idMatch = line.match(/^\s+- id:\s*(.+)$/);
   if (idMatch) {
     finalizeCurrent();
@@ -123,7 +151,6 @@ for (const rawLine of lines) {
 
   if (!currentCase) continue;
 
-  // automated field
   const autoMatch = line.match(/^\s+automated:\s*(.+)$/);
   if (autoMatch) {
     currentCase.automated = autoMatch[1].trim();
@@ -131,7 +158,6 @@ for (const rawLine of lines) {
     continue;
   }
 
-  // feature field
   const featMatch = line.match(/^\s+feature:\s*(.+)$/);
   if (featMatch) {
     currentCase.feature = featMatch[1].trim().replace(/^'|'$/g, '');
@@ -139,13 +165,11 @@ for (const rawLine of lines) {
     continue;
   }
 
-  // labels: key (opens label list)
   if (/^\s+labels:\s*$/.test(line)) {
     inLabels = true;
     continue;
   }
 
-  // Label entry within labels block: "    - labelname"
   if (inLabels && /^\s+-\s+(\S+)/.test(line)) {
     const labelMatch = line.match(/^\s+-\s+(\S+)/);
     if (labelMatch) {
@@ -154,7 +178,6 @@ for (const rawLine of lines) {
     continue;
   }
 
-  // Any other key (not a label line) ends the labels block
   if (inLabels && /^\s+\w+/.test(line) && !/^\s+-\s+/.test(line)) {
     inLabels = false;
   }
@@ -165,12 +188,20 @@ finalizeCurrent();
 // ── Filter and output ─────────────────────────────────────────────────────────
 
 const matching = testCases.filter((tc) => {
-  if (!tc.labels.includes(labelFilter)) return false;
+  if (labelFilter && !tc.labels.includes(labelFilter)) return false;
+  if (excludeLabel && tc.labels.includes(excludeLabel)) return false;
+  if (automatedOnly && tc.automated !== 'true') return false;
   if (assistedOnly && tc.automated !== 'assisted') return false;
   if (noAssisted && tc.automated === 'assisted') return false;
   return true;
 });
 
-for (const tc of matching) {
-  process.stdout.write(`${tc.id}\n`);
+const ids = matching.map((tc) => tc.id);
+
+if (outputFormat === 'csv') {
+  process.stdout.write(ids.join(', '));
+} else {
+  for (const id of ids) {
+    process.stdout.write(`${id}\n`);
+  }
 }

--- a/packages/rangelink-vscode-extension/scripts/resolve-qa-labels.js
+++ b/packages/rangelink-vscode-extension/scripts/resolve-qa-labels.js
@@ -15,13 +15,13 @@ let excludeLabel = '';
 let outputFormat = 'lines';
 let yamlPath = '';
 
-const printUsage = () => {
+const printUsage = (exitCode = 2) => {
   process.stderr.write(
     'Usage: resolve-qa-labels.js [--label <name>] [--assisted] [--no-assisted]\n' +
       '                          [--automated-only] [--exclude-label <name>]\n' +
       '                          [--format csv|lines] [--yaml <path>]\n',
   );
-  process.exit(2);
+  process.exit(exitCode);
 };
 
 for (let i = 0; i < args.length; i++) {
@@ -68,7 +68,7 @@ for (let i = 0; i < args.length; i++) {
       yamlPath = args[++i];
       break;
     case '--help':
-      printUsage();
+      printUsage(0);
       break;
     default:
       process.stderr.write(`Unknown option: ${args[i]}\n`);

--- a/tests/shell/extract-test-stats.bats
+++ b/tests/shell/extract-test-stats.bats
@@ -25,6 +25,12 @@ FIXTURES="$PROJECT_ROOT/tests/shell/fixtures"
   [[ "$output" == *"Usage:"* ]]
 }
 
+@test "--mode without value: exits 2 with usage" {
+  run "$SCRIPT" --mode
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Error: --mode requires a value"* ]]
+}
+
 # --- File existence ---
 
 @test "nonexistent file: exits 1" {

--- a/tests/shell/extract-test-stats.bats
+++ b/tests/shell/extract-test-stats.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+SCRIPT="$PROJECT_ROOT/.github/scripts/ci/extract-test-stats.sh"
+FIXTURES="$PROJECT_ROOT/tests/shell/fixtures"
+
+# --- Argument validation ---
+
+@test "missing mode and file: exits 2 with usage" {
+  run "$SCRIPT"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "invalid mode: exits 2 with error" {
+  run "$SCRIPT" --mode unknown /dev/null
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"must be 'jest' or 'mocha'"* ]]
+}
+
+@test "missing file: exits 2 with usage" {
+  run "$SCRIPT" --mode jest
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+# --- File existence ---
+
+@test "nonexistent file: exits 1" {
+  run "$SCRIPT" --mode jest "$TEST_TEMP_DIR/nonexistent.txt"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"file not found"* ]]
+}
+
+# --- Jest mode ---
+
+@test "jest: extracts passed and total from valid output" {
+  run "$SCRIPT" --mode jest "$FIXTURES/jest-valid.txt"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "unit-passed=1889" ]
+  [ "${lines[1]}" = "unit-total=1889" ]
+}
+
+@test "jest: picks last package's counts in multi-package output" {
+  run "$SCRIPT" --mode jest "$FIXTURES/jest-multi-package.txt"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "unit-passed=1889" ]
+  [ "${lines[1]}" = "unit-total=1889" ]
+}
+
+@test "jest: ignores Snapshots and Test Suites lines" {
+  # The fixture has Test Suites and Snapshots lines with numbers before 'total'.
+  # The anchored grep must only match the 'Tests:' line.
+  run "$SCRIPT" --mode jest "$FIXTURES/jest-snapshots.txt"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "unit-passed=42" ]
+  [ "${lines[1]}" = "unit-total=42" ]
+}
+
+@test "jest: empty file defaults to 0" {
+  touch "$TEST_TEMP_DIR/empty.txt"
+  run "$SCRIPT" --mode jest "$TEST_TEMP_DIR/empty.txt"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "unit-passed=0" ]
+  [ "${lines[1]}" = "unit-total=0" ]
+}
+
+# --- Mocha mode ---
+
+@test "mocha: extracts passing and failed counts from valid output" {
+  run "$SCRIPT" --mode mocha "$FIXTURES/mocha-valid.txt"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "int-passing=175" ]
+  [ "${lines[1]}" = "int-failed=0" ]
+}
+
+@test "mocha: extracts failed count when failures exist" {
+  run "$SCRIPT" --mode mocha "$FIXTURES/mocha-failing.txt"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "int-passing=170" ]
+  [ "${lines[1]}" = "int-failed=5" ]
+}
+
+@test "mocha: outputs 0 when no passing line exists" {
+  run "$SCRIPT" --mode mocha "$FIXTURES/mocha-no-match.txt"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "int-passing=0" ]
+  [ "${lines[1]}" = "int-failed=5" ]
+}
+
+@test "mocha: empty file defaults to 0" {
+  touch "$TEST_TEMP_DIR/empty.txt"
+  run "$SCRIPT" --mode mocha "$TEST_TEMP_DIR/empty.txt"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "int-passing=0" ]
+  [ "${lines[1]}" = "int-failed=0" ]
+}

--- a/tests/shell/fixtures/jest-multi-package.txt
+++ b/tests/shell/fixtures/jest-multi-package.txt
@@ -1,0 +1,9 @@
+packages/barebone-logger test: Test Suites: 3 passed, 3 total
+packages/barebone-logger test: Tests:       12 passed, 12 total
+packages/barebone-logger test: Snapshots:   0 total
+packages/rangelink-core-ts test: Test Suites: 28 passed, 28 total
+packages/rangelink-core-ts test: Tests:       586 passed, 586 total
+packages/rangelink-core-ts test: Snapshots:   0 total
+packages/rangelink-vscode-extension test: Test Suites: 108 passed, 108 total
+packages/rangelink-vscode-extension test: Tests:       1889 passed, 1889 total
+packages/rangelink-vscode-extension test: Snapshots:   0 total

--- a/tests/shell/fixtures/jest-snapshots.txt
+++ b/tests/shell/fixtures/jest-snapshots.txt
@@ -1,0 +1,4 @@
+packages/rangelink-vscode-extension test: Test Suites: 5 passed, 5 total
+packages/rangelink-vscode-extension test: Tests:       42 passed, 42 total
+packages/rangelink-vscode-extension test: Snapshots:   0 total
+packages/rangelink-vscode-extension test: Test Suites: 5 passed, 5 total

--- a/tests/shell/fixtures/jest-valid.txt
+++ b/tests/shell/fixtures/jest-valid.txt
@@ -1,0 +1,3 @@
+packages/rangelink-vscode-extension test: Test Suites: 108 passed, 108 total
+packages/rangelink-vscode-extension test: Tests:       1889 passed, 1889 total
+packages/rangelink-vscode-extension test: Snapshots:   0 total

--- a/tests/shell/fixtures/mocha-failing.txt
+++ b/tests/shell/fixtures/mocha-failing.txt
@@ -1,0 +1,3 @@
+  170 passing (5m)
+  5 failing
+  2 pending

--- a/tests/shell/fixtures/mocha-no-match.txt
+++ b/tests/shell/fixtures/mocha-no-match.txt
@@ -1,0 +1,2 @@
+  0 passing (0s)
+  5 failing

--- a/tests/shell/fixtures/mocha-valid.txt
+++ b/tests/shell/fixtures/mocha-valid.txt
@@ -1,0 +1,3 @@
+  175 passing (2m)
+  3 pending
+  0 failing

--- a/tests/shell/test_helper.bash
+++ b/tests/shell/test_helper.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Shared test helper for bats test suites.
+# Source from .bats files via: load test_helper
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+setup() {
+  TEST_TEMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "${TEST_TEMP_DIR:?}"
+}


### PR DESCRIPTION
## Summary

Extracts the inline test-stats grep from composite actions into a standalone, tested shell script — the first batch of a broader cleanup spanning ~20 inline scripts across 8 action files. The inline Python in post-pr-ci-summary is absorbed into the existing `resolve-qa-labels.js` (which already parsed QA YAML), eliminating a duplicated YAML parser and removing the PyYAML dependency from CI.

Adds bats test infrastructure (`tests/shell/`, `pnpm test:bats`, CI workflow) so regex/shell bugs are caught locally in ~100ms instead of an 8-minute CI cycle. Remaining scripts and bats coverage for existing package-level scripts are deferred to follow-up issues (#574, #575, and more to come).

## Changes

- New `.github/scripts/ci/extract-test-stats.sh` — extracts Jest/mocha test stats via perl regex (cross-platform, no grep -P dependency). Mocha mode now extracts both passing and failed counts. Replaces duplicated inline grep in 3 composite actions.
- `resolve-qa-labels.js` extended with `--automated-only`, `--exclude-label`, `--format csv` flags and optional `--label`. Now serves both `test-release-run.sh` (label-based MOCHA_GREP) and `post-pr-ci-summary` (automated=true TC ID extraction). Removes the need for a separate Python script and its PyYAML dependency.
- `post-pr-ci-summary` action: added failed integration test count row and copyable re-run command block (extracted from the test report) to the PR comment. New `int-failed` and `report-file` inputs.
- New `tests/shell/` — bats test suite (12 tests) with shared `test_helper.bash` and fixture files for `extract-test-stats.sh`.
- New `.github/workflows/test-shell-scripts.yml` — runs `bats tests/shell/` on every push via `bats-core/bats-action@4.0.0`. Scoped broadly for any project shell script tests, not just CI plumbing.
- New `pnpm test:bats` script in root `package.json` for local test runs.
- Documentation: CHANGELOG not needed (internal CI infrastructure). README not needed.

## Key Discoveries

- `grep -oP` is not cross-platform — macOS grep lacks `-P`. Switched to `perl -nle` which works on both macOS and Linux.
- `|| echo "0"` fallback was broken — without pipefail, `tail -1` succeeds on empty input (exit 0) so `||` never fires. Replaced with `${VAR:-0}`.
- `Tests:.*\K\d+(?= total)` greedily consumed leading digits, matching only the trailing digit (1889 → 9). Fixed with `\s` boundary: `Tests:.*\s\K\d+(?= total)`.
- GitHub Actions composite actions resolve `$GITHUB_ACTION_PATH` to the action's directory at runtime, so scripts are referenced via relative path `$GITHUB_ACTION_PATH/../../scripts/ci/`.
- `resolve-qa-labels.js` already had a manual YAML parser and label filtering — extending it was simpler than maintaining a separate Python script with PyYAML.

## Test Plan

- [x] All existing Jest tests pass (`pnpm test`)
- [x] 12 bats tests pass (`bats tests/shell/`)
- [x] Formatting clean (`pnpm format:fix`)
- [ ] CI: `test-shell-scripts.yml` job runs successfully on PR

## Related

- Closes https://github.com/couimet/rangeLink/issues/572
- Follow-up issues: #574 (bats for test-release-run.sh), #575 (bats for validate-qa-coverage.sh)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integration test failure counts now appear in PR CI summary comments
  * Failed test re-run commands are automatically extracted and displayed in PR comments for easier debugging

* **Chores**
  * Refactored CI infrastructure for improved test statistics extraction and reporting
  * Enhanced QA label resolution with additional filtering capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/rangeLink/pull/576)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->