### PR TITLE
[issues/549] Harmonize status bar and toast message prefixes

### DIFF
--- a/packages/rangelink-vscode-extension/CHANGELOG.md
+++ b/packages/rangelink-vscode-extension/CHANGELOG.md
@@ -182,6 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Unbind hidden when nothing bound** - "RangeLink: Unbind" now hides from the command palette when no destination is bound (via `when: rangelink.isBound`) instead of showing grayed out (#571)
   - **Before:** Unbind always appeared in the command palette, grayed out when unbound
   - **After:** Unbind only appears when a destination is bound, matching the existing menu and keybinding behavior
+- **Consistent status bar prefix** - Every status bar message now carries `RangeLink: ` (or `✓ RangeLink: ` for success confirmations) so the source is always identifiable in the shared IDE status bar (#549)
+  - Toast messages (info/warning/error) no longer carry `RangeLink: ` since VS Code already shows the extension source in the toast popup
 
 ### Fixed
 

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
@@ -2527,7 +2527,7 @@ test_cases:
     steps:
       - 'Drag the src/utils/helper.ts tab to a second tab group (or right-click the tab → Split Right/Down)'
       - 'Observe the notification area immediately after the split'
-    expected_result: 'A warning toast appears: "RangeLink: Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed." No paste was attempted — the warning fires on tab change, not on paste.'
+    expected_result: 'A warning toast appears: "Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed." No paste was attempted — the warning fires on tab change, not on paste.'
     automated: true
 
   - id: duplicate-tab-group-002
@@ -2551,7 +2551,7 @@ test_cases:
     steps:
       - 'Select any text in a different file'
       - 'Press Cmd+R Cmd+L (or any bound-destination send command: R-V, R-L, Send File Path)'
-    expected_result: 'Paste does not occur. An error toast appears: "RangeLink: Bound editor is open in multiple tab groups. Close the duplicate tab and try again." No text is inserted into either instance of src/utils/helper.ts.'
+    expected_result: 'Paste does not occur. An error toast appears: "Bound editor is open in multiple tab groups. Close the duplicate tab and try again." No text is inserted into either instance of src/utils/helper.ts.'
     automated: true
 
   - id: duplicate-tab-group-004
@@ -2565,7 +2565,7 @@ test_cases:
       - 'Observe the notification area — no toast should appear'
       - 'Open src/utils/helper.ts again in a second tab group (re-enter the duplicate state)'
       - 'Observe the notification area again'
-    expected_result: 'Step 2: No toast appears when the duplicate is closed. Step 4: A fresh warning toast appears — "RangeLink: Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed." — confirming the flag was reset and re-entry into the duplicate state is correctly detected.'
+    expected_result: 'Step 2: No toast appears when the duplicate is closed. Step 4: A fresh warning toast appears — "Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed." — confirming the flag was reset and re-entry into the duplicate state is correctly detected.'
     automated: true
 
   # ---------------------------------------------------------------------------
@@ -2683,7 +2683,7 @@ test_cases:
     steps:
       - 'Use Cmd+R Cmd+G (or Ctrl+R Ctrl+G) and type Untitled-99#L1'
       - 'Press Enter'
-    expected_result: 'A warning toast is shown: "RangeLink: Cannot find file: Untitled-99". No file opens.'
+    expected_result: 'A warning toast is shown: "Cannot find file: Untitled-99". No file opens.'
     automated: true
 
   - id: untitled-navigation-004
@@ -2753,7 +2753,7 @@ test_cases:
       - 'Navigation toast settings are at their defaults (both true)'
     steps:
       - 'Click a RangeLink pointing to an exact position (e.g., file.ts#L3)'
-    expected_result: 'Navigation succeeds and an info toast is shown: "RangeLink: Navigated to file.ts @ 3".'
+    expected_result: 'Navigation succeeds and an info toast is shown: "Navigated to file.ts @ 3".'
     automated: true
 
   # ---------------------------------------------------------------------------
@@ -2777,7 +2777,7 @@ test_cases:
       - 'Two or more files with the same name exist in different directories (e.g., index.ts in src/ and lib/)'
     steps:
       - 'Click a RangeLink using only the ambiguous filename (e.g., index.ts#L1)'
-    expected_result: 'A warning toast is shown: "RangeLink: Multiple files match: index.ts". No navigation occurs.'
+    expected_result: 'A warning toast is shown: "Multiple files match: index.ts". No navigation occurs.'
     automated: true
 
   - id: filename-fallback-navigation-003
@@ -2787,7 +2787,7 @@ test_cases:
       - 'No file named nonexistent-file.ts exists in the workspace'
     steps:
       - 'Click a RangeLink using a nonexistent bare filename (e.g., nonexistent-file.ts#L1)'
-    expected_result: 'A warning toast is shown: "RangeLink: Cannot find file: nonexistent-file.ts". No navigation occurs.'
+    expected_result: 'A warning toast is shown: "Cannot find file: nonexistent-file.ts". No navigation occurs.'
     automated: true
 
   - id: filename-fallback-navigation-004

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/logBasedUiAssertions.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/logBasedUiAssertions.ts
@@ -12,7 +12,10 @@ const TOAST_FN_MAP = {
   error: 'VscodeAdapter.showErrorMessage',
 } as const;
 
-const STATUS_BAR_FN = 'VscodeAdapter.setStatusBarMessage';
+const STATUS_BAR_FNS = [
+  'VscodeAdapter.setStatusBarMessage',
+  'VscodeAdapter.setSuccessfulStatusBarMessage',
+];
 
 type ToastType = keyof typeof TOAST_FN_MAP;
 
@@ -45,10 +48,10 @@ const parseLogContext = (line: string): LoggingContext | undefined => {
   return undefined;
 };
 
-const findLogEntry = (lines: string[], expectedFn: string, expectedMessage: string): boolean =>
+const findLogEntry = (lines: string[], expectedFns: string[], expectedMessage: string): boolean =>
   lines.some((line) => {
     const ctx = parseLogContext(line);
-    return ctx !== undefined && ctx.fn === expectedFn && ctx.message === expectedMessage;
+    return ctx !== undefined && expectedFns.includes(ctx.fn) && ctx.message === expectedMessage;
   });
 
 /**
@@ -56,7 +59,7 @@ const findLogEntry = (lines: string[], expectedFn: string, expectedMessage: stri
  */
 export const assertToastLogged = (lines: string[], opts: ToastAssertionOptions): void => {
   assert.ok(
-    findLogEntry(lines, TOAST_FN_MAP[opts.type], opts.message),
+    findLogEntry(lines, [TOAST_FN_MAP[opts.type]], opts.message),
     `Expected ${opts.type} toast with message "${opts.message}" but it was not found in ${lines.length} log lines`,
   );
 };
@@ -66,7 +69,7 @@ export const assertToastLogged = (lines: string[], opts: ToastAssertionOptions):
  */
 export const assertNoToastLogged = (lines: string[], opts: ToastAssertionOptions): void => {
   assert.ok(
-    !findLogEntry(lines, TOAST_FN_MAP[opts.type], opts.message),
+    !findLogEntry(lines, [TOAST_FN_MAP[opts.type]], opts.message),
     `Expected ${opts.type} toast with message "${opts.message}" to NOT be logged, but it was found`,
   );
 };
@@ -76,7 +79,7 @@ export const assertNoToastLogged = (lines: string[], opts: ToastAssertionOptions
  */
 export const assertStatusBarMsgLogged = (lines: string[], opts: MessageAssertionOptions): void => {
   assert.ok(
-    findLogEntry(lines, STATUS_BAR_FN, opts.message),
+    findLogEntry(lines, STATUS_BAR_FNS, opts.message),
     `Expected status bar message "${opts.message}" but it was not found in ${lines.length} log lines`,
   );
 };
@@ -89,7 +92,7 @@ export const assertNoStatusBarMsgLogged = (
   opts: MessageAssertionOptions,
 ): void => {
   assert.ok(
-    !findLogEntry(lines, STATUS_BAR_FN, opts.message),
+    !findLogEntry(lines, STATUS_BAR_FNS, opts.message),
     `Expected status bar message "${opts.message}" to NOT be logged, but it was found`,
   );
 };

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
@@ -75,7 +75,7 @@ standardSuite('R-D Bind to Destination', (log) => {
     );
 
     assertStatusBarMsgLogged(lines, {
-      message: '✓ RangeLink bound to Terminal ("rl-btd-004")',
+      message: '✓ RangeLink: Bound to Terminal ("rl-btd-004")',
     });
 
     assertNoStatusBarMsgLogged(lines, {
@@ -124,7 +124,7 @@ standardSuite('R-D Bind to Destination', (log) => {
     );
 
     assertStatusBarMsgLogged(lines, {
-      message: `✓ RangeLink bound to Text Editor ("${fnB}")`,
+      message: `✓ RangeLink: Bound to Text Editor ("${fnB}")`,
     });
 
     assertNoStatusBarMsgLogged(lines, {
@@ -151,7 +151,7 @@ standardSuite('R-D Bind to Destination', (log) => {
       'GitHub Copilot Chat',
     ];
     const boundToAny = AI_ASSISTANT_DISPLAY_NAMES.some((name) =>
-      lines.some((line) => line.includes(`✓ RangeLink bound to ${name}`)),
+      lines.some((line) => line.includes(`✓ RangeLink: Bound to ${name}`)),
     );
     assert.ok(
       boundToAny,
@@ -205,7 +205,7 @@ standardSuite('R-D Bind to Destination', (log) => {
     );
 
     assertNoStatusBarMsgLogged(lines, {
-      message: '✓ RangeLink bound to Terminal ("rl-btd-007-b")',
+      message: '✓ RangeLink: Bound to Terminal ("rl-btd-007-b")',
     });
     assertNoStatusBarMsgLogged(lines, {
       message: 'Unbound Terminal ("rl-btd-007-a"), now bound to Terminal ("rl-btd-007-b")',
@@ -240,7 +240,7 @@ standardSuite('R-D Bind to Destination', (log) => {
     });
 
     assertNoStatusBarMsgLogged(lines, {
-      message: '✓ RangeLink bound to Terminal ("rl-btd-008-a")',
+      message: '✓ RangeLink: Bound to Terminal ("rl-btd-008-a")',
     });
 
     log('✓ Replacement binding toast logged; old binding not re-confirmed');
@@ -273,7 +273,7 @@ standardSuite('R-D Bind to Destination', (log) => {
       message: 'Unbound Terminal ("rl-btd-009-a"), now bound to Terminal ("rl-btd-009-b")',
     });
     assertNoStatusBarMsgLogged(lines, {
-      message: '✓ RangeLink bound to Terminal ("rl-btd-009-b")',
+      message: '✓ RangeLink: Bound to Terminal ("rl-btd-009-b")',
     });
     assert.strictEqual(
       verdict,
@@ -300,7 +300,7 @@ standardSuite('R-D Bind to Destination', (log) => {
     assert.ok(items, 'Expected showQuickPick log entry (picker did open)');
 
     assertNoStatusBarMsgLogged(lines, {
-      message: '✓ RangeLink bound to Terminal ("rl-btd-010")',
+      message: '✓ RangeLink: Bound to Terminal ("rl-btd-010")',
     });
     assertNoStatusBarMsgLogged(lines, {
       message: 'RangeLink: No destination bound',
@@ -340,7 +340,7 @@ standardSuite('R-D Bind to Destination', (log) => {
       'GitHub Copilot Chat',
     ];
     const alreadyBoundLogged = AI_ASSISTANT_DISPLAY_NAMES.some((name) =>
-      lines.some((line) => line.includes(`RangeLink: Already bound to ${name}`)),
+      lines.some((line) => line.includes(`Already bound to ${name}`)),
     );
     assert.ok(
       alreadyBoundLogged,

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
@@ -344,7 +344,7 @@ standardSuite('R-D Bind to Destination', (log) => {
     );
     assert.ok(
       alreadyBoundLogged,
-      `Expected "RangeLink: Already bound to <AI assistant>" info toast for one of: ${AI_ASSISTANT_DISPLAY_NAMES.join(', ')}`,
+      `Expected "Already bound to <AI assistant>" info toast for one of: ${AI_ASSISTANT_DISPLAY_NAMES.join(', ')}`,
     );
 
     log('✓ Already-bound info toast logged; no confirmation dialog shown');

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/builtInAiAssistants.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/builtInAiAssistants.test.ts
@@ -25,7 +25,7 @@ import {
 
 const AI_ASSISTANTS_GROUP_LABEL = 'AI Assistants';
 const CLAUDE_CODE_DISPLAY_NAME = 'Claude Code Chat';
-const CLAUDE_CODE_BIND_STATUS_BAR_MESSAGE = '✓ RangeLink bound to Claude Code Chat';
+const CLAUDE_CODE_BIND_STATUS_BAR_MESSAGE = '✓ RangeLink: Bound to Claude Code Chat';
 
 standardSuite('Built-in AI Assistants', (log) => {
   const tmpFileUris: vscode.Uri[] = [];

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
@@ -92,7 +92,7 @@ standardSuite('Context Menus — Editor Content', (log) => {
     assertTerminalBufferContains(capturing.getCapturedText(), relativePath);
     assertTerminalBufferContains(capturing.getCapturedText(), '#L1-L2');
     assertStatusBarMsgLogged(lines, {
-      message: `✓ RangeLink copied to clipboard & sent to Terminal ("${terminalName}")`,
+      message: `✓ RangeLink: RangeLink copied to clipboard & sent to Terminal ("${terminalName}")`,
     });
 
     log('✓ Editor-content "Send RangeLink" delivered workspace-relative link to bound terminal');
@@ -129,7 +129,7 @@ standardSuite('Context Menus — Editor Content', (log) => {
     assertTerminalBufferContains(capturing.getCapturedText(), uri.fsPath);
     assertTerminalBufferContains(capturing.getCapturedText(), '#L1-L2');
     assertStatusBarMsgLogged(lines, {
-      message: `✓ RangeLink copied to clipboard & sent to Terminal ("${terminalName}")`,
+      message: `✓ RangeLink: RangeLink copied to clipboard & sent to Terminal ("${terminalName}")`,
     });
 
     log('✓ Editor-content "Send RangeLink (Absolute)" delivered absolute link to bound terminal');
@@ -167,7 +167,7 @@ standardSuite('Context Menus — Editor Content', (log) => {
     assertTerminalBufferContains(capturing.getCapturedText(), relativePath);
     assertTerminalBufferContains(capturing.getCapturedText(), '#L1-L2');
     assertStatusBarMsgLogged(lines, {
-      message: `✓ Portable RangeLink copied to clipboard & sent to Terminal ("${terminalName}")`,
+      message: `✓ RangeLink: Portable RangeLink copied to clipboard & sent to Terminal ("${terminalName}")`,
     });
 
     log('✓ Editor-content "Send Portable Link" delivered portable link to bound terminal');
@@ -204,7 +204,7 @@ standardSuite('Context Menus — Editor Content', (log) => {
     assertTerminalBufferContains(capturing.getCapturedText(), uri.fsPath);
     assertTerminalBufferContains(capturing.getCapturedText(), '#L1-L2');
     assertStatusBarMsgLogged(lines, {
-      message: `✓ Portable RangeLink copied to clipboard & sent to Terminal ("${terminalName}")`,
+      message: `✓ RangeLink: Portable RangeLink copied to clipboard & sent to Terminal ("${terminalName}")`,
     });
 
     log(
@@ -253,7 +253,7 @@ standardSuite('Context Menus — Editor Content', (log) => {
     log(`TC 005 captured (normalized): ${JSON.stringify(normalizedCapture)}`);
     assertTerminalBufferContains(normalizedCapture, 'line 1\nline 2\nline 3');
     assertStatusBarMsgLogged(lines, {
-      message: `✓ Selected text copied to clipboard & sent to Terminal ("${terminalName}")`,
+      message: `✓ RangeLink: Selected text copied to clipboard & sent to Terminal ("${terminalName}")`,
     });
 
     log('✓ Editor-content "Send Selected Text" delivered raw selected text to bound terminal');
@@ -379,7 +379,7 @@ standardSuite('Context Menus — Editor Content', (log) => {
     assertFnLogged(lines, { fn: 'BindToTextEditorCommand.executeWithUri' });
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
     assertStatusBarMsgLogged(lines, {
-      message: `✓ RangeLink bound to Text Editor ("${fn}")`,
+      message: `✓ RangeLink: Bound to Text Editor ("${fn}")`,
     });
 
     log('✓ Editor-content "Bind Here" committed a text-editor binding for the current file');
@@ -420,7 +420,7 @@ standardSuite('Context Menus — Editor Content', (log) => {
 
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: false });
     assertStatusBarMsgLogged(lines, {
-      message: `✓ RangeLink unbound from Terminal ("${terminalName}")`,
+      message: `✓ RangeLink: Unbound from Terminal ("${terminalName}")`,
     });
 
     log('✓ Editor-content "Unbind" was visible (clicked it) and fired the unbind path');

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorTab.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorTab.test.ts
@@ -130,7 +130,7 @@ standardSuite('Context Menus — Editor Tab', (log) => {
     assertFnLogged(lines, { fn: 'BindToTextEditorCommand.executeWithUri' });
 
     assertStatusBarMsgLogged(lines, {
-      message: `✓ RangeLink bound to Text Editor ("${fn}")`,
+      message: `✓ RangeLink: Bound to Text Editor ("${fn}")`,
     });
 
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
@@ -167,7 +167,7 @@ standardSuite('Context Menus — Editor Tab', (log) => {
     const lines = logCapture.getLinesSince('before-ctxmenu-tab-004');
 
     assertStatusBarMsgLogged(lines, {
-      message: `✓ RangeLink unbound from Terminal ("${terminalName}")`,
+      message: `✓ RangeLink: Unbound from Terminal ("${terminalName}")`,
     });
 
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: false });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuExplorer.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuExplorer.test.ts
@@ -129,7 +129,7 @@ standardSuite('Context Menus — Explorer', (log) => {
     assertFnLogged(lines, { fn: 'BindToTextEditorCommand.executeWithUri' });
 
     assertStatusBarMsgLogged(lines, {
-      message: `✓ RangeLink bound to Text Editor ("${fn}")`,
+      message: `✓ RangeLink: Bound to Text Editor ("${fn}")`,
     });
 
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
@@ -166,7 +166,7 @@ standardSuite('Context Menus — Explorer', (log) => {
     const lines = logCapture.getLinesSince('before-ctxmenu-exp-004');
 
     assertStatusBarMsgLogged(lines, {
-      message: `✓ RangeLink unbound from Terminal ("${terminalName}")`,
+      message: `✓ RangeLink: Unbound from Terminal ("${terminalName}")`,
     });
 
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: false });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
@@ -56,7 +56,7 @@ standardSuite('Context Menus — Terminal', (log) => {
     const lines = logCapture.getLinesSince('before-ctxmenu-term-001');
 
     assertStatusBarMsgLogged(lines, {
-      message: `✓ RangeLink bound to Terminal ("${terminalName}")`,
+      message: `✓ RangeLink: Bound to Terminal ("${terminalName}")`,
     });
 
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
@@ -84,7 +84,7 @@ standardSuite('Context Menus — Terminal', (log) => {
     const lines = logCapture.getLinesSince('before-ctxmenu-term-002');
 
     assertStatusBarMsgLogged(lines, {
-      message: `✓ RangeLink bound to Terminal ("${terminalName}")`,
+      message: `✓ RangeLink: Bound to Terminal ("${terminalName}")`,
     });
 
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
@@ -115,7 +115,7 @@ standardSuite('Context Menus — Terminal', (log) => {
     const lines = logCapture.getLinesSince('before-ctxmenu-term-003');
 
     assertStatusBarMsgLogged(lines, {
-      message: `✓ RangeLink unbound from Terminal ("${terminalName}")`,
+      message: `✓ RangeLink: Unbound from Terminal ("${terminalName}")`,
     });
 
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: false });
@@ -147,7 +147,7 @@ standardSuite('Context Menus — Terminal', (log) => {
     const lines = logCapture.getLinesSince('before-ctxmenu-term-004');
 
     assertStatusBarMsgLogged(lines, {
-      message: `✓ RangeLink bound to Terminal ("${targetName}")`,
+      message: `✓ RangeLink: Bound to Terminal ("${targetName}")`,
     });
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
 
@@ -189,7 +189,7 @@ standardSuite('Context Menus — Terminal', (log) => {
     const lines = logCapture.getLinesSince('before-ctxmenu-term-005');
 
     assertStatusBarMsgLogged(lines, {
-      message: `✓ RangeLink bound to Terminal ("${targetName}")`,
+      message: `✓ RangeLink: Bound to Terminal ("${targetName}")`,
     });
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
 
@@ -261,7 +261,7 @@ standardSuite('Context Menus — Terminal', (log) => {
     );
 
     assertStatusBarMsgLogged(lines, {
-      message: `✓ Selected text copied to clipboard & sent to Text Editor ("${editorFn}")`,
+      message: `✓ RangeLink: Selected text copied to clipboard & sent to Text Editor ("${editorFn}")`,
     });
 
     log('✓ Terminal context-menu "Send Selection to Destination" routed selection to bound editor');
@@ -309,7 +309,7 @@ standardSuite('Context Menus — Terminal', (log) => {
     assert.ok(readLogged, 'Expected TerminalSelectionService log (selection was read)');
 
     assertStatusBarMsgLogged(lines, {
-      message: `✓ Selected text copied to clipboard & sent to Terminal ("${boundName}")`,
+      message: `✓ RangeLink: Selected text copied to clipboard & sent to Terminal ("${boundName}")`,
     });
 
     const focusLogged = lines.some(
@@ -399,7 +399,7 @@ standardSuite('Context Menus — Terminal', (log) => {
     const lines = logCapture.getLinesSince('before-sts-010');
 
     assertStatusBarMsgLogged(lines, {
-      message: `✓ Selected text copied to clipboard & sent to Terminal ("${terminalName}")`,
+      message: `✓ RangeLink: Selected text copied to clipboard & sent to Terminal ("${terminalName}")`,
     });
 
     assertTerminalBufferContains(capturing.getCapturedText(), markerText);
@@ -464,7 +464,7 @@ standardSuite('Context Menus — Terminal', (log) => {
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
 
     assertStatusBarMsgLogged(lines, {
-      message: `✓ Selected text copied to clipboard & sent to Terminal ("${destName}")`,
+      message: `✓ RangeLink: Selected text copied to clipboard & sent to Terminal ("${destName}")`,
     });
 
     assertTerminalBufferContains(capturingDest.getCapturedText(), markerText);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
@@ -33,8 +33,7 @@ import {
   writeClipboardSentinel,
 } from '../helpers';
 
-const NO_TERMINAL_SELECTION_MSG =
-  'RangeLink: No text selected in the terminal. Select text and try again.';
+const NO_TERMINAL_SELECTION_MSG = 'No text selected in the terminal. Select text and try again.';
 
 standardSuite('Core Send Commands', (log) => {
   const tmpFileUris: vscode.Uri[] = [];
@@ -86,7 +85,7 @@ standardSuite('Core Send Commands', (log) => {
     const lines = logCapture.getLinesSince('before-r-l-002');
     const destBasename = path.basename(destUri.fsPath);
     assertStatusBarMsgLogged(lines, {
-      message: `✓ RangeLink copied to clipboard & sent to Text Editor ("${destBasename}")`,
+      message: `✓ RangeLink: RangeLink copied to clipboard & sent to Text Editor ("${destBasename}")`,
     });
     log('✓ R-L inserted RangeLink into bound text editor destination');
   });
@@ -163,7 +162,7 @@ standardSuite('Core Send Commands', (log) => {
     );
 
     assertStatusBarMsgLogged(logCapture.getLinesSince('before-r-c-001'), {
-      message: '✓ RangeLink copied to clipboard',
+      message: '✓ RangeLink: RangeLink copied to clipboard',
     });
     log('✓ R-C wrote link to clipboard; terminal received nothing');
   });
@@ -190,7 +189,7 @@ standardSuite('Core Send Commands', (log) => {
     assertTerminalBufferContains(capturing.getCapturedText(), '#L');
 
     assertStatusBarMsgLogged(logCapture.getLinesSince('before-r-l-004'), {
-      message: '✓ RangeLink copied to clipboard & sent to Terminal ("csc-r-l-004-dest")',
+      message: '✓ RangeLink: RangeLink copied to clipboard & sent to Terminal ("csc-r-l-004-dest")',
     });
     log('✓ Command Palette "Send RangeLink" delivered link to bound terminal destination');
   });
@@ -228,7 +227,7 @@ standardSuite('Core Send Commands', (log) => {
       'Terminal should not have received anything from "Copy RangeLink"',
     );
     assertStatusBarMsgLogged(logCapture.getLinesSince('before-r-c-002'), {
-      message: '✓ RangeLink copied to clipboard',
+      message: '✓ RangeLink: RangeLink copied to clipboard',
     });
     log('✓ Command Palette "Copy RangeLink" wrote link to clipboard; terminal received nothing');
   });
@@ -259,7 +258,8 @@ standardSuite('Core Send Commands', (log) => {
     assertTerminalBufferContains(capturing.getCapturedText(), MARKER);
 
     assertStatusBarMsgLogged(logCapture.getLinesSince('before-sts-001'), {
-      message: '✓ Selected text copied to clipboard & sent to Terminal ("csc-sts-001-dest")',
+      message:
+        '✓ RangeLink: Selected text copied to clipboard & sent to Terminal ("csc-sts-001-dest")',
     });
     log('✓ R-V sent selected terminal text to bound destination');
   });
@@ -401,14 +401,14 @@ standardSuite('Core Send Commands', (log) => {
     const lines = logCapture.getLinesSince('before-sts-006');
     assertToastLogged(lines, {
       type: 'error',
-      message: 'RangeLink: No active editor',
+      message: 'No active editor',
     });
     assert.ok(
       !lines.some((line) => line.includes('VscodeAdapter.writeTextToClipboard')),
       'Expected no clipboard write when R-L invoked from terminal focus',
     );
     assertNoStatusBarMsgLogged(lines, {
-      message: '✓ RangeLink copied to clipboard & sent to Terminal ("csc-sts-006-dest")',
+      message: '✓ RangeLink: RangeLink copied to clipboard & sent to Terminal ("csc-sts-006-dest")',
     });
     log('✓ R-L from terminal focus shows no-active-editor error');
   });
@@ -427,7 +427,7 @@ standardSuite('Core Send Commands', (log) => {
     const lines = logCapture.getLinesSince('before-sts-007');
     assertToastLogged(lines, {
       type: 'error',
-      message: 'RangeLink: No active editor',
+      message: 'No active editor',
     });
     assert.ok(
       !lines.some((line) => line.includes('VscodeAdapter.writeTextToClipboard')),
@@ -454,7 +454,7 @@ standardSuite('Core Send Commands', (log) => {
 
     const lines = logCapture.getLinesSince('before-r-l-001');
     assertStatusBarMsgLogged(lines, {
-      message: '✓ RangeLink copied to clipboard & sent to Terminal ("csc-r-l-001-dest")',
+      message: '✓ RangeLink: RangeLink copied to clipboard & sent to Terminal ("csc-r-l-001-dest")',
     });
     const captured = capturing.getCapturedText();
     assertTerminalBufferContains(captured, 'csc-r-l-001');
@@ -486,11 +486,12 @@ standardSuite('Core Send Commands', (log) => {
 
     const lines = logCapture.getLinesSince('before-fullline-001');
     assertStatusBarMsgLogged(lines, {
-      message: '✓ RangeLink copied to clipboard & sent to Terminal ("csc-fullline-001-dest")',
+      message:
+        '✓ RangeLink: RangeLink copied to clipboard & sent to Terminal ("csc-fullline-001-dest")',
     });
     assertNoToastLogged(lines, {
       type: 'error',
-      message: 'RangeLink: No active editor',
+      message: 'No active editor',
     });
     const captured = capturing.getCapturedText();
     assertTerminalBufferContains(captured, 'csc-fullline-001');

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/dirtyBufferWarning.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/dirtyBufferWarning.test.ts
@@ -358,7 +358,8 @@ standardSuite('Dirty Buffer Warning', (_log) => {
 
       const lines = logCapture.getLinesSince('before-007');
       assertStatusBarMsgLogged(lines, {
-        message: '✓ RangeLink copied to clipboard & sent to Terminal ("dirty-buffer-test")',
+        message:
+          '✓ RangeLink: RangeLink copied to clipboard & sent to Terminal ("dirty-buffer-test")',
       });
       assertNoToastLogged(lines, {
         type: 'warning',

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filePathNavigation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filePathNavigation.test.ts
@@ -68,7 +68,7 @@ standardSuite('File Path Navigation', (_log) => {
     const lines = logCapture.getLinesSince('before-fp-011');
     assertToastLogged(lines, {
       type: 'warning',
-      message: `RangeLink: Cannot find file: ${nonExistentPath}`,
+      message: `Cannot find file: ${nonExistentPath}`,
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filenameOnlyNavigation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filenameOnlyNavigation.test.ts
@@ -96,7 +96,7 @@ standardSuite('Filename-Only Navigation Fallback', (_log) => {
     const lines = logCapture.getLinesSince('before-fallback-001');
     assertToastLogged(lines, {
       type: 'info',
-      message: `RangeLink: Navigated to ${uniqueFilename} @ 5`,
+      message: `Navigated to ${uniqueFilename} @ 5`,
     });
   });
 
@@ -120,7 +120,7 @@ standardSuite('Filename-Only Navigation Fallback', (_log) => {
     const lines = logCapture.getLinesSince('before-fallback-002');
     assertToastLogged(lines, {
       type: 'warning',
-      message: `RangeLink: Multiple files match: ${duplicateFilename}`,
+      message: `Multiple files match: ${duplicateFilename}`,
     });
   });
 
@@ -144,7 +144,7 @@ standardSuite('Filename-Only Navigation Fallback', (_log) => {
     const lines = logCapture.getLinesSince('before-fallback-003');
     assertToastLogged(lines, {
       type: 'warning',
-      message: `RangeLink: Cannot find file: ${missingFilename}`,
+      message: `Cannot find file: ${missingFilename}`,
     });
   });
 
@@ -177,7 +177,7 @@ standardSuite('Filename-Only Navigation Fallback', (_log) => {
     const lines = logCapture.getLinesSince('before-fallback-004');
     assertToastLogged(lines, {
       type: 'info',
-      message: `RangeLink: Navigated to ${relativeFilePath} @ 10`,
+      message: `Navigated to ${relativeFilePath} @ 10`,
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/goToRangeLink.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/goToRangeLink.test.ts
@@ -84,7 +84,7 @@ standardSuite('R-G Go to Link', (log) => {
     assertInputBoxLogged(lines, INPUT_BOX_OPTS);
     assertToastLogged(lines, {
       type: 'info',
-      message: `RangeLink: Navigated to ${fn} @ 3-7`,
+      message: `Navigated to ${fn} @ 3-7`,
     });
 
     const editor = vscode.window.activeTextEditor;
@@ -134,7 +134,7 @@ standardSuite('R-G Go to Link', (log) => {
     assertInputBoxLogged(lines, INPUT_BOX_OPTS);
     assertToastLogged(lines, {
       type: 'info',
-      message: `RangeLink: Navigated to ${fn} @ 3:5-3:20`,
+      message: `Navigated to ${fn} @ 3:5-3:20`,
     });
 
     const editor = vscode.window.activeTextEditor;
@@ -177,7 +177,7 @@ standardSuite('R-G Go to Link', (log) => {
     assertInputBoxLogged(lines, INPUT_BOX_OPTS);
     assertToastLogged(lines, {
       type: 'error',
-      message: `RangeLink: Invalid link format: '${invalidInput}'`,
+      message: `Invalid link format: '${invalidInput}'`,
     });
 
     const invalidFormatLogged = lines.some(
@@ -215,7 +215,7 @@ standardSuite('R-G Go to Link', (log) => {
     assertInputBoxLogged(lines, INPUT_BOX_OPTS);
     assertToastLogged(lines, {
       type: 'error',
-      message: 'RangeLink: Please enter a link to navigate',
+      message: 'Please enter a link to navigate',
     });
 
     const emptyInputLogged = lines.some(
@@ -255,7 +255,7 @@ standardSuite('R-G Go to Link', (log) => {
     assertInputBoxLogged(lines, INPUT_BOX_OPTS);
     assertToastLogged(lines, {
       type: 'warning',
-      message: `RangeLink: Cannot find file: ${missingPath}`,
+      message: `Cannot find file: ${missingPath}`,
     });
 
     assert.strictEqual(

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationClamping.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationClamping.test.ts
@@ -64,7 +64,7 @@ standardSuite('Navigation Clamping', (_log) => {
     const lines = logCapture.getLinesSince('before-clamping-001');
     assertToastLogged(lines, {
       type: 'warning',
-      message: `RangeLink: Navigated to ${testFilename} @ 50 (clamped: line exceeded file length)`,
+      message: `Navigated to ${testFilename} @ 50 (clamped: line exceeded file length)`,
     });
   });
 
@@ -97,7 +97,7 @@ standardSuite('Navigation Clamping', (_log) => {
     const lines = logCapture.getLinesSince('before-clamping-002');
     assertToastLogged(lines, {
       type: 'warning',
-      message: `RangeLink: Navigated to ${testFilename} @ 1:200 (clamped: column exceeded line length)`,
+      message: `Navigated to ${testFilename} @ 1:200 (clamped: column exceeded line length)`,
     });
   });
 
@@ -125,7 +125,7 @@ standardSuite('Navigation Clamping', (_log) => {
     const lines = logCapture.getLinesSince('before-clamping-003');
     assertToastLogged(lines, {
       type: 'info',
-      message: `RangeLink: Navigated to ${testFilename} @ 5:10`,
+      message: `Navigated to ${testFilename} @ 5:10`,
     });
   });
 
@@ -164,7 +164,7 @@ standardSuite('Navigation Clamping', (_log) => {
     const lines = logCapture.getLinesSince('before-clamping-004');
     assertToastLogged(lines, {
       type: 'warning',
-      message: `RangeLink: Navigated to ${testFilename} @ 50:200 (clamped: line and column exceeded bounds)`,
+      message: `Navigated to ${testFilename} @ 50:200 (clamped: line and column exceeded bounds)`,
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationPrecision.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationPrecision.test.ts
@@ -60,7 +60,7 @@ standardSuite('Navigation Precision', (_log) => {
     const lines = logCapture.getLinesSince('before-nav-001');
     assertToastLogged(lines, {
       type: 'info',
-      message: `RangeLink: Navigated to ${testFilename} @ 10`,
+      message: `Navigated to ${testFilename} @ 10`,
     });
   });
 
@@ -93,7 +93,7 @@ standardSuite('Navigation Precision', (_log) => {
     const lines = logCapture.getLinesSince('before-nav-002');
     assertToastLogged(lines, {
       type: 'info',
-      message: `RangeLink: Navigated to ${testFilename} @ 10-15`,
+      message: `Navigated to ${testFilename} @ 10-15`,
     });
   });
 
@@ -121,7 +121,7 @@ standardSuite('Navigation Precision', (_log) => {
     const lines = logCapture.getLinesSince('before-char-001');
     assertToastLogged(lines, {
       type: 'info',
-      message: `RangeLink: Navigated to ${testFilename} @ 10:5`,
+      message: `Navigated to ${testFilename} @ 10:5`,
     });
   });
 
@@ -149,7 +149,7 @@ standardSuite('Navigation Precision', (_log) => {
     const lines = logCapture.getLinesSince('before-char-002');
     assertToastLogged(lines, {
       type: 'info',
-      message: `RangeLink: Navigated to ${testFilename} @ 10:5-15:10`,
+      message: `Navigated to ${testFilename} @ 10:5-15:10`,
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationToastSettings.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationToastSettings.test.ts
@@ -64,11 +64,11 @@ standardSuite('Navigation Toast Settings', (_log) => {
     const lines = logCapture.getLinesSince('before-toast-settings-001');
     assertSuppressionLogged(lines, {
       fn: 'RangeLinkNavigationHandler.navigateToLink',
-      suppressedMessage: `RangeLink: Navigated to ${testFilename} @ 5`,
+      suppressedMessage: `Navigated to ${testFilename} @ 5`,
     });
     assertNoToastLogged(lines, {
       type: 'info',
-      message: `RangeLink: Navigated to ${testFilename} @ 5`,
+      message: `Navigated to ${testFilename} @ 5`,
     });
   });
 
@@ -97,11 +97,11 @@ standardSuite('Navigation Toast Settings', (_log) => {
     const lines = logCapture.getLinesSince('before-toast-settings-002');
     assertSuppressionLogged(lines, {
       fn: 'RangeLinkNavigationHandler.navigateToLink',
-      suppressedMessage: `RangeLink: Navigated to ${testFilename} @ 50 (clamped: line exceeded file length)`,
+      suppressedMessage: `Navigated to ${testFilename} @ 50 (clamped: line exceeded file length)`,
     });
     assertNoToastLogged(lines, {
       type: 'warning',
-      message: `RangeLink: Navigated to ${testFilename} @ 50 (clamped: line exceeded file length)`,
+      message: `Navigated to ${testFilename} @ 50 (clamped: line exceeded file length)`,
     });
   });
 
@@ -121,11 +121,11 @@ standardSuite('Navigation Toast Settings', (_log) => {
     const lines = logCapture.getLinesSince('before-toast-settings-003');
     assertToastLogged(lines, {
       type: 'info',
-      message: `RangeLink: Navigated to ${testFilename} @ 3`,
+      message: `Navigated to ${testFilename} @ 3`,
     });
     assertNoToastLogged(lines, {
       type: 'warning',
-      message: `RangeLink: Navigated to ${testFilename} @ 3 (clamped: line exceeded file length)`,
+      message: `Navigated to ${testFilename} @ 3 (clamped: line exceeded file length)`,
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/sendFilePath.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/sendFilePath.test.ts
@@ -52,7 +52,7 @@ standardSuite('Send File Path', (log) => {
     const relativePath = vscode.workspace.asRelativePath(fileUri, false);
     const lines = logCapture.getLinesSince('before-001');
     assertStatusBarMsgLogged(lines, {
-      message: '✓ File path copied to clipboard & sent to Terminal ("sfp-test")',
+      message: '✓ RangeLink: File path copied to clipboard & sent to Terminal ("sfp-test")',
     });
     assertTerminalBufferEquals(capturing.getCapturedText(), ` ${relativePath} `);
     assertFilePathLogged(lines, {

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/textEditorDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/textEditorDestination.test.ts
@@ -191,7 +191,7 @@ standardSuite('Text Editor Destination', (log) => {
   });
 
   const WARN_DUPLICATE_TAB_GROUPS =
-    'RangeLink: Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed.';
+    'Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed.';
 
   test('duplicate-tab-group-001: warning toast fires when bound file is opened in a second editor group', async () => {
     const destUri = createWorkspaceFile('dtg-001-dest', 'destination file\n');
@@ -323,7 +323,7 @@ standardSuite('Text Editor Destination', (log) => {
     assertToastLogged(logCapture.getLinesSince('before-dtg-003'), {
       type: 'error',
       message:
-        'RangeLink: Bound editor is open in multiple tab groups. Close the duplicate tab and try again.',
+        'Bound editor is open in multiple tab groups. Close the duplicate tab and try again.',
     });
 
     const destContentAfter = (await vscode.workspace.openTextDocument(destUri)).getText();

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/unbind.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/unbind.test.ts
@@ -43,7 +43,7 @@ standardSuite('Unbind Destination', (_log) => {
 
     const lines = logCapture.getLinesSince('before-unbind-001');
     assertStatusBarMsgLogged(lines, {
-      message: '✓ RangeLink unbound from Terminal ("rl-unbind-test")',
+      message: '✓ RangeLink: Unbound from Terminal ("rl-unbind-test")',
     });
 
     await vscode.window.showTextDocument(doc);
@@ -78,7 +78,7 @@ standardSuite('Unbind Destination', (_log) => {
 
     const lines = logCapture.getLinesSince('before-unbind-004');
     assertStatusBarMsgLogged(lines, {
-      message: '✓ RangeLink unbound from Terminal ("rl-unbind-004-test")',
+      message: '✓ RangeLink: Unbound from Terminal ("rl-unbind-004-test")',
     });
   });
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/untitledNavigation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/untitledNavigation.test.ts
@@ -115,15 +115,15 @@ standardSuite('Untitled File Navigation', (_log) => {
     const lines = logCapture.getLinesSince('before-untitled-nav-001');
     assertToastLogged(lines, {
       type: 'info',
-      message: `RangeLink: Navigated to ${untitledDisplayName} @ 5`,
+      message: `Navigated to ${untitledDisplayName} @ 5`,
     });
     assertNoToastLogged(lines, {
       type: 'warning',
-      message: `RangeLink: Cannot find file: ${untitledDisplayName}`,
+      message: `Cannot find file: ${untitledDisplayName}`,
     });
     assertNoToastLogged(lines, {
       type: 'error',
-      message: `RangeLink: Failed to navigate to ${untitledDisplayName}`,
+      message: `Failed to navigate to ${untitledDisplayName}`,
     });
   });
 
@@ -155,11 +155,11 @@ standardSuite('Untitled File Navigation', (_log) => {
     const lines = logCapture.getLinesSince('before-untitled-nav-002');
     assertToastLogged(lines, {
       type: 'info',
-      message: `RangeLink: Navigated to ${untitledDisplayName} @ 3-7`,
+      message: `Navigated to ${untitledDisplayName} @ 3-7`,
     });
     assertNoToastLogged(lines, {
       type: 'warning',
-      message: `RangeLink: Cannot find file: ${untitledDisplayName}`,
+      message: `Cannot find file: ${untitledDisplayName}`,
     });
   });
 
@@ -184,11 +184,11 @@ standardSuite('Untitled File Navigation', (_log) => {
     const lines = logCapture.getLinesSince('before-untitled-nav-003');
     assertToastLogged(lines, {
       type: 'warning',
-      message: `RangeLink: Cannot find file: ${fakeName}`,
+      message: `Cannot find file: ${fakeName}`,
     });
     assertNoToastLogged(lines, {
       type: 'info',
-      message: `RangeLink: Navigated to ${fakeName} @ 1`,
+      message: `Navigated to ${fakeName} @ 1`,
     });
   });
 
@@ -219,11 +219,11 @@ standardSuite('Untitled File Navigation', (_log) => {
     const lines = logCapture.getLinesSince('before-untitled-nav-004');
     assertToastLogged(lines, {
       type: 'info',
-      message: `RangeLink: Navigated to ${untitledDisplayName} @ 5:10-5:20`,
+      message: `Navigated to ${untitledDisplayName} @ 5:10-5:20`,
     });
     assertNoToastLogged(lines, {
       type: 'warning',
-      message: `RangeLink: Cannot find file: ${untitledDisplayName}`,
+      message: `Cannot find file: ${untitledDisplayName}`,
     });
   });
 
@@ -256,11 +256,11 @@ standardSuite('Untitled File Navigation', (_log) => {
     const lines = logCapture.getLinesSince('before-untitled-nav-005');
     assertToastLogged(lines, {
       type: 'warning',
-      message: `RangeLink: Navigated to ${untitledDisplayName} @ 50 (clamped: line exceeded file length)`,
+      message: `Navigated to ${untitledDisplayName} @ 50 (clamped: line exceeded file length)`,
     });
     assertNoToastLogged(lines, {
       type: 'error',
-      message: `RangeLink: Failed to navigate to ${untitledDisplayName}`,
+      message: `Failed to navigate to ${untitledDisplayName}`,
     });
   });
 
@@ -293,11 +293,11 @@ standardSuite('Untitled File Navigation', (_log) => {
     const lines = logCapture.getLinesSince('before-untitled-nav-006');
     assertToastLogged(lines, {
       type: 'info',
-      message: `RangeLink: Navigated to ${lowercaseName} @ 5`,
+      message: `Navigated to ${lowercaseName} @ 5`,
     });
     assertNoToastLogged(lines, {
       type: 'warning',
-      message: `RangeLink: Cannot find file: ${untitledDisplayName}`,
+      message: `Cannot find file: ${untitledDisplayName}`,
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/AddBookmarkCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/AddBookmarkCommand.test.ts
@@ -53,9 +53,7 @@ describe('AddBookmarkCommand', () => {
 
         await command.execute();
 
-        expect(mockShowErrorMessage).toHaveBeenCalledWith(
-          'RangeLink: Cannot add bookmark - no active editor',
-        );
+        expect(mockShowErrorMessage).toHaveBeenCalledWith('Cannot add bookmark - no active editor');
         expect(mockBookmarkService.addBookmark).not.toHaveBeenCalled();
         expect(mockLogger.debug).toHaveBeenCalledWith(
           { fn: 'AddBookmarkCommand.execute' },
@@ -289,7 +287,7 @@ describe('AddBookmarkCommand', () => {
         await command.execute();
 
         expect(mockShowErrorMessage).toHaveBeenCalledWith(
-          'RangeLink: Cannot bookmark unsaved file. Save the file first, or select an existing RangeLink to bookmark.',
+          'Cannot bookmark unsaved file. Save the file first, or select an existing RangeLink to bookmark.',
         );
         expect(mockBookmarkService.addBookmark).not.toHaveBeenCalled();
         expect(mockLogger.debug).toHaveBeenCalledWith(
@@ -325,7 +323,7 @@ describe('AddBookmarkCommand', () => {
         await command.execute();
 
         expect(mockShowErrorMessage).toHaveBeenCalledWith(
-          'RangeLink: Cannot add bookmark - failed to generate link from selection',
+          'Cannot add bookmark - failed to generate link from selection',
         );
         expect(mockBookmarkService.addBookmark).not.toHaveBeenCalled();
       });
@@ -377,9 +375,7 @@ describe('AddBookmarkCommand', () => {
 
         await command.execute();
 
-        expect(mockShowErrorMessage).toHaveBeenCalledWith(
-          'RangeLink: Bookmark label cannot be empty',
-        );
+        expect(mockShowErrorMessage).toHaveBeenCalledWith('Bookmark label cannot be empty');
         expect(mockBookmarkService.addBookmark).not.toHaveBeenCalled();
         expect(mockLogger.debug).toHaveBeenCalledWith(
           { fn: 'AddBookmarkCommand.execute' },
@@ -414,7 +410,7 @@ describe('AddBookmarkCommand', () => {
 
         await command.execute();
 
-        expect(mockShowErrorMessage).toHaveBeenCalledWith('RangeLink: Failed to save bookmark');
+        expect(mockShowErrorMessage).toHaveBeenCalledWith('Failed to save bookmark');
         expect(mockLogger.error).toHaveBeenCalledWith(
           { fn: 'AddBookmarkCommand.execute', error: storageError },
           'Failed to save bookmark',
@@ -443,7 +439,7 @@ describe('AddBookmarkCommand', () => {
         await command.execute();
 
         expect(mockSetStatusBarMessage).toHaveBeenCalledWith(
-          '✓ Bookmark saved: Success Bookmark',
+          '✓ RangeLink: Bookmark saved: Success Bookmark',
           2000,
         );
         expect(mockLogger.info).toHaveBeenCalledWith(

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/BindToTerminalCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/BindToTerminalCommand.test.ts
@@ -65,7 +65,7 @@ describe('BindToTerminalCommand', () => {
         expect(result).toStrictEqual({ outcome: 'no-resource' });
         expect(mockAvailabilityService.getTerminalItems).toHaveBeenCalledWith(Infinity, undefined);
         expect(mockAdapter.__getVscodeInstance().window.showErrorMessage).toHaveBeenCalledWith(
-          'RangeLink: No active terminal. Open a terminal and try again.',
+          'No active terminal. Open a terminal and try again.',
         );
         expect(mockLogger.debug).toHaveBeenCalledWith(
           { fn: 'BindToTerminalCommand.execute', terminalCount: 0 },

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/BindToTextEditorCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/BindToTextEditorCommand.test.ts
@@ -59,7 +59,7 @@ describe('BindToTextEditorCommand', () => {
 
       expect(result).toStrictEqual({ outcome: 'no-resource' });
       expect(showErrorMessageMock).toHaveBeenCalledWith(
-        'RangeLink: No active text editor. Open a file and try again.',
+        'No active text editor. Open a file and try again.',
       );
       expect(showFilePickerSpy).not.toHaveBeenCalled();
       expect(mockLogger.debug).toHaveBeenCalledWith(

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/GoToRangeLinkCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/GoToRangeLinkCommand.test.ts
@@ -73,9 +73,7 @@ describe('GoToRangeLinkCommand', () => {
 
         await command.execute();
 
-        expect(mockShowErrorMessage).toHaveBeenCalledWith(
-          'RangeLink: Please enter a link to navigate',
-        );
+        expect(mockShowErrorMessage).toHaveBeenCalledWith('Please enter a link to navigate');
         expect(mockNavigationHandler.parseLink).not.toHaveBeenCalled();
         expect(mockNavigationHandler.navigateToLink).not.toHaveBeenCalled();
         expect(mockLogger.debug).toHaveBeenCalledWith(
@@ -97,9 +95,7 @@ describe('GoToRangeLinkCommand', () => {
 
         await command.execute();
 
-        expect(mockShowErrorMessage).toHaveBeenCalledWith(
-          'RangeLink: Please enter a link to navigate',
-        );
+        expect(mockShowErrorMessage).toHaveBeenCalledWith('Please enter a link to navigate');
         expect(mockNavigationHandler.parseLink).not.toHaveBeenCalled();
         expect(mockNavigationHandler.navigateToLink).not.toHaveBeenCalled();
         expect(mockLogger.debug).toHaveBeenCalledWith(
@@ -133,7 +129,7 @@ describe('GoToRangeLinkCommand', () => {
 
         expect(mockNavigationHandler.parseLink).toHaveBeenCalledWith(invalidInput);
         expect(mockShowErrorMessage).toHaveBeenCalledWith(
-          "RangeLink: Invalid link format: 'not-a-valid-link'",
+          "Invalid link format: 'not-a-valid-link'",
         );
         expect(mockNavigationHandler.navigateToLink).not.toHaveBeenCalled();
         expect(mockLogger.debug).toHaveBeenCalledWith(
@@ -164,9 +160,7 @@ describe('GoToRangeLinkCommand', () => {
         await command.execute();
 
         expect(mockNavigationHandler.parseLink).toHaveBeenCalledWith(trimmedInput);
-        expect(mockShowErrorMessage).toHaveBeenCalledWith(
-          "RangeLink: Invalid link format: 'invalid-link'",
-        );
+        expect(mockShowErrorMessage).toHaveBeenCalledWith("Invalid link format: 'invalid-link'");
         expect(mockLogger.debug).toHaveBeenCalledWith(
           {
             fn: 'GoToRangeLinkCommand.execute',

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/ManageBookmarksCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/ManageBookmarksCommand.test.ts
@@ -324,7 +324,7 @@ describe('ManageBookmarksCommand', () => {
           button: deleteButton,
         });
 
-        expect(mockShowErrorMessage).toHaveBeenCalledWith('RangeLink: Failed to delete bookmark');
+        expect(mockShowErrorMessage).toHaveBeenCalledWith('Failed to delete bookmark');
         expect(mockLogger.warn).toHaveBeenCalledWith(
           {
             fn: 'ManageBookmarksCommand.confirmAndDelete',

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/PasteDestinationManager.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/PasteDestinationManager.test.ts
@@ -247,7 +247,7 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal ("bash")',
+        '✓ RangeLink: Bound to Terminal ("bash")',
         2000,
       );
       expect(mockLogger.info).toHaveBeenCalledWith(
@@ -298,7 +298,7 @@ describe('PasteDestinationManager', () => {
         destinationName: 'Terminal ("bash")',
       });
       expect(mockAdapter.__getVscodeInstance().window.showInformationMessage).toHaveBeenCalledWith(
-        'RangeLink: Already bound to Terminal ("bash")',
+        'Already bound to Terminal ("bash")',
       );
 
       controlledManager.dispose();
@@ -321,7 +321,7 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal ("zsh")',
+        '✓ RangeLink: Bound to Terminal ("zsh")',
         2000,
       );
     });
@@ -347,7 +347,7 @@ describe('PasteDestinationManager', () => {
       );
       expect(localAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Cursor AI Assistant',
+        '✓ RangeLink: Bound to Cursor AI Assistant',
         2000,
       );
       expectContextKeys(localAdapter.__getVscodeInstance(), { 'rangelink.isBound': true });
@@ -369,7 +369,7 @@ describe('PasteDestinationManager', () => {
       expect(formatMessageSpy).toHaveBeenCalledWith('ERROR_CURSOR_AI_NOT_AVAILABLE');
 
       expect(mockAdapter.__getVscodeInstance().window.showErrorMessage).toHaveBeenCalledWith(
-        'RangeLink: Cannot bind Cursor AI Assistant - not running in Cursor IDE',
+        'Cannot bind Cursor AI Assistant - not running in Cursor IDE',
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).not.toHaveBeenCalled();
       expectContextKeys(mockAdapter.__getVscodeInstance(), { 'rangelink.isBound': false });
@@ -389,7 +389,7 @@ describe('PasteDestinationManager', () => {
       expect(manager.isBound()).toBe(false);
       expect(formatMessageSpy).toHaveBeenCalledWith('ERROR_CLAUDE_CODE_NOT_AVAILABLE');
       expect(mockAdapter.__getVscodeInstance().window.showErrorMessage).toHaveBeenCalledWith(
-        'RangeLink: Cannot bind Claude Code - extension not installed or not active',
+        'Cannot bind Claude Code - extension not installed or not active',
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).not.toHaveBeenCalled();
       expectContextKeys(mockAdapter.__getVscodeInstance(), { 'rangelink.isBound': false });
@@ -411,7 +411,7 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Claude Code Chat',
+        '✓ RangeLink: Bound to Claude Code Chat',
         2000,
       );
       expectContextKeys(mockAdapter.__getVscodeInstance(), { 'rangelink.isBound': true });
@@ -433,7 +433,7 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to GitHub Copilot Chat',
+        '✓ RangeLink: Bound to GitHub Copilot Chat',
         2000,
       );
       expectContextKeys(mockAdapter.__getVscodeInstance(), { 'rangelink.isBound': true });
@@ -461,7 +461,7 @@ describe('PasteDestinationManager', () => {
       expect(manager.isBound()).toBe(false);
       expect(formatMessageSpy).toHaveBeenCalledWith('ERROR_GITHUB_COPILOT_CHAT_NOT_AVAILABLE');
       expect(mockAdapter.__getVscodeInstance().window.showErrorMessage).toHaveBeenCalledWith(
-        'RangeLink: Cannot bind GitHub Copilot Chat - extension not installed or not active',
+        'Cannot bind GitHub Copilot Chat - extension not installed or not active',
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).not.toHaveBeenCalled();
       expectContextKeys(mockAdapter.__getVscodeInstance(), { 'rangelink.isBound': false });
@@ -483,14 +483,14 @@ describe('PasteDestinationManager', () => {
         details: { failedBindDetails: 'ALREADY_BOUND_TO_SAME' },
       });
       expect(localAdapter.__getVscodeInstance().window.showInformationMessage).toHaveBeenCalledWith(
-        'RangeLink: Already bound to Cursor AI Assistant',
+        'Already bound to Cursor AI Assistant',
       );
       expect(localAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(
         1,
       );
       expect(localAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Cursor AI Assistant',
+        '✓ RangeLink: Bound to Cursor AI Assistant',
         2000,
       );
 
@@ -516,12 +516,12 @@ describe('PasteDestinationManager', () => {
         details: { failedBindDetails: 'ALREADY_BOUND_TO_SAME' },
       });
       expect(mockAdapter.__getVscodeInstance().window.showInformationMessage).toHaveBeenCalledWith(
-        'RangeLink: Already bound to GitHub Copilot Chat',
+        'Already bound to GitHub Copilot Chat',
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to GitHub Copilot Chat',
+        '✓ RangeLink: Bound to GitHub Copilot Chat',
         2000,
       );
     });
@@ -553,7 +553,7 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Text Editor ("file.ts")',
+        '✓ RangeLink: Bound to Text Editor ("file.ts")',
         2000,
       );
       expect(mockLogger.info).toHaveBeenCalledWith(
@@ -608,7 +608,7 @@ describe('PasteDestinationManager', () => {
         fileName: 'gone.ts',
       });
       expect(mockAdapter.__getVscodeInstance().window.showErrorMessage).toHaveBeenCalledWith(
-        'RangeLink: Could not open "gone.ts". Try again or choose another file.',
+        'Could not open "gone.ts". Try again or choose another file.',
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).not.toHaveBeenCalled();
       expectContextKeys(mockAdapter.__getVscodeInstance(), { 'rangelink.isBound': false });
@@ -654,12 +654,12 @@ describe('PasteDestinationManager', () => {
         backgroundUri,
       );
       expect(mockAdapter.__getVscodeInstance().window.showInformationMessage).toHaveBeenCalledWith(
-        'RangeLink: "file.ts" opened at last cursor position. Adjust cursor before pasting.',
+        '"file.ts" opened at last cursor position. Adjust cursor before pasting.',
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Text Editor ("file.ts")',
+        '✓ RangeLink: Bound to Text Editor ("file.ts")',
         2000,
       );
     });
@@ -704,7 +704,7 @@ describe('PasteDestinationManager', () => {
         fileName: 'file.ts',
       });
       expect(mockAdapter.__getVscodeInstance().window.showErrorMessage).toHaveBeenCalledWith(
-        'RangeLink: "file.ts" opened in a different editor group. Try again or choose another file.',
+        '"file.ts" opened in a different editor group. Try again or choose another file.',
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).not.toHaveBeenCalled();
       expectContextKeys(mockAdapter.__getVscodeInstance(), { 'rangelink.isBound': false });
@@ -737,7 +737,7 @@ describe('PasteDestinationManager', () => {
         scheme: 'git',
       });
       expect(mockAdapter.__getVscodeInstance().window.showErrorMessage).toHaveBeenCalledWith(
-        'RangeLink: Cannot bind to read-only editor (git)',
+        'Cannot bind to read-only editor (git)',
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).not.toHaveBeenCalled();
       expectContextKeys(mockAdapter.__getVscodeInstance(), { 'rangelink.isBound': false });
@@ -771,7 +771,7 @@ describe('PasteDestinationManager', () => {
         fileName: testFileName,
       });
       expect(mockAdapter.__getVscodeInstance().window.showErrorMessage).toHaveBeenCalledWith(
-        `RangeLink: Cannot bind to ${testFileName} - binary file`,
+        `Cannot bind to ${testFileName} - binary file`,
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).not.toHaveBeenCalled();
       expectContextKeys(mockAdapter.__getVscodeInstance(), { 'rangelink.isBound': false });
@@ -809,7 +809,7 @@ describe('PasteDestinationManager', () => {
       );
       expect(localAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal ("bash")',
+        '✓ RangeLink: Bound to Terminal ("bash")',
         2000,
       );
 
@@ -845,7 +845,7 @@ describe('PasteDestinationManager', () => {
       );
       expect(localAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Cursor AI Assistant',
+        '✓ RangeLink: Bound to Cursor AI Assistant',
         2000,
       );
 
@@ -881,7 +881,7 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal ("bash")',
+        '✓ RangeLink: Bound to Terminal ("bash")',
         2000,
       );
     });
@@ -929,7 +929,7 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to GitHub Copilot Chat',
+        '✓ RangeLink: Bound to GitHub Copilot Chat',
         2000,
       );
     });
@@ -970,7 +970,7 @@ describe('PasteDestinationManager', () => {
       );
       expect(localAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Cursor AI Assistant',
+        '✓ RangeLink: Bound to Cursor AI Assistant',
         2000,
       );
 
@@ -1009,7 +1009,7 @@ describe('PasteDestinationManager', () => {
       });
       expect(showQuickPickMock).not.toHaveBeenCalled();
       expect(localAdapter.__getVscodeInstance().window.showInformationMessage).toHaveBeenCalledWith(
-        'RangeLink: Already bound to Claude Code Chat',
+        'Already bound to Claude Code Chat',
       );
       expect(mockLogger.debug).toHaveBeenCalledWith(
         {
@@ -1085,12 +1085,12 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(2);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal ("bash")',
+        '✓ RangeLink: Bound to Terminal ("bash")',
         2000,
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         2,
-        '✓ RangeLink unbound from Terminal ("bash")',
+        '✓ RangeLink: Unbound from Terminal ("bash")',
         2000,
       );
       expectContextKeys(mockAdapter.__getVscodeInstance(), { 'rangelink.isBound': false });
@@ -1110,12 +1110,12 @@ describe('PasteDestinationManager', () => {
       );
       expect(localAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Cursor AI Assistant',
+        '✓ RangeLink: Bound to Cursor AI Assistant',
         2000,
       );
       expect(localAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         2,
-        '✓ RangeLink unbound from Cursor AI Assistant',
+        '✓ RangeLink: Unbound from Cursor AI Assistant',
         2000,
       );
       expectContextKeys(localAdapter.__getVscodeInstance(), { 'rangelink.isBound': false });
@@ -1136,12 +1136,12 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(2);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to GitHub Copilot Chat',
+        '✓ RangeLink: Bound to GitHub Copilot Chat',
         2000,
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         2,
-        '✓ RangeLink unbound from GitHub Copilot Chat',
+        '✓ RangeLink: Unbound from GitHub Copilot Chat',
         2000,
       );
       expectContextKeys(mockAdapter.__getVscodeInstance(), { 'rangelink.isBound': false });
@@ -1160,12 +1160,12 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(2);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Claude Code Chat',
+        '✓ RangeLink: Bound to Claude Code Chat',
         2000,
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         2,
-        '✓ RangeLink unbound from Claude Code Chat',
+        '✓ RangeLink: Unbound from Claude Code Chat',
         2000,
       );
       expectContextKeys(mockAdapter.__getVscodeInstance(), { 'rangelink.isBound': false });
@@ -1192,12 +1192,12 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(2);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Text Editor ("file.ts")',
+        '✓ RangeLink: Bound to Text Editor ("file.ts")',
         2000,
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         2,
-        '✓ RangeLink unbound from Text Editor ("file.ts")',
+        '✓ RangeLink: Unbound from Text Editor ("file.ts")',
         2000,
       );
       expectContextKeys(mockAdapter.__getVscodeInstance(), { 'rangelink.isBound': false });
@@ -1270,12 +1270,12 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(2);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal ("bash")',
+        '✓ RangeLink: Bound to Terminal ("bash")',
         2000,
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         2,
-        'RangeLink copied to clipboard & sent to Terminal ("bash")',
+        '✓ RangeLink: RangeLink copied to clipboard & sent to Terminal ("bash")',
         2000,
       );
       expect(mockLogger.debug).toHaveBeenCalledWith(
@@ -1321,10 +1321,14 @@ describe('PasteDestinationManager', () => {
       expect(mockSetStatusBarMessage).toHaveBeenCalledTimes(2);
       expect(mockSetStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Cursor AI Assistant',
+        '✓ RangeLink: Bound to Cursor AI Assistant',
         2000,
       );
-      expect(mockSetStatusBarMessage).toHaveBeenNthCalledWith(2, TEST_STATUS_MESSAGE, 2000);
+      expect(mockSetStatusBarMessage).toHaveBeenNthCalledWith(
+        2,
+        '✓ RangeLink: RangeLink copied to clipboard',
+        2000,
+      );
       expect(mockShowInformationMessage).toHaveBeenCalledWith(successInstruction);
 
       cursorManager.dispose();
@@ -1345,12 +1349,12 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(2);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to GitHub Copilot Chat',
+        '✓ RangeLink: Bound to GitHub Copilot Chat',
         2000,
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         2,
-        'RangeLink copied to clipboard & sent to GitHub Copilot Chat',
+        '✓ RangeLink: RangeLink copied to clipboard & sent to GitHub Copilot Chat',
         2000,
       );
     });
@@ -1397,7 +1401,7 @@ describe('PasteDestinationManager', () => {
       );
       expect(localAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal ("bash")',
+        '✓ RangeLink: Bound to Terminal ("bash")',
         2000,
       );
 
@@ -1438,10 +1442,14 @@ describe('PasteDestinationManager', () => {
       expect(mockSetStatusBarMessage).toHaveBeenCalledTimes(2);
       expect(mockSetStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Cursor AI Assistant',
+        '✓ RangeLink: Bound to Cursor AI Assistant',
         2000,
       );
-      expect(mockSetStatusBarMessage).toHaveBeenNthCalledWith(2, TEST_STATUS_MESSAGE, 2000);
+      expect(mockSetStatusBarMessage).toHaveBeenNthCalledWith(
+        2,
+        '✓ RangeLink: RangeLink copied to clipboard',
+        2000,
+      );
       expect(mockShowWarningMessage).toHaveBeenCalledWith(failureInstruction);
 
       cursorManager.dispose();
@@ -1459,12 +1467,12 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(2);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal ("bash")',
+        '✓ RangeLink: Bound to Terminal ("bash")',
         2000,
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         2,
-        'RangeLink copied to clipboard',
+        '✓ RangeLink: RangeLink copied to clipboard',
         2000,
       );
       expect(mockLogger.debug).toHaveBeenCalledWith(
@@ -1611,12 +1619,12 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(2);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal ("bash")',
+        '✓ RangeLink: Bound to Terminal ("bash")',
         2000,
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         2,
-        'RangeLink copied to clipboard',
+        '✓ RangeLink: RangeLink copied to clipboard',
         2000,
       );
     });
@@ -1636,17 +1644,17 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(3);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal ("bash")',
+        '✓ RangeLink: Bound to Terminal ("bash")',
         2000,
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         2,
-        '✓ RangeLink unbound from Terminal ("bash")',
+        '✓ RangeLink: Unbound from Terminal ("bash")',
         2000,
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         3,
-        'Destination binding removed (terminal closed)',
+        'RangeLink: Destination binding removed (terminal closed)',
         2000,
       );
     });
@@ -1666,7 +1674,7 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal ("bash")',
+        '✓ RangeLink: Bound to Terminal ("bash")',
         2000,
       );
     });
@@ -1688,7 +1696,7 @@ describe('PasteDestinationManager', () => {
       );
       expect(localAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Cursor AI Assistant',
+        '✓ RangeLink: Bound to Cursor AI Assistant',
         2000,
       );
 
@@ -1725,12 +1733,12 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(3);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Text Editor ("file.ts")',
+        '✓ RangeLink: Bound to Text Editor ("file.ts")',
         2000,
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         2,
-        '✓ RangeLink unbound from Text Editor ("file.ts")',
+        '✓ RangeLink: Unbound from Text Editor ("file.ts")',
         2000,
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
@@ -1761,7 +1769,7 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Text Editor ("file.ts")',
+        '✓ RangeLink: Bound to Text Editor ("file.ts")',
         2000,
       );
     });
@@ -1783,7 +1791,7 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal ("bash")',
+        '✓ RangeLink: Bound to Terminal ("bash")',
         2000,
       );
     });
@@ -1834,7 +1842,7 @@ describe('PasteDestinationManager', () => {
 
       expect(formatMessageSpy).toHaveBeenCalledWith('WARN_TEXT_EDITOR_DUPLICATE_TAB_GROUPS');
       expect(mockAdapter.__getVscodeInstance().window.showWarningMessage).toHaveBeenCalledWith(
-        'RangeLink: Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed.',
+        'Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed.',
       );
       expect(mockLogger.warn).toHaveBeenCalledWith(
         {
@@ -1987,7 +1995,7 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal ("bash")',
+        '✓ RangeLink: Bound to Terminal ("bash")',
         2000,
       );
     });
@@ -2011,7 +2019,7 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal ("bash")',
+        '✓ RangeLink: Bound to Terminal ("bash")',
         2000,
       );
     });
@@ -2028,7 +2036,7 @@ describe('PasteDestinationManager', () => {
       );
       expect(localAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Cursor AI Assistant',
+        '✓ RangeLink: Bound to Cursor AI Assistant',
         2000,
       );
 
@@ -2051,12 +2059,12 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(2);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal ("bash")',
+        '✓ RangeLink: Bound to Terminal ("bash")',
         2000,
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         2,
-        '✓ RangeLink unbound from Terminal ("bash")',
+        '✓ RangeLink: Unbound from Terminal ("bash")',
         2000,
       );
     });
@@ -2290,12 +2298,12 @@ describe('PasteDestinationManager', () => {
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenCalledTimes(2);
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenNthCalledWith(
           1,
-          '✓ RangeLink bound to Terminal ("TestTerminal")',
+          '✓ RangeLink: Bound to Terminal ("TestTerminal")',
           2000,
         );
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenNthCalledWith(
           2,
-          'Unbound Terminal ("TestTerminal"), now bound to Text Editor ("file.ts")',
+          '✓ RangeLink: Unbound Terminal ("TestTerminal"), now bound to Text Editor ("file.ts")',
           2000,
         );
       });
@@ -2367,7 +2375,7 @@ describe('PasteDestinationManager', () => {
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenCalledTimes(1);
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenNthCalledWith(
           1,
-          '✓ RangeLink bound to Terminal ("TestTerminal")',
+          '✓ RangeLink: Bound to Terminal ("TestTerminal")',
           2000,
         );
       });
@@ -2407,7 +2415,7 @@ describe('PasteDestinationManager', () => {
 
         // Assert: Info message shown (not error) with actual terminal name
         expect(mockVscode.window.showInformationMessage).toHaveBeenCalledWith(
-          'RangeLink: Already bound to Terminal ("TestTerminal")',
+          'Already bound to Terminal ("TestTerminal")',
         );
 
         // Assert: QuickPick NOT shown (no confirmation needed)
@@ -2417,7 +2425,7 @@ describe('PasteDestinationManager', () => {
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenCalledTimes(1);
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenNthCalledWith(
           1,
-          '✓ RangeLink bound to Terminal ("TestTerminal")',
+          '✓ RangeLink: Bound to Terminal ("TestTerminal")',
           2000,
         );
 
@@ -2452,7 +2460,7 @@ describe('PasteDestinationManager', () => {
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenCalledTimes(1);
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenNthCalledWith(
           1,
-          '✓ RangeLink bound to Terminal ("TestTerminal")',
+          '✓ RangeLink: Bound to Terminal ("TestTerminal")',
           2000,
         );
 
@@ -2517,7 +2525,7 @@ describe('PasteDestinationManager', () => {
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenCalledTimes(1);
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenNthCalledWith(
           1,
-          '✓ RangeLink bound to Terminal ("TestTerminal")',
+          '✓ RangeLink: Bound to Terminal ("TestTerminal")',
           2000,
         );
       });
@@ -2563,12 +2571,12 @@ describe('PasteDestinationManager', () => {
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenCalledTimes(2);
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenNthCalledWith(
           1,
-          '✓ RangeLink bound to Terminal ("bash")',
+          '✓ RangeLink: Bound to Terminal ("bash")',
           2000,
         );
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenNthCalledWith(
           2,
-          'Content sent successfully & sent to Terminal ("bash")',
+          '✓ RangeLink: Content sent successfully & sent to Terminal ("bash")',
           2000,
         );
 
@@ -2590,12 +2598,12 @@ describe('PasteDestinationManager', () => {
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenCalledTimes(2);
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenNthCalledWith(
           1,
-          '✓ RangeLink bound to GitHub Copilot Chat',
+          '✓ RangeLink: Bound to GitHub Copilot Chat',
           2000,
         );
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenNthCalledWith(
           2,
-          'Content sent successfully & sent to GitHub Copilot Chat',
+          '✓ RangeLink: Content sent successfully & sent to GitHub Copilot Chat',
           2000,
         );
       });
@@ -2625,7 +2633,7 @@ describe('PasteDestinationManager', () => {
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenCalledTimes(1);
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenNthCalledWith(
           1,
-          '✓ RangeLink bound to Terminal ("bash")',
+          '✓ RangeLink: Bound to Terminal ("bash")',
           2000,
         );
         expect(mockVscode.window.showErrorMessage).not.toHaveBeenCalled();
@@ -2646,12 +2654,12 @@ describe('PasteDestinationManager', () => {
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenCalledTimes(2);
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenNthCalledWith(
           1,
-          '✓ RangeLink bound to Terminal ("bash")',
+          '✓ RangeLink: Bound to Terminal ("bash")',
           2000,
         );
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenNthCalledWith(
           2,
-          'Content sent successfully & sent to Terminal ("bash")',
+          '✓ RangeLink: Content sent successfully & sent to Terminal ("bash")',
           2000,
         );
 
@@ -2699,7 +2707,7 @@ describe('PasteDestinationManager', () => {
         });
         expect(manager.getBoundDestination()).toBe(firstDest);
         expect(mockVscode.window.showInformationMessage).toHaveBeenCalledWith(
-          'RangeLink: Already bound to Terminal ("bash")',
+          'Already bound to Terminal ("bash")',
         );
         expect(mockLogger.debug).toHaveBeenCalledWith(
           {
@@ -2712,7 +2720,7 @@ describe('PasteDestinationManager', () => {
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenCalledTimes(1);
         expect(mockVscode.window.setStatusBarMessage).toHaveBeenNthCalledWith(
           1,
-          '✓ RangeLink bound to Terminal ("bash")',
+          '✓ RangeLink: Bound to Terminal ("bash")',
           2000,
         );
       });
@@ -2772,12 +2780,12 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(2);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal',
+        '✓ RangeLink: Bound to Terminal',
         2000,
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         2,
-        '✓ Focused Terminal: "bash"',
+        '✓ RangeLink: Focused Terminal: "bash"',
         2000,
       );
     });
@@ -2815,12 +2823,12 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(2);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal',
+        '✓ RangeLink: Bound to Terminal',
         2000,
       );
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         2,
-        '✓ Focused Terminal: "bash"',
+        '✓ RangeLink: Focused Terminal: "bash"',
         2000,
       );
     });
@@ -2857,7 +2865,7 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal',
+        '✓ RangeLink: Bound to Terminal',
         2000,
       );
     });
@@ -2885,7 +2893,7 @@ describe('PasteDestinationManager', () => {
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       expect(mockAdapter.__getVscodeInstance().window.setStatusBarMessage).toHaveBeenNthCalledWith(
         1,
-        '✓ RangeLink bound to Terminal',
+        '✓ RangeLink: Bound to Terminal',
         2000,
       );
     });

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/EditorFocusCapability.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/EditorFocusCapability.test.ts
@@ -98,7 +98,7 @@ describe('EditorFocusCapability', () => {
         expect(error).toStrictEqual({ reason: 'EDITOR_AMBIGUOUS_COLUMNS' });
       });
       expect(showErrorSpy).toHaveBeenCalledWith(
-        'RangeLink: Bound editor is open in multiple tab groups. Close the duplicate tab and try again.',
+        'Bound editor is open in multiple tab groups. Close the duplicate tab and try again.',
       );
       expect(mockLogger.warn).toHaveBeenCalledWith(
         {
@@ -225,7 +225,7 @@ describe('EditorFocusCapability', () => {
         expect(error).toStrictEqual({ reason: 'EDITOR_NOT_VISIBLE' });
       });
       expect(showErrorSpy).toHaveBeenCalledWith(
-        'RangeLink: Bound editor is no longer visible. Re-open the file and bind again.',
+        'Bound editor is no longer visible. Re-open the file and bind again.',
       );
       expect(mockLogger.warn).toHaveBeenCalledWith(
         { fn: 'EditorFocusCapability.resolveViewColumn', editorUri: DOCUMENT_URI_STRING },
@@ -263,7 +263,7 @@ describe('EditorFocusCapability', () => {
         expect(error).toStrictEqual({ reason: 'EDITOR_AMBIGUOUS_COLUMNS' });
       });
       expect(showErrorSpy).toHaveBeenCalledWith(
-        'RangeLink: Bound editor is open in multiple tab groups. Close the duplicate tab and try again.',
+        'Bound editor is open in multiple tab groups. Close the duplicate tab and try again.',
       );
       expect(mockLogger.warn).toHaveBeenCalledWith(
         {
@@ -394,7 +394,7 @@ describe('EditorFocusCapability', () => {
         expect(error).toStrictEqual({ reason: 'EDITOR_NOT_VISIBLE' });
       });
       expect(showErrorSpy).toHaveBeenCalledWith(
-        'RangeLink: Bound editor is no longer visible. Re-open the file and bind again.',
+        'Bound editor is no longer visible. Re-open the file and bind again.',
       );
       expect(mockLogger.warn).toHaveBeenCalledWith(
         { fn: 'EditorFocusCapability.resolveViewColumn', editorUri: DOCUMENT_URI_STRING },

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/destinationBuilders.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/destinationBuilders.test.ts
@@ -447,7 +447,7 @@ describe('destinationBuilders', () => {
       const builder = createCustomAiAssistantBuilder(customConfig);
       const destination = builder({ kind: customConfig.kind }, context);
 
-      expect(destination.getJumpSuccessMessage()).toBe('✓ Focused Spark AI');
+      expect(destination.getJumpSuccessMessage()).toBe('Focused Spark AI');
     });
 
     it('allCommands includes insertCommands when present', async () => {

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockTerminalPasteDestination.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockTerminalPasteDestination.ts
@@ -21,7 +21,7 @@ import {
  * - id: 'terminal'
  * - displayName: 'Terminal'
  * - getLoggingDetails: { terminalName: 'bash' }
- * - getJumpSuccessMessage: '✓ Focused Terminal: "bash"'
+ * - getJumpSuccessMessage: 'Focused Terminal: "bash"'
  *
  * @param overrides - Optional partial object to override default properties/methods
  * @returns Mock terminal destination with jest.fn() implementations

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockTerminalPasteDestination.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockTerminalPasteDestination.ts
@@ -33,7 +33,7 @@ export const createMockTerminalPasteDestination = (
     id: 'terminal',
     displayName: 'Terminal',
     getLoggingDetails: jest.fn().mockReturnValue({ terminalName: 'bash' }),
-    getJumpSuccessMessage: jest.fn().mockReturnValue('✓ Focused Terminal: "bash"'),
+    getJumpSuccessMessage: jest.fn().mockReturnValue('Focused Terminal: "bash"'),
     ...overrides,
   });
 };

--- a/packages/rangelink-vscode-extension/src/__tests__/ide/vscode/VscodeAdapter.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/ide/vscode/VscodeAdapter.test.ts
@@ -110,12 +110,19 @@ describe('VscodeAdapter', () => {
 
       const result = adapter.setStatusBarMessage(message);
 
-      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith(message, 2000);
+      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith(
+        'RangeLink: test message',
+        2000,
+      );
       expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledTimes(1);
-      expect(result).toBeDefined();
-      expect(result.dispose).toBeDefined();
+      const rawDisposable = mockVSCode.window.setStatusBarMessage.mock.results[0].value;
+      expect(result).toBe(rawDisposable);
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'VscodeAdapter.setStatusBarMessage', message, timeout: 2000 },
+        {
+          fn: 'VscodeAdapter.setStatusBarMessage',
+          message: 'RangeLink: test message',
+          timeout: 2000,
+        },
         'Setting status bar message',
       );
     });
@@ -126,11 +133,19 @@ describe('VscodeAdapter', () => {
 
       const result = adapter.setStatusBarMessage(message, customTimeout);
 
-      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith(message, customTimeout);
+      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith(
+        'RangeLink: test message',
+        customTimeout,
+      );
       expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledTimes(1);
-      expect(result).toBeDefined();
+      const rawDisposable = mockVSCode.window.setStatusBarMessage.mock.results[0].value;
+      expect(result).toBe(rawDisposable);
       expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'VscodeAdapter.setStatusBarMessage', message, timeout: customTimeout },
+        {
+          fn: 'VscodeAdapter.setStatusBarMessage',
+          message: 'RangeLink: test message',
+          timeout: customTimeout,
+        },
         'Setting status bar message',
       );
     });
@@ -140,16 +155,88 @@ describe('VscodeAdapter', () => {
 
       adapter.setStatusBarMessage(message, 0);
 
-      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith(message, 0);
+      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith(
+        'RangeLink: test message',
+        0,
+      );
     });
 
     it('should return disposable that can be disposed', () => {
       const result = adapter.setStatusBarMessage('test');
 
-      expect(result).toBeDefined();
-      expect(result.dispose).toBeDefined();
+      const rawDisposable = mockVSCode.window.setStatusBarMessage.mock.results[0].value;
+      expect(result).toBe(rawDisposable);
       expect(typeof result.dispose).toBe('function');
       result.dispose();
+      expect(result.dispose).toHaveBeenCalled();
+    });
+  });
+
+  describe('setSuccessfulStatusBarMessage', () => {
+    it('should set success status bar message with default timeout when not specified', () => {
+      const message = 'success message';
+
+      const result = adapter.setSuccessfulStatusBarMessage(message);
+
+      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith(
+        '✓ RangeLink: success message',
+        2000,
+      );
+      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledTimes(1);
+      const rawDisposable = mockVSCode.window.setStatusBarMessage.mock.results[0].value;
+      expect(result).toBe(rawDisposable);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        {
+          fn: 'VscodeAdapter.setSuccessfulStatusBarMessage',
+          message: '✓ RangeLink: success message',
+          timeout: 2000,
+        },
+        'Setting status bar message',
+      );
+    });
+
+    it('should forward custom timeout to underlying VSCode API', () => {
+      const message = 'success message';
+      const customTimeout = 5000;
+
+      const result = adapter.setSuccessfulStatusBarMessage(message, customTimeout);
+
+      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith(
+        '✓ RangeLink: success message',
+        customTimeout,
+      );
+      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledTimes(1);
+      const rawDisposable = mockVSCode.window.setStatusBarMessage.mock.results[0].value;
+      expect(result).toBe(rawDisposable);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        {
+          fn: 'VscodeAdapter.setSuccessfulStatusBarMessage',
+          message: '✓ RangeLink: success message',
+          timeout: customTimeout,
+        },
+        'Setting status bar message',
+      );
+    });
+
+    it('should handle zero timeout', () => {
+      const message = 'success message';
+
+      adapter.setSuccessfulStatusBarMessage(message, 0);
+
+      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith(
+        '✓ RangeLink: success message',
+        0,
+      );
+    });
+
+    it('should return disposable that can be disposed', () => {
+      const result = adapter.setSuccessfulStatusBarMessage('test');
+
+      const rawDisposable = mockVSCode.window.setStatusBarMessage.mock.results[0].value;
+      expect(result).toBe(rawDisposable);
+      expect(typeof result.dispose).toBe('function');
+      result.dispose();
+      expect(result.dispose).toHaveBeenCalled();
     });
   });
 
@@ -237,7 +324,7 @@ describe('VscodeAdapter', () => {
 
     it('should handle error message with details', async () => {
       const detailedError =
-        'RangeLink: Invalid delimiter configuration. Using defaults. Check Output → RangeLink for details.';
+        'Invalid delimiter configuration. Using defaults. Check Output → RangeLink for details.';
 
       await adapter.showErrorMessage(detailedError);
 

--- a/packages/rangelink-vscode-extension/src/__tests__/integration-helpers/logBasedUiAssertions.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/integration-helpers/logBasedUiAssertions.test.ts
@@ -26,21 +26,21 @@ describe('logBasedUiAssertions', () => {
 
     it('passes when matching warning toast is found', () => {
       const lines = [
-        '[DEBUG] {"fn":"VscodeAdapter.showWarningMessage","message":"RangeLink: Bound file is open in multiple editor groups."} Showing warning message',
+        '[DEBUG] {"fn":"VscodeAdapter.showWarningMessage","message":"Bound file is open in multiple editor groups."} Showing warning message',
       ];
 
       assertToastLogged(lines, {
         type: 'warning',
-        message: 'RangeLink: Bound file is open in multiple editor groups.',
+        message: 'Bound file is open in multiple editor groups.',
       });
     });
 
     it('passes when matching error toast is found', () => {
       const lines = [
-        '[DEBUG] {"fn":"VscodeAdapter.showErrorMessage","message":"RangeLink: Failed"} Showing error message',
+        '[DEBUG] {"fn":"VscodeAdapter.showErrorMessage","message":"Failed"} Showing error message',
       ];
 
-      assertToastLogged(lines, { type: 'error', message: 'RangeLink: Failed' });
+      assertToastLogged(lines, { type: 'error', message: 'Failed' });
     });
 
     it('throws when toast type matches but message differs', () => {
@@ -153,12 +153,12 @@ describe('logBasedUiAssertions', () => {
   describe('assertSuppressionLogged', () => {
     it('passes when suppression log with matching fn and suppressedMessage is found', () => {
       const lines = [
-        '[DEBUG] {"fn":"RangeLinkNavigationHandler.navigateToLink","suppressedMessage":"RangeLink: Navigated to file.ts @ 5"} Navigated toast suppressed by setting',
+        '[DEBUG] {"fn":"RangeLinkNavigationHandler.navigateToLink","suppressedMessage":"Navigated to file.ts @ 5"} Navigated toast suppressed by setting',
       ];
 
       assertSuppressionLogged(lines, {
         fn: 'RangeLinkNavigationHandler.navigateToLink',
-        suppressedMessage: 'RangeLink: Navigated to file.ts @ 5',
+        suppressedMessage: 'Navigated to file.ts @ 5',
       });
     });
 

--- a/packages/rangelink-vscode-extension/src/__tests__/navigation/FilePathNavigationHandler.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/navigation/FilePathNavigationHandler.test.ts
@@ -152,9 +152,7 @@ describe('FilePathNavigationHandler', () => {
 
       await handler.navigateToFile('/nonexistent/file.ts');
 
-      expect(showWarningMessageSpy).toHaveBeenCalledWith(
-        'RangeLink: Cannot find file: /nonexistent/file.ts',
-      );
+      expect(showWarningMessageSpy).toHaveBeenCalledWith('Cannot find file: /nonexistent/file.ts');
       expect(mockLogger.warn).toHaveBeenCalledWith(
         {
           fn: 'FilePathNavigationHandler.navigateToFile',
@@ -173,9 +171,7 @@ describe('FilePathNavigationHandler', () => {
 
       await handler.navigateToFile('index.ts');
 
-      expect(showWarningMessageSpy).toHaveBeenCalledWith(
-        'RangeLink: Multiple files match: index.ts',
-      );
+      expect(showWarningMessageSpy).toHaveBeenCalledWith('Multiple files match: index.ts');
       expect(mockLogger.warn).toHaveBeenCalledWith(
         {
           fn: 'FilePathNavigationHandler.navigateToFile',
@@ -213,7 +209,7 @@ describe('FilePathNavigationHandler', () => {
       await expect(handler.navigateToFile('/path/file.ts')).rejects.toThrow(navigationError);
 
       expect(showErrorMessageSpy).toHaveBeenCalledWith(
-        'RangeLink: Failed to open file /path/file.ts: Failed to open document',
+        'Failed to open file /path/file.ts: Failed to open document',
       );
       expect(mockLogger.error).toHaveBeenCalledWith(
         {

--- a/packages/rangelink-vscode-extension/src/__tests__/navigation/RangeLinkNavigationHandler.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/navigation/RangeLinkNavigationHandler.test.ts
@@ -447,9 +447,7 @@ describe('RangeLinkNavigationHandler', () => {
 
         expect(mockAdapter.findOpenUntitledFile).toHaveBeenCalledWith('Untitled-1');
         expect(mockShowWarningMessage).not.toHaveBeenCalled();
-        expect(mockShowInformationMessage).toHaveBeenCalledWith(
-          'RangeLink: Navigated to Untitled-1 @ 10',
-        );
+        expect(mockShowInformationMessage).toHaveBeenCalledWith('Navigated to Untitled-1 @ 10');
         expect(mockLogger.info).toHaveBeenCalledWith(
           {
             fn: 'RangeLinkNavigationHandler.navigateToLink',
@@ -541,9 +539,7 @@ describe('RangeLinkNavigationHandler', () => {
 
         expect(mockAdapter.findOpenUntitledFile).toHaveBeenCalledWith('Sans titre-1');
         expect(mockShowWarningMessage).not.toHaveBeenCalled();
-        expect(mockShowInformationMessage).toHaveBeenCalledWith(
-          'RangeLink: Navigated to Sans titre-1 @ 3',
-        );
+        expect(mockShowInformationMessage).toHaveBeenCalledWith('Navigated to Sans titre-1 @ 3');
       });
     });
 
@@ -600,9 +596,7 @@ describe('RangeLinkNavigationHandler', () => {
         await handler.navigateToLink(parsed, linkText);
 
         expect(mockShowWarningMessage).not.toHaveBeenCalled();
-        expect(mockShowInformationMessage).toHaveBeenCalledWith(
-          'RangeLink: Navigated to Untitled-1 @ 10',
-        );
+        expect(mockShowInformationMessage).toHaveBeenCalledWith('Navigated to Untitled-1 @ 10');
 
         expect(mockEditor.revealRange).toHaveBeenCalledTimes(1);
         expect(mockEditor.revealRange).toHaveBeenCalledWith(mockRange, 2);
@@ -638,9 +632,7 @@ describe('RangeLinkNavigationHandler', () => {
 
         expect(mockAdapter.findOpenUntitledFile).toHaveBeenCalledWith('src/missing.ts');
         expect(mockShowWarningMessage).toHaveBeenCalledTimes(1);
-        expect(mockShowWarningMessage).toHaveBeenCalledWith(
-          'RangeLink: Cannot find file: src/missing.ts',
-        );
+        expect(mockShowWarningMessage).toHaveBeenCalledWith('Cannot find file: src/missing.ts');
       });
 
       it('should show "file not found" warning for absolute path "/tmp/missing.ts"', async () => {
@@ -669,9 +661,7 @@ describe('RangeLinkNavigationHandler', () => {
 
         await handler.navigateToLink(parsed, '/tmp/missing.ts#L1');
 
-        expect(mockShowWarningMessage).toHaveBeenCalledWith(
-          'RangeLink: Cannot find file: /tmp/missing.ts',
-        );
+        expect(mockShowWarningMessage).toHaveBeenCalledWith('Cannot find file: /tmp/missing.ts');
       });
 
       it('should show "file not found" for non-English untitled name not currently open', async () => {
@@ -701,9 +691,7 @@ describe('RangeLinkNavigationHandler', () => {
         await handler.navigateToLink(parsed, 'Sans titre-1#L1');
 
         expect(mockAdapter.findOpenUntitledFile).toHaveBeenCalledWith('Sans titre-1');
-        expect(mockShowWarningMessage).toHaveBeenCalledWith(
-          'RangeLink: Cannot find file: Sans titre-1',
-        );
+        expect(mockShowWarningMessage).toHaveBeenCalledWith('Cannot find file: Sans titre-1');
       });
 
       it('should show "file not found" for "Untitled-3" not currently open', async () => {
@@ -733,9 +721,7 @@ describe('RangeLinkNavigationHandler', () => {
         await handler.navigateToLink(parsed, 'Untitled-3#L1');
 
         expect(mockAdapter.findOpenUntitledFile).toHaveBeenCalledWith('Untitled-3');
-        expect(mockShowWarningMessage).toHaveBeenCalledWith(
-          'RangeLink: Cannot find file: Untitled-3',
-        );
+        expect(mockShowWarningMessage).toHaveBeenCalledWith('Cannot find file: Untitled-3');
       });
     });
 
@@ -766,9 +752,7 @@ describe('RangeLinkNavigationHandler', () => {
 
         await handler.navigateToLink(parsed, 'index.ts#L1');
 
-        expect(mockShowWarningMessage).toHaveBeenCalledWith(
-          'RangeLink: Multiple files match: index.ts',
-        );
+        expect(mockShowWarningMessage).toHaveBeenCalledWith('Multiple files match: index.ts');
         expect(findOpenUntitledFileSpy).not.toHaveBeenCalled();
         expect(showTextDocumentSpy).not.toHaveBeenCalled();
         expect(mockLogger.warn).toHaveBeenCalledWith(
@@ -852,7 +836,7 @@ describe('RangeLinkNavigationHandler', () => {
 
         // Should show error message to user
         expect(mockShowErrorMessage).toHaveBeenCalledWith(
-          'RangeLink: Failed to navigate to file.ts: Failed to open document',
+          'Failed to navigate to file.ts: Failed to open document',
         );
       });
 
@@ -890,7 +874,7 @@ describe('RangeLinkNavigationHandler', () => {
 
         // Should handle non-Error exception and show error message
         expect(mockShowErrorMessage).toHaveBeenCalledWith(
-          'RangeLink: Failed to navigate to file.ts: string error',
+          'Failed to navigate to file.ts: string error',
         );
       });
     });
@@ -960,7 +944,7 @@ describe('RangeLinkNavigationHandler', () => {
       );
 
       expect(showWarningMessageSpy).toHaveBeenCalledWith(
-        'RangeLink: Navigated to file.ts @ 50 (clamped: line exceeded file length)',
+        'Navigated to file.ts @ 50 (clamped: line exceeded file length)',
       );
       expect(showInformationMessageSpy).not.toHaveBeenCalled();
     });
@@ -996,7 +980,7 @@ describe('RangeLinkNavigationHandler', () => {
       );
 
       expect(showWarningMessageSpy).toHaveBeenCalledWith(
-        'RangeLink: Navigated to file.ts @ 1:100 (clamped: column exceeded line length)',
+        'Navigated to file.ts @ 1:100 (clamped: column exceeded line length)',
       );
       expect(showInformationMessageSpy).not.toHaveBeenCalled();
     });
@@ -1018,9 +1002,7 @@ describe('RangeLinkNavigationHandler', () => {
 
       expect(mockLogger.warn).not.toHaveBeenCalled();
 
-      expect(showInformationMessageSpy).toHaveBeenCalledWith(
-        'RangeLink: Navigated to file.ts @ 5:3-5:8',
-      );
+      expect(showInformationMessageSpy).toHaveBeenCalledWith('Navigated to file.ts @ 5:3-5:8');
       expect(showWarningMessageSpy).not.toHaveBeenCalled();
     });
   });
@@ -1190,7 +1172,7 @@ describe('RangeLinkNavigationHandler', () => {
         {
           fn: 'RangeLinkNavigationHandler.navigateToLink',
           linkText: "'recipes/baking/chicken pie.ts'#L3C5-L42C10",
-          suppressedMessage: 'RangeLink: Navigated to recipes/baking/chicken pie.ts @ 3:5-42:10',
+          suppressedMessage: 'Navigated to recipes/baking/chicken pie.ts @ 3:5-42:10',
         },
         'Navigated toast suppressed by setting',
       );
@@ -1245,7 +1227,7 @@ describe('RangeLinkNavigationHandler', () => {
           fn: 'RangeLinkNavigationHandler.navigateToLink',
           linkText: "'recipes/baking/chicken pie.ts'#L50",
           suppressedMessage:
-            'RangeLink: Navigated to recipes/baking/chicken pie.ts @ 50 (clamped: line exceeded file length)',
+            'Navigated to recipes/baking/chicken pie.ts @ 50 (clamped: line exceeded file length)',
         },
         'Clamping warning suppressed by setting',
       );
@@ -1289,7 +1271,7 @@ describe('RangeLinkNavigationHandler', () => {
       await handler.navigateToLink(parsed, "'recipes/baking/chicken pie.ts'#L3C5-L42C10");
 
       expect(showInfoSpy).toHaveBeenCalledWith(
-        'RangeLink: Navigated to recipes/baking/chicken pie.ts @ 3:5-42:10',
+        'Navigated to recipes/baking/chicken pie.ts @ 3:5-42:10',
       );
       expect(mockConfigReader.getBoolean).toHaveBeenCalledWith(
         'navigation.showNavigatedToast',

--- a/packages/rangelink-vscode-extension/src/__tests__/navigation/RangeLinkTerminalProvider.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/navigation/RangeLinkTerminalProvider.test.ts
@@ -171,7 +171,7 @@ describe('RangeLinkTerminalProvider', () => {
       );
 
       expect(mockShowWarningMessage).toHaveBeenCalledWith(
-        'RangeLink: Cannot navigate - invalid link format: file.ts#L0',
+        'Cannot navigate - invalid link format: file.ts#L0',
       );
 
       expect(mockLogger.info).not.toHaveBeenCalled();

--- a/packages/rangelink-vscode-extension/src/__tests__/statusBar/RangeLinkStatusBar.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/statusBar/RangeLinkStatusBar.test.ts
@@ -557,7 +557,7 @@ describe('RangeLinkStatusBar', () => {
         },
         'Bind failed from status bar menu',
       );
-      expect(showErrorMessageMock).toHaveBeenCalledWith('RangeLink: Failed to bind destination');
+      expect(showErrorMessageMock).toHaveBeenCalledWith('Failed to bind destination');
     });
 
     it('logs when info item is selected', async () => {
@@ -711,7 +711,7 @@ describe('RangeLinkStatusBar', () => {
         },
         'Bind failed from overflow terminal picker',
       );
-      expect(showErrorMessageMock).toHaveBeenCalledWith('RangeLink: Failed to bind destination');
+      expect(showErrorMessageMock).toHaveBeenCalledWith('Failed to bind destination');
     });
 
     it('re-opens status bar menu when user cancels secondary terminal picker', async () => {
@@ -855,7 +855,7 @@ describe('RangeLinkStatusBar', () => {
         },
         'Bind failed from overflow file picker',
       );
-      expect(showErrorMessageMock).toHaveBeenCalledWith('RangeLink: Failed to bind destination');
+      expect(showErrorMessageMock).toHaveBeenCalledWith('Failed to bind destination');
     });
 
     it('returns early and shows toast when no file items are available in secondary picker', async () => {
@@ -879,7 +879,7 @@ describe('RangeLinkStatusBar', () => {
         'No files available in secondary picker',
       );
       expect(showErrorMessageMock).toHaveBeenCalledWith(
-        'RangeLink: No active text editor. Open a file and try again.',
+        'No active text editor. Open a file and try again.',
       );
     });
 
@@ -988,7 +988,7 @@ describe('RangeLinkStatusBar', () => {
         'Bookmark send failed',
       );
       expect(showErrorMessageMock).toHaveBeenCalledWith(
-        'RangeLink: Cannot send bookmark — no destination is currently bound',
+        'Cannot send bookmark — no destination is currently bound',
       );
       expect(mockLogger.debug).toHaveBeenCalledTimes(1);
       expect(mockLogger.debug).toHaveBeenCalledWith(
@@ -1024,7 +1024,7 @@ describe('RangeLinkStatusBar', () => {
         { fn: 'RangeLinkStatusBar.openMenu', selectedItem, error: sendError },
         'Bookmark send failed',
       );
-      expect(showErrorMessageMock).toHaveBeenCalledWith('RangeLink: Failed to send bookmark');
+      expect(showErrorMessageMock).toHaveBeenCalledWith('Failed to send bookmark');
     });
   });
 

--- a/packages/rangelink-vscode-extension/src/commands/AddBookmarkCommand.ts
+++ b/packages/rangelink-vscode-extension/src/commands/AddBookmarkCommand.ts
@@ -140,7 +140,7 @@ export class AddBookmarkCommand {
 
     this.logger.info({ ...logCtx, label: trimmedLabel, link: linkToBookmark }, 'Bookmark saved');
 
-    this.ideAdapter.setStatusBarMessage(
+    this.ideAdapter.setSuccessfulStatusBarMessage(
       formatMessage(MessageCode.STATUS_BAR_BOOKMARK_SAVED, { label: trimmedLabel }),
     );
   }

--- a/packages/rangelink-vscode-extension/src/config/__tests__/getDelimitersForExtension.test.ts
+++ b/packages/rangelink-vscode-extension/src/config/__tests__/getDelimitersForExtension.test.ts
@@ -80,7 +80,7 @@ describe('getDelimitersForExtension', () => {
 
       expect(result).toStrictEqual(DEFAULT_DELIMITERS);
       expect(errorFeedbackProvider.showErrorMessage).toHaveBeenCalledWith(
-        'RangeLink: Invalid delimiter configuration. Using defaults. Check Output → RangeLink for details.',
+        'Invalid delimiter configuration. Using defaults. Check Output → RangeLink for details.',
       );
       expect(errorFeedbackProvider.showErrorMessage).toHaveBeenCalledTimes(1);
     });

--- a/packages/rangelink-vscode-extension/src/destinations/PasteDestinationManager.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/PasteDestinationManager.ts
@@ -165,7 +165,7 @@ export class PasteDestinationManager implements vscode.Disposable {
       `Successfully unbound from ${displayName}`,
     );
 
-    this.vscodeAdapter.setStatusBarMessage(
+    this.vscodeAdapter.setSuccessfulStatusBarMessage(
       formatMessage(MessageCode.STATUS_BAR_DESTINATION_UNBOUND, { destinationName: displayName }),
     );
   }
@@ -264,7 +264,7 @@ export class PasteDestinationManager implements vscode.Disposable {
 
     if (!options?.silent) {
       const successMessage = this.boundDestination.getJumpSuccessMessage();
-      this.vscodeAdapter.setStatusBarMessage(successMessage);
+      this.vscodeAdapter.setSuccessfulStatusBarMessage(successMessage);
     }
 
     this.logger.info(logCtx, `Successfully focused ${displayName}`);
@@ -714,7 +714,7 @@ export class PasteDestinationManager implements vscode.Disposable {
           destinationName: newDestinationName,
         });
 
-    this.vscodeAdapter.setStatusBarMessage(toastMessage);
+    this.vscodeAdapter.setSuccessfulStatusBarMessage(toastMessage);
   }
 
   /**
@@ -763,14 +763,14 @@ export class PasteDestinationManager implements vscode.Disposable {
       const successInstruction = destination.getUserInstruction?.(AutoPasteResult.Success);
 
       if (successInstruction) {
-        this.vscodeAdapter.setStatusBarMessage(options.basicStatusMessage);
+        this.vscodeAdapter.setSuccessfulStatusBarMessage(options.basicStatusMessage);
         void this.vscodeAdapter.showInformationMessage(successInstruction);
       } else {
         const enhancedMessage = formatMessage(MessageCode.STATUS_BAR_LINK_SENT_TO_DESTINATION, {
           statusMessage: options.basicStatusMessage,
           destinationName: displayName,
         });
-        this.vscodeAdapter.setStatusBarMessage(enhancedMessage);
+        this.vscodeAdapter.setSuccessfulStatusBarMessage(enhancedMessage);
       }
 
       return true;
@@ -779,7 +779,7 @@ export class PasteDestinationManager implements vscode.Disposable {
     const failureInstruction = destination.getUserInstruction?.(AutoPasteResult.Failure);
 
     if (failureInstruction) {
-      this.vscodeAdapter.setStatusBarMessage(options.basicStatusMessage);
+      this.vscodeAdapter.setSuccessfulStatusBarMessage(options.basicStatusMessage);
       void this.vscodeAdapter.showWarningMessage(failureInstruction);
     } else {
       const errorMsg = this.buildPasteFailureMessage(destination, options.basicStatusMessage);

--- a/packages/rangelink-vscode-extension/src/i18n/messages.en.ts
+++ b/packages/rangelink-vscode-extension/src/i18n/messages.en.ts
@@ -10,7 +10,7 @@ const NO_DESTINATIONS_AVAILABLE =
 export const messagesEn: Record<MessageCode, string> = {
   // Keep the keys in alphabetical order.
 
-  [MessageCode.ALREADY_BOUND_TO_DESTINATION]: 'RangeLink: Already bound to {destinationName}',
+  [MessageCode.ALREADY_BOUND_TO_DESTINATION]: 'Already bound to {destinationName}',
   [MessageCode.BOOKMARK_ACTION_ADD]: '$(add) Save Selection as Bookmark',
   [MessageCode.BOOKMARK_ACTION_MANAGE]: '$(gear) Manage Bookmarks...',
   [MessageCode.BOOKMARK_ADD_INPUT_PLACEHOLDER]: 'Enter a label for this bookmark',
@@ -23,10 +23,10 @@ export const messagesEn: Record<MessageCode, string> = {
   [MessageCode.BOOKMARK_MANAGE_CONFIRM_DELETE_YES]: 'Delete',
   [MessageCode.BOOKMARK_MANAGE_DELETED]: '✓ Bookmark deleted: {label}',
   [MessageCode.BOOKMARK_MANAGE_EMPTY]: 'No bookmarks to manage',
-  [MessageCode.BOOKMARK_MANAGE_ERROR_DELETE_FAILED]: 'RangeLink: Failed to delete bookmark',
+  [MessageCode.BOOKMARK_MANAGE_ERROR_DELETE_FAILED]: 'Failed to delete bookmark',
   [MessageCode.BOOKMARK_MANAGE_PLACEHOLDER]: 'Select a bookmark to manage',
   [MessageCode.BOOKMARK_MANAGE_TITLE]: 'Manage Bookmarks',
-  [MessageCode.BOUND_EDITOR_CLOSED_AUTO_UNBOUND]: 'RangeLink: Bound editor closed. Unbound.',
+  [MessageCode.BOUND_EDITOR_CLOSED_AUTO_UNBOUND]: 'Bound editor closed. Unbound.',
 
   [MessageCode.CONFIG_LOADED]: 'Configuration loaded',
   [MessageCode.CONFIG_USING_DEFAULTS]: 'Using default configuration',
@@ -47,60 +47,55 @@ export const messagesEn: Record<MessageCode, string> = {
   [MessageCode.DESTINATION_TERMINAL_DISPLAY_FORMAT]: 'Terminal ("{name}")',
 
   [MessageCode.ERROR_BACKGROUND_TAB_OPEN_FAILED]:
-    'RangeLink: Could not open "{fileName}". Try again or choose another file.',
+    'Could not open "{fileName}". Try again or choose another file.',
   [MessageCode.ERROR_BACKGROUND_TAB_WRONG_VIEW_COLUMN]:
-    'RangeLink: "{fileName}" opened in a different editor group. Try again or choose another file.',
-  [MessageCode.ERROR_BOOKMARK_EMPTY_LABEL]: 'RangeLink: Bookmark label cannot be empty',
+    '"{fileName}" opened in a different editor group. Try again or choose another file.',
+  [MessageCode.ERROR_BOOKMARK_EMPTY_LABEL]: 'Bookmark label cannot be empty',
   [MessageCode.ERROR_BOOKMARK_LINK_GENERATION_FAILED]:
-    'RangeLink: Cannot add bookmark - failed to generate link from selection',
-  [MessageCode.ERROR_BOOKMARK_NO_ACTIVE_EDITOR]:
-    'RangeLink: Cannot add bookmark - no active editor',
-  [MessageCode.ERROR_BOOKMARK_SAVE_FAILED]: 'RangeLink: Failed to save bookmark',
-  [MessageCode.ERROR_BOOKMARK_SEND_FAILED]: 'RangeLink: Failed to send bookmark',
+    'Cannot add bookmark - failed to generate link from selection',
+  [MessageCode.ERROR_BOOKMARK_NO_ACTIVE_EDITOR]: 'Cannot add bookmark - no active editor',
+  [MessageCode.ERROR_BOOKMARK_SAVE_FAILED]: 'Failed to save bookmark',
+  [MessageCode.ERROR_BOOKMARK_SEND_FAILED]: 'Failed to send bookmark',
   [MessageCode.ERROR_BOOKMARK_SEND_NO_DESTINATION]:
-    'RangeLink: Cannot send bookmark — no destination is currently bound',
+    'Cannot send bookmark — no destination is currently bound',
   [MessageCode.ERROR_BOOKMARK_UNTITLED_FILE]:
-    'RangeLink: Cannot bookmark unsaved file. Save the file first, or select an existing RangeLink to bookmark.',
-  [MessageCode.ERROR_BIND_FAILED]: 'RangeLink: Failed to bind destination',
+    'Cannot bookmark unsaved file. Save the file first, or select an existing RangeLink to bookmark.',
+  [MessageCode.ERROR_BIND_FAILED]: 'Failed to bind destination',
   [MessageCode.ERROR_CLAUDE_CODE_NOT_AVAILABLE]:
-    'RangeLink: Cannot bind Claude Code - extension not installed or not active',
+    'Cannot bind Claude Code - extension not installed or not active',
   [MessageCode.ERROR_CURSOR_AI_NOT_AVAILABLE]:
-    'RangeLink: Cannot bind Cursor AI Assistant - not running in Cursor IDE',
+    'Cannot bind Cursor AI Assistant - not running in Cursor IDE',
   [MessageCode.ERROR_CUSTOM_AI_NOT_AVAILABLE]:
-    'RangeLink: Cannot bind {extensionName} - extension not installed or not active',
-  [MessageCode.ERROR_FILE_PATH_NAVIGATION_FAILED]: 'RangeLink: Failed to open file {path}: {error}',
+    'Cannot bind {extensionName} - extension not installed or not active',
+  [MessageCode.ERROR_FILE_PATH_NAVIGATION_FAILED]: 'Failed to open file {path}: {error}',
   [MessageCode.ERROR_GITHUB_COPILOT_CHAT_NOT_AVAILABLE]:
-    'RangeLink: Cannot bind GitHub Copilot Chat - extension not installed or not active',
+    'Cannot bind GitHub Copilot Chat - extension not installed or not active',
   [MessageCode.ERROR_INVALID_DELIMITER_CONFIG]:
-    'RangeLink: Invalid delimiter configuration. Using defaults. Check Output → RangeLink for details.',
-  [MessageCode.ERROR_LINK_GENERATION_FAILED]: 'RangeLink: Failed to generate {linkTypeName}',
-  [MessageCode.ERROR_NAVIGATION_FAILED]: 'RangeLink: Failed to navigate to {path}: {error}',
-  [MessageCode.ERROR_NO_ACTIVE_EDITOR]: 'RangeLink: No active editor',
-  [MessageCode.ERROR_NO_ACTIVE_TERMINAL]:
-    'RangeLink: No active terminal. Open a terminal and try again.',
-  [MessageCode.ERROR_NO_ACTIVE_TEXT_EDITOR]:
-    'RangeLink: No active text editor. Open a file and try again.',
+    'Invalid delimiter configuration. Using defaults. Check Output → RangeLink for details.',
+  [MessageCode.ERROR_LINK_GENERATION_FAILED]: 'Failed to generate {linkTypeName}',
+  [MessageCode.ERROR_NAVIGATION_FAILED]: 'Failed to navigate to {path}: {error}',
+  [MessageCode.ERROR_NO_ACTIVE_EDITOR]: 'No active editor',
+  [MessageCode.ERROR_NO_ACTIVE_TERMINAL]: 'No active terminal. Open a terminal and try again.',
+  [MessageCode.ERROR_NO_ACTIVE_TEXT_EDITOR]: 'No active text editor. Open a file and try again.',
   [MessageCode.ERROR_NO_TERMINAL_TEXT_SELECTED]:
-    'RangeLink: No text selected in the terminal. Select text and try again.',
+    'No text selected in the terminal. Select text and try again.',
   [MessageCode.ERROR_NO_TEXT_SELECTED]:
-    'RangeLink: No text selected. Click in the file, select text, and try again.',
-  [MessageCode.ERROR_PASTE_FILE_PATH_NO_ACTIVE_FILE]:
-    'RangeLink: No active file. Open a file and try again.',
+    'No text selected. Click in the file, select text, and try again.',
+  [MessageCode.ERROR_PASTE_FILE_PATH_NO_ACTIVE_FILE]: 'No active file. Open a file and try again.',
   [MessageCode.ERROR_TERMINAL_CLIPBOARD_READ_FAILED]:
-    'RangeLink: Could not read terminal selection. Please try again.',
+    'Could not read terminal selection. Please try again.',
   [MessageCode.ERROR_TERMINAL_COPY_COMMAND_FAILED]:
-    'RangeLink: Could not read terminal selection. Please try again.',
+    'Could not read terminal selection. Please try again.',
   [MessageCode.ERROR_TERMINAL_COPY_LINK_NOT_SUPPORTED]:
-    'RangeLink: R-C generates code location links and requires an editor selection. Use R-V to paste terminal text.',
+    'R-C generates code location links and requires an editor selection. Use R-V to paste terminal text.',
   [MessageCode.ERROR_TERMINAL_LINK_INVALID_FORMAT]:
-    'RangeLink: Cannot navigate - invalid link format: {linkText}',
+    'Cannot navigate - invalid link format: {linkText}',
   [MessageCode.ERROR_TEXT_EDITOR_AMBIGUOUS_COLUMNS]:
-    'RangeLink: Bound editor is open in multiple tab groups. Close the duplicate tab and try again.',
-  [MessageCode.ERROR_TEXT_EDITOR_BINARY_FILE]: 'RangeLink: Cannot bind to {fileName} - binary file',
+    'Bound editor is open in multiple tab groups. Close the duplicate tab and try again.',
+  [MessageCode.ERROR_TEXT_EDITOR_BINARY_FILE]: 'Cannot bind to {fileName} - binary file',
   [MessageCode.ERROR_TEXT_EDITOR_NOT_VISIBLE]:
-    'RangeLink: Bound editor is no longer visible. Re-open the file and bind again.',
-  [MessageCode.ERROR_TEXT_EDITOR_READ_ONLY]:
-    'RangeLink: Cannot bind to read-only editor ({scheme})',
+    'Bound editor is no longer visible. Re-open the file and bind again.',
+  [MessageCode.ERROR_TEXT_EDITOR_READ_ONLY]: 'Cannot bind to read-only editor ({scheme})',
   [MessageCode.ERROR_VERSION_INFO_NOT_AVAILABLE]: 'Version information not available',
 
   [MessageCode.FILE_PICKER_ACTIVE_BADGE]: 'active',
@@ -114,7 +109,7 @@ export const messagesEn: Record<MessageCode, string> = {
   [MessageCode.FILE_PICKER_TITLE]: 'RangeLink',
 
   [MessageCode.INFO_BACKGROUND_TAB_OPENED]:
-    'RangeLink: "{fileName}" opened at last cursor position. Adjust cursor before pasting.',
+    '"{fileName}" opened at last cursor position. Adjust cursor before pasting.',
   [MessageCode.INFO_BIND_NO_DESTINATIONS_AVAILABLE]: NO_DESTINATIONS_AVAILABLE,
   [MessageCode.INFO_BIND_QUICK_PICK_PLACEHOLDER]: 'RangeLink: Choose a destination to bind to',
   [MessageCode.INFO_CLAUDE_CODE_NOT_AVAILABLE]:
@@ -130,15 +125,15 @@ export const messagesEn: Record<MessageCode, string> = {
     'RangeLink can seamlessly integrate with GitHub Copilot Chat for faster context sharing of precise code ranges.\n\nInstall and activate the GitHub Copilot Chat extension to use it as a paste destination.',
   [MessageCode.INFO_GITHUB_COPILOT_CHAT_USER_INSTRUCTIONS]:
     'Paste (Cmd/Ctrl+V) in GitHub Copilot chat to use.',
-  [MessageCode.INFO_JUMP_FOCUS_FAILED]: 'RangeLink: Failed to focus {destinationName}',
+  [MessageCode.INFO_JUMP_FOCUS_FAILED]: 'Failed to focus {destinationName}',
   [MessageCode.INFO_JUMP_NO_DESTINATIONS_AVAILABLE]: NO_DESTINATIONS_AVAILABLE,
   [MessageCode.INFO_JUMP_QUICK_PICK_PLACEHOLDER]:
     'RangeLink: No destination bound. Choose destination to jump to',
-  [MessageCode.INFO_NAVIGATION_EMPTY_INPUT]: 'RangeLink: Please enter a link to navigate',
+  [MessageCode.INFO_NAVIGATION_EMPTY_INPUT]: 'Please enter a link to navigate',
   [MessageCode.INFO_NAVIGATION_INPUT_BOX_PLACEHOLDER]: 'recipes/baking/chickenpie.ts#L3C14-L15C9',
   [MessageCode.INFO_NAVIGATION_INPUT_BOX_PROMPT]: 'Enter RangeLink to navigate',
-  [MessageCode.INFO_NAVIGATION_INVALID_LINK]: "RangeLink: Invalid link format: '{input}'",
-  [MessageCode.INFO_NAVIGATION_SUCCESS]: 'RangeLink: Navigated to {path} @ {position}',
+  [MessageCode.INFO_NAVIGATION_INVALID_LINK]: "Invalid link format: '{input}'",
+  [MessageCode.INFO_NAVIGATION_SUCCESS]: 'Navigated to {path} @ {position}',
   [MessageCode.INFO_NEW_VERSION_NOTIFICATION]: 'RangeLink updated to v{version}. See what changed!',
   [MessageCode.INFO_NEW_VERSION_SKIP_BUTTON]: 'Skip for this version',
   [MessageCode.INFO_NEW_VERSION_WHATS_NEW_BUTTON]: "What's New",
@@ -166,20 +161,20 @@ export const messagesEn: Record<MessageCode, string> = {
 
   [MessageCode.STATUS_BAR_DESTINATION_BINDING_REMOVED_TERMINAL_CLOSED]:
     'Destination binding removed (terminal closed)',
-  [MessageCode.STATUS_BAR_DESTINATION_BOUND]: '✓ RangeLink bound to {destinationName}',
-  [MessageCode.STATUS_BAR_DESTINATION_NOT_BOUND]: 'RangeLink: No destination bound',
+  [MessageCode.STATUS_BAR_DESTINATION_BOUND]: 'Bound to {destinationName}',
+  [MessageCode.STATUS_BAR_DESTINATION_NOT_BOUND]: 'No destination bound',
   [MessageCode.STATUS_BAR_DESTINATION_REBOUND]:
     'Unbound {previousDestination}, now bound to {newDestination}',
-  [MessageCode.STATUS_BAR_DESTINATION_UNBOUND]: '✓ RangeLink unbound from {destinationName}',
+  [MessageCode.STATUS_BAR_DESTINATION_UNBOUND]: 'Unbound from {destinationName}',
   [MessageCode.STATUS_BAR_ITEM_TEXT]: '$(link) RangeLink',
-  [MessageCode.STATUS_BAR_JUMP_SUCCESS_CLAUDE_CODE]: '✓ Focused Claude Code Chat',
-  [MessageCode.STATUS_BAR_JUMP_SUCCESS_CURSOR_AI]: '✓ Focused Cursor AI Assistant',
-  [MessageCode.STATUS_BAR_JUMP_SUCCESS_CUSTOM_AI]: '✓ Focused {extensionName}',
-  [MessageCode.STATUS_BAR_JUMP_SUCCESS_EDITOR]: '✓ Focused Editor: "{resourceName}"',
-  [MessageCode.STATUS_BAR_JUMP_SUCCESS_GITHUB_COPILOT_CHAT]: '✓ Focused GitHub Copilot Chat',
-  [MessageCode.STATUS_BAR_JUMP_SUCCESS_TERMINAL]: '✓ Focused Terminal: "{resourceName}"',
-  [MessageCode.STATUS_BAR_BOOKMARK_SAVED]: '✓ Bookmark saved: {label}',
-  [MessageCode.STATUS_BAR_LINK_COPIED_TO_CLIPBOARD]: '✓ {linkTypeName} copied to clipboard',
+  [MessageCode.STATUS_BAR_JUMP_SUCCESS_CLAUDE_CODE]: 'Focused Claude Code Chat',
+  [MessageCode.STATUS_BAR_JUMP_SUCCESS_CURSOR_AI]: 'Focused Cursor AI Assistant',
+  [MessageCode.STATUS_BAR_JUMP_SUCCESS_CUSTOM_AI]: 'Focused {extensionName}',
+  [MessageCode.STATUS_BAR_JUMP_SUCCESS_EDITOR]: 'Focused Editor: "{resourceName}"',
+  [MessageCode.STATUS_BAR_JUMP_SUCCESS_GITHUB_COPILOT_CHAT]: 'Focused GitHub Copilot Chat',
+  [MessageCode.STATUS_BAR_JUMP_SUCCESS_TERMINAL]: 'Focused Terminal: "{resourceName}"',
+  [MessageCode.STATUS_BAR_BOOKMARK_SAVED]: 'Bookmark saved: {label}',
+  [MessageCode.STATUS_BAR_LINK_COPIED_TO_CLIPBOARD]: '{linkTypeName} copied to clipboard',
   [MessageCode.STATUS_BAR_LINK_SENT_TO_DESTINATION]: '{statusMessage} & sent to {destinationName}',
   [MessageCode.STATUS_BAR_MENU_BOOKMARKS_SECTION_LABEL]: 'Bookmarks',
   [MessageCode.STATUS_BAR_MENU_DESTINATIONS_CHOOSE_BELOW]:
@@ -212,7 +207,7 @@ export const messagesEn: Record<MessageCode, string> = {
   [MessageCode.WARN_FILE_PATH_DIRTY_BUFFER_SAVE]: 'Save & Send',
   [MessageCode.WARN_FILE_PATH_DIRTY_BUFFER_SAVE_FAILED]:
     'File could not be saved. File path send aborted.',
-  [MessageCode.WARN_FILE_PATH_NOT_FOUND]: 'RangeLink: Cannot find file: {path}',
+  [MessageCode.WARN_FILE_PATH_NOT_FOUND]: 'Cannot find file: {path}',
   [MessageCode.WARN_LINK_DIRTY_BUFFER]:
     'File has unsaved changes. Link may point to wrong position after save.',
   [MessageCode.WARN_LINK_DIRTY_BUFFER_CONTINUE]: 'Generate Anyway',
@@ -220,18 +215,18 @@ export const messagesEn: Record<MessageCode, string> = {
   [MessageCode.WARN_LINK_DIRTY_BUFFER_SAVE_FAILED]:
     'File could not be saved. Link generation aborted.',
   [MessageCode.WARN_NAVIGATION_CLAMPED]:
-    'RangeLink: Navigated to {path} @ {position} (clamped: {clampingSummary})',
+    'Navigated to {path} @ {position} (clamped: {clampingSummary})',
   [MessageCode.WARN_NAVIGATION_CLAMPED_SUMMARY_BOTH]: 'line and column exceeded bounds',
   [MessageCode.WARN_NAVIGATION_CLAMPED_SUMMARY_CHARACTER]: 'column exceeded line length',
   [MessageCode.WARN_NAVIGATION_CLAMPED_SUMMARY_LINE]: 'line exceeded file length',
-  [MessageCode.WARN_NAVIGATION_FILENAME_AMBIGUOUS]: 'RangeLink: Multiple files match: {path}',
-  [MessageCode.WARN_NAVIGATION_FILE_NOT_FOUND]: 'RangeLink: Cannot find file: {path}',
+  [MessageCode.WARN_NAVIGATION_FILENAME_AMBIGUOUS]: 'Multiple files match: {path}',
+  [MessageCode.WARN_NAVIGATION_FILE_NOT_FOUND]: 'Cannot find file: {path}',
   [MessageCode.WARN_PASTE_FAILED_EDITOR_HIDDEN]:
     '{statusMessage}. Could not send to editor. Bound editor is hidden behind other tabs.',
   [MessageCode.WARN_PASTE_FAILED_TERMINAL]:
     '{statusMessage}. Could not send to terminal. Terminal may be closed or not accepting input.',
   [MessageCode.WARN_TEXT_EDITOR_DUPLICATE_TAB_GROUPS]:
-    'RangeLink: Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed.',
+    'Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed.',
 
   // Keep the keys in alphabetical order.
 };

--- a/packages/rangelink-vscode-extension/src/ide/vscode/VscodeAdapter.ts
+++ b/packages/rangelink-vscode-extension/src/ide/vscode/VscodeAdapter.ts
@@ -1,6 +1,7 @@
 import type { Logger } from 'barebone-logger';
 import * as vscode from 'vscode';
 
+import { displayName } from '../../../package.json';
 import {
   AI_ASSISTANT_PASTE_COMMANDS,
   CLIPBOARD_POST_PASTE_DELAY_MS,
@@ -28,6 +29,8 @@ import type { QuickPickProvider } from '../QuickPickProvider';
  * Default timeout for status bar messages in milliseconds.
  */
 const DEFAULT_STATUS_BAR_TIMEOUT_MS = 2000;
+const STATUS_BAR_PREFIX = `${displayName}: `;
+const STATUS_BAR_SUCCESS_PREFIX = `✓ ${STATUS_BAR_PREFIX}`;
 
 const getUnknownFilename = (): string => formatMessage(MessageCode.UNKNOWN_FILENAME_FALLBACK);
 
@@ -140,16 +143,39 @@ export class VscodeAdapter
   }
 
   /**
-   * Show temporary status bar message using VSCode API
+   * Show temporary status bar message prefixed with "RangeLink: ".
    */
   setStatusBarMessage(
     message: string,
     timeout: number = DEFAULT_STATUS_BAR_TIMEOUT_MS,
   ): vscode.Disposable {
-    this.logger.debug(
-      { fn: 'VscodeAdapter.setStatusBarMessage', message, timeout },
-      'Setting status bar message',
+    return this.setStatusBarMessageInternal(
+      `${STATUS_BAR_PREFIX}${message}`,
+      timeout,
+      'VscodeAdapter.setStatusBarMessage',
     );
+  }
+
+  /**
+   * Show temporary success status bar message prefixed with "✓ RangeLink: ".
+   */
+  setSuccessfulStatusBarMessage(
+    message: string,
+    timeout: number = DEFAULT_STATUS_BAR_TIMEOUT_MS,
+  ): vscode.Disposable {
+    return this.setStatusBarMessageInternal(
+      `${STATUS_BAR_SUCCESS_PREFIX}${message}`,
+      timeout,
+      'VscodeAdapter.setSuccessfulStatusBarMessage',
+    );
+  }
+
+  private setStatusBarMessageInternal(
+    message: string,
+    timeout: number,
+    fn: string,
+  ): vscode.Disposable {
+    this.logger.debug({ fn, message, timeout }, 'Setting status bar message');
     return this.ideInstance.window.setStatusBarMessage(message, timeout);
   }
 

--- a/packages/rangelink-vscode-extension/src/services/ClipboardRouter.ts
+++ b/packages/rangelink-vscode-extension/src/services/ClipboardRouter.ts
@@ -94,7 +94,7 @@ export class ClipboardRouter {
           ? 'Skipping destination (clipboard-only command)'
           : 'No destination bound - copied to clipboard only';
       this.logger.info({ fn: fnName }, reason);
-      this.ideAdapter.setStatusBarMessage(basicStatusMessage);
+      this.ideAdapter.setSuccessfulStatusBarMessage(basicStatusMessage);
       return false;
     }
 
@@ -107,7 +107,7 @@ export class ClipboardRouter {
         { fn: fnName, boundDestination: displayName },
         'Content not eligible for paste - skipping auto-paste',
       );
-      this.ideAdapter.setStatusBarMessage(basicStatusMessage);
+      this.ideAdapter.setSuccessfulStatusBarMessage(basicStatusMessage);
       return false;
     }
 
@@ -119,7 +119,7 @@ export class ClipboardRouter {
       };
       const selfPasteMessage = formatMessage(selfPasteMessageCodes[control.contentType]);
       this.ideAdapter.showInformationMessage(selfPasteMessage);
-      this.ideAdapter.setStatusBarMessage(basicStatusMessage);
+      this.ideAdapter.setSuccessfulStatusBarMessage(basicStatusMessage);
       return false;
     }
 

--- a/packages/rangelink-vscode-extension/src/services/__tests__/SelectionValidator.test.ts
+++ b/packages/rangelink-vscode-extension/src/services/__tests__/SelectionValidator.test.ts
@@ -58,7 +58,7 @@ describe('SelectionValidator', () => {
       const result = validator.validateSelectionsAndShowError();
 
       expect(result).toBeUndefined();
-      expect(showErrorSpy).toHaveBeenCalledWith('RangeLink: No active editor');
+      expect(showErrorSpy).toHaveBeenCalledWith('No active editor');
       expect(mockLogger.warn).toHaveBeenCalledWith(
         {
           fn: 'SelectionValidator.validateSelectionsAndShowError',
@@ -93,7 +93,7 @@ describe('SelectionValidator', () => {
 
       expect(result).toBeUndefined();
       expect(showErrorSpy).toHaveBeenCalledWith(
-        'RangeLink: No text selected. Click in the file, select text, and try again.',
+        'No text selected. Click in the file, select text, and try again.',
       );
       expect(mockLogger.warn).toHaveBeenCalledWith(
         {

--- a/packages/rangelink-vscode-extension/src/utils/__tests__/formatMessage.test.ts
+++ b/packages/rangelink-vscode-extension/src/utils/__tests__/formatMessage.test.ts
@@ -339,7 +339,7 @@ describe('formatMessage', () => {
     it('should format STATUS_BAR_DESTINATION_NOT_BOUND (static)', () => {
       const result = formatMessage(MessageCode.STATUS_BAR_DESTINATION_NOT_BOUND);
 
-      expect(result).toStrictEqual('RangeLink: No destination bound');
+      expect(result).toStrictEqual('No destination bound');
     });
 
     it('should format STATUS_BAR_DESTINATION_UNBOUND with destinationName param', () => {
@@ -347,7 +347,7 @@ describe('formatMessage', () => {
         destinationName: 'Terminal',
       });
 
-      expect(result).toStrictEqual('✓ RangeLink unbound from Terminal');
+      expect(result).toStrictEqual('Unbound from Terminal');
     });
 
     it('should format STATUS_BAR_DESTINATION_BINDING_REMOVED_TERMINAL_CLOSED (static)', () => {
@@ -363,7 +363,7 @@ describe('formatMessage', () => {
         destinationName: 'Cursor AI Assistant',
       });
 
-      expect(result).toStrictEqual('✓ RangeLink bound to Cursor AI Assistant');
+      expect(result).toStrictEqual('Bound to Cursor AI Assistant');
     });
 
     it('should format STATUS_BAR_DESTINATION_REBOUND with two params', () => {
@@ -388,7 +388,7 @@ describe('formatMessage', () => {
         path: 'src/missing.ts',
       });
 
-      expect(result).toStrictEqual('RangeLink: Cannot find file: src/missing.ts');
+      expect(result).toStrictEqual('Cannot find file: src/missing.ts');
     });
 
     it('should format INFO_NAVIGATION_SUCCESS with path and position params', () => {
@@ -397,7 +397,7 @@ describe('formatMessage', () => {
         position: 'L42C10',
       });
 
-      expect(result).toStrictEqual('RangeLink: Navigated to src/utils/helper.ts @ L42C10');
+      expect(result).toStrictEqual('Navigated to src/utils/helper.ts @ L42C10');
     });
 
     it('should format ERROR_NAVIGATION_FAILED with path and error params', () => {
@@ -406,9 +406,7 @@ describe('formatMessage', () => {
         error: 'File is not readable',
       });
 
-      expect(result).toStrictEqual(
-        'RangeLink: Failed to navigate to src/broken.ts: File is not readable',
-      );
+      expect(result).toStrictEqual('Failed to navigate to src/broken.ts: File is not readable');
     });
   });
 });


### PR DESCRIPTION
## Summary

Centralizes all status bar message prefixing in `VscodeAdapter` so every status bar message consistently carries `RangeLink: ` or `✓ RangeLink: ` without requiring each template or call site to bake in the prefix. Toast messages (info/warning/error) no longer carry `RangeLink: ` since VS Code already shows a Source attribution for those.

## Changes

- Added `setSuccessfulStatusBarMessage(message, timeout)` to `VscodeAdapter` — prepends `✓ RangeLink: `, delegates to a shared private method with `setStatusBarMessage` which prepends `RangeLink: `
- Stripped all `RangeLink: `, `✓ `, and `✓ RangeLink ` prefixes from status bar templates in `messages.en.ts` — templates now carry only message payload
- Removed `RangeLink: ` prefix from all toast message templates — VS Code's toast popup already shows the extension source
- Switched 11 success-path call sites from `setStatusBarMessage` to `setSuccessfulStatusBarMessage` (bind/unbind/jump/copy/bookmark)
- Updated all unit test and integration test assertions for the new prefix behavior
- Documentation: CHANGELOG not needed (internal prefix harmonization); README not needed

## Test Plan

- [ ] All 1894 unit tests pass
- [ ] All integration tests pass (automated + assisted)

## Related

- Closes https://github.com/couimet/rangeLink/issues/549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Refined status bar message formatting with consistent "RangeLink: " prefixing for better visual clarity.
  * Enhanced success notifications with checkmark styling (✓ RangeLink: ...).
  * Simplified toast and error messages by removing redundant prefixes for cleaner user feedback.

* **Tests**
  * Updated integration and unit test suites to validate refined message formatting and UI behavior across binding, navigation, and clipboard operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/rangeLink/pull/578)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->