### PR TITLE
[issues/563] Close QA coverage gaps from single-write clipboard refactor (PR #556)

### DIFF
--- a/packages/rangelink-vscode-extension/TESTING.md
+++ b/packages/rangelink-vscode-extension/TESTING.md
@@ -182,11 +182,36 @@ When `--assisted` is passed, only TCs marked `automated: assisted` are included.
 1. Add the test to the relevant themed file in `src/__integration-tests__/suite/` — do not create a separate directory.
 2. Prefix the test name with `[assisted]`: `test('[assisted] my-tc-id: description', ...)`.
 3. Call `printAssistedBanner()` in `suiteSetup()` if this is the first `[assisted]` test in the suite.
-4. Use `waitForHuman(tcId, action, consoleSteps, notificationSummary)` to pause for human input.
+4. Use `waitForHuman(tcId, action, consoleSteps)` or `waitForHumanVerdict(tcId, action, consoleSteps)` to pause for human input — see [Choosing between waitForHuman and waitForHumanVerdict](#choosing-between-waitforhuman-and-waitforhumanverdict) below for when to use each.
 5. Add assertions after `waitForHuman` returns (log-based, clipboard, etc.).
 6. Clean up in `teardown`/`suiteTeardown` — close editors, dispose terminals, delete temp files.
 
 **Two-screen workflow:** Run `pnpm test:release` in a terminal on one screen. The VS Code test host opens on the other. Instructions appear in both the terminal (structured steps) and as a persistent notification in VS Code (flowing summary). Perform the action, click Cancel on the notification, and the test continues.
+
+### Choosing between waitForHuman and waitForHumanVerdict
+
+The two helpers serve different contracts. Pick the right one based on what the test asserts.
+
+**`waitForHuman`** — use when the human performs a UI action that cannot be automated, and programmatic assertions verify the outcome. The human's role is mechanical (open a picker, press a chord, click a context menu). Clicking Cancel without performing the action causes the subsequent programmatic assertions to fail — the test cannot pass green against a broken state.
+
+Examples of correct `waitForHuman` usage:
+- Human selects an item from a QuickPick; log assertions verify the picked item and the effect
+- Human right-clicks a context menu; assertions read the terminal buffer or editor content
+- Human types text into an input box; assertions verify navigation or log output
+
+**`waitForHumanVerdict`** — use when the human's eye IS the assertion. The human observes a visible outcome (content arriving in a webview, a UI element appearing/disappearing, clipboard content after paste) and clicks PASS or FAIL. Always assert on the verdict:
+
+```typescript
+const verdict = await waitForHumanVerdict('tc-id', 'Did X appear?', ['step 1', 'step 2']);
+assert.strictEqual(verdict, 'pass', 'Human reported X did not appear');
+```
+
+Examples of correct `waitForHumanVerdict` usage:
+- Verifying a RangeLink appeared in Claude Code / Cursor AI / Copilot Chat (webviews are not inspectable)
+- Verifying clipboard was restored after paste to an AI assistant (human checks via manual paste)
+- Verifying a UI element is visible/hidden when no programmatic signal exists
+
+**Warmup pattern** — when a test needs a warm send before the actual verdict (warm paste tests), use `waitForHuman` for the warmup step and `waitForHumanVerdict` for the verdict step. The warmup is setup, not assertion — the verdict covers the test contract.
 
 ---
 

--- a/packages/rangelink-vscode-extension/TESTING.md
+++ b/packages/rangelink-vscode-extension/TESTING.md
@@ -195,6 +195,7 @@ The two helpers serve different contracts. Pick the right one based on what the 
 **`waitForHuman`** — use when the human performs a UI action that cannot be automated, and programmatic assertions verify the outcome. The human's role is mechanical (open a picker, press a chord, click a context menu). Clicking Cancel without performing the action causes the subsequent programmatic assertions to fail — the test cannot pass green against a broken state.
 
 Examples of correct `waitForHuman` usage:
+
 - Human selects an item from a QuickPick; log assertions verify the picked item and the effect
 - Human right-clicks a context menu; assertions read the terminal buffer or editor content
 - Human types text into an input box; assertions verify navigation or log output
@@ -207,6 +208,7 @@ assert.strictEqual(verdict, 'pass', 'Human reported X did not appear');
 ```
 
 Examples of correct `waitForHumanVerdict` usage:
+
 - Verifying a RangeLink appeared in Claude Code / Cursor AI / Copilot Chat (webviews are not inspectable)
 - Verifying clipboard was restored after paste to an AI assistant (human checks via manual paste)
 - Verifying a UI element is visible/hidden when no programmatic signal exists

--- a/packages/rangelink-vscode-extension/package.json
+++ b/packages/rangelink-vscode-extension/package.json
@@ -52,7 +52,7 @@
     "test:coverage": "jest --coverage --coverageReporters=text --coverageReporters=text-summary --coverageReporters=html",
     "test:fast": "jest --coverage --testPathIgnorePatterns '<rootDir>/src/__integration-tests__/' '\\.integration\\.test\\.ts$'",
     "test:release": "./scripts/test-release-run.sh",
-    "test:release:automated": "./scripts/test-release-run.sh --automated",
+    "test:release:automated": "./scripts/test-release-run.sh --automated --without-extensions",
     "test:release:grep": "./scripts/test-release-run.sh --grep",
     "test:release:prepare": "pnpm compile && rm -rf out/__integration-tests__ && tsc -p tsconfig.integration.json && node scripts/setup-integration-test-settings.js",
     "test:release:with-extensions": "./scripts/test-release-run.sh --with-extensions",

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
@@ -559,11 +559,10 @@ test_cases:
       - 'Terminal "cbp-001-dest" pre-bound by the test'
     steps:
       - 'Test writes sentinel to clipboard automatically'
-      - 'Click into the test file (cbp-001-...) and select lines 2-4'
-      - 'Press Cmd+R Cmd+L — link appears in terminal "cbp-001-dest"'
-      - 'Press Cancel — test reads clipboard and asserts it equals the sentinel'
+      - 'Test programmatically selects lines 2-4 and invokes R-L'
+      - 'Test asserts clipboard restored to sentinel and terminal buffer contains link'
     expected_result: 'Clipboard contains the sentinel value (not the RangeLink). assertClipboardRestored passes — preserve=always silently restored the clipboard after delivery.'
-    automated: assisted
+    automated: true
 
   - id: clipboard-preservation-002
     labels:
@@ -627,11 +626,10 @@ test_cases:
       - 'Terminal "cbp-005-dest" pre-bound by the test'
     steps:
       - 'Test writes sentinel to clipboard automatically'
-      - 'Click back into the test file, select 2-3 lines'
-      - 'Press Cmd+R Cmd+L — link appears in terminal "cbp-005-dest"'
-      - 'Press Cancel — test reads clipboard and asserts it equals the sentinel'
+      - 'Test programmatically selects lines 2-3 and invokes R-L'
+      - 'Test asserts clipboard restored to sentinel and terminal buffer contains link'
     expected_result: 'Clipboard contains the sentinel value (not the RangeLink). assertClipboardRestored passes — preserve=always silently restored the clipboard after delivery.'
-    automated: assisted
+    automated: true
 
   - id: clipboard-preservation-006
     labels:
@@ -718,6 +716,149 @@ test_cases:
     expected_result: 'Clipboard contains the generated RangeLink (not CLIPBOARD_SENTINEL). isClipboardRestorationApplicable returns false because getUserInstruction(Failure) is defined. The "Paste manually" warning toast was shown.'
     command_to_run: 'pnpm test:release:grep "clipboard-preservation-010"'
     automated: assisted
+
+  - id: clipboard-preservation-011
+    labels:
+      - clipboard
+      - requires-extensions
+    feature: 'Clipboard Preservation — AI Assistant Lifecycle'
+    scenario: 'Cold paste to Claude Code: prior clipboard content is restored after paste'
+    preconditions:
+      - 'Claude Code bound as destination (not already open)'
+      - 'rangelink.clipboard.preserve = "always" (default)'
+      - 'Prior clipboard content exists (e.g., "prior-content")'
+    steps:
+      - 'Copy "prior-content" to clipboard'
+      - 'Select lines 1-2 in a test file and press R-L'
+      - 'After the RangeLink appears in Claude Code chat, paste (Cmd+V) into a text editor'
+      - 'Click PASS if the pasted content is "prior-content" (restored), FAIL if RangeLink text appears instead'
+    expected_result: 'Prior clipboard content is restored after the paste operation completes and CLIPBOARD_POST_PASTE_DELAY_MS elapses.'
+    automated: assisted
+
+  - id: clipboard-preservation-012
+    labels:
+      - clipboard
+      - requires-extensions
+    feature: 'Clipboard Preservation — AI Assistant Lifecycle'
+    scenario: 'Warm paste to Claude Code: prior clipboard content is restored (panel already open)'
+    preconditions:
+      - 'Claude Code bound and panel is already open (warm)'
+      - 'rangelink.clipboard.preserve = "always" (default)'
+      - 'Prior clipboard content exists'
+    steps:
+      - 'Copy "prior-content" to clipboard'
+      - 'Ensure Claude Code panel is visible'
+      - 'Select lines 1-2 and press R-L'
+      - 'After paste, paste (Cmd+V) into a text editor'
+      - 'Click PASS if "prior-content" is restored, FAIL otherwise'
+    expected_result: 'Single clipboard write. Prior content restored after CLIPBOARD_POST_PASTE_DELAY_MS without cold-start refocus overhead.'
+    automated: assisted
+
+  - id: clipboard-preservation-013
+    labels:
+      - clipboard
+      - requires-extensions
+    feature: 'Clipboard Preservation — AI Assistant Lifecycle'
+    scenario: 'Cold paste to Cursor AI: prior clipboard content is restored after paste'
+    preconditions:
+      - 'Cursor AI bound as destination (not already open)'
+      - 'rangelink.clipboard.preserve = "always" (default)'
+      - 'Prior clipboard content exists'
+    steps:
+      - 'Copy "prior-content" to clipboard'
+      - 'Select lines 1-2 in a test file and press R-L'
+      - 'After paste, paste (Cmd+V) into a text editor'
+      - 'Click PASS if "prior-content" is restored, FAIL otherwise'
+    expected_result: 'Prior clipboard content is restored after paste completes.'
+    automated: assisted
+
+  - id: clipboard-preservation-014
+    labels:
+      - clipboard
+      - requires-extensions
+    feature: 'Clipboard Preservation — AI Assistant Lifecycle'
+    scenario: 'Warm paste to Cursor AI: prior clipboard content is restored (panel already open)'
+    preconditions:
+      - 'Cursor AI bound and panel is already open (warm)'
+      - 'rangelink.clipboard.preserve = "always" (default)'
+      - 'Prior clipboard content exists'
+    steps:
+      - 'Copy "prior-content" to clipboard'
+      - 'Ensure Cursor AI panel is visible'
+      - 'Select lines and press R-L'
+      - 'After paste, paste (Cmd+V) into a text editor'
+      - 'Click PASS if "prior-content" is restored, FAIL otherwise'
+    expected_result: 'Prior clipboard content restored after warm paste.'
+    automated: assisted
+
+  - id: clipboard-preservation-015
+    labels:
+      - clipboard
+    feature: 'Clipboard Preservation — AI Assistant Lifecycle'
+    scenario: 'Cold paste to GitHub Copilot Chat: prior clipboard content is restored after paste'
+    preconditions:
+      - 'GitHub Copilot Chat bound as destination (not already open)'
+      - 'rangelink.clipboard.preserve = "always" (default)'
+      - 'Prior clipboard content exists'
+    steps:
+      - 'Copy "prior-content" to clipboard'
+      - 'Select lines 1-2 in a test file and press R-L'
+      - 'After paste, paste (Cmd+V) into a text editor'
+      - 'Click PASS if "prior-content" is restored, FAIL otherwise'
+    expected_result: 'Prior clipboard content is restored after paste completes.'
+    automated: assisted
+
+  - id: clipboard-preservation-016
+    labels:
+      - clipboard
+    feature: 'Clipboard Preservation — AI Assistant Lifecycle'
+    scenario: 'Warm paste to GitHub Copilot Chat: prior clipboard content is restored (panel already open)'
+    preconditions:
+      - 'GitHub Copilot Chat bound and panel is already open (warm)'
+      - 'rangelink.clipboard.preserve = "always" (default)'
+      - 'Prior clipboard content exists'
+    steps:
+      - 'Copy "prior-content" to clipboard'
+      - 'Ensure Copilot Chat panel is visible'
+      - 'Select lines and press R-L'
+      - 'After paste, paste (Cmd+V) into a text editor'
+      - 'Click PASS if "prior-content" is restored, FAIL otherwise'
+    expected_result: 'Prior clipboard content restored after warm paste.'
+    automated: assisted
+
+  - id: clipboard-preservation-017
+    labels:
+      - clipboard
+    feature: 'Clipboard Preservation — AI Assistant Lifecycle'
+    scenario: 'AI assistant focus/paste command throws: RangeLink stays on clipboard for manual paste'
+    preconditions:
+      - 'Custom AI assistant "Dummy AI (Focus-Fail)" bound'
+      - 'rangelink.clipboard.preserve = "always" (default)'
+    steps:
+      - 'Copy "prior-content" to clipboard'
+      - 'Select lines and press R-L targeting the failing assistant'
+      - 'The focus command throws — extension logs paste failure'
+      - 'Paste (Cmd+V) into a text editor'
+      - 'Click PASS if the clipboard contains the RangeLink (NOT restored), FAIL if "prior-content" was restored'
+    expected_result: 'RangeLink remains on clipboard (prior content NOT restored). isClipboardRestorationApplicable returns false — user must paste manually.'
+    automated: assisted
+
+  - id: clipboard-preservation-018
+    labels:
+      - clipboard
+    feature: 'Clipboard Preservation — AI Assistant Lifecycle'
+    scenario: 'Two rapid R-L operations to the same AI assistant — last write wins, prior content restored once'
+    preconditions:
+      - 'Claude Code bound as destination'
+      - 'rangelink.clipboard.preserve = "always" (default)'
+    steps:
+      - 'Copy "prior-content" to clipboard'
+      - 'Select lines 1-2 and press R-L (first send)'
+      - 'Immediately select lines 3-4 and press R-L (second send) without waiting for first to complete'
+      - 'After both pastes, paste (Cmd+V) into a text editor'
+      - 'Verify clipboard state'
+    expected_result: 'Both RangeLinks are delivered. Prior clipboard content is restored after the last operation completes. No clipboard corruption from overlapping writes.'
+    automated: false
 
   # ---------------------------------------------------------------------------
   # Section 6 — Send File Path Commands
@@ -2437,54 +2578,26 @@ test_cases:
     feature: 'Smart Padding'
     scenario: 'Whitespace-only text preserved when sent to destination with smart padding enabled'
     preconditions:
-      - 'A text editor is bound as destination'
+      - 'A terminal is bound as destination'
       - 'smartPadding.pasteContent set to "none" (default)'
     steps:
       - 'Select whitespace-only text (e.g., spaces or tabs) in an editor'
-      - 'Press R-V or use Send Selected Text to send it to the bound editor destination'
+      - 'Press R-V to send it to the bound destination'
     expected_result: 'The whitespace-only text is delivered to the destination intact — not trimmed to empty string. Smart padding adds spaces (not newlines) around it without destroying the content.'
-    automated: true
-
-  - id: smart-padding-002
-    labels:
-      - clipboard
-    feature: 'Smart Padding'
-    scenario: 'Simple text with pasteContent=both adds leading and trailing space'
-    preconditions:
-      - 'A text editor is bound as destination'
-      - 'smartPadding.pasteContent set to "both"'
-    steps:
-      - 'Select text (e.g., "hello world") in an editor'
-      - 'Press R-V to send it to the bound editor destination'
-    expected_result: 'The destination receives " hello world " — a leading space and trailing space are added by smart padding.'
     automated: true
 
   - id: smart-padding-003
     labels:
       - clipboard
     feature: 'Smart Padding'
-    scenario: 'Multiline selection sent to editor destination'
+    scenario: 'Multiline selection sent to destination'
     preconditions:
-      - 'A text editor is bound as destination'
+      - 'A terminal is bound as destination'
       - 'smartPadding.pasteContent set to "none" (default)'
     steps:
       - 'Select multiple lines in an editor'
-      - 'Press R-V to send it to the bound editor destination'
+      - 'Press R-V to send it to the bound destination'
     expected_result: 'All selected lines arrive at the destination intact with no padding (pasteContent=none).'
-    automated: true
-
-  - id: smart-padding-004
-    labels:
-      - clipboard
-    feature: 'Smart Padding'
-    scenario: 'pasteContent=none sends exact text without padding'
-    preconditions:
-      - 'A text editor is bound as destination'
-      - 'smartPadding.pasteContent set to "none" (default)'
-    steps:
-      - 'Select text in an editor'
-      - 'Press R-V to send it to the bound editor destination'
-    expected_result: 'The destination receives the exact selected text with no added spaces.'
     automated: true
 
   - id: smart-padding-005
@@ -2493,11 +2606,11 @@ test_cases:
     feature: 'Smart Padding'
     scenario: 'pasteContent=before adds leading space only'
     preconditions:
-      - 'A text editor is bound as destination'
+      - 'A terminal is bound as destination'
       - 'smartPadding.pasteContent set to "before"'
     steps:
       - 'Select text (e.g., "hello") in an editor'
-      - 'Press R-V to send it to the bound editor destination'
+      - 'Press R-V to send it to the bound destination'
     expected_result: 'The destination receives " hello" — only a leading space is added.'
     automated: true
 
@@ -2507,12 +2620,88 @@ test_cases:
     feature: 'Smart Padding'
     scenario: 'pasteContent=after adds trailing space only'
     preconditions:
-      - 'A text editor is bound as destination'
+      - 'A terminal is bound as destination'
       - 'smartPadding.pasteContent set to "after"'
     steps:
       - 'Select text (e.g., "hello") in an editor'
-      - 'Press R-V to send it to the bound editor destination'
+      - 'Press R-V to send it to the bound destination'
     expected_result: 'The destination receives "hello " — only a trailing space is added.'
+    automated: true
+
+  - id: smart-padding-007
+    labels:
+      - clipboard
+    feature: 'Smart Padding — Single-Write Architecture'
+    scenario: 'pasteContent=both: text selection sent to destination has leading and trailing space'
+    preconditions:
+      - 'smartPadding.pasteContent set to "both"'
+      - 'A terminal is bound as destination'
+    steps:
+      - 'Select text "hello world" in the source editor'
+      - 'Press R-V to send it to the bound destination'
+      - 'Verify destination receives " hello world " — both leading and trailing spaces'
+    expected_result: 'The destination receives " hello world " — both leading and trailing spaces applied by applySmartPadding upstream.'
+    automated: true
+
+  - id: smart-padding-008
+    labels:
+      - clipboard
+    feature: 'Smart Padding — Single-Write Architecture'
+    scenario: 'pasteFilePath=both: file path sent to terminal has leading and trailing space'
+    preconditions:
+      - 'smartPadding.pasteFilePath set to "both"'
+      - 'A terminal is bound as destination'
+    steps:
+      - 'Open a file in the editor'
+      - 'Press R-F to send its path to the bound terminal'
+      - 'Verify terminal receives the file path with leading and trailing spaces'
+    expected_result: 'The terminal receives the padded file path with leading and trailing spaces.'
+    automated: true
+
+  - id: smart-padding-009
+    labels:
+      - clipboard
+      - requires-extensions
+    feature: 'Smart Padding — Single-Write Architecture'
+    scenario: 'pasteLink=both: RangeLink sent to AI assistant has leading and trailing space'
+    preconditions:
+      - 'smartPadding.pasteLink set to "both"'
+      - 'Claude Code or another AI assistant is bound as destination'
+    steps:
+      - 'Select lines 1-2 in a test file'
+      - 'Press R-L to generate and send a RangeLink to the AI assistant'
+      - 'Click PASS if the chat input shows the link with leading and trailing spaces, FAIL otherwise'
+    expected_result: 'The AI assistant chat input contains the RangeLink with leading and trailing spaces applied by applySmartPadding.'
+    automated: assisted
+
+  - id: smart-padding-010
+    labels:
+      - clipboard
+    feature: 'Smart Padding — Single-Write Architecture'
+    scenario: 'pasteContent=both: terminal selection sent to editor has padding applied'
+    preconditions:
+      - 'smartPadding.pasteContent set to "both"'
+      - 'A text editor is bound as destination'
+    steps:
+      - 'In a terminal, select some text using the mouse and press R-C to copy'
+      - 'Press R-V to send the terminal selection to the bound editor'
+      - 'Click PASS if the editor receives padded content, FAIL otherwise'
+    expected_result: 'The editor receives the terminal selection with leading and trailing spaces applied by applySmartPadding.'
+    automated: assisted
+
+  - id: smart-padding-011
+    labels:
+      - clipboard
+    feature: 'Smart Padding — Single-Write Architecture'
+    scenario: 'pasteContent=none: no padding applied when setting is off'
+    preconditions:
+      - 'smartPadding.pasteContent set to "none"'
+      - 'A terminal is bound as destination'
+    steps:
+      - 'Select text "hello" in the source editor'
+      - 'Press R-V to send it to the bound destination'
+      - 'Verify destination receives exactly "hello" — no padding applied'
+    expected_result: 'The destination receives "hello" without any added spaces — applySmartPadding returns text unchanged when mode is none.'
     automated: true
 
   # ---------------------------------------------------------------------------
@@ -3001,27 +3190,27 @@ test_cases:
   - id: custom-ai-assistant-015
     labels:
       - clipboard
-    feature: 'Custom AI Assistants — Built-in Override'
-    scenario: 'custom config with built-in extensionId registers under the built-in kind'
+    feature: 'Built-in AI Assistants'
+    scenario: 'GitHub Copilot Chat registers as a built-in destination kind'
     preconditions:
-      - 'Settings entry with extensionId github.copilot-chat and custom insertCommands pointing to dummy extension'
+      - 'No user override for github-copilot-chat in rangelink.customAiAssistants'
     steps:
-      - 'Extension activates with override config'
+      - 'Extension activates'
       - 'Check activation logs for registration of github-copilot-chat kind'
-    expected_result: 'Exactly one registration for github-copilot-chat kind (override replaces built-in); no separate custom-ai: registration'
+    expected_result: 'Exactly one registration for github-copilot-chat kind as a built-in destination'
     automated: true
 
   - id: custom-ai-assistant-016
     labels:
       - clipboard
-    feature: 'Custom AI Assistants — Built-in Override'
-    scenario: 'built-in override does not register a separate custom-ai: kind'
+    feature: 'Built-in AI Assistants'
+    scenario: 'GitHub Copilot Chat does not register as custom-ai: prefixed kind'
     preconditions:
-      - 'Settings entry with extensionId github.copilot-chat and custom insertCommands pointing to dummy extension'
+      - 'No user override for github-copilot-chat in rangelink.customAiAssistants'
     steps:
-      - 'Extension activates with override config'
+      - 'Extension activates'
       - 'Check activation logs for absence of custom-ai:github.copilot-chat registration'
-    expected_result: 'No custom-ai:github.copilot-chat registration found — override takes over the built-in kind instead'
+    expected_result: 'No custom-ai:github.copilot-chat registration found — registers as built-in kind only'
     automated: true
 
   - id: custom-ai-assistant-017
@@ -3044,6 +3233,8 @@ test_cases:
   # ---------------------------------------------------------------------------
 
   - id: claude-code-001
+    labels:
+      - requires-extensions
     feature: 'Built-in AI Assistants'
     scenario: 'Claude Code Chat appears in destination picker when extension is active'
     preconditions:
@@ -3059,6 +3250,7 @@ test_cases:
   - id: claude-code-002
     labels:
       - clipboard
+      - requires-extensions
     feature: 'Built-in AI Assistants'
     scenario: 'Binding to Claude Code Chat and sending a link delivers content to chat'
     preconditions:
@@ -3132,6 +3324,7 @@ test_cases:
   - id: claude-code-004
     labels:
       - clipboard
+      - requires-extensions
     feature: 'Built-in AI Assistants'
     scenario: 'Cold panel paste verification — content arrives in Claude Code chat input after a single R-L since bind'
     preconditions:
@@ -3149,6 +3342,7 @@ test_cases:
   - id: claude-code-005
     labels:
       - clipboard
+      - requires-extensions
     feature: 'Built-in AI Assistants'
     scenario: 'Warm panel paste verification — content arrives in Claude Code chat input on second R-L without cold-start refocus signals'
     preconditions:

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
@@ -733,7 +733,7 @@ test_cases:
       - 'After the RangeLink appears in Claude Code chat, paste (Cmd+V) into a text editor'
       - 'Click PASS if the pasted content is "prior-content" (restored), FAIL if RangeLink text appears instead'
     expected_result: 'Prior clipboard content is restored after the paste operation completes and CLIPBOARD_POST_PASTE_DELAY_MS elapses.'
-    automated: assisted
+    automated: true
 
   - id: clipboard-preservation-012
     labels:
@@ -752,7 +752,7 @@ test_cases:
       - 'After paste, paste (Cmd+V) into a text editor'
       - 'Click PASS if "prior-content" is restored, FAIL otherwise'
     expected_result: 'Single clipboard write. Prior content restored after CLIPBOARD_POST_PASTE_DELAY_MS without cold-start refocus overhead.'
-    automated: assisted
+    automated: true
 
   - id: clipboard-preservation-013
     labels:
@@ -770,7 +770,7 @@ test_cases:
       - 'After paste, paste (Cmd+V) into a text editor'
       - 'Click PASS if "prior-content" is restored, FAIL otherwise'
     expected_result: 'Prior clipboard content is restored after paste completes.'
-    automated: assisted
+    automated: true
 
   - id: clipboard-preservation-014
     labels:
@@ -789,7 +789,7 @@ test_cases:
       - 'After paste, paste (Cmd+V) into a text editor'
       - 'Click PASS if "prior-content" is restored, FAIL otherwise'
     expected_result: 'Prior clipboard content restored after warm paste.'
-    automated: assisted
+    automated: true
 
   - id: clipboard-preservation-015
     labels:
@@ -806,7 +806,7 @@ test_cases:
       - 'After paste, paste (Cmd+V) into a text editor'
       - 'Click PASS if "prior-content" is restored, FAIL otherwise'
     expected_result: 'Prior clipboard content is restored after paste completes.'
-    automated: assisted
+    automated: true
 
   - id: clipboard-preservation-016
     labels:
@@ -824,7 +824,7 @@ test_cases:
       - 'After paste, paste (Cmd+V) into a text editor'
       - 'Click PASS if "prior-content" is restored, FAIL otherwise'
     expected_result: 'Prior clipboard content restored after warm paste.'
-    automated: assisted
+    automated: true
 
   - id: clipboard-preservation-017
     labels:
@@ -832,14 +832,13 @@ test_cases:
     feature: 'Clipboard Preservation — AI Assistant Lifecycle'
     scenario: 'AI assistant focus/paste command throws: RangeLink stays on clipboard for manual paste'
     preconditions:
-      - 'Custom AI assistant "Dummy AI (Focus-Fail)" bound'
+      - 'Custom AI assistant "Dummy AI (Focus-Fail)" bound via R-D picker'
       - 'rangelink.clipboard.preserve = "always" (default)'
     steps:
-      - 'Copy "prior-content" to clipboard'
-      - 'Select lines and press R-L targeting the failing assistant'
-      - 'The focus command throws — extension logs paste failure'
-      - 'Paste (Cmd+V) into a text editor'
-      - 'Click PASS if the clipboard contains the RangeLink (NOT restored), FAIL if "prior-content" was restored'
+      - 'Human binds "Dummy AI (Focus-Fail)" via R-D picker'
+      - 'Sentinel written, selection set, R-L dispatched programmatically'
+      - 'Focus command throws — extension logs paste failure'
+      - 'assertClipboardChanged + #L check verify RangeLink remained on clipboard'
     expected_result: 'RangeLink remains on clipboard (prior content NOT restored). isClipboardRestorationApplicable returns false — user must paste manually.'
     automated: assisted
 

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
@@ -728,11 +728,10 @@ test_cases:
       - 'rangelink.clipboard.preserve = "always" (default)'
       - 'Prior clipboard content exists (e.g., "prior-content")'
     steps:
-      - 'Copy "prior-content" to clipboard'
-      - 'Select lines 1-2 in a test file and press R-L'
-      - 'After the RangeLink appears in Claude Code chat, paste (Cmd+V) into a text editor'
-      - 'Click PASS if the pasted content is "prior-content" (restored), FAIL if RangeLink text appears instead'
-    expected_result: 'Prior clipboard content is restored after the paste operation completes and CLIPBOARD_POST_PASTE_DELAY_MS elapses.'
+      - 'Sentinel written to clipboard programmatically'
+      - 'R-L dispatched programmatically to cold-bound Claude Code'
+      - 'assertClipboardRestored verifies sentinel is back on clipboard'
+    expected_result: 'Prior clipboard content is restored after the paste operation completes.'
     automated: true
 
   - id: clipboard-preservation-012
@@ -746,12 +745,11 @@ test_cases:
       - 'rangelink.clipboard.preserve = "always" (default)'
       - 'Prior clipboard content exists'
     steps:
-      - 'Copy "prior-content" to clipboard'
-      - 'Ensure Claude Code panel is visible'
-      - 'Select lines 1-2 and press R-L'
-      - 'After paste, paste (Cmd+V) into a text editor'
-      - 'Click PASS if "prior-content" is restored, FAIL otherwise'
-    expected_result: 'Single clipboard write. Prior content restored after CLIPBOARD_POST_PASTE_DELAY_MS without cold-start refocus overhead.'
+      - 'Warmup R-L dispatched programmatically'
+      - 'Sentinel written to clipboard programmatically'
+      - 'Second R-L dispatched programmatically to warm-bound Claude Code'
+      - 'assertClipboardRestored verifies sentinel is back on clipboard'
+    expected_result: 'Single clipboard write. Prior content restored without cold-start refocus overhead.'
     automated: true
 
   - id: clipboard-preservation-013
@@ -765,10 +763,9 @@ test_cases:
       - 'rangelink.clipboard.preserve = "always" (default)'
       - 'Prior clipboard content exists'
     steps:
-      - 'Copy "prior-content" to clipboard'
-      - 'Select lines 1-2 in a test file and press R-L'
-      - 'After paste, paste (Cmd+V) into a text editor'
-      - 'Click PASS if "prior-content" is restored, FAIL otherwise'
+      - 'Sentinel written to clipboard programmatically'
+      - 'R-L dispatched programmatically to cold-bound Cursor AI'
+      - 'assertClipboardRestored verifies sentinel is back on clipboard'
     expected_result: 'Prior clipboard content is restored after paste completes.'
     automated: true
 
@@ -783,11 +780,10 @@ test_cases:
       - 'rangelink.clipboard.preserve = "always" (default)'
       - 'Prior clipboard content exists'
     steps:
-      - 'Copy "prior-content" to clipboard'
-      - 'Ensure Cursor AI panel is visible'
-      - 'Select lines and press R-L'
-      - 'After paste, paste (Cmd+V) into a text editor'
-      - 'Click PASS if "prior-content" is restored, FAIL otherwise'
+      - 'Warmup R-L dispatched programmatically'
+      - 'Sentinel written to clipboard programmatically'
+      - 'Second R-L dispatched programmatically to warm-bound Cursor AI'
+      - 'assertClipboardRestored verifies sentinel is back on clipboard'
     expected_result: 'Prior clipboard content restored after warm paste.'
     automated: true
 
@@ -801,10 +797,9 @@ test_cases:
       - 'rangelink.clipboard.preserve = "always" (default)'
       - 'Prior clipboard content exists'
     steps:
-      - 'Copy "prior-content" to clipboard'
-      - 'Select lines 1-2 in a test file and press R-L'
-      - 'After paste, paste (Cmd+V) into a text editor'
-      - 'Click PASS if "prior-content" is restored, FAIL otherwise'
+      - 'Sentinel written to clipboard programmatically'
+      - 'R-L dispatched programmatically to cold-bound Copilot Chat'
+      - 'assertClipboardRestored verifies sentinel is back on clipboard'
     expected_result: 'Prior clipboard content is restored after paste completes.'
     automated: true
 
@@ -818,11 +813,10 @@ test_cases:
       - 'rangelink.clipboard.preserve = "always" (default)'
       - 'Prior clipboard content exists'
     steps:
-      - 'Copy "prior-content" to clipboard'
-      - 'Ensure Copilot Chat panel is visible'
-      - 'Select lines and press R-L'
-      - 'After paste, paste (Cmd+V) into a text editor'
-      - 'Click PASS if "prior-content" is restored, FAIL otherwise'
+      - 'Warmup R-L dispatched programmatically'
+      - 'Sentinel written to clipboard programmatically'
+      - 'Second R-L dispatched programmatically to warm-bound Copilot Chat'
+      - 'assertClipboardRestored verifies sentinel is back on clipboard'
     expected_result: 'Prior clipboard content restored after warm paste.'
     automated: true
 
@@ -2591,7 +2585,7 @@ test_cases:
     feature: 'Smart Padding'
     scenario: 'Multiline selection sent to destination'
     preconditions:
-      - 'A terminal is bound as destination'
+      - 'A text editor is bound as destination'
       - 'smartPadding.pasteContent set to "none" (default)'
     steps:
       - 'Select multiple lines in an editor'

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
@@ -894,7 +894,7 @@ test_cases:
       - 'Press Cmd+R Cmd+Shift+F'
       - 'Observe terminal'
     expected_result: 'Terminal receives full absolute path (e.g. /Users/you/project/src/utils/helper.ts).'
-    automated: assisted
+    automated: true
 
   - id: send-file-path-003
     labels:
@@ -926,7 +926,7 @@ test_cases:
       - 'Press Cmd+R Cmd+F'
       - 'Observe terminal output'
     expected_result: "Terminal receives 'src/my folder/helper.ts' — single-quoted."
-    automated: assisted
+    automated: true
 
   - id: send-file-path-005
     labels:
@@ -941,7 +941,7 @@ test_cases:
       - 'Press Cmd+R Cmd+F'
       - 'Observe terminal'
     expected_result: "Terminal receives 'src/utils (v2)/helper.ts' — single-quoted."
-    automated: assisted
+    automated: true
 
   - id: send-file-path-006
     labels:
@@ -1013,7 +1013,7 @@ test_cases:
       - 'Type Send Current File Path, press Enter'
       - 'Observe terminal'
     expected_result: 'Terminal receives workspace-relative path. Same as Cmd+R Cmd+F.'
-    automated: assisted
+    automated: true
 
   - id: send-file-path-011
     labels:
@@ -1027,7 +1027,7 @@ test_cases:
       - 'Type Send Current File Path (Absolute), press Enter'
       - 'Observe terminal'
     expected_result: 'Terminal receives absolute path. Same as Cmd+R Cmd+Shift+F.'
-    automated: assisted
+    automated: true
 
   - id: send-file-path-012
     labels:
@@ -1042,7 +1042,7 @@ test_cases:
       - 'Observe that the bound editor is brought to the foreground'
       - 'Confirm file path appears in the bound editor at cursor position'
     expected_result: 'Bound editor is surfaced automatically and receives the file path. Source editor had focus; paste still landed in bound editor.'
-    automated: assisted
+    automated: true
 
   # ---------------------------------------------------------------------------
   # Section 7 — Context Menu Integrations
@@ -2329,7 +2329,7 @@ test_cases:
       - 'Press Cmd+R Cmd+L'
       - 'Observe file B'
     expected_result: 'RangeLink text inserted at cursor in file B. Success toast confirms send.'
-    automated: assisted
+    automated: true
 
   - id: core-send-commands-r-l-003
     labels:
@@ -2374,7 +2374,7 @@ test_cases:
       - 'Type Send RangeLink and press Enter on RangeLink: Send RangeLink'
       - 'Observe terminal'
     expected_result: 'Terminal receives the RangeLink. Identical to R-L keybinding.'
-    automated: assisted
+    automated: true
 
   - id: core-send-commands-r-c-002
     labels:
@@ -2390,7 +2390,7 @@ test_cases:
       - 'Observe terminal — nothing should arrive'
       - 'Press Cmd+V in any text field'
     expected_result: 'Terminal received nothing. Clipboard contains the RangeLink.'
-    automated: assisted
+    automated: true
 
   - id: core-send-commands-r-l-005
     labels:

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
@@ -755,7 +755,6 @@ test_cases:
   - id: clipboard-preservation-013
     labels:
       - clipboard
-      - requires-extensions
     feature: 'Clipboard Preservation — AI Assistant Lifecycle'
     scenario: 'Cold paste to Cursor AI: prior clipboard content is restored after paste'
     preconditions:
@@ -767,12 +766,11 @@ test_cases:
       - 'R-L dispatched programmatically to cold-bound Cursor AI'
       - 'assertClipboardRestored verifies sentinel is back on clipboard'
     expected_result: 'Prior clipboard content is restored after paste completes.'
-    automated: true
+    automated: false
 
   - id: clipboard-preservation-014
     labels:
       - clipboard
-      - requires-extensions
     feature: 'Clipboard Preservation — AI Assistant Lifecycle'
     scenario: 'Warm paste to Cursor AI: prior clipboard content is restored (panel already open)'
     preconditions:
@@ -785,7 +783,7 @@ test_cases:
       - 'Second R-L dispatched programmatically to warm-bound Cursor AI'
       - 'assertClipboardRestored verifies sentinel is back on clipboard'
     expected_result: 'Prior clipboard content restored after warm paste.'
-    automated: true
+    automated: false
 
   - id: clipboard-preservation-015
     labels:

--- a/packages/rangelink-vscode-extension/scripts/test-release-run.sh
+++ b/packages/rangelink-vscode-extension/scripts/test-release-run.sh
@@ -8,6 +8,7 @@
 #   ./scripts/test-release-run.sh --grep "pattern"           # filtered by Mocha grep
 #   ./scripts/test-release-run.sh --grep "\[assisted\]"      # only [assisted] tests
 #   ./scripts/test-release-run.sh --with-extensions          # installs real marketplace extensions (Gemini, Claude Code)
+#   ./scripts/test-release-run.sh --without-extensions        # exclude tests requiring marketplace extensions
 #   ./scripts/test-release-run.sh --label "clipboard"         # only tests with matching label in QA YAML
 #   ./scripts/test-release-run.sh --label "clipboard" --assisted  # label + assisted-only filter
 #   ./scripts/test-release-run.sh --label "clipboard" --no-assisted # label + exclude assisted tests
@@ -25,6 +26,7 @@ VSCODE_TEST_CONFIG=""
 GREP_PATTERN=""
 COMMAND="pnpm test:release"
 WITH_EXTENSIONS=false
+WITHOUT_EXTENSIONS=false
 LABEL_FILTER=""
 ASSISTED_ONLY=false
 NO_ASSISTED=false
@@ -35,6 +37,7 @@ while [[ $# -gt 0 ]]; do
     --assisted) ASSISTED_ONLY=true; shift ;;
     --no-assisted) NO_ASSISTED=true; shift ;;
     --with-extensions) MODE="with-extensions"; VSCODE_TEST_CONFIG="--config .vscode-test.with-extensions.mjs"; COMMAND="pnpm test:release:with-extensions"; WITH_EXTENSIONS=true; shift ;;
+    --without-extensions) WITHOUT_EXTENSIONS=true; shift ;;
     --grep)
       if [[ $# -lt 2 ]]; then
         echo "Error: --grep requires a pattern argument" >&2
@@ -75,6 +78,12 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Guard: --with-extensions and --without-extensions are mutually exclusive
+if [[ "$WITH_EXTENSIONS" == "true" && "$WITHOUT_EXTENSIONS" == "true" ]]; then
+  echo "Error: --with-extensions and --without-extensions are mutually exclusive" >&2
+  exit 1
+fi
+
 # Resolve --label to test IDs from the latest QA YAML
 if [[ -n "$LABEL_FILTER" ]]; then
   RESOLVE_ARGS=("--label" "$LABEL_FILTER")
@@ -86,6 +95,11 @@ if [[ -n "$LABEL_FILTER" ]]; then
     exit 1
   }
 
+  if [[ -z "$LABEL_IDS" ]]; then
+    echo "Error: label '$LABEL_FILTER' matched zero tests" >&2
+    exit 1
+  fi
+
   LABEL_GREP=$(echo "$LABEL_IDS" | paste -sd '|' -)
   LABEL_COUNT=$(echo "$LABEL_IDS" | wc -l | tr -d ' ')
   echo "Label '$LABEL_FILTER' matched ${LABEL_COUNT} test(s): $LABEL_GREP"
@@ -93,7 +107,6 @@ if [[ -n "$LABEL_FILTER" ]]; then
 
   if [[ -n "$GREP_PATTERN" ]]; then
     GREP_PATTERN="$GREP_PATTERN|$LABEL_GREP"
-    COMMAND="$COMMAND --grep \"$LABEL_GREP\""
   else
     GREP_PATTERN="$LABEL_GREP"
     if [[ "$MODE" == "all" ]]; then
@@ -105,9 +118,41 @@ if [[ -n "$LABEL_FILTER" ]]; then
   fi
 fi
 
-if [[ -z "$GREP_PATTERN" && ( "$MODE" == "automated" || "$NO_ASSISTED" == true ) ]]; then
-  export MOCHA_GREP='\[assisted\]'
+# Build inclusion and exclusion patterns, then set MOCHA_GREP/MOCHA_INVERT.
+# Order matters: exclusions are combined first, then the final grep is set
+# once so that --grep, --automated, and --without-extensions compose correctly.
+unset MOCHA_GREP MOCHA_INVERT
+MOCHA_INCLUDE="${GREP_PATTERN:-}"
+MOCHA_EXCLUDE=""
+
+if [[ "$MODE" == "automated" || "$NO_ASSISTED" == true ]]; then
+  MOCHA_EXCLUDE='\[assisted\]'
+fi
+
+if [[ "$WITHOUT_EXTENSIONS" == "true" ]]; then
+  EXT_IDS=$(node "$SCRIPT_DIR/resolve-qa-labels.js" --label requires-extensions) || {
+    echo "$EXT_IDS" >&2
+    exit 1
+  }
+  EXT_GREP=$(echo "$EXT_IDS" | paste -sd '|' -)
+  EXT_COUNT=$(echo "$EXT_IDS" | wc -l | tr -d ' ')
+  echo "Excluding ${EXT_COUNT} test(s) requiring extensions: $EXT_GREP"
+  echo ""
+
+  if [[ -n "$MOCHA_EXCLUDE" ]]; then
+    MOCHA_EXCLUDE="${MOCHA_EXCLUDE}|${EXT_GREP}"
+  else
+    MOCHA_EXCLUDE="$EXT_GREP"
+  fi
+fi
+
+if [[ -n "$MOCHA_INCLUDE" && -n "$MOCHA_EXCLUDE" ]]; then
+  export MOCHA_GREP="^(?!.*(${MOCHA_EXCLUDE})).*(${MOCHA_INCLUDE})"
+elif [[ -n "$MOCHA_EXCLUDE" ]]; then
+  export MOCHA_GREP="$MOCHA_EXCLUDE"
   export MOCHA_INVERT=true
+elif [[ -n "$MOCHA_INCLUDE" ]]; then
+  export MOCHA_GREP="$MOCHA_INCLUDE"
 fi
 
 OUTPUT_DIR="$PACKAGE_ROOT/qa/output"
@@ -150,9 +195,6 @@ fi
 
 TEST_EXIT=0
 # shellcheck disable=SC2086
-if [[ -n "$GREP_PATTERN" ]]; then
-  export MOCHA_GREP="$GREP_PATTERN"
-fi
 npx vscode-test $VSCODE_TEST_CONFIG 2>&1 | sed 's/\x1b\[[0-9;]*m//g' | tee -a "$REPORT_FILE" || TEST_EXIT=$?
 
 if [[ -n "$GREP_PATTERN" && $TEST_EXIT -eq 0 ]]; then
@@ -190,6 +232,9 @@ FINAL_EXIT=$((TEST_EXIT > QA_EXIT ? TEST_EXIT : QA_EXIT))
       fi
       if [[ "$WITH_EXTENSIONS" == "true" ]]; then
         RERUN_CMD="$RERUN_CMD --with-extensions"
+      fi
+      if [[ "$WITHOUT_EXTENSIONS" == "true" ]]; then
+        RERUN_CMD="$RERUN_CMD --without-extensions"
       fi
       echo ""
       echo ""

--- a/packages/rangelink-vscode-extension/scripts/test-release-run.sh
+++ b/packages/rangelink-vscode-extension/scripts/test-release-run.sh
@@ -134,15 +134,20 @@ if [[ "$WITHOUT_EXTENSIONS" == "true" ]]; then
     echo "$EXT_IDS" >&2
     exit 1
   }
-  EXT_GREP=$(echo "$EXT_IDS" | paste -sd '|' -)
-  EXT_COUNT=$(echo "$EXT_IDS" | wc -l | tr -d ' ')
-  echo "Excluding ${EXT_COUNT} test(s) requiring extensions: $EXT_GREP"
-  echo ""
+  if [[ -n "$EXT_IDS" ]]; then
+    EXT_GREP=$(echo "$EXT_IDS" | paste -sd '|' -)
+    EXT_COUNT=$(echo "$EXT_IDS" | wc -l | tr -d ' ')
+    echo "Excluding ${EXT_COUNT} test(s) requiring extensions: $EXT_GREP"
+    echo ""
 
-  if [[ -n "$MOCHA_EXCLUDE" ]]; then
-    MOCHA_EXCLUDE="${MOCHA_EXCLUDE}|${EXT_GREP}"
+    if [[ -n "$MOCHA_EXCLUDE" ]]; then
+      MOCHA_EXCLUDE="${MOCHA_EXCLUDE}|${EXT_GREP}"
+    else
+      MOCHA_EXCLUDE="$EXT_GREP"
+    fi
   else
-    MOCHA_EXCLUDE="$EXT_GREP"
+    echo "No tests requiring extensions to exclude."
+    echo ""
   fi
 fi
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/capturingPtyHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/capturingPtyHelpers.ts
@@ -87,10 +87,11 @@ export const createAndBindCapturingTerminal = async (
  * Use for content-level validation of what reached the terminal.
  */
 export const assertTerminalBufferEquals = (captured: string, expected: string): void => {
+  const normalized = captured.replace(/\r\n/g, '\n').replace(/\r/g, '\n').replace(/\n$/, '');
   assert.strictEqual(
-    captured,
+    normalized,
     expected,
-    `Terminal buffer mismatch:\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(captured)}`,
+    `Terminal buffer mismatch:\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(normalized)}`,
   );
 };
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/editorHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/editorHelpers.ts
@@ -20,6 +20,10 @@ export const waitForActiveEditor = async (
   return false;
 };
 
+export const clearSelection = (editor: vscode.TextEditor): void => {
+  editor.selection = new vscode.Selection(0, 0, 0, 0);
+};
+
 /**
  * Collapse the active editor's selection to position (0,0).
  * Call before navigateViaHandleLinkClick to guarantee the navigation's
@@ -29,8 +33,7 @@ export const waitForActiveEditor = async (
 export const clearEditorSelection = async (): Promise<void> => {
   const editor = vscode.window.activeTextEditor;
   if (editor !== undefined) {
-    const origin = new vscode.Position(0, 0);
-    editor.selection = new vscode.Selection(origin, origin);
+    clearSelection(editor);
     await settle();
   }
 };

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/fileHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/fileHelpers.ts
@@ -72,3 +72,26 @@ export const cleanupFiles = (uris: vscode.Uri[]): void => {
 export const closeAllEditors = async (): Promise<void> => {
   await vscode.commands.executeCommand('workbench.action.closeAllEditors');
 };
+
+/**
+ * Open a file as a source editor with a text selection, using a viewColumn
+ * that avoids the VS Code test runner's focus-steal issue.
+ *
+ * In the automated test host, showTextDocument in an already-used column may
+ * not transfer focus — the prior dest editor stays active. Using a fresh
+ * column (one not occupied by dest-setup editors) works around this.
+ *
+ * Returns the editor so callers can dispatch paste/navigate commands.
+ */
+export const openSourceWithSelection = async (
+  uri: vscode.Uri,
+  viewColumn: vscode.ViewColumn,
+): Promise<vscode.TextEditor> => {
+  const doc = await vscode.workspace.openTextDocument(uri);
+  const editor = await vscode.window.showTextDocument(doc, viewColumn);
+  const lastLine = doc.lineAt(doc.lineCount - 1);
+  const endPos = lastLine.range.end;
+  editor.selection = new vscode.Selection(new vscode.Position(0, 0), endPos);
+  await settle();
+  return editor;
+};

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/index.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/index.ts
@@ -26,6 +26,7 @@ export {
   createWorkspaceFile,
   findTestItemsByPrefix,
   openEditor,
+  openSourceWithSelection,
 } from './fileHelpers';
 export { getLogCapture } from './getLogCapture';
 export {

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/index.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/index.ts
@@ -14,6 +14,7 @@ export {
 } from './clipboardHelpers';
 export {
   clearEditorSelection,
+  clearSelection,
   openUntitledDoc,
   selectAll,
   waitForActiveEditor,

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/index.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/index.ts
@@ -1,72 +1,13 @@
-export { type HumanVerdict, waitForHuman, waitForHumanVerdict } from './assistedTestHelper';
-export {
-  assertTerminalBufferContains,
-  assertTerminalBufferEquals,
-  type CapturingTerminal,
-  createAndBindCapturingTerminal,
-  createCapturingTerminal,
-} from './capturingPtyHelpers';
-export {
-  assertClipboardChanged,
-  assertClipboardRestored,
-  CLIPBOARD_SENTINEL,
-  writeClipboardSentinel,
-} from './clipboardHelpers';
-export {
-  clearEditorSelection,
-  clearSelection,
-  openUntitledDoc,
-  selectAll,
-  waitForActiveEditor,
-} from './editorHelpers';
-export {
-  cleanupFiles,
-  closeAllEditors,
-  createAndOpenFile,
-  createFileAt,
-  createWorkspaceFile,
-  findTestItemsByPrefix,
-  openEditor,
-  openSourceWithSelection,
-} from './fileHelpers';
-export { getLogCapture } from './getLogCapture';
-export {
-  assertClipboardWriteLogged,
-  assertFilePathLogged,
-  assertFnLogged,
-  assertInputBoxLogged,
-  assertNoSetContextLogged,
-  assertNoStatusBarMsgLogged,
-  assertNoToastLogged,
-  assertPasteCommandLogged,
-  assertQuickPickItemsLogged,
-  assertSetContextLogged,
-  assertStatusBarMsgLogged,
-  assertTerminalPasteLogged,
-  extractQuickPickItemsLogged,
-  parseQuickPickItemsFromLogLine,
-  assertSuppressionLogged,
-  assertToastLogged,
-} from './logBasedUiAssertions';
-export { createLogger } from './logHelpers';
-export { navigateViaHandleLinkClick } from './navigationHelpers';
-export { loadSettingsProfile, resetRangelinkSettings } from './settingsHelpers';
-export { standardSuite } from './standardSuite';
-export {
-  createAndBindTerminal,
-  createTerminal,
-  disposeAllTerminals,
-  findTerminalItems,
-} from './terminalHelpers';
-export {
-  activateExtension,
-  getExtensionVersion,
-  getWorkspaceRoot,
-  openAndDismiss,
-  POLL_INTERVAL_MS,
-  POLL_TIMEOUT_MS,
-  settle,
-  SETTLE_MS,
-  TERMINAL_READY_MS,
-  waitForExtensionActive,
-} from './testEnv';
+export * from './assistedTestHelper';
+export * from './capturingPtyHelpers';
+export * from './clipboardHelpers';
+export * from './editorHelpers';
+export * from './fileHelpers';
+export * from './getLogCapture';
+export * from './logBasedUiAssertions';
+export * from './logHelpers';
+export * from './navigationHelpers';
+export * from './settingsHelpers';
+export * from './standardSuite';
+export * from './terminalHelpers';
+export * from './testEnv';

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/settingsHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/settingsHelpers.ts
@@ -28,6 +28,7 @@ export const loadSettingsProfile = async (
 
   for (const [key, value] of Object.entries(settings)) {
     await config.update(key, value, vscode.ConfigurationTarget.Global);
+    await config.update(key, value, vscode.ConfigurationTarget.Workspace);
   }
   log(`loadSettingsProfile: applied ${Object.keys(settings).length} settings from ${profileName}`);
 };

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/terminalHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/terminalHelpers.ts
@@ -2,6 +2,11 @@ import * as vscode from 'vscode';
 
 import { settle, TERMINAL_READY_MS } from './testEnv';
 
+export const echoToTerminal = (terminal: vscode.Terminal, text: string): void => {
+  const escaped = text.replace(/'/g, "'\\''");
+  terminal.sendText(`echo '${escaped}'`, true);
+};
+
 export const disposeAllTerminals = (): void => {
   for (const t of vscode.window.terminals) {
     t.dispose();

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/terminalHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/terminalHelpers.ts
@@ -32,11 +32,6 @@ export const findTerminalItems = (items: Record<string, unknown>[]): Record<stri
       (item.label as string).includes('Terminal ('),
   );
 
-export const echoToTerminal = (terminal: vscode.Terminal, text: string): void => {
-  const escaped = text.replace(/'/g, "'\\''");
-  terminal.sendText(`echo '${escaped}'`, true);
-};
-
 export const createAndBindTerminal = async (name: string): Promise<vscode.Terminal> => {
   const terminal = vscode.window.createTerminal({ name });
   terminal.show(true);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/terminalHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/terminalHelpers.ts
@@ -27,6 +27,11 @@ export const findTerminalItems = (items: Record<string, unknown>[]): Record<stri
       (item.label as string).includes('Terminal ('),
   );
 
+export const echoToTerminal = (terminal: vscode.Terminal, text: string): void => {
+  const escaped = text.replace(/'/g, "'\\''");
+  terminal.sendText(`echo '${escaped}'`, true);
+};
+
 export const createAndBindTerminal = async (name: string): Promise<vscode.Terminal> => {
   const terminal = vscode.window.createTerminal({ name });
   terminal.show(true);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/builtInAiAssistants.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/builtInAiAssistants.test.ts
@@ -21,9 +21,10 @@ import {
   EXTENSION_ID_GEMINI_CODE_ASSIST,
 } from '../../utils/aiAssistants/builtInAiAssistants';
 import {
+  assertClipboardChanged,
+  assertClipboardRestored,
   assertStatusBarMsgLogged,
   cleanupFiles,
-  CLIPBOARD_SENTINEL,
   createWorkspaceFile,
   extractQuickPickItemsLogged,
   getLogCapture,
@@ -34,6 +35,7 @@ import {
   waitForExtensionActive,
   waitForHuman,
   waitForHumanVerdict,
+  writeClipboardSentinel,
 } from '../helpers';
 
 const AI_ASSISTANTS_GROUP_LABEL = 'AI Assistants';
@@ -447,7 +449,7 @@ standardSuite('Built-in AI Assistants', (log) => {
     log('✓ Warm paste: content delivered to Gemini Code Assist (cold + warm both PASS)');
   });
 
-  test('[assisted] clipboard-preservation-011: cold paste to Claude Code — prior clipboard restored', async () => {
+  test('clipboard-preservation-011: cold paste to Claude Code — prior clipboard restored', async () => {
     const fileUri = createWorkspaceFile('cp-011', 'line 1\nline 2\nline 3\n');
     tmpFileUris.push(fileUri);
     const editor = await openEditor(fileUri);
@@ -459,23 +461,15 @@ standardSuite('Built-in AI Assistants', (log) => {
     editor.selection = new vscode.Selection(0, 0, 1, 6);
     await settle();
 
-    const verdict = await waitForHumanVerdict(
-      'clipboard-preservation-011',
-      'Cold paste: verify prior clipboard is restored after Claude Code paste',
-      [
-        '1. Copy the sentinel value to clipboard — select some text and Cmd+C, then type Cmd+V to verify it is on clipboard',
-        '2. Lines 1-2 already selected in cp-011 — press Cmd+R Cmd+L',
-        '3. Wait for the RangeLink to appear in Claude Code chat',
-        '4. Open a new editor tab (Cmd+N) and paste (Cmd+V)',
-        `5. Click PASS if the pasted content is "${CLIPBOARD_SENTINEL}" (restored), FAIL if RangeLink appears instead`,
-      ],
-    );
+    await writeClipboardSentinel();
 
-    assert.strictEqual(verdict, 'pass');
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
+    await settle();
+    await assertClipboardRestored('clipboard-preservation-011: always + Claude Code cold paste');
     log('✓ clipboard-preservation-011: prior clipboard restored after cold paste');
   });
 
-  test('[assisted] clipboard-preservation-012: warm paste to Claude Code — prior clipboard restored', async () => {
+  test('clipboard-preservation-012: warm paste to Claude Code — prior clipboard restored', async () => {
     const fileUri = createWorkspaceFile('cp-012', 'line 1\nline 2\nline 3\nline 4\n');
     tmpFileUris.push(fileUri);
     const editor = await openEditor(fileUri);
@@ -488,37 +482,22 @@ standardSuite('Built-in AI Assistants', (log) => {
     editor.selection = new vscode.Selection(0, 0, 1, 6);
     await settle();
 
-    await waitForHuman(
-      'clipboard-preservation-012-warmup',
-      'Warmup: press Cmd+R Cmd+L to send pre-selected lines 1-2, confirm link appears, then Cancel',
-      [
-        '1. Lines 1-2 already selected in cp-012 — press Cmd+R Cmd+L',
-        '2. Confirm the RangeLink appears in Claude Code chat',
-        '3. Press Cancel to continue',
-      ],
-    );
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
     await settle();
 
     // Pre-select lines 3-4 for the warm send
     editor.selection = new vscode.Selection(2, 0, 3, 6);
     await settle();
 
-    const verdict = await waitForHumanVerdict(
-      'clipboard-preservation-012',
-      'Warm paste: verify prior clipboard restored after second send',
-      [
-        '1. Copy the sentinel value to clipboard — select some text and Cmd+C, then type Cmd+V to verify it is on clipboard',
-        '2. Lines 3-4 already selected in cp-012 — press Cmd+R Cmd+L',
-        '3. Open a new editor tab (Cmd+N) and paste (Cmd+V)',
-        `4. Click PASS if pasted content is "${CLIPBOARD_SENTINEL}" (restored), FAIL otherwise`,
-      ],
-    );
+    await writeClipboardSentinel();
 
-    assert.strictEqual(verdict, 'pass');
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
+    await settle();
+    await assertClipboardRestored('clipboard-preservation-012: always + Claude Code warm paste');
     log('✓ clipboard-preservation-012: prior clipboard restored after warm paste');
   });
 
-  test('[assisted] clipboard-preservation-013: cold paste to Cursor AI — prior clipboard restored', async () => {
+  test('clipboard-preservation-013: cold paste to Cursor AI — prior clipboard restored', async () => {
     const fileUri = createWorkspaceFile('cp-013', 'line 1\nline 2\nline 3\n');
     tmpFileUris.push(fileUri);
     const editor = await openEditor(fileUri);
@@ -530,23 +509,15 @@ standardSuite('Built-in AI Assistants', (log) => {
     editor.selection = new vscode.Selection(0, 0, 1, 6);
     await settle();
 
-    const verdict = await waitForHumanVerdict(
-      'clipboard-preservation-013',
-      'Cold paste to Cursor AI: verify prior clipboard is restored',
-      [
-        '1. Copy a known string (e.g., "PRIOR-CURSOR") to clipboard — select it and Cmd+C',
-        '2. Lines 1-2 already selected in cp-013 — press Cmd+R Cmd+L',
-        '3. Wait for the RangeLink to appear in Cursor AI chat',
-        '4. Open a new editor tab (Cmd+N) and paste (Cmd+V)',
-        '5. Click PASS if the pasted content is "PRIOR-CURSOR" (restored), FAIL if RangeLink appears instead',
-      ],
-    );
+    await writeClipboardSentinel();
 
-    assert.strictEqual(verdict, 'pass');
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
+    await settle();
+    await assertClipboardRestored('clipboard-preservation-013: always + Cursor AI cold paste');
     log('✓ clipboard-preservation-013: cold Cursor AI paste — clipboard restored');
   });
 
-  test('[assisted] clipboard-preservation-014: warm paste to Cursor AI — prior clipboard restored', async () => {
+  test('clipboard-preservation-014: warm paste to Cursor AI — prior clipboard restored', async () => {
     const fileUri = createWorkspaceFile('cp-014', 'line 1\nline 2\nline 3\nline 4\n');
     tmpFileUris.push(fileUri);
     const editor = await openEditor(fileUri);
@@ -559,37 +530,22 @@ standardSuite('Built-in AI Assistants', (log) => {
     editor.selection = new vscode.Selection(0, 0, 1, 6);
     await settle();
 
-    await waitForHuman(
-      'clipboard-preservation-014-warmup',
-      'Warmup: press Cmd+R Cmd+L to send pre-selected lines 1-2, confirm link appears in Cursor AI, then Cancel',
-      [
-        '1. Lines 1-2 already selected in cp-014 — press Cmd+R Cmd+L',
-        '2. Confirm the RangeLink appears in Cursor AI chat',
-        '3. Press Cancel to continue',
-      ],
-    );
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
     await settle();
 
     // Pre-select lines 3-4 for the warm send
     editor.selection = new vscode.Selection(2, 0, 3, 6);
     await settle();
 
-    const verdict = await waitForHumanVerdict(
-      'clipboard-preservation-014',
-      'Warm paste to Cursor AI: verify prior clipboard restored after second send',
-      [
-        '1. Copy a known string (e.g., "PRIOR-CURSOR-WARM") to clipboard — select it and Cmd+C',
-        '2. Lines 3-4 already selected in cp-014 — press Cmd+R Cmd+L',
-        '3. Open a new editor tab (Cmd+N) and paste (Cmd+V)',
-        '4. Click PASS if pasted content is "PRIOR-CURSOR-WARM" (restored), FAIL otherwise',
-      ],
-    );
+    await writeClipboardSentinel();
 
-    assert.strictEqual(verdict, 'pass');
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
+    await settle();
+    await assertClipboardRestored('clipboard-preservation-014: always + Cursor AI warm paste');
     log('✓ clipboard-preservation-014: warm Cursor AI paste — clipboard restored');
   });
 
-  test('[assisted] clipboard-preservation-015: cold paste to Copilot Chat — prior clipboard restored', async () => {
+  test('clipboard-preservation-015: cold paste to Copilot Chat — prior clipboard restored', async () => {
     const fileUri = createWorkspaceFile('cp-015', 'line 1\nline 2\nline 3\n');
     tmpFileUris.push(fileUri);
     const editor = await openEditor(fileUri);
@@ -601,23 +557,15 @@ standardSuite('Built-in AI Assistants', (log) => {
     editor.selection = new vscode.Selection(0, 0, 1, 6);
     await settle();
 
-    const verdict = await waitForHumanVerdict(
-      'clipboard-preservation-015',
-      'Cold paste to GitHub Copilot Chat: verify prior clipboard is restored',
-      [
-        '1. Copy a known string (e.g., "PRIOR-COPILOT") to clipboard — select it and Cmd+C',
-        '2. Lines 1-2 already selected in cp-015 — press Cmd+R Cmd+L',
-        '3. Wait for the RangeLink to appear in Copilot Chat input',
-        '4. Open a new editor tab (Cmd+N) and paste (Cmd+V)',
-        '5. Click PASS if the pasted content is "PRIOR-COPILOT" (restored), FAIL if RangeLink appears instead',
-      ],
-    );
+    await writeClipboardSentinel();
 
-    assert.strictEqual(verdict, 'pass');
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
+    await settle();
+    await assertClipboardRestored('clipboard-preservation-015: always + Copilot Chat cold paste');
     log('✓ clipboard-preservation-015: cold Copilot Chat paste — clipboard restored');
   });
 
-  test('[assisted] clipboard-preservation-016: warm paste to Copilot Chat — prior clipboard restored', async () => {
+  test('clipboard-preservation-016: warm paste to Copilot Chat — prior clipboard restored', async () => {
     const fileUri = createWorkspaceFile('cp-016', 'line 1\nline 2\nline 3\nline 4\n');
     tmpFileUris.push(fileUri);
     const editor = await openEditor(fileUri);
@@ -630,33 +578,18 @@ standardSuite('Built-in AI Assistants', (log) => {
     editor.selection = new vscode.Selection(0, 0, 1, 6);
     await settle();
 
-    await waitForHuman(
-      'clipboard-preservation-016-warmup',
-      'Warmup: press Cmd+R Cmd+L to send pre-selected lines 1-2, confirm link appears in Copilot Chat, then Cancel',
-      [
-        '1. Lines 1-2 already selected in cp-016 — press Cmd+R Cmd+L',
-        '2. Confirm the RangeLink appears in Copilot Chat input',
-        '3. Press Cancel to continue',
-      ],
-    );
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
     await settle();
 
     // Pre-select lines 3-4 for the warm send
     editor.selection = new vscode.Selection(2, 0, 3, 6);
     await settle();
 
-    const verdict = await waitForHumanVerdict(
-      'clipboard-preservation-016',
-      'Warm paste to GitHub Copilot Chat: verify prior clipboard restored after second send',
-      [
-        '1. Copy a known string (e.g., "PRIOR-COPILOT-WARM") to clipboard — select it and Cmd+C',
-        '2. Lines 3-4 already selected in cp-016 — press Cmd+R Cmd+L',
-        '3. Open a new editor tab (Cmd+N) and paste (Cmd+V)',
-        '4. Click PASS if pasted content is "PRIOR-COPILOT-WARM" (restored), FAIL otherwise',
-      ],
-    );
+    await writeClipboardSentinel();
 
-    assert.strictEqual(verdict, 'pass');
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
+    await settle();
+    await assertClipboardRestored('clipboard-preservation-016: always + Copilot Chat warm paste');
     log('✓ clipboard-preservation-016: warm Copilot Chat paste — clipboard restored');
   });
 
@@ -666,23 +599,25 @@ standardSuite('Built-in AI Assistants', (log) => {
     const editor = await openEditor(fileUri);
     await settle();
 
+    await waitForHuman(
+      'clipboard-preservation-017',
+      'Bind "Dummy AI (Focus-Fail)" via R-D picker, then Cancel',
+      [
+        '1. Press Cmd+R Cmd+D → select "Dummy AI (Focus-Fail)" from the picker',
+        '2. Press Cancel to continue (assertions happen automatically)',
+      ],
+    );
+    await settle();
+
     editor.selection = new vscode.Selection(0, 0, 1, 6);
     await settle();
 
-    const verdict = await waitForHumanVerdict(
-      'clipboard-preservation-017',
-      'Failed paste: verify RangeLink stays on clipboard when AI assistant focus/paste throws',
-      [
-        '1. PRECONDITION: Bind a Custom AI assistant named "Dummy AI (Focus-Fail)" that uses a failing focus command',
-        '2. Copy the sentinel value to clipboard — select some text and Cmd+C, then type Cmd+V to verify it is on clipboard',
-        '3. Lines 1-2 already selected in cp-017 — press Cmd+R Cmd+L',
-        '4. The paste should fail (focus command throws)',
-        '5. Open a new editor tab (Cmd+N) and paste (Cmd+V)',
-        `6. Click PASS if the clipboard contains the RangeLink (NOT restored), FAIL if "${CLIPBOARD_SENTINEL}" was restored`,
-      ],
-    );
+    await writeClipboardSentinel();
 
-    assert.strictEqual(verdict, 'pass');
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
+    await settle();
+    const clipboard017 = await assertClipboardChanged('clipboard-preservation-017: failed paste');
+    assert.ok(clipboard017.includes('#L'), `Expected RangeLink on clipboard, got: ${clipboard017}`);
     log('✓ clipboard-preservation-017: failed paste — RangeLink stays on clipboard');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/builtInAiAssistants.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/builtInAiAssistants.test.ts
@@ -5,8 +5,10 @@ import * as vscode from 'vscode';
 
 import {
   CMD_BIND_TO_CLAUDE_CODE,
+  CMD_BIND_TO_CURSOR_AI,
   CMD_BIND_TO_DESTINATION,
   CMD_BIND_TO_GEMINI_CODE_ASSIST,
+  CMD_BIND_TO_GITHUB_COPILOT_CHAT,
   CMD_COPY_LINK_RELATIVE,
   CMD_JUMP_TO_DESTINATION,
 } from '../../constants/commandIds';
@@ -21,6 +23,7 @@ import {
 import {
   assertStatusBarMsgLogged,
   cleanupFiles,
+  CLIPBOARD_SENTINEL,
   createWorkspaceFile,
   extractQuickPickItemsLogged,
   getLogCapture,
@@ -29,6 +32,7 @@ import {
   settle,
   standardSuite,
   waitForExtensionActive,
+  waitForHuman,
   waitForHumanVerdict,
 } from '../helpers';
 
@@ -441,6 +445,245 @@ standardSuite('Built-in AI Assistants', (log) => {
     );
 
     log('✓ Warm paste: content delivered to Gemini Code Assist (cold + warm both PASS)');
+  });
+
+  test('[assisted] clipboard-preservation-011: cold paste to Claude Code — prior clipboard restored', async () => {
+    const fileUri = createWorkspaceFile('cp-011', 'line 1\nline 2\nline 3\n');
+    tmpFileUris.push(fileUri);
+    const editor = await openEditor(fileUri);
+    await settle();
+
+    await vscode.commands.executeCommand(CMD_BIND_TO_CLAUDE_CODE);
+    await settle();
+
+    editor.selection = new vscode.Selection(0, 0, 1, 6);
+    await settle();
+
+    const verdict = await waitForHumanVerdict(
+      'clipboard-preservation-011',
+      'Cold paste: verify prior clipboard is restored after Claude Code paste',
+      [
+        '1. Copy the sentinel value to clipboard — select some text and Cmd+C, then type Cmd+V to verify it is on clipboard',
+        '2. Lines 1-2 already selected in cp-011 — press Cmd+R Cmd+L',
+        '3. Wait for the RangeLink to appear in Claude Code chat',
+        '4. Open a new editor tab (Cmd+N) and paste (Cmd+V)',
+        `5. Click PASS if the pasted content is "${CLIPBOARD_SENTINEL}" (restored), FAIL if RangeLink appears instead`,
+      ],
+    );
+
+    assert.strictEqual(verdict, 'pass');
+    log('✓ clipboard-preservation-011: prior clipboard restored after cold paste');
+  });
+
+  test('[assisted] clipboard-preservation-012: warm paste to Claude Code — prior clipboard restored', async () => {
+    const fileUri = createWorkspaceFile('cp-012', 'line 1\nline 2\nline 3\nline 4\n');
+    tmpFileUris.push(fileUri);
+    const editor = await openEditor(fileUri);
+    await settle();
+
+    await vscode.commands.executeCommand(CMD_BIND_TO_CLAUDE_CODE);
+    await settle();
+
+    // Warmup: lines 1-2 pre-selected
+    editor.selection = new vscode.Selection(0, 0, 1, 6);
+    await settle();
+
+    await waitForHuman(
+      'clipboard-preservation-012-warmup',
+      'Warmup: press Cmd+R Cmd+L to send pre-selected lines 1-2, confirm link appears, then Cancel',
+      [
+        '1. Lines 1-2 already selected in cp-012 — press Cmd+R Cmd+L',
+        '2. Confirm the RangeLink appears in Claude Code chat',
+        '3. Press Cancel to continue',
+      ],
+    );
+    await settle();
+
+    // Pre-select lines 3-4 for the warm send
+    editor.selection = new vscode.Selection(2, 0, 3, 6);
+    await settle();
+
+    const verdict = await waitForHumanVerdict(
+      'clipboard-preservation-012',
+      'Warm paste: verify prior clipboard restored after second send',
+      [
+        '1. Copy the sentinel value to clipboard — select some text and Cmd+C, then type Cmd+V to verify it is on clipboard',
+        '2. Lines 3-4 already selected in cp-012 — press Cmd+R Cmd+L',
+        '3. Open a new editor tab (Cmd+N) and paste (Cmd+V)',
+        `4. Click PASS if pasted content is "${CLIPBOARD_SENTINEL}" (restored), FAIL otherwise`,
+      ],
+    );
+
+    assert.strictEqual(verdict, 'pass');
+    log('✓ clipboard-preservation-012: prior clipboard restored after warm paste');
+  });
+
+  test('[assisted] clipboard-preservation-013: cold paste to Cursor AI — prior clipboard restored', async () => {
+    const fileUri = createWorkspaceFile('cp-013', 'line 1\nline 2\nline 3\n');
+    tmpFileUris.push(fileUri);
+    const editor = await openEditor(fileUri);
+    await settle();
+
+    await vscode.commands.executeCommand(CMD_BIND_TO_CURSOR_AI);
+    await settle();
+
+    editor.selection = new vscode.Selection(0, 0, 1, 6);
+    await settle();
+
+    const verdict = await waitForHumanVerdict(
+      'clipboard-preservation-013',
+      'Cold paste to Cursor AI: verify prior clipboard is restored',
+      [
+        '1. Copy a known string (e.g., "PRIOR-CURSOR") to clipboard — select it and Cmd+C',
+        '2. Lines 1-2 already selected in cp-013 — press Cmd+R Cmd+L',
+        '3. Wait for the RangeLink to appear in Cursor AI chat',
+        '4. Open a new editor tab (Cmd+N) and paste (Cmd+V)',
+        '5. Click PASS if the pasted content is "PRIOR-CURSOR" (restored), FAIL if RangeLink appears instead',
+      ],
+    );
+
+    assert.strictEqual(verdict, 'pass');
+    log('✓ clipboard-preservation-013: cold Cursor AI paste — clipboard restored');
+  });
+
+  test('[assisted] clipboard-preservation-014: warm paste to Cursor AI — prior clipboard restored', async () => {
+    const fileUri = createWorkspaceFile('cp-014', 'line 1\nline 2\nline 3\nline 4\n');
+    tmpFileUris.push(fileUri);
+    const editor = await openEditor(fileUri);
+    await settle();
+
+    await vscode.commands.executeCommand(CMD_BIND_TO_CURSOR_AI);
+    await settle();
+
+    // Warmup: lines 1-2 pre-selected
+    editor.selection = new vscode.Selection(0, 0, 1, 6);
+    await settle();
+
+    await waitForHuman(
+      'clipboard-preservation-014-warmup',
+      'Warmup: press Cmd+R Cmd+L to send pre-selected lines 1-2, confirm link appears in Cursor AI, then Cancel',
+      [
+        '1. Lines 1-2 already selected in cp-014 — press Cmd+R Cmd+L',
+        '2. Confirm the RangeLink appears in Cursor AI chat',
+        '3. Press Cancel to continue',
+      ],
+    );
+    await settle();
+
+    // Pre-select lines 3-4 for the warm send
+    editor.selection = new vscode.Selection(2, 0, 3, 6);
+    await settle();
+
+    const verdict = await waitForHumanVerdict(
+      'clipboard-preservation-014',
+      'Warm paste to Cursor AI: verify prior clipboard restored after second send',
+      [
+        '1. Copy a known string (e.g., "PRIOR-CURSOR-WARM") to clipboard — select it and Cmd+C',
+        '2. Lines 3-4 already selected in cp-014 — press Cmd+R Cmd+L',
+        '3. Open a new editor tab (Cmd+N) and paste (Cmd+V)',
+        '4. Click PASS if pasted content is "PRIOR-CURSOR-WARM" (restored), FAIL otherwise',
+      ],
+    );
+
+    assert.strictEqual(verdict, 'pass');
+    log('✓ clipboard-preservation-014: warm Cursor AI paste — clipboard restored');
+  });
+
+  test('[assisted] clipboard-preservation-015: cold paste to Copilot Chat — prior clipboard restored', async () => {
+    const fileUri = createWorkspaceFile('cp-015', 'line 1\nline 2\nline 3\n');
+    tmpFileUris.push(fileUri);
+    const editor = await openEditor(fileUri);
+    await settle();
+
+    await vscode.commands.executeCommand(CMD_BIND_TO_GITHUB_COPILOT_CHAT);
+    await settle();
+
+    editor.selection = new vscode.Selection(0, 0, 1, 6);
+    await settle();
+
+    const verdict = await waitForHumanVerdict(
+      'clipboard-preservation-015',
+      'Cold paste to GitHub Copilot Chat: verify prior clipboard is restored',
+      [
+        '1. Copy a known string (e.g., "PRIOR-COPILOT") to clipboard — select it and Cmd+C',
+        '2. Lines 1-2 already selected in cp-015 — press Cmd+R Cmd+L',
+        '3. Wait for the RangeLink to appear in Copilot Chat input',
+        '4. Open a new editor tab (Cmd+N) and paste (Cmd+V)',
+        '5. Click PASS if the pasted content is "PRIOR-COPILOT" (restored), FAIL if RangeLink appears instead',
+      ],
+    );
+
+    assert.strictEqual(verdict, 'pass');
+    log('✓ clipboard-preservation-015: cold Copilot Chat paste — clipboard restored');
+  });
+
+  test('[assisted] clipboard-preservation-016: warm paste to Copilot Chat — prior clipboard restored', async () => {
+    const fileUri = createWorkspaceFile('cp-016', 'line 1\nline 2\nline 3\nline 4\n');
+    tmpFileUris.push(fileUri);
+    const editor = await openEditor(fileUri);
+    await settle();
+
+    await vscode.commands.executeCommand(CMD_BIND_TO_GITHUB_COPILOT_CHAT);
+    await settle();
+
+    // Warmup: lines 1-2 pre-selected
+    editor.selection = new vscode.Selection(0, 0, 1, 6);
+    await settle();
+
+    await waitForHuman(
+      'clipboard-preservation-016-warmup',
+      'Warmup: press Cmd+R Cmd+L to send pre-selected lines 1-2, confirm link appears in Copilot Chat, then Cancel',
+      [
+        '1. Lines 1-2 already selected in cp-016 — press Cmd+R Cmd+L',
+        '2. Confirm the RangeLink appears in Copilot Chat input',
+        '3. Press Cancel to continue',
+      ],
+    );
+    await settle();
+
+    // Pre-select lines 3-4 for the warm send
+    editor.selection = new vscode.Selection(2, 0, 3, 6);
+    await settle();
+
+    const verdict = await waitForHumanVerdict(
+      'clipboard-preservation-016',
+      'Warm paste to GitHub Copilot Chat: verify prior clipboard restored after second send',
+      [
+        '1. Copy a known string (e.g., "PRIOR-COPILOT-WARM") to clipboard — select it and Cmd+C',
+        '2. Lines 3-4 already selected in cp-016 — press Cmd+R Cmd+L',
+        '3. Open a new editor tab (Cmd+N) and paste (Cmd+V)',
+        '4. Click PASS if pasted content is "PRIOR-COPILOT-WARM" (restored), FAIL otherwise',
+      ],
+    );
+
+    assert.strictEqual(verdict, 'pass');
+    log('✓ clipboard-preservation-016: warm Copilot Chat paste — clipboard restored');
+  });
+
+  test('[assisted] clipboard-preservation-017: failed paste — RangeLink stays on clipboard for manual paste', async () => {
+    const fileUri = createWorkspaceFile('cp-017', 'line 1\nline 2\nline 3\n');
+    tmpFileUris.push(fileUri);
+    const editor = await openEditor(fileUri);
+    await settle();
+
+    editor.selection = new vscode.Selection(0, 0, 1, 6);
+    await settle();
+
+    const verdict = await waitForHumanVerdict(
+      'clipboard-preservation-017',
+      'Failed paste: verify RangeLink stays on clipboard when AI assistant focus/paste throws',
+      [
+        '1. PRECONDITION: Bind a Custom AI assistant named "Dummy AI (Focus-Fail)" that uses a failing focus command',
+        '2. Copy the sentinel value to clipboard — select some text and Cmd+C, then type Cmd+V to verify it is on clipboard',
+        '3. Lines 1-2 already selected in cp-017 — press Cmd+R Cmd+L',
+        '4. The paste should fail (focus command throws)',
+        '5. Open a new editor tab (Cmd+N) and paste (Cmd+V)',
+        `6. Click PASS if the clipboard contains the RangeLink (NOT restored), FAIL if "${CLIPBOARD_SENTINEL}" was restored`,
+      ],
+    );
+
+    assert.strictEqual(verdict, 'pass');
+    log('✓ clipboard-preservation-017: failed paste — RangeLink stays on clipboard');
   });
 });
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
@@ -15,7 +15,6 @@ import {
   assertTerminalBufferContains,
   type CapturingTerminal,
   cleanupFiles,
-  CLIPBOARD_SENTINEL,
   createAndBindCapturingTerminal,
   createTerminal,
   createWorkspaceFile,

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
@@ -184,20 +184,22 @@ standardSuite('Clipboard Preservation — Assisted', (log) => {
     tmpFileUris.push(fileUri);
 
     const relPath = vscode.workspace.asRelativePath(fileUri);
-    const expectedLink = `${relPath}#L1-L3`;
+    const expectedLink = `${relPath}#L1C1-L3C7`;
 
-    await openEditor(fileUri);
+    const editor = await openEditor(fileUri);
     await writeClipboardSentinel();
+
+    editor.selection = new vscode.Selection(0, 0, 2, 6);
+    await settle();
 
     await waitForHuman(
       'clipboard-preservation-004',
-      `clipboard.preserve="always". Press Cmd+R Cmd+D → bind "Dummy AI (Tier 1)"; click back into the cbp-004 file, select exactly lines 1-3, press Cmd+R Cmd+L. Sentinel: "${CLIPBOARD_SENTINEL}".`,
+      `Press Cmd+R Cmd+D → bind "Dummy AI (Tier 1)", click back into the editor, press Cmd+R Cmd+L`,
       [
         '1. Press Cmd+R Cmd+D → select "Dummy AI (Tier 1)" from the picker',
-        `2. Click back into the test file (${relPath})`,
-        '3. Select exactly lines 1-3 (click line 1, shift-click end of line 3)',
-        '4. Press Cmd+R Cmd+L — the link should appear in Dummy AI Tier 1 textarea',
-        '5. Press Cancel to continue (assertions happen automatically)',
+        '2. Click back into the editor (lines 1-3 are pre-selected)',
+        '3. Press Cmd+R Cmd+L — the link should appear in Dummy AI Tier 1 textarea',
+        '4. Press Cancel to continue (assertions happen automatically)',
       ],
     );
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
@@ -26,6 +26,7 @@ import {
   standardSuite,
   TERMINAL_READY_MS,
   waitForHuman,
+  CLIPBOARD_SENTINEL,
   writeClipboardSentinel,
 } from '../helpers';
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
@@ -118,26 +118,25 @@ standardSuite('Clipboard Preservation — Assisted', (log) => {
     await settle();
   });
 
-  test('[assisted] clipboard-preservation-001: always mode — R-L to terminal restores clipboard', async () => {
+  test('clipboard-preservation-001: always mode — R-L to terminal restores clipboard', async () => {
     const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1} content`);
     const fileUri = createWorkspaceFile('cbp-001', lines.join('\n') + '\n');
     tmpFileUris.push(fileUri);
 
     const capturing: CapturingTerminal = await createAndBindCapturingTerminal('cbp-001-dest');
 
-    await openEditor(fileUri);
+    const editor001 = await openEditor(fileUri);
+    const lastSelectedLine = editor001.document.lineAt(3);
+    editor001.selection = new vscode.Selection(
+      new vscode.Position(1, 0),
+      lastSelectedLine.range.end,
+    );
+    await settle();
     await writeClipboardSentinel();
 
-    await waitForHuman(
-      'clipboard-preservation-001',
-      `clipboard.preserve="always". Terminal "cbp-001-dest" is bound. Select lines 2-4 in the test file and press Cmd+R Cmd+L. Sentinel: "${CLIPBOARD_SENTINEL}".`,
-      [
-        '1. Click into the open test file (cbp-001-...)',
-        '2. Select lines 2 through 4',
-        '3. Press Cmd+R Cmd+L — the link should appear in terminal "cbp-001-dest"',
-        '4. Press Cancel to continue (clipboard assertion happens automatically)',
-      ],
-    );
+    capturing.clearCaptured();
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
+    await settle();
 
     await assertClipboardRestored('clipboard-preservation-001: always + R-L');
     assertTerminalBufferContains(capturing.getCapturedText(), '#L');
@@ -217,26 +216,25 @@ standardSuite('Clipboard Preservation — Assisted', (log) => {
     log('✓ Clipboard restored to sentinel and link landed in Dummy AI after R-L');
   });
 
-  test('[assisted] clipboard-preservation-005: always mode — terminal paste (fresh bind) restores clipboard', async () => {
+  test('clipboard-preservation-005: always mode — terminal paste (fresh bind) restores clipboard', async () => {
     const lines = Array.from({ length: 10 }, (_, i) => `entry ${i + 1}`);
     const fileUri = createWorkspaceFile('cbp-005', lines.join('\n') + '\n');
     tmpFileUris.push(fileUri);
 
     const capturing: CapturingTerminal = await createAndBindCapturingTerminal('cbp-005-dest');
 
-    await openEditor(fileUri);
+    const editor005 = await openEditor(fileUri);
+    const lastSelectedLine = editor005.document.lineAt(2);
+    editor005.selection = new vscode.Selection(
+      new vscode.Position(1, 0),
+      lastSelectedLine.range.end,
+    );
+    await settle();
     await writeClipboardSentinel();
 
-    await waitForHuman(
-      'clipboard-preservation-005',
-      `clipboard.preserve="always". Terminal "cbp-005-dest" is bound. Select 2-3 lines in the test file and press Cmd+R Cmd+L. Sentinel: "${CLIPBOARD_SENTINEL}".`,
-      [
-        '1. Click into the open test file (cbp-005-...)',
-        '2. Select 2 or 3 lines',
-        '3. Press Cmd+R Cmd+L — the link should appear in terminal "cbp-005-dest"',
-        '4. Press Cancel to continue (clipboard assertion happens automatically)',
-      ],
-    );
+    capturing.clearCaptured();
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
+    await settle();
 
     await assertClipboardRestored('clipboard-preservation-005: always + terminal paste');
     assertTerminalBufferContains(capturing.getCapturedText(), '#L');

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
@@ -11,6 +11,7 @@ import {
   assertStatusBarMsgLogged,
   assertTerminalBufferContains,
   cleanupFiles,
+  clearSelection,
   createAndBindCapturingTerminal,
   createAndOpenFile,
   getLogCapture,
@@ -434,7 +435,7 @@ standardSuite('Context Menus — Editor Content', (log) => {
     await createAndBindCapturingTerminal(terminalName);
 
     const editor = await openEditor(uri);
-    editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0));
+    clearSelection(editor);
     await settle();
 
     const logCapture = getLogCapture();

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
@@ -17,6 +17,7 @@ import {
   createAndOpenFile,
   createCapturingTerminal,
   createTerminal,
+  echoToTerminal,
   extractQuickPickItemsLogged,
   getLogCapture,
   settle,
@@ -230,7 +231,7 @@ standardSuite('Context Menus — Terminal', (log) => {
     const terminal = await createTerminal(terminalName);
 
     const markerText = 'STS_005_MARKER_TEXT';
-    terminal.sendText(`echo ${markerText}`, true);
+    echoToTerminal(terminal, markerText);
     await settle(TERMINAL_READY_MS);
 
     const logCapture = getLogCapture();
@@ -280,7 +281,7 @@ standardSuite('Context Menus — Terminal', (log) => {
 
     const sourceTerminal = await createTerminal(sourceName);
     const markerText = 'STS_008_CROSS_TERMINAL_MARKER';
-    sourceTerminal.sendText(`echo ${markerText}`, true);
+    echoToTerminal(sourceTerminal, markerText);
     await settle(TERMINAL_READY_MS);
 
     const logCapture = getLogCapture();
@@ -331,7 +332,7 @@ standardSuite('Context Menus — Terminal', (log) => {
     const terminal = await createTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await settle();
-    terminal.sendText(`echo STS_009_MARKER_TEXT`, true);
+    echoToTerminal(terminal, 'STS_009_MARKER_TEXT');
     await settle(TERMINAL_READY_MS);
 
     const logCapture = getLogCapture();
@@ -423,7 +424,7 @@ standardSuite('Context Menus — Terminal', (log) => {
 
     const sourceTerminal = await createTerminal(sourceName);
     const markerText = 'STS_011_MARKER_TEXT';
-    sourceTerminal.sendText(`echo ${markerText}`, true);
+    echoToTerminal(sourceTerminal, markerText);
     await settle(TERMINAL_READY_MS);
 
     const logCapture = getLogCapture();
@@ -484,7 +485,7 @@ standardSuite('Context Menus — Terminal', (log) => {
     const terminal = await createTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await settle();
-    terminal.sendText(`echo STS_012_MARKER_TEXT`, true);
+    echoToTerminal(terminal, 'STS_012_MARKER_TEXT');
     await settle(TERMINAL_READY_MS);
 
     const logCapture = getLogCapture();
@@ -539,7 +540,7 @@ standardSuite('Context Menus — Terminal', (log) => {
     const terminalName = 'rl-sts-013';
     const terminal = await createTerminal(terminalName);
     const markerText = 'STS_013_AI_DELIVERY_MARKER';
-    terminal.sendText(`echo ${markerText}`, true);
+    echoToTerminal(terminal, markerText);
     await settle(TERMINAL_READY_MS);
 
     const logCapture = getLogCapture();

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
@@ -175,7 +175,7 @@ standardSuite('Core Send Commands', (log) => {
     log('✓ R-C wrote link to clipboard; terminal received nothing');
   });
 
-  test('core-send-commands-r-l-004: Command Palette "Send RangeLink" behaves identically to R-L keybinding', async () => {
+  test('core-send-commands-r-l-004: Command dispatch "Send RangeLink" behaves identically to R-L keybinding', async () => {
     const fileUri = createWorkspaceFile('csc-r-l-004', 'line 1\nline 2\nline 3\n');
     tmpFileUris.push(fileUri);
 
@@ -198,10 +198,10 @@ standardSuite('Core Send Commands', (log) => {
     assertStatusBarMsgLogged(logCapture.getLinesSince('before-r-l-004'), {
       message: '✓ RangeLink: RangeLink copied to clipboard & sent to Terminal ("csc-r-l-004-dest")',
     });
-    log('✓ Command Palette "Send RangeLink" delivered exact link to bound terminal destination');
+    log('✓ Command dispatch "Send RangeLink" delivered exact link to bound terminal destination');
   });
 
-  test('core-send-commands-r-c-002: Command Palette "Copy RangeLink" behaves identically to R-C keybinding', async () => {
+  test('core-send-commands-r-c-002: Command dispatch "Copy RangeLink" behaves identically to R-C keybinding', async () => {
     const fileUri = createWorkspaceFile('csc-r-c-002', 'line 1\nline 2\nline 3\n');
     tmpFileUris.push(fileUri);
 
@@ -221,7 +221,7 @@ standardSuite('Core Send Commands', (log) => {
 
     const relPath = vscode.workspace.asRelativePath(fileUri);
     const expectedContent = `${relPath}#L1-L2`;
-    const clipboard = await assertClipboardChanged('R-C palette should write link to clipboard');
+    const clipboard = await assertClipboardChanged('R-C command dispatch should write link to clipboard');
     assert.strictEqual(
       clipboard,
       expectedContent,
@@ -237,7 +237,7 @@ standardSuite('Core Send Commands', (log) => {
       message: '✓ RangeLink: RangeLink copied to clipboard',
     });
     log(
-      '✓ Command Palette "Copy RangeLink" wrote exact link to clipboard; terminal received nothing',
+      '✓ Command dispatch "Copy RangeLink" wrote exact link to clipboard; terminal received nothing',
     );
   });
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
@@ -221,7 +221,9 @@ standardSuite('Core Send Commands', (log) => {
 
     const relPath = vscode.workspace.asRelativePath(fileUri);
     const expectedContent = `${relPath}#L1-L2`;
-    const clipboard = await assertClipboardChanged('R-C command dispatch should write link to clipboard');
+    const clipboard = await assertClipboardChanged(
+      'R-C command dispatch should write link to clipboard',
+    );
     assert.strictEqual(
       clipboard,
       expectedContent,

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
@@ -232,7 +232,9 @@ standardSuite('Core Send Commands', (log) => {
     assertStatusBarMsgLogged(logCapture.getLinesSince('before-r-c-002'), {
       message: '✓ RangeLink: RangeLink copied to clipboard',
     });
-    log('✓ Command Palette "Copy RangeLink" wrote exact link to clipboard; terminal received nothing');
+    log(
+      '✓ Command Palette "Copy RangeLink" wrote exact link to clipboard; terminal received nothing',
+    );
   });
 
   test('[assisted] send-terminal-selection-001: Cmd+R Cmd+V with terminal text selected sends to bound destination', async () => {

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
@@ -17,9 +17,11 @@ import {
   assertNoToastLogged,
   assertStatusBarMsgLogged,
   assertTerminalBufferContains,
+  assertTerminalBufferEquals,
   assertToastLogged,
   type CapturingTerminal,
   cleanupFiles,
+  clearSelection,
   createAndBindCapturingTerminal,
   createWorkspaceFile,
   extractQuickPickItemsLogged,
@@ -45,7 +47,7 @@ standardSuite('Core Send Commands', (log) => {
     await settle();
   });
 
-  test('[assisted] core-send-commands-r-l-002: R-L sends RangeLink to bound text editor destination', async () => {
+  test('core-send-commands-r-l-002: R-L sends RangeLink to bound text editor destination', async () => {
     const srcUri = createWorkspaceFile(
       'csc-r-l-002-src',
       'line 1\nline 2\nline 3\nline 4\nline 5\n',
@@ -54,12 +56,13 @@ standardSuite('Core Send Commands', (log) => {
     tmpFileUris.push(srcUri, destUri);
 
     const destDoc = await vscode.workspace.openTextDocument(destUri);
-    await vscode.window.showTextDocument(destDoc, vscode.ViewColumn.Two);
+    const destEditor = await vscode.window.showTextDocument(destDoc, vscode.ViewColumn.Two);
+    clearSelection(destEditor);
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
     await settle();
 
     const srcDoc = await vscode.workspace.openTextDocument(srcUri);
-    const srcEditor = await vscode.window.showTextDocument(srcDoc, vscode.ViewColumn.One);
+    const srcEditor = await vscode.window.showTextDocument(srcDoc, vscode.ViewColumn.Beside);
     srcEditor.selection = new vscode.Selection(
       new vscode.Position(1, 0),
       new vscode.Position(3, 0),
@@ -69,25 +72,26 @@ standardSuite('Core Send Commands', (log) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-r-l-002');
 
-    await waitForHuman(
-      'core-send-commands-r-l-002',
-      'Lines 2-3 selected in "csc-r-l-002-src". "csc-r-l-002-dest" is bound as text editor destination.',
-      ['1. Press Cmd+R Cmd+L'],
-    );
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
+    await settle();
+
+    const lines = logCapture.getLinesSince('before-r-l-002');
 
     const updatedDestDoc = await vscode.workspace.openTextDocument(destUri);
     const destText = updatedDestDoc.getText();
-    assert.ok(
-      destText.includes('#L'),
-      `Expected RangeLink inserted into dest editor, got: ${JSON.stringify(destText)}`,
+    const relPath = vscode.workspace.asRelativePath(srcUri);
+    const expectedContent = ` ${relPath}#L2-L3 `;
+    assert.strictEqual(
+      destText,
+      expectedContent,
+      `Expected dest editor to contain exactly "${expectedContent}", got: ${JSON.stringify(destText)}`,
     );
 
-    const lines = logCapture.getLinesSince('before-r-l-002');
     const destBasename = path.basename(destUri.fsPath);
     assertStatusBarMsgLogged(lines, {
       message: `✓ RangeLink: RangeLink copied to clipboard & sent to Text Editor ("${destBasename}")`,
     });
-    log('✓ R-L inserted RangeLink into bound text editor destination');
+    log('✓ R-L sent exact RangeLink to bound text editor destination');
   });
 
   test('[assisted] core-send-commands-r-l-003: R-L sends RangeLink to bound AI assistant destination', async () => {
@@ -167,7 +171,7 @@ standardSuite('Core Send Commands', (log) => {
     log('✓ R-C wrote link to clipboard; terminal received nothing');
   });
 
-  test('[assisted] core-send-commands-r-l-004: Command Palette "Send RangeLink" behaves identically to R-L keybinding', async () => {
+  test('core-send-commands-r-l-004: Command Palette "Send RangeLink" behaves identically to R-L keybinding', async () => {
     const fileUri = createWorkspaceFile('csc-r-l-004', 'line 1\nline 2\nline 3\n');
     tmpFileUris.push(fileUri);
 
@@ -180,21 +184,20 @@ standardSuite('Core Send Commands', (log) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-r-l-004');
 
-    await waitForHuman(
-      'core-send-commands-r-l-004',
-      '"csc-r-l-004-dest" is bound. Lines 1-2 selected.',
-      ['1. Press Cmd+Shift+P → "RangeLink: Send RangeLink"'],
-    );
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
+    await settle();
 
-    assertTerminalBufferContains(capturing.getCapturedText(), '#L');
+    const relPath = vscode.workspace.asRelativePath(fileUri);
+    const expectedContent = ` ${relPath}#L1-L2 `;
+    assertTerminalBufferEquals(capturing.getCapturedText(), expectedContent);
 
     assertStatusBarMsgLogged(logCapture.getLinesSince('before-r-l-004'), {
       message: '✓ RangeLink: RangeLink copied to clipboard & sent to Terminal ("csc-r-l-004-dest")',
     });
-    log('✓ Command Palette "Send RangeLink" delivered link to bound terminal destination');
+    log('✓ Command Palette "Send RangeLink" delivered exact link to bound terminal destination');
   });
 
-  test('[assisted] core-send-commands-r-c-002: Command Palette "Copy RangeLink" behaves identically to R-C keybinding', async () => {
+  test('core-send-commands-r-c-002: Command Palette "Copy RangeLink" behaves identically to R-C keybinding', async () => {
     const fileUri = createWorkspaceFile('csc-r-c-002', 'line 1\nline 2\nline 3\n');
     tmpFileUris.push(fileUri);
 
@@ -209,16 +212,16 @@ standardSuite('Core Send Commands', (log) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-r-c-002');
 
-    await waitForHuman(
-      'core-send-commands-r-c-002',
-      '"csc-r-c-002-dest" is bound but should NOT receive anything. Lines 1-2 selected.',
-      ['1. Press Cmd+Shift+P → "RangeLink: Copy RangeLink"'],
-    );
+    await vscode.commands.executeCommand(CMD_COPY_LINK_ONLY_RELATIVE);
+    await settle();
 
+    const relPath = vscode.workspace.asRelativePath(fileUri);
+    const expectedContent = `${relPath}#L1-L2`;
     const clipboard = await assertClipboardChanged('R-C palette should write link to clipboard');
-    assert.ok(
-      clipboard.includes('#L'),
-      `Expected line-range link in clipboard, got: ${JSON.stringify(clipboard)}`,
+    assert.strictEqual(
+      clipboard,
+      expectedContent,
+      `Expected exact link on clipboard, got: ${JSON.stringify(clipboard)}`,
     );
 
     assert.strictEqual(
@@ -229,7 +232,7 @@ standardSuite('Core Send Commands', (log) => {
     assertStatusBarMsgLogged(logCapture.getLinesSince('before-r-c-002'), {
       message: '✓ RangeLink: RangeLink copied to clipboard',
     });
-    log('✓ Command Palette "Copy RangeLink" wrote link to clipboard; terminal received nothing');
+    log('✓ Command Palette "Copy RangeLink" wrote exact link to clipboard; terminal received nothing');
   });
 
   test('[assisted] send-terminal-selection-001: Cmd+R Cmd+V with terminal text selected sends to bound destination', async () => {

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
@@ -23,6 +23,7 @@ import {
   cleanupFiles,
   clearSelection,
   createAndBindCapturingTerminal,
+  createTerminal,
   createWorkspaceFile,
   extractQuickPickItemsLogged,
   getLogCapture,
@@ -40,8 +41,10 @@ const NO_TERMINAL_SELECTION_MSG = 'No text selected in the terminal. Select text
 
 standardSuite('Core Send Commands', (log) => {
   const tmpFileUris: vscode.Uri[] = [];
+  const tmpTerminals: vscode.Terminal[] = [];
 
   teardown(async () => {
+    for (const t of tmpTerminals.splice(0)) t.dispose();
     await vscode.commands.executeCommand('dummyAi.clearAll');
     cleanupFiles(tmpFileUris);
     tmpFileUris.splice(0);
@@ -244,12 +247,9 @@ standardSuite('Core Send Commands', (log) => {
     const capturing: CapturingTerminal = await createAndBindCapturingTerminal('csc-sts-001-dest');
     await settle();
 
-    const srcTerminal = vscode.window.createTerminal({ name: 'csc-sts-001-src' });
-    srcTerminal.show(true);
+    const srcTerminal = await createTerminal('csc-sts-001-src', tmpTerminals);
 
-    await settle(TERMINAL_READY_MS);
-
-    srcTerminal.sendText(`echo "${MARKER}"`, true);
+    echoToTerminal(srcTerminal, MARKER);
     await settle(TERMINAL_READY_MS);
 
     const logCapture = getLogCapture();
@@ -271,10 +271,7 @@ standardSuite('Core Send Commands', (log) => {
   });
 
   test('send-terminal-selection-003: R-V with no text selected in terminal shows error message', async () => {
-    const terminal = vscode.window.createTerminal({ name: 'csc-sts-003' });
-    terminal.show(true);
-
-    await settle(TERMINAL_READY_MS);
+    await createTerminal('csc-sts-003', tmpTerminals);
 
     // On macOS, terminal.copySelection leaves the clipboard unchanged when nothing
     // is selected — so we prime the clipboard to empty so the preserve/read roundtrip
@@ -297,12 +294,9 @@ standardSuite('Core Send Commands', (log) => {
   test('[assisted] send-terminal-selection-004: R-V with no bound destination opens destination picker', async () => {
     const MARKER = 'rl-sts-004-marker';
 
-    const srcTerminal = vscode.window.createTerminal({ name: 'csc-sts-004-src' });
-    srcTerminal.show(true);
+    const srcTerminal = await createTerminal('csc-sts-004-src', tmpTerminals);
 
-    await settle(TERMINAL_READY_MS);
-
-    srcTerminal.sendText(`echo "${MARKER}"`, true);
+    echoToTerminal(srcTerminal, MARKER);
     await settle(TERMINAL_READY_MS);
 
     const logCapture004 = getLogCapture();

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
@@ -32,6 +32,7 @@ import {
   standardSuite,
   TERMINAL_READY_MS,
   waitForHuman,
+  echoToTerminal,
   writeClipboardSentinel,
 } from '../helpers';
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/customAiAssistants.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/customAiAssistants.test.ts
@@ -15,6 +15,7 @@ import {
   settle,
   standardSuite,
   waitForHuman,
+  waitForHumanVerdict,
   writeClipboardSentinel,
 } from '../helpers';
 
@@ -142,42 +143,32 @@ standardSuite('Custom AI Assistants', (_log) => {
     );
   });
 
-  test('custom-ai-assistant-015: built-in override registers under built-in kind', () => {
+  test('custom-ai-assistant-015: built-in GitHub Copilot Chat registers as a destination kind', () => {
     const logCapture = getLogCapture();
     const allLines = logCapture.getAllLines();
 
-    const overrideRegistration = allLines.find(
-      (line) =>
-        line.includes('Registering builder for destination') &&
-        line.includes('"kind":"github-copilot-chat"'),
-    );
-    assert.ok(
-      overrideRegistration,
-      'Expected override entry (github.copilot-chat extensionId) to register under github-copilot-chat kind',
-    );
-
-    const customAiRegistrations = allLines.filter(
+    const copilotRegistrations = allLines.filter(
       (line) =>
         line.includes('Registering builder for destination') &&
         line.includes('"kind":"github-copilot-chat"'),
     );
     assert.strictEqual(
-      customAiRegistrations.length,
+      copilotRegistrations.length,
       1,
-      `Expected exactly 1 registration for github-copilot-chat (override replaces built-in) but found ${customAiRegistrations.length}`,
+      `Expected exactly 1 registration for github-copilot-chat but found ${copilotRegistrations.length}`,
     );
   });
 
-  test('custom-ai-assistant-016: built-in override does not register a separate custom-ai kind', async () => {
+  test('custom-ai-assistant-016: built-in GitHub Copilot Chat does not register as custom-ai kind', async () => {
     const logCapture = getLogCapture();
     const allLines = logCapture.getAllLines();
 
-    const overrideRegistration = allLines.find(
+    const copilotRegistration = allLines.find(
       (line) =>
         line.includes('Registering builder for destination') &&
         line.includes('"kind":"github-copilot-chat"'),
     );
-    assert.ok(overrideRegistration, 'Expected github-copilot-chat registration log');
+    assert.ok(copilotRegistration, 'Expected github-copilot-chat registration log');
 
     const noSeparateCustomRegistration = allLines.filter(
       (line) =>
@@ -187,7 +178,7 @@ standardSuite('Custom AI Assistants', (_log) => {
     assert.strictEqual(
       noSeparateCustomRegistration.length,
       0,
-      'Override should NOT register as custom-ai:github.copilot-chat — it takes over the built-in kind',
+      'GitHub Copilot Chat should register as built-in kind, not custom-ai: prefixed',
     );
   });
 
@@ -445,14 +436,15 @@ standardSuite('Custom AI Assistants — Paste Flow', (log) => {
     );
     assert.ok(skipRestoreLog, 'Expected clipboard restoration skip log');
 
-    await waitForHuman(
+    const verdict = await waitForHumanVerdict(
       'custom-ai-assistant-012-paste',
-      'Cmd+V in the Dummy AI tier2 textarea to verify clipboard has the link',
+      'Cmd+V in the Dummy AI tier2 textarea to verify clipboard has the link. Click PASS if the RangeLink appears, FAIL otherwise.',
       [
         'Click on the Dummy AI sidebar panel (tier2 textarea).',
         'Press Cmd+V to paste — the RangeLink should appear.',
       ],
     );
+    assert.strictEqual(verdict, 'pass');
 
     const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as
       | { tier1: string; tier2: string }
@@ -525,14 +517,15 @@ standardSuite('Custom AI Assistants — Paste Flow', (log) => {
     );
     assert.ok(skipRestoreLog, 'Expected clipboard restoration skip log for fallback→focusCommands');
 
-    await waitForHuman(
+    const verdict = await waitForHumanVerdict(
       'custom-ai-assistant-013-paste',
-      'Cmd+V in the Dummy AI tier2 textarea to verify clipboard has the link',
+      'Cmd+V in the Dummy AI tier2 textarea to verify clipboard has the link. Click PASS if the RangeLink appears, FAIL otherwise.',
       [
         'Click on the Dummy AI sidebar panel (tier2 textarea).',
         'Press Cmd+V to paste — the RangeLink should appear.',
       ],
     );
+    assert.strictEqual(verdict, 'pass');
 
     const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as
       | { tier1: string; tier2: string }

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/customAiAssistants.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/customAiAssistants.test.ts
@@ -143,6 +143,9 @@ standardSuite('Custom AI Assistants', (_log) => {
     );
   });
 
+  const EXPECTED_GITHUB_COPILOT_CHAT_REGISTRATION_COUNT = 1;
+  const EXPECTED_NO_CUSTOM_AI_COPILOT_REGISTRATIONS = 0;
+
   test('custom-ai-assistant-015: built-in GitHub Copilot Chat registers as a destination kind', () => {
     const logCapture = getLogCapture();
     const allLines = logCapture.getAllLines();
@@ -154,7 +157,7 @@ standardSuite('Custom AI Assistants', (_log) => {
     );
     assert.strictEqual(
       copilotRegistrations.length,
-      1,
+      EXPECTED_GITHUB_COPILOT_CHAT_REGISTRATION_COUNT,
       `Expected exactly 1 registration for github-copilot-chat but found ${copilotRegistrations.length}`,
     );
   });
@@ -177,7 +180,7 @@ standardSuite('Custom AI Assistants', (_log) => {
     );
     assert.strictEqual(
       noSeparateCustomRegistration.length,
-      0,
+      EXPECTED_NO_CUSTOM_AI_COPILOT_REGISTRATIONS,
       'GitHub Copilot Chat should register as built-in kind, not custom-ai: prefixed',
     );
   });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/linkGeneration.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/linkGeneration.test.ts
@@ -175,13 +175,12 @@ standardSuite('Link Generation — Clickable Links (Assisted)', (log) => {
 
     const verdict = await waitForHumanVerdict(
       'url-exclusion-002',
-      'Hover over https://example.com/path/file.ts#L10 in the editor',
+      'Verify RangeLink does NOT add its own hover/tooltip on a regular https:// URL',
       [
-        '1. Look at the line: https://example.com/path/file.ts#L10',
-        '2. Hover your cursor over any part of that URL',
-        '3. PASS if: no RangeLink tooltip or clickable underline appears',
-        '4. A browser-style VS Code link tooltip is OK — only RangeLink must NOT add its own',
-        '5. FAIL if: a RangeLink tooltip or clickable underline appears',
+        '1. Hover your cursor over https://example.com/path/file.ts#L10 in the editor',
+        '2. The URL will show a regular VS Code browser-style link hover — that is expected and fine',
+        '3. PASS if: RangeLink does NOT add its own clickable underline or tooltip',
+        '4. FAIL if: RangeLink adds a clickable underline or tooltip on the URL',
       ],
     );
 
@@ -203,11 +202,11 @@ standardSuite('Link Generation — Clickable Links (Assisted)', (log) => {
 
     const verdict = await waitForHumanVerdict(
       'document-link-tooltip-001',
-      'Hover over src/utils/helper.ts#L5 in the editor',
+      'Hover over the RangeLink — expect a clean human-readable tooltip (file path + line number)',
       [
         '1. Look at the line: See code at src/utils/helper.ts#L5 for details',
-        '2. Hover your cursor over the link text (it should be underlined/clickable)',
-        '3. PASS if: the tooltip shows clean human-readable text (file path and line number)',
+        '2. Hover your cursor over the RangeLink (it should be underlined/clickable)',
+        '3. PASS if: the RangeLink tooltip shows clean text (file path and line number)',
         '4. FAIL if: the tooltip shows raw JSON, a command: URI, or internal parameters',
       ],
     );

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/sendFilePath.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/sendFilePath.test.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 
 import {
   CMD_BIND_TO_TEXT_EDITOR_HERE,
+  CMD_PASTE_CURRENT_FILE_PATH_ABSOLUTE,
   CMD_PASTE_CURRENT_FILE_PATH_RELATIVE,
 } from '../../constants/commandIds';
 import {
@@ -63,7 +64,7 @@ standardSuite('Send File Path', (log) => {
     log('✓ R-F sends workspace-relative path to terminal');
   });
 
-  test('[assisted] send-file-path-002: Cmd+R Cmd+Shift+F sends absolute path to bound terminal', async () => {
+  test('send-file-path-002: Cmd+R Cmd+Shift+F sends absolute path to bound terminal', async () => {
     const capturing = await createAndBindCapturingTerminal('sfp-test');
 
     const fileUri = createWorkspaceFile('sfp-002', 'content\n');
@@ -75,16 +76,7 @@ standardSuite('Send File Path', (log) => {
     logCapture.mark('before-002');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'send-file-path-002',
-      'Cmd+R Cmd+Shift+F sends absolute path to bound terminal',
-      [
-        'Focus the file open in the editor.',
-        'Press Cmd+R Cmd+Shift+F (Send File Path Absolute).',
-        'Confirm terminal "sfp-test" receives the full absolute path.',
-      ],
-    );
-
+    await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_ABSOLUTE);
     await settle();
 
     const absolutePath = fileUri.fsPath;
@@ -94,11 +86,11 @@ standardSuite('Send File Path', (log) => {
       uriSource: 'command-palette',
       filePath: absolutePath,
     });
-    assertTerminalBufferContains(capturing.getCapturedText(), absolutePath);
-    log('✓ Cmd+R Cmd+Shift+F sends absolute path to terminal');
+    assertTerminalBufferEquals(capturing.getCapturedText(), ` ${absolutePath} `);
+    log('✓ Cmd+R Cmd+Shift+F sends exact absolute path to terminal');
   });
 
-  test('[assisted] send-file-path-004: terminal destination — path with spaces is auto-quoted in single quotes', async () => {
+  test('send-file-path-004: terminal destination — path with spaces is auto-quoted in single quotes', async () => {
     const capturing = await createAndBindCapturingTerminal('sfp-test');
 
     const fileUri = createFileAt('__rl-test-my folder.ts', 'content\n');
@@ -110,19 +102,16 @@ standardSuite('Send File Path', (log) => {
     logCapture.mark('before-004');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'send-file-path-004',
-      'R-F on file with spaces in path → terminal receives single-quoted path',
-      [
-        'Focus the file open in the editor.',
-        "Press Cmd+R Cmd+F — terminal should receive the path wrapped in single quotes (e.g. '__rl-test-my folder.ts').",
-      ],
-    );
-
+    await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE);
     await settle();
 
     const relativePath = vscode.workspace.asRelativePath(fileUri, false);
     const lines = logCapture.getLinesSince('before-004');
+    assertFilePathLogged(lines, {
+      pathFormat: 'workspace-relative',
+      uriSource: 'command-palette',
+      filePath: relativePath,
+    });
     const quotedLog = lines.find(
       (l) => l.includes('Quoted path for unsafe characters') && l.includes(relativePath),
     );
@@ -130,11 +119,11 @@ standardSuite('Send File Path', (log) => {
       quotedLog,
       'Expected "Quoted path for unsafe characters" log — path with spaces must be quoted before terminal send',
     );
-    assertTerminalBufferContains(capturing.getCapturedText(), `'${relativePath}'`);
+    assertTerminalBufferEquals(capturing.getCapturedText(), ` '${relativePath}' `);
     log('✓ Path with spaces auto-quoted for terminal destination');
   });
 
-  test('[assisted] send-file-path-005: terminal destination — path with parentheses is auto-quoted in single quotes', async () => {
+  test('send-file-path-005: terminal destination — path with parentheses is auto-quoted in single quotes', async () => {
     const capturing = await createAndBindCapturingTerminal('sfp-test');
 
     const fileUri = createFileAt('__rl-test-utils (v2).ts', 'content\n');
@@ -146,19 +135,16 @@ standardSuite('Send File Path', (log) => {
     logCapture.mark('before-005');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'send-file-path-005',
-      'R-F on file with parentheses in path → terminal receives single-quoted path',
-      [
-        'Focus the file open in the editor.',
-        "Press Cmd+R Cmd+F — terminal should receive the path wrapped in single quotes (e.g. '__rl-test-utils (v2).ts').",
-      ],
-    );
-
+    await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE);
     await settle();
 
     const relativePath = vscode.workspace.asRelativePath(fileUri, false);
     const lines = logCapture.getLinesSince('before-005');
+    assertFilePathLogged(lines, {
+      pathFormat: 'workspace-relative',
+      uriSource: 'command-palette',
+      filePath: relativePath,
+    });
     const quotedLog = lines.find(
       (l) => l.includes('Quoted path for unsafe characters') && l.includes(relativePath),
     );
@@ -166,7 +152,7 @@ standardSuite('Send File Path', (log) => {
       quotedLog,
       'Expected "Quoted path for unsafe characters" log — path with parentheses must be quoted before terminal send',
     );
-    assertTerminalBufferContains(capturing.getCapturedText(), `'${relativePath}'`);
+    assertTerminalBufferEquals(capturing.getCapturedText(), ` '${relativePath}' `);
     log('✓ Path with parentheses auto-quoted for terminal destination');
   });
 
@@ -186,7 +172,10 @@ standardSuite('Send File Path', (log) => {
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
     await settle();
 
-    await openEditor(sourceUri, vscode.ViewColumn.One);
+    await vscode.window.showTextDocument(
+      await vscode.workspace.openTextDocument(sourceUri),
+      vscode.ViewColumn.Beside,
+    );
     await settle();
 
     const logCapture = getLogCapture();
@@ -339,7 +328,7 @@ standardSuite('Send File Path', (log) => {
     log('✓ Unbound R-F opens picker; path sent after selection');
   });
 
-  test('[assisted] send-file-path-010: Command Palette "Send Current File Path" sends workspace-relative path', async () => {
+  test('send-file-path-010: Command Palette "Send Current File Path" sends workspace-relative path', async () => {
     const capturing = await createAndBindCapturingTerminal('sfp-test');
 
     const fileUri = createWorkspaceFile('sfp-010', 'content\n');
@@ -351,17 +340,7 @@ standardSuite('Send File Path', (log) => {
     logCapture.mark('before-010');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'send-file-path-010',
-      'Command Palette "Send Current File Path" sends workspace-relative path',
-      [
-        'Focus the file open in the editor.',
-        'Open Command Palette (Cmd+Shift+P).',
-        'Type "Send Current File Path" and press Enter.',
-        'Confirm terminal "sfp-test" receives the workspace-relative path (not absolute).',
-      ],
-    );
-
+    await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE);
     await settle();
 
     const relativePath = vscode.workspace.asRelativePath(fileUri, false);
@@ -375,7 +354,7 @@ standardSuite('Send File Path', (log) => {
     log('✓ Command Palette "Send Current File Path" sends workspace-relative path');
   });
 
-  test('[assisted] send-file-path-011: Command Palette "Send Current File Path (Absolute)" sends absolute path', async () => {
+  test('send-file-path-011: Command Palette "Send Current File Path (Absolute)" sends absolute path', async () => {
     const capturing = await createAndBindCapturingTerminal('sfp-test');
 
     const fileUri = createWorkspaceFile('sfp-011', 'content\n');
@@ -387,17 +366,7 @@ standardSuite('Send File Path', (log) => {
     logCapture.mark('before-011');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'send-file-path-011',
-      'Command Palette "Send Current File Path (Absolute)" sends absolute path',
-      [
-        'Focus the file open in the editor.',
-        'Open Command Palette (Cmd+Shift+P).',
-        'Type "Send Current File Path (Absolute)" and press Enter.',
-        'Confirm terminal "sfp-test" receives the full absolute path.',
-      ],
-    );
-
+    await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_ABSOLUTE);
     await settle();
 
     const absolutePath = fileUri.fsPath;
@@ -407,11 +376,11 @@ standardSuite('Send File Path', (log) => {
       uriSource: 'command-palette',
       filePath: absolutePath,
     });
-    assertTerminalBufferContains(capturing.getCapturedText(), absolutePath);
+    assertTerminalBufferEquals(capturing.getCapturedText(), ` ${absolutePath} `);
     log('✓ Command Palette "Send Current File Path (Absolute)" sends absolute path');
   });
 
-  test('[assisted] send-file-path-012: bound text editor hidden behind another tab — paste still lands in bound editor', async () => {
+  test('send-file-path-012: bound text editor hidden behind another tab — paste still lands in bound editor', async () => {
     const ANCHOR_START = 'ANCHOR_START';
     const ANCHOR_END = 'ANCHOR_END';
     const destUri = createWorkspaceFile('sfp-012-dest', `${ANCHOR_START}\n${ANCHOR_END}\n`);
@@ -439,16 +408,7 @@ standardSuite('Send File Path', (log) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-012');
 
-    await waitForHuman(
-      'send-file-path-012',
-      'R-F with bound editor hidden behind another tab in same column — paste still lands in bound editor',
-      [
-        'The source file is active (sfp-012-source). The bound editor (sfp-012-dest) is hidden behind it in the same column.',
-        'Press Cmd+R Cmd+F.',
-        'Observe that the bound editor is brought to the foreground and receives the file path.',
-      ],
-    );
-
+    await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE);
     await settle();
 
     assert.strictEqual(
@@ -465,11 +425,12 @@ standardSuite('Send File Path', (log) => {
       filePath: relativePath,
     });
     const destDoc = await vscode.workspace.openTextDocument(destUri);
-    const content = destDoc.getText();
-    assert.ok(
-      content.includes(`${ANCHOR_START}\n ${relativePath} ${ANCHOR_END}`),
-      `Expected file path inserted in bound editor at cursor position, got: ${JSON.stringify(content)}`,
+    const expectedContent = `${ANCHOR_START}\n ${relativePath} ${ANCHOR_END}\n`;
+    assert.strictEqual(
+      destDoc.getText(),
+      expectedContent,
+      `Expected exact dest content, got: ${JSON.stringify(destDoc.getText())}`,
     );
-    log('✓ Bound editor brought to foreground and received file path');
+    log('✓ Bound editor brought to foreground and received exact file path');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/smartPadding.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/smartPadding.test.ts
@@ -17,6 +17,7 @@ import {
   createAndBindCapturingTerminal,
   createTerminal,
   createWorkspaceFile,
+  echoToTerminal,
   getWorkspaceRoot,
   openEditor,
   openUntitledDoc,
@@ -381,7 +382,7 @@ standardSuite('Smart Padding — Single-Write Architecture', (log) => {
     await settle();
 
     const terminal = await createTerminal('pad-010-src', tmpTerminals);
-    terminal.sendText('echo hello', true);
+    echoToTerminal(terminal, 'hello');
     await settle();
 
     await waitForHuman(

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/smartPadding.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/smartPadding.test.ts
@@ -5,171 +5,64 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 import {
+  CMD_BIND_TO_GITHUB_COPILOT_CHAT,
+  CMD_BIND_TO_TEXT_EDITOR_HERE,
+  CMD_COPY_LINK_RELATIVE,
+  CMD_PASTE_CURRENT_FILE_PATH_RELATIVE,
+  CMD_PASTE_TO_DESTINATION,
+} from '../../constants/commandIds';
+import {
+  assertTerminalBufferEquals,
   cleanupFiles,
+  createAndBindCapturingTerminal,
+  createTerminal,
+  createWorkspaceFile,
   getWorkspaceRoot,
+  openEditor,
   openUntitledDoc,
   settle,
   standardSuite,
-  waitForActiveEditor,
+  waitForHuman,
+  waitForHumanVerdict,
 } from '../helpers';
 
-standardSuite('Smart Padding — Editor-to-Editor R-V', (log) => {
-  let sourceFileUri: vscode.Uri;
-  let destFileUri: vscode.Uri;
+// ---------------------------------------------------------------------------
+// Suites — Editor-to-Editor R-V (tests requiring real editor destinations)
+//
+// Each test gets its own standardSuite so that suite-level setup/teardown
+// (closeAllEditors, unbind) fully resets state between tests. Untitled
+// documents are particularly susceptible to cross-test contamination.
+// ---------------------------------------------------------------------------
 
-  suiteSetup(async () => {
-    log('suiteSetup: activating extension');
-  });
+standardSuite('Smart Padding — Editor-to-Editor R-V: 001-untitled', (log) => {
+  let sourceFileUri: vscode.Uri;
 
   setup(async () => {
     const ts = Date.now();
     const sourcePath = path.join(getWorkspaceRoot(), `__rl-test-sp-source-${ts}.txt`);
-    const destPath = path.join(getWorkspaceRoot(), `__rl-test-sp-dest-${ts}.txt`);
-
     fs.writeFileSync(sourcePath, '', 'utf8');
-    fs.writeFileSync(destPath, '', 'utf8');
-
     sourceFileUri = vscode.Uri.file(sourcePath);
-    destFileUri = vscode.Uri.file(destPath);
-    log('setup: created source and dest files');
   });
 
   teardown(async () => {
-    cleanupFiles([sourceFileUri, destFileUri]);
-    log('teardown: complete');
-  });
-
-  const setupEditorPair = async (
-    sourceContent: string,
-  ): Promise<{ sourceEditor: vscode.TextEditor; destEditor: vscode.TextEditor }> => {
-    fs.writeFileSync(sourceFileUri.fsPath, sourceContent, 'utf8');
-
-    log('setupEditorPair: opening source in ViewColumn.One');
-    const sourceDoc = await vscode.workspace.openTextDocument(sourceFileUri);
-    await vscode.window.showTextDocument(sourceDoc, vscode.ViewColumn.One);
-
-    log('setupEditorPair: opening dest in ViewColumn.Two');
-    const destDoc = await vscode.workspace.openTextDocument(destFileUri);
-    const destEditor = await vscode.window.showTextDocument(destDoc, vscode.ViewColumn.Two);
-
-    log('setupEditorPair: binding dest via bindToTextEditorHere (with URI to bypass picker)');
-    await vscode.commands.executeCommand('rangelink.bindToTextEditorHere', destFileUri);
-    await settle();
-
-    log('setupEditorPair: re-focusing source in ViewColumn.One');
-    const sourceEditor = await vscode.window.showTextDocument(sourceDoc, vscode.ViewColumn.One);
-    const focused = await waitForActiveEditor(sourceFileUri.toString(), log);
-    log(`setupEditorPair: source active=${focused}, viewColumn=${sourceEditor.viewColumn}`);
-    assert.ok(
-      focused,
-      'Source editor must be active before R-V — if this fails, external focus steal likely occurred',
-    );
-
-    return { sourceEditor, destEditor };
-  };
-
-  const setupUntitledEditorPair = async (
-    sourceContent: string,
-  ): Promise<{ sourceEditor: vscode.TextEditor; destDoc: vscode.TextDocument }> => {
-    fs.writeFileSync(sourceFileUri.fsPath, sourceContent, 'utf8');
-
-    log('setupUntitledEditorPair: opening source in ViewColumn.One');
-    const sourceDoc = await vscode.workspace.openTextDocument(sourceFileUri);
-    await vscode.window.showTextDocument(sourceDoc, vscode.ViewColumn.One);
-
-    log('setupUntitledEditorPair: creating untitled dest in ViewColumn.Two');
-    const destDoc = await openUntitledDoc({ viewColumn: vscode.ViewColumn.Two });
-    log(
-      `setupUntitledEditorPair: dest scheme=${destDoc.uri.scheme}, uri=${destDoc.uri.toString()}`,
-    );
-
-    log('setupUntitledEditorPair: binding untitled dest (with URI to bypass picker)');
-    await vscode.commands.executeCommand('rangelink.bindToTextEditorHere', destDoc.uri);
-    await settle();
-
-    log('setupUntitledEditorPair: re-focusing source in ViewColumn.One');
-    const sourceEditor = await vscode.window.showTextDocument(sourceDoc, vscode.ViewColumn.One);
-    const focused = await waitForActiveEditor(sourceFileUri.toString(), log);
-    log(`setupUntitledEditorPair: source active=${focused}`);
-    assert.ok(
-      focused,
-      'Source editor must be active before R-V — if this fails, external focus steal likely occurred',
-    );
-
-    return { sourceEditor, destDoc };
-  };
-
-  test('smart-padding-001: whitespace-only text preserved when sent to editor destination', async () => {
-    const whitespaceContent = '   \t   ';
-    log(
-      'smart-padding-001: starting — whitespace-only content, default profile (pasteContent=none)',
-    );
-
-    const { sourceEditor, destEditor } = await setupEditorPair(whitespaceContent);
-
-    const lastLine = sourceEditor.document.lineCount - 1;
-    const lastChar = sourceEditor.document.lineAt(lastLine).text.length;
-    sourceEditor.selection = new vscode.Selection(
-      new vscode.Position(0, 0),
-      new vscode.Position(lastLine, lastChar),
-    );
-    log(`smart-padding-001: selected ${lastChar} chars`);
-
-    await vscode.commands.executeCommand('rangelink.pasteSelectedTextToDestination');
-    await settle();
-
-    const destContent = destEditor.document.getText();
-    log(
-      `smart-padding-001: destContent=${JSON.stringify(destContent)} (length=${destContent.length})`,
-    );
-
-    assert.ok(
-      destContent.length > 0,
-      'Expected destination to have content after R-V, but it was empty — whitespace was likely rejected by eligibility check',
-    );
-    assert.ok(
-      destContent.includes('\t'),
-      `Expected destination to contain tab from source, but got: ${JSON.stringify(destContent)}`,
-    );
-    log('smart-padding-001: PASSED');
-  });
-
-  test('smart-padding-002: simple text with pasteContent=both adds leading and trailing space', async () => {
-    const sourceContent = 'hello world';
-    log('smart-padding-002: starting — loading default profile then overriding pasteContent=both');
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('smartPadding.pasteContent', 'both', vscode.ConfigurationTarget.Global);
-
-    const { sourceEditor, destEditor } = await setupEditorPair(sourceContent);
-
-    sourceEditor.selection = new vscode.Selection(
-      new vscode.Position(0, 0),
-      new vscode.Position(0, sourceContent.length),
-    );
-    log(`smart-padding-002: selected ${sourceContent.length} chars`);
-
-    await vscode.commands.executeCommand('rangelink.pasteSelectedTextToDestination');
-    await settle();
-
-    const destContent = destEditor.document.getText();
-    log(
-      `smart-padding-002: destContent=${JSON.stringify(destContent)} (length=${destContent.length})`,
-    );
-
-    assert.strictEqual(
-      destContent,
-      ' hello world ',
-      `Expected ' hello world ' (padding=both), but got: ${JSON.stringify(destContent)}`,
-    );
-    log('smart-padding-002: PASSED');
+    cleanupFiles([sourceFileUri]);
   });
 
   test('smart-padding-001-untitled: whitespace-only text sent to untitled editor destination', async () => {
     const whitespaceContent = '   \t   ';
     log('smart-padding-001-untitled: starting — default profile');
 
-    const { sourceEditor, destDoc } = await setupUntitledEditorPair(whitespaceContent);
+    fs.writeFileSync(sourceFileUri.fsPath, whitespaceContent, 'utf8');
+
+    const destDoc = await vscode.workspace.openTextDocument({ content: '', language: 'plaintext' });
+    await vscode.window.showTextDocument(destDoc, vscode.ViewColumn.Two);
+
+    await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE, destDoc.uri);
+    await settle();
+
+    const sourceDoc = await vscode.workspace.openTextDocument(sourceFileUri);
+    const sourceEditor = await vscode.window.showTextDocument(sourceDoc, vscode.ViewColumn.Three);
+    await settle();
 
     const lastLine = sourceEditor.document.lineCount - 1;
     const lastChar = sourceEditor.document.lineAt(lastLine).text.length;
@@ -178,204 +71,84 @@ standardSuite('Smart Padding — Editor-to-Editor R-V', (log) => {
       new vscode.Position(lastLine, lastChar),
     );
 
-    await vscode.commands.executeCommand('rangelink.pasteSelectedTextToDestination');
+    await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
     await settle();
 
     const destContent = destDoc.getText();
-    log(
-      `smart-padding-001-untitled: destContent=${JSON.stringify(destContent)} (length=${destContent.length})`,
-    );
-
     assert.ok(
       destContent.length > 0,
       `Expected untitled dest to have content, but it was empty. isClosed=${destDoc.isClosed}`,
     );
-    log('smart-padding-001-untitled: PASSED');
+  });
+});
+
+standardSuite('Smart Padding — Editor-to-Editor R-V: langswitch', (log) => {
+  let sourceFileUri001: vscode.Uri;
+  let sourceFileUri002: vscode.Uri;
+
+  setup(async () => {
+    const ts = Date.now();
+    const sourcePath001 = path.join(getWorkspaceRoot(), `__rl-test-sp-ls1-${ts}.txt`);
+    const sourcePath002 = path.join(getWorkspaceRoot(), `__rl-test-sp-ls2-${ts}.txt`);
+    fs.writeFileSync(sourcePath001, '', 'utf8');
+    fs.writeFileSync(sourcePath002, '', 'utf8');
+    sourceFileUri001 = vscode.Uri.file(sourcePath001);
+    sourceFileUri002 = vscode.Uri.file(sourcePath002);
   });
 
-  test('smart-padding-003: multiline selection sent to editor destination', async () => {
-    const sourceContent = 'line 1\nline 2\nline 3';
-    log('smart-padding-003: starting — multiline, default profile (pasteContent=none)');
-
-    const { sourceEditor, destEditor } = await setupEditorPair(sourceContent);
-
-    const lastLine = sourceEditor.document.lineCount - 1;
-    const lastChar = sourceEditor.document.lineAt(lastLine).text.length;
-    sourceEditor.selection = new vscode.Selection(
-      new vscode.Position(0, 0),
-      new vscode.Position(lastLine, lastChar),
-    );
-    log(`smart-padding-003: selected lines 0-${lastLine}`);
-
-    await vscode.commands.executeCommand('rangelink.pasteSelectedTextToDestination');
-    await settle();
-
-    const destContent = destEditor.document.getText();
-    log(
-      `smart-padding-003: destContent=${JSON.stringify(destContent)} (length=${destContent.length})`,
-    );
-
-    assert.strictEqual(
-      destContent,
-      'line 1\nline 2\nline 3',
-      `Expected exact multiline content (pasteContent=none), but got: ${JSON.stringify(destContent)}`,
-    );
-    log('smart-padding-003: PASSED');
-  });
-
-  test('smart-padding-004: pasteContent=none sends exact text without padding', async () => {
-    const sourceContent = 'hello';
-    log('smart-padding-004: starting — default profile (pasteContent=none)');
-
-    const { sourceEditor, destEditor } = await setupEditorPair(sourceContent);
-
-    sourceEditor.selection = new vscode.Selection(
-      new vscode.Position(0, 0),
-      new vscode.Position(0, sourceContent.length),
-    );
-
-    await vscode.commands.executeCommand('rangelink.pasteSelectedTextToDestination');
-    await settle();
-
-    const destContent = destEditor.document.getText();
-    log(`smart-padding-004: destContent=${JSON.stringify(destContent)}`);
-
-    assert.strictEqual(
-      destContent,
-      'hello',
-      `Expected exact 'hello' (no padding), but got: ${JSON.stringify(destContent)}`,
-    );
-    log('smart-padding-004: PASSED');
-  });
-
-  test('smart-padding-005: pasteContent=before adds leading space only', async () => {
-    const sourceContent = 'hello';
-    log('smart-padding-005: starting — pasteContent=before');
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('smartPadding.pasteContent', 'before', vscode.ConfigurationTarget.Global);
-
-    const { sourceEditor, destEditor } = await setupEditorPair(sourceContent);
-
-    sourceEditor.selection = new vscode.Selection(
-      new vscode.Position(0, 0),
-      new vscode.Position(0, sourceContent.length),
-    );
-
-    await vscode.commands.executeCommand('rangelink.pasteSelectedTextToDestination');
-    await settle();
-
-    const destContent = destEditor.document.getText();
-    log(`smart-padding-005: destContent=${JSON.stringify(destContent)}`);
-
-    assert.strictEqual(
-      destContent,
-      ' hello',
-      `Expected ' hello' (leading space only), but got: ${JSON.stringify(destContent)}`,
-    );
-    log('smart-padding-005: PASSED');
-  });
-
-  test('smart-padding-006: pasteContent=after adds trailing space only', async () => {
-    const sourceContent = 'hello';
-    log('smart-padding-006: starting — pasteContent=after');
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('smartPadding.pasteContent', 'after', vscode.ConfigurationTarget.Global);
-
-    const { sourceEditor, destEditor } = await setupEditorPair(sourceContent);
-
-    sourceEditor.selection = new vscode.Selection(
-      new vscode.Position(0, 0),
-      new vscode.Position(0, sourceContent.length),
-    );
-
-    await vscode.commands.executeCommand('rangelink.pasteSelectedTextToDestination');
-    await settle();
-
-    const destContent = destEditor.document.getText();
-    log(`smart-padding-006: destContent=${JSON.stringify(destContent)}`);
-
-    assert.strictEqual(
-      destContent,
-      'hello ',
-      `Expected 'hello ' (trailing space only), but got: ${JSON.stringify(destContent)}`,
-    );
-    log('smart-padding-006: PASSED');
+  teardown(async () => {
+    cleanupFiles([sourceFileUri001, sourceFileUri002]);
   });
 
   test('langswitch-binding-001: binding survives manual language-mode change on untitled file', async () => {
     const sourceContent = 'hello world';
-    log('langswitch: starting');
+    log('langswitch-001: starting');
 
-    fs.writeFileSync(sourceFileUri.fsPath, sourceContent, 'utf8');
+    fs.writeFileSync(sourceFileUri001.fsPath, sourceContent, 'utf8');
 
     const destDoc = await openUntitledDoc({ viewColumn: vscode.ViewColumn.Two });
-    const originalUri = destDoc.uri.toString();
     const originalLanguage = destDoc.languageId;
-    log(`langswitch: dest uri=${originalUri}, language=${originalLanguage}`);
 
-    await vscode.commands.executeCommand('rangelink.bindToTextEditorHere', destDoc.uri);
+    await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE, destDoc.uri);
     await settle();
 
-    log('langswitch: changing language to markdown');
     const updatedDestDoc = await vscode.languages.setTextDocumentLanguage(destDoc, 'markdown');
     await settle();
-    log(
-      `langswitch: language now=${updatedDestDoc.languageId}, uriChanged=${originalUri !== updatedDestDoc.uri.toString()}, sameRef=${destDoc === updatedDestDoc}`,
-    );
 
-    const visibleEditors = vscode.window.visibleTextEditors;
-    const destVisible = visibleEditors.filter((e) => e.document.uri.toString() === originalUri);
-    log(
-      `langswitch: visibleEditors=${visibleEditors.length}, destVisible=${destVisible.length}, destViewColumns=${destVisible.map((e) => e.viewColumn)}`,
-    );
-
-    const sourceDoc = await vscode.workspace.openTextDocument(sourceFileUri);
-    const sourceEditor = await vscode.window.showTextDocument(sourceDoc, {
-      viewColumn: vscode.ViewColumn.One,
-      preserveFocus: false,
-    });
-    await vscode.commands.executeCommand('workbench.action.focusFirstEditorGroup');
-    const sourceFocused = await waitForActiveEditor(sourceFileUri.toString(), log);
-    log(`langswitch: source active=${sourceFocused}, viewColumn=${sourceEditor.viewColumn}`);
-    assert.ok(sourceFocused, 'Source editor must be active before R-V');
+    const sourceDoc = await vscode.workspace.openTextDocument(sourceFileUri001);
+    const sourceEditor = await vscode.window.showTextDocument(sourceDoc, vscode.ViewColumn.Three);
+    await settle();
 
     sourceEditor.selection = new vscode.Selection(
       new vscode.Position(0, 0),
       new vscode.Position(0, sourceContent.length),
     );
 
-    await vscode.commands.executeCommand('rangelink.pasteSelectedTextToDestination');
+    await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
     await settle();
 
     const destContent = updatedDestDoc.getText();
-    log(`langswitch: destContent=${JSON.stringify(destContent)} (length=${destContent.length})`);
-
     assert.ok(
       destContent.length > 0,
       `POSSIBLE BUG: dest empty after language change. language=${originalLanguage}→${updatedDestDoc.languageId}, isClosed=${updatedDestDoc.isClosed}`,
     );
-    log('langswitch: PASSED');
   });
 
   test('langswitch-binding-002: binding survives language change after content insertion', async () => {
     const sourceContent = 'hello world';
-    log('content-lang: starting');
 
-    fs.writeFileSync(sourceFileUri.fsPath, sourceContent, 'utf8');
+    fs.writeFileSync(sourceFileUri002.fsPath, sourceContent, 'utf8');
 
     const destDoc = await vscode.workspace.openTextDocument({ content: '', language: 'plaintext' });
-    const destEditor = await vscode.window.showTextDocument(destDoc, vscode.ViewColumn.Two);
-    log(`content-lang: dest uri=${destDoc.uri.toString()}, language=${destDoc.languageId}`);
+    await vscode.window.showTextDocument(destDoc, vscode.ViewColumn.Two);
 
-    await vscode.commands.executeCommand('rangelink.bindToTextEditorHere', destDoc.uri);
+    await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE, destDoc.uri);
     await settle();
 
     const mdContent = '```typescript\nconst x = 1;\n```\n';
-    await destEditor.edit((editBuilder) => {
-      editBuilder.insert(new vscode.Position(0, 0), mdContent);
-    });
+    const edit = new vscode.WorkspaceEdit();
+    edit.insert(destDoc.uri, new vscode.Position(0, 0), mdContent);
+    await vscode.workspace.applyEdit(edit);
     await settle();
 
     let currentDestDoc = destDoc;
@@ -383,35 +156,273 @@ standardSuite('Smart Padding — Editor-to-Editor R-V', (log) => {
       currentDestDoc = await vscode.languages.setTextDocumentLanguage(destDoc, 'markdown');
       await settle();
     }
-    log(
-      `content-lang: language now=${currentDestDoc.languageId}, sameRef=${destDoc === currentDestDoc}`,
-    );
 
-    const sourceDoc = await vscode.workspace.openTextDocument(sourceFileUri);
-    const sourceEditor = await vscode.window.showTextDocument(sourceDoc, {
-      viewColumn: vscode.ViewColumn.One,
-      preserveFocus: false,
-    });
-    await vscode.commands.executeCommand('workbench.action.focusFirstEditorGroup');
-    const sourceFocused = await waitForActiveEditor(sourceFileUri.toString(), log);
-    log(`content-lang: source active=${sourceFocused}, viewColumn=${sourceEditor.viewColumn}`);
-    assert.ok(sourceFocused, 'Source editor must be active before R-V');
+    const sourceDoc = await vscode.workspace.openTextDocument(sourceFileUri002);
+    const sourceEditor = await vscode.window.showTextDocument(sourceDoc, vscode.ViewColumn.Three);
+    await settle();
 
     sourceEditor.selection = new vscode.Selection(
       new vscode.Position(0, 0),
       new vscode.Position(0, sourceContent.length),
     );
 
-    await vscode.commands.executeCommand('rangelink.pasteSelectedTextToDestination');
+    await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
     await settle();
 
     const destContent = currentDestDoc.getText();
-    log(`content-lang: destContent=${JSON.stringify(destContent)}`);
-
     assert.ok(
       destContent.includes(sourceContent),
       `POSSIBLE BUG: dest doesn't contain source text after language change. language=${currentDestDoc.languageId}, isClosed=${currentDestDoc.isClosed}`,
     );
-    log('content-lang: PASSED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite — Single-Write Architecture (CapturingTerminal + assisted tests)
+// ---------------------------------------------------------------------------
+
+standardSuite('Smart Padding — Single-Write Architecture', (log) => {
+  const tmpFileUris: vscode.Uri[] = [];
+  const tmpTerminals: vscode.Terminal[] = [];
+
+  teardown(async () => {
+    for (const t of tmpTerminals.splice(0)) t.dispose();
+    cleanupFiles(tmpFileUris);
+    tmpFileUris.length = 0;
+    await settle();
+  });
+
+  test('smart-padding-001: whitespace-only text preserved when sent to destination', async () => {
+    const whitespaceContent = '   \t   ';
+
+    const sourceUri = createWorkspaceFile('pad-001', whitespaceContent);
+    tmpFileUris.push(sourceUri);
+
+    const capturing = await createAndBindCapturingTerminal('pad-001-dest', tmpTerminals);
+    await settle();
+
+    const sourceEditor = await openEditor(sourceUri);
+    const lastLine = sourceEditor.document.lineCount - 1;
+    const lastChar = sourceEditor.document.lineAt(lastLine).text.length;
+    sourceEditor.selection = new vscode.Selection(
+      new vscode.Position(0, 0),
+      new vscode.Position(lastLine, lastChar),
+    );
+    await settle();
+
+    capturing.clearCaptured();
+    await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
+    await settle();
+
+    const captured = capturing.getCapturedText();
+    assert.ok(
+      captured.length > 0,
+      `Expected whitespace content to be sent, but captured was empty`,
+    );
+    assert.ok(
+      captured.includes('\t'),
+      `Expected captured content to contain tab, got: ${JSON.stringify(captured)}`,
+    );
+    log('✓ smart-padding-001: whitespace preserved');
+  });
+
+  test('smart-padding-003: multiline content preserved through destination', async () => {
+    const expected = 'line 1\nline 2\nline 3';
+
+    const sourceUri = createWorkspaceFile('pad-003', expected + '\n');
+    tmpFileUris.push(sourceUri);
+
+    const capturing = await createAndBindCapturingTerminal('pad-003-dest', tmpTerminals);
+    await settle();
+
+    const sourceEditor = await openEditor(sourceUri);
+    const docText = sourceEditor.document.getText(new vscode.Range(0, 0, 2, 6));
+
+    capturing.clearCaptured();
+    capturing.terminal.sendText(docText);
+    await settle();
+
+    assertTerminalBufferEquals(capturing.getCapturedText(), expected);
+    log('✓ smart-padding-003: multiline content preserved through destination');
+  });
+
+  test('smart-padding-005: pasteContent=before adds leading space only', async () => {
+    await vscode.workspace
+      .getConfiguration('rangelink')
+      .update('smartPadding.pasteContent', 'before', vscode.ConfigurationTarget.Global);
+
+    const sourceUri = createWorkspaceFile('pad-005', 'hello\n');
+    tmpFileUris.push(sourceUri);
+
+    const capturing = await createAndBindCapturingTerminal('pad-005-dest', tmpTerminals);
+    await settle();
+
+    const sourceEditor = await openEditor(sourceUri);
+    sourceEditor.selection = new vscode.Selection(0, 0, 0, 5);
+    await settle();
+
+    capturing.clearCaptured();
+    await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
+    await settle();
+
+    assertTerminalBufferEquals(capturing.getCapturedText(), ' hello');
+    log('✓ smart-padding-005: leading space applied');
+  });
+
+  test('smart-padding-006: pasteContent=after adds trailing space only', async () => {
+    await vscode.workspace
+      .getConfiguration('rangelink')
+      .update('smartPadding.pasteContent', 'after', vscode.ConfigurationTarget.Global);
+
+    const sourceUri = createWorkspaceFile('pad-006', 'hello\n');
+    tmpFileUris.push(sourceUri);
+
+    const capturing = await createAndBindCapturingTerminal('pad-006-dest', tmpTerminals);
+    await settle();
+
+    const sourceEditor = await openEditor(sourceUri);
+    sourceEditor.selection = new vscode.Selection(0, 0, 0, 5);
+    await settle();
+
+    capturing.clearCaptured();
+    await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
+    await settle();
+
+    assertTerminalBufferEquals(capturing.getCapturedText(), 'hello ');
+    log('✓ smart-padding-006: trailing space applied');
+  });
+
+  test('smart-padding-007: pasteContent=both — text selection sent to destination has leading and trailing space', async () => {
+    await vscode.workspace
+      .getConfiguration('rangelink')
+      .update('smartPadding.pasteContent', 'both', vscode.ConfigurationTarget.Global);
+
+    const sourceUri = createWorkspaceFile('pad-007', 'hello world\n');
+    tmpFileUris.push(sourceUri);
+
+    const capturing = await createAndBindCapturingTerminal('pad-007-dest', tmpTerminals);
+    await settle();
+
+    const sourceEditor = await openEditor(sourceUri);
+    sourceEditor.selection = new vscode.Selection(0, 0, 0, 11);
+    await settle();
+
+    capturing.clearCaptured();
+    await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
+    await settle();
+
+    assertTerminalBufferEquals(capturing.getCapturedText(), ' hello world ');
+    log('✓ smart-padding-007: padded text selection sent to destination');
+  });
+
+  test('smart-padding-008: pasteFilePath=both — file path sent to terminal has leading and trailing space', async () => {
+    await vscode.workspace
+      .getConfiguration('rangelink')
+      .update('smartPadding.pasteFilePath', 'both', vscode.ConfigurationTarget.Global);
+
+    const fileUri = createWorkspaceFile('pad-008', 'content\n');
+    tmpFileUris.push(fileUri);
+
+    const capturing = await createAndBindCapturingTerminal('pad-008-dest', tmpTerminals);
+    await settle();
+
+    await openEditor(fileUri);
+    await settle();
+
+    capturing.clearCaptured();
+    await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE);
+    await settle();
+
+    const relativePath = vscode.workspace.asRelativePath(fileUri, false);
+    assertTerminalBufferEquals(capturing.getCapturedText(), ` ${relativePath} `);
+    log('✓ smart-padding-008: padded file path sent to terminal');
+  });
+
+  test('[assisted] smart-padding-009: pasteLink=both — RangeLink sent to AI assistant has leading and trailing space', async () => {
+    const fileUri = createWorkspaceFile('pad-009', 'line 1\nline 2\nline 3\n');
+    tmpFileUris.push(fileUri);
+    const editor = await openEditor(fileUri);
+    await settle();
+
+    await vscode.commands.executeCommand(CMD_BIND_TO_GITHUB_COPILOT_CHAT);
+    await settle();
+
+    editor.selection = new vscode.Selection(0, 0, 1, 6);
+    await settle();
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
+    await settle();
+
+    const verdict = await waitForHumanVerdict(
+      'smart-padding-009',
+      'Verify padded RangeLink sent to GitHub Copilot Chat',
+      [
+        '1. smartPadding.pasteLink is already set to "both"',
+        '2. Lines 1-2 were selected and R-L sent the link to Copilot Chat',
+        '3. Look at the Copilot Chat input — the link should have leading and trailing spaces',
+        '4. Click PASS if padding was applied, FAIL otherwise',
+      ],
+    );
+
+    assert.strictEqual(verdict, 'pass');
+    log('✓ smart-padding-009: RangeLink sent to Copilot with padding (human verified)');
+  });
+
+  test('[assisted] smart-padding-010: terminal selection sent to editor with padding=both', async () => {
+    await vscode.workspace
+      .getConfiguration('rangelink')
+      .update('smartPadding.pasteContent', 'both', vscode.ConfigurationTarget.Global);
+
+    const destUri = createWorkspaceFile('pad-010-dest', '');
+    tmpFileUris.push(destUri);
+
+    const destDoc = await vscode.workspace.openTextDocument(destUri);
+    await vscode.window.showTextDocument(destDoc, vscode.ViewColumn.Two);
+    await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE, destUri);
+    await settle();
+
+    const terminal = await createTerminal('pad-010-src', tmpTerminals);
+    terminal.sendText('echo hello', true);
+    await settle();
+
+    await waitForHuman(
+      'smart-padding-010',
+      'Select "hello" in the terminal and press R-V to paste to the bound editor',
+      [
+        '1. In terminal "pad-010-src", mouse-select the output "hello"',
+        '2. Press R-C to copy the terminal selection, then press R-V to send',
+        '3. The bound editor (pad-010-dest) will receive the padded text',
+        '4. Click the notification Cancel button when done',
+      ],
+    );
+
+    const destContent = (await vscode.workspace.openTextDocument(destUri)).getText();
+    assert.ok(
+      destContent.includes(' hello '),
+      `Expected dest to contain padded text " hello ", got: "${destContent}"`,
+    );
+    log('✓ smart-padding-010: terminal selection sent to editor with padding (code verified)');
+  });
+
+  test('smart-padding-011: pasteContent=none — no padding applied when setting is off', async () => {
+    await vscode.workspace
+      .getConfiguration('rangelink')
+      .update('smartPadding.pasteContent', 'none', vscode.ConfigurationTarget.Global);
+
+    const sourceUri = createWorkspaceFile('pad-011', 'hello\n');
+    tmpFileUris.push(sourceUri);
+
+    const capturing = await createAndBindCapturingTerminal('pad-011-dest', tmpTerminals);
+    await settle();
+
+    const sourceEditor = await openEditor(sourceUri);
+    sourceEditor.selection = new vscode.Selection(0, 0, 0, 5);
+    await settle();
+
+    capturing.clearCaptured();
+    await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
+    await settle();
+
+    assertTerminalBufferEquals(capturing.getCapturedText(), 'hello');
+    log('✓ smart-padding-011: no padding when disabled');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/smartPadding.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/smartPadding.test.ts
@@ -233,17 +233,27 @@ standardSuite('Smart Padding — Single-Write Architecture', (log) => {
     const sourceUri = createWorkspaceFile('pad-003', expected + '\n');
     tmpFileUris.push(sourceUri);
 
-    const capturing = await createAndBindCapturingTerminal('pad-003-dest', tmpTerminals);
+    const destDoc = await vscode.workspace.openTextDocument({ content: '', language: 'plaintext' });
+    await vscode.window.showTextDocument(destDoc, vscode.ViewColumn.Two);
+    await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
     await settle();
 
-    const sourceEditor = await openEditor(sourceUri);
-    const docText = sourceEditor.document.getText(new vscode.Range(0, 0, 2, 6));
-
-    capturing.clearCaptured();
-    capturing.terminal.sendText(docText);
+    const sourceEditor = await openEditor(sourceUri, vscode.ViewColumn.Beside);
+    sourceEditor.selection = new vscode.Selection(
+      new vscode.Position(0, 0),
+      new vscode.Position(2, 6),
+    );
     await settle();
 
-    assertTerminalBufferEquals(capturing.getCapturedText(), expected);
+    await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
+    await settle();
+
+    const destContent = destDoc.getText();
+    assert.strictEqual(
+      destContent,
+      expected,
+      `Expected multiline content to arrive intact, got: ${JSON.stringify(destContent)}`,
+    );
     log('✓ smart-padding-003: multiline content preserved through destination');
   });
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/textEditorDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/textEditorDestination.test.ts
@@ -2,16 +2,21 @@ import assert from 'node:assert';
 
 import * as vscode from 'vscode';
 
-import { CMD_BIND_TO_TEXT_EDITOR_HERE, CMD_COPY_LINK_RELATIVE } from '../../constants/commandIds';
+import {
+  CMD_BIND_TO_TEXT_EDITOR_HERE,
+  CMD_COPY_LINK_RELATIVE,
+  CMD_PASTE_TO_DESTINATION,
+} from '../../constants/commandIds';
 import {
   assertNoToastLogged,
   assertToastLogged,
   cleanupFiles,
   createWorkspaceFile,
   getLogCapture,
+  openSourceWithSelection,
   settle,
   standardSuite,
-  waitForHuman,
+  waitForHumanVerdict,
 } from '../helpers';
 
 standardSuite('Text Editor Destination', (log) => {
@@ -38,17 +43,8 @@ standardSuite('Text Editor Destination', (log) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-ted-001');
 
-    await waitForHuman(
-      'text-editor-destination-001',
-      'The file is bound to itself. Press Cmd+R Cmd+L — verify info message appears and file is unchanged.',
-      [
-        '1. The current file is already set as its own destination (bound via test setup)',
-        '2. Text "self-paste" is already selected',
-        '3. Press Cmd+R Cmd+L',
-        '4. Verify an info notification appears saying the link was copied and cannot auto-paste to same file',
-        '5. Verify the file content has NOT changed',
-      ],
-    );
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
+    await settle();
 
     const lines = logCapture.getLinesSince('before-ted-001');
 
@@ -57,6 +53,17 @@ standardSuite('Text Editor Destination', (log) => {
       message:
         'RangeLink copied to clipboard. Cannot auto-paste to same file. Tip: Use R-C for clipboard-only links.',
     });
+
+    const verdict = await waitForHumanVerdict(
+      'text-editor-destination-001',
+      'Verify info message appeared and file content is unchanged',
+      [
+        '1. An info notification appeared about self-paste',
+        '2. The file content has NOT changed',
+        '3. Click PASS if both checks pass, FAIL otherwise',
+      ],
+    );
+    assert.strictEqual(verdict, 'pass');
 
     log('✓ Self-paste R-L: info toast shown, file unchanged (log verified)');
   });
@@ -93,16 +100,8 @@ standardSuite('Text Editor Destination', (log) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-htl-001');
 
-    await waitForHuman(
-      'hidden-tab-paste-001',
-      'R-L with bound editor hidden behind another tab — paste still lands in bound editor',
-      [
-        '1. The source file is active (htl-001-source). The bound editor (htl-001-dest) is hidden behind it in the same column.',
-        `2. "${SOURCE_CONTENT}" is already selected.`,
-        '3. Press Cmd+R Cmd+L.',
-        '4. Observe that the bound editor is brought to the foreground and receives the RangeLink.',
-      ],
-    );
+    await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
+    await settle();
 
     const lines = logCapture.getLinesSince('before-htl-001');
 
@@ -160,16 +159,8 @@ standardSuite('Text Editor Destination', (log) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-htl-002');
 
-    await waitForHuman(
-      'hidden-tab-paste-002',
-      'R-V with bound editor hidden behind another tab — paste still lands in bound editor',
-      [
-        '1. The source file is active (htl-002-source). The bound editor (htl-002-dest) is hidden behind it in the same column.',
-        `2. "${SELECTED_TEXT}" is already selected.`,
-        '3. Press Cmd+R Cmd+V.',
-        '4. Observe that the bound editor is brought to the foreground and receives the selected text.',
-      ],
-    );
+    await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
+    await settle();
 
     const lines = logCapture.getLinesSince('before-htl-002');
 
@@ -303,16 +294,10 @@ standardSuite('Text Editor Destination', (log) => {
     });
     await settle();
 
-    // Focus source in col 1 with selection.
-    const sourceEditor = await vscode.window.showTextDocument(
-      await vscode.workspace.openTextDocument(sourceUri),
-      { viewColumn: vscode.ViewColumn.One, preview: false },
-    );
-    sourceEditor.selection = new vscode.Selection(
-      new vscode.Position(0, 0),
-      new vscode.Position(0, SOURCE_TEXT.length),
-    );
-    await settle();
+    // Open source in col 4 — a fresh column that reliably gets focus in the
+    // test runner (col 2 and 3 are occupied by dest; col 1 is unreliable
+    // after prior tests have manipulated it).
+    await openSourceWithSelection(sourceUri, vscode.ViewColumn.Four);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-dtg-003');
@@ -418,7 +403,6 @@ standardSuite('Text Editor Destination', (log) => {
     tmpFileUris.push(destUri, sourceUri, dummyUri);
 
     const destDoc = await vscode.workspace.openTextDocument(destUri);
-    const sourceDoc = await vscode.workspace.openTextDocument(sourceUri);
 
     // Open dest in col 2, bind (boundViewColumn = 2).
     const destEditor = await vscode.window.showTextDocument(destDoc, {
@@ -449,16 +433,9 @@ standardSuite('Text Editor Destination', (log) => {
     });
     await settle();
 
-    // Focus source in col 1 with a text selection.
-    const sourceEditor = await vscode.window.showTextDocument(sourceDoc, {
-      viewColumn: vscode.ViewColumn.One,
-      preview: false,
-    });
-    sourceEditor.selection = new vscode.Selection(
-      new vscode.Position(0, 0),
-      new vscode.Position(0, SOURCE_TEXT.length),
-    );
-    await settle();
+    // Open source in col 4 — a fresh column that reliably gets focus.
+    // Col 2 is occupied by dummy (dest hidden behind it), col 3 by dest.
+    await openSourceWithSelection(sourceUri, vscode.ViewColumn.Four);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-svc-001');

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/insertFactories/aiAssistantInsertFactory.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/insertFactories/aiAssistantInsertFactory.test.ts
@@ -12,6 +12,7 @@ describe('AIAssistantInsertFactory', () => {
 
   it('delegates to ideAdapter.pasteClipboardToAiAssistant and returns true on success', async () => {
     const mockAdapter = createMockVscodeAdapter();
+    jest.spyOn(mockAdapter, 'writeTextToClipboard');
     const pasteSpy = jest.spyOn(mockAdapter, 'pasteClipboardToAiAssistant').mockResolvedValue(true);
 
     const factory = new AIAssistantInsertFactory(mockAdapter, mockLogger);
@@ -22,10 +23,12 @@ describe('AIAssistantInsertFactory', () => {
     expect(result).toBe(true);
     expect(pasteSpy).toHaveBeenCalledWith();
     expect(mockLogger.warn).not.toHaveBeenCalled();
+    expect(mockAdapter.writeTextToClipboard).not.toHaveBeenCalled();
   });
 
   it('returns false when pasteClipboardToAiAssistant returns false', async () => {
     const mockAdapter = createMockVscodeAdapter();
+    jest.spyOn(mockAdapter, 'writeTextToClipboard');
     jest.spyOn(mockAdapter, 'pasteClipboardToAiAssistant').mockResolvedValue(false);
 
     const factory = new AIAssistantInsertFactory(mockAdapter, mockLogger);
@@ -38,5 +41,6 @@ describe('AIAssistantInsertFactory', () => {
       { fn: 'AIAssistantInsertFactory.insert', allCommandsFailed: true },
       'Clipboard paste command failed',
     );
+    expect(mockAdapter.writeTextToClipboard).not.toHaveBeenCalled();
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/insertFactories/terminalInsertFactory.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/insertFactories/terminalInsertFactory.test.ts
@@ -12,6 +12,7 @@ describe('TerminalInsertFactory', () => {
 
   it('delegates to ideAdapter.pasteIntoTerminal and returns true on success', async () => {
     const mockAdapter = createMockVscodeAdapter();
+    jest.spyOn(mockAdapter, 'writeTextToClipboard');
     const mockTerminal = createMockTerminal({ name: 'My Terminal' });
     const pasteIntoTerminalSpy = jest
       .spyOn(mockAdapter, 'pasteIntoTerminal')
@@ -29,10 +30,12 @@ describe('TerminalInsertFactory', () => {
       { fn: 'TerminalInsertFactory.insert', terminalName: 'My Terminal' },
       'Terminal paste succeeded',
     );
+    expect(mockAdapter.writeTextToClipboard).not.toHaveBeenCalled();
   });
 
   it('returns false when pasteIntoTerminal throws', async () => {
     const mockAdapter = createMockVscodeAdapter();
+    jest.spyOn(mockAdapter, 'writeTextToClipboard');
     const mockTerminal = createMockTerminal({ name: 'My Terminal' });
     const testError = new Error('Paste failed');
     jest.spyOn(mockAdapter, 'pasteIntoTerminal').mockRejectedValue(testError);
@@ -47,10 +50,12 @@ describe('TerminalInsertFactory', () => {
       { fn: 'TerminalInsertFactory.insert', terminalName: 'My Terminal', error: testError },
       'Terminal paste failed',
     );
+    expect(mockAdapter.writeTextToClipboard).not.toHaveBeenCalled();
   });
 
   it('captures terminal reference in closure', async () => {
     const mockAdapter = createMockVscodeAdapter();
+    jest.spyOn(mockAdapter, 'writeTextToClipboard');
     const terminal1 = createMockTerminal({ name: 'Terminal 1' });
     const terminal2 = createMockTerminal({ name: 'Terminal 2' });
     const pasteIntoTerminalSpy = jest
@@ -67,5 +72,6 @@ describe('TerminalInsertFactory', () => {
     expect(pasteIntoTerminalSpy).toHaveBeenNthCalledWith(1, terminal1);
     expect(pasteIntoTerminalSpy).toHaveBeenNthCalledWith(2, terminal2);
     expect(mockLogger.error).not.toHaveBeenCalled();
+    expect(mockAdapter.writeTextToClipboard).not.toHaveBeenCalled();
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/services/ClipboardRouter.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/services/ClipboardRouter.test.ts
@@ -148,6 +148,109 @@ describe('ClipboardRouter', () => {
       expect(mockDestinationManager.isClipboardRestorationApplicable).toHaveBeenCalledWith(true);
     });
 
+    it('passes pasteSucceeded=true to isClipboardRestorationApplicable when sendFn succeeds', async () => {
+      const dest = createMockTerminalPasteDestination({ displayName: 'Terminal' });
+      mockDestinationManager = createMockDestinationManager({
+        isBound: true,
+        boundDestination: dest,
+      });
+      let capturedShouldRestore: (() => boolean) | undefined;
+      mockPreserver.preserve.mockImplementation(
+        async (fn: () => Promise<unknown>, shouldRestore?: () => boolean) => {
+          capturedShouldRestore = shouldRestore;
+          return fn();
+        },
+      );
+
+      router = new ClipboardRouter(
+        mockAdapter,
+        mockDestinationManager,
+        mockPicker,
+        mockPreserver,
+        mockLogger,
+      );
+
+      const options = buildOptions({
+        strategies: {
+          sendFn: jest.fn().mockResolvedValue(true),
+          isEligibleFn: jest.fn().mockResolvedValue(true),
+        },
+      });
+
+      await router.copyAndSendToDestination(options);
+
+      capturedShouldRestore?.();
+      expect(mockDestinationManager.isClipboardRestorationApplicable).toHaveBeenCalledWith(true);
+    });
+
+    it('passes pasteSucceeded=false to isClipboardRestorationApplicable when content is ineligible', async () => {
+      const dest = createMockTerminalPasteDestination({ displayName: 'Terminal' });
+      mockDestinationManager = createMockDestinationManager({
+        isBound: true,
+        boundDestination: dest,
+      });
+      let capturedShouldRestore: (() => boolean) | undefined;
+      mockPreserver.preserve.mockImplementation(
+        async (fn: () => Promise<unknown>, shouldRestore?: () => boolean) => {
+          capturedShouldRestore = shouldRestore;
+          return fn();
+        },
+      );
+
+      router = new ClipboardRouter(
+        mockAdapter,
+        mockDestinationManager,
+        mockPicker,
+        mockPreserver,
+        mockLogger,
+      );
+
+      const options = buildOptions({
+        strategies: { sendFn: jest.fn(), isEligibleFn: jest.fn().mockResolvedValue(false) },
+      });
+
+      await router.copyAndSendToDestination(options);
+
+      capturedShouldRestore?.();
+      expect(mockDestinationManager.isClipboardRestorationApplicable).toHaveBeenCalledWith(false);
+    });
+
+    it('passes pasteSucceeded=false to isClipboardRestorationApplicable for self-paste detection', async () => {
+      const sourceUri = createMockUri('/workspace/file.ts');
+      const dest = createMockTerminalPasteDestination({ displayName: 'Terminal' });
+      mockDestinationManager = createMockDestinationManager({
+        isBound: true,
+        boundDestination: dest,
+      });
+      let capturedShouldRestore: (() => boolean) | undefined;
+      mockPreserver.preserve.mockImplementation(
+        async (fn: () => Promise<unknown>, shouldRestore?: () => boolean) => {
+          capturedShouldRestore = shouldRestore;
+          return fn();
+        },
+      );
+
+      jest.spyOn(isSameFileDestinationModule, 'isSameFileDestination').mockReturnValue(true);
+
+      router = new ClipboardRouter(
+        mockAdapter,
+        mockDestinationManager,
+        mockPicker,
+        mockPreserver,
+        mockLogger,
+      );
+
+      const options = buildOptions({
+        content: { clipboard: 'link', send: 'link', sourceUri },
+        strategies: { sendFn: jest.fn(), isEligibleFn: jest.fn().mockResolvedValue(true) },
+      });
+
+      await router.copyAndSendToDestination(options);
+
+      capturedShouldRestore?.();
+      expect(mockDestinationManager.isClipboardRestorationApplicable).toHaveBeenCalledWith(false);
+    });
+
     it('skips preservation when destinationBehavior is ClipboardOnly', async () => {
       const dest = createMockTerminalPasteDestination({ displayName: 'Terminal' });
       mockDestinationManager = createMockDestinationManager({

--- a/packages/rangelink-vscode-extension/src/__tests__/services/FilePathPaster.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/services/FilePathPaster.test.ts
@@ -146,6 +146,23 @@ describe('FilePathPaster', () => {
       await paster.pasteFilePathToDestination(uri, PathFormat.Absolute);
 
       expect(mockClipboardRouter.copyAndSendToDestination).toHaveBeenCalledTimes(1);
+      expect(mockClipboardRouter.copyAndSendToDestination).toHaveBeenCalledWith({
+        control: {
+          contentType: 'Text',
+          destinationBehavior: 'bound-destination',
+        },
+        content: {
+          clipboard: ' /workspace/src/file.ts ',
+          send: ' /workspace/src/file.ts ',
+          sourceUri: uri,
+        },
+        strategies: {
+          sendFn: expect.any(Function) as unknown,
+          isEligibleFn: expect.any(Function) as unknown,
+        },
+        contentName: 'File path',
+        fnName: 'pasteFilePath',
+      });
       expect(mockLogger.debug).toHaveBeenCalledWith(
         {
           fn: 'FilePathPaster.pasteFilePath',

--- a/packages/rangelink-vscode-extension/src/__tests__/services/LinkGenerator.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/services/LinkGenerator.test.ts
@@ -311,6 +311,23 @@ describe('LinkGenerator', () => {
         'Sending link to destination',
       );
       expect(mockClipboardRouter.copyAndSendToDestination).toHaveBeenCalledTimes(1);
+      expect(mockClipboardRouter.copyAndSendToDestination).toHaveBeenCalledWith({
+        control: {
+          contentType: 'Link',
+          destinationBehavior: 'bound-destination',
+        },
+        content: {
+          clipboard: ' src/file.ts#L1 ',
+          send: { ...link, link: ' src/file.ts#L1 ' },
+          sourceUri: mockDoc.uri,
+        },
+        strategies: {
+          sendFn: expect.any(Function) as unknown,
+          isEligibleFn: expect.any(Function) as unknown,
+        },
+        contentName: 'RangeLink',
+        fnName: 'copyToClipboardAndDestination',
+      });
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/services/TerminalSelectionService.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/services/TerminalSelectionService.test.ts
@@ -166,7 +166,7 @@ describe('TerminalSelectionService', () => {
           sendFn: expect.any(Function) as unknown,
           isEligibleFn: expect.any(Function) as unknown,
         },
-        contentName: expect.any(String) as unknown,
+        contentName: 'Selected text',
         fnName: 'pasteTerminalSelectionToDestination',
       });
       expect(mockLogger.debug).toHaveBeenCalledWith(

--- a/packages/rangelink-vscode-extension/src/__tests__/services/TerminalSelectionService.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/services/TerminalSelectionService.test.ts
@@ -147,11 +147,28 @@ describe('TerminalSelectionService', () => {
       mockClipboardRouter.resolveDestinationBehavior.mockResolvedValue(
         DestinationBehavior.BoundDestination,
       );
+      mockConfigReader.getPaddingMode.mockReturnValue('both');
 
       const result = await service.pasteTerminalSelectionToDestination();
 
       expect(result).toStrictEqual({ outcome: 'success' });
       expect(mockClipboardRouter.copyAndSendToDestination).toHaveBeenCalledTimes(1);
+      expect(mockClipboardRouter.copyAndSendToDestination).toHaveBeenCalledWith({
+        control: {
+          contentType: 'Text',
+          destinationBehavior: 'bound-destination',
+        },
+        content: {
+          clipboard: ' selected text ',
+          send: ' selected text ',
+        },
+        strategies: {
+          sendFn: expect.any(Function) as unknown,
+          isEligibleFn: expect.any(Function) as unknown,
+        },
+        contentName: expect.any(String) as unknown,
+        fnName: 'pasteTerminalSelectionToDestination',
+      });
       expect(mockLogger.debug).toHaveBeenCalledWith(
         {
           fn: 'TerminalSelectionService.pasteTerminalSelectionToDestination',

--- a/packages/rangelink-vscode-extension/src/__tests__/services/TextSelectionPaster.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/services/TextSelectionPaster.test.ts
@@ -70,10 +70,28 @@ describe('TextSelectionPaster', () => {
     mockClipboardRouter.resolveDestinationBehavior.mockResolvedValue(
       DestinationBehavior.BoundDestination,
     );
+    mockConfigReader.getPaddingMode.mockReturnValue('both');
 
     await paster.pasteSelectedTextToDestination();
 
     expect(mockClipboardRouter.copyAndSendToDestination).toHaveBeenCalledTimes(1);
+    expect(mockClipboardRouter.copyAndSendToDestination).toHaveBeenCalledWith({
+      control: {
+        contentType: 'Text',
+        destinationBehavior: 'bound-destination',
+      },
+      content: {
+        clipboard: ' selected text ',
+        send: ' selected text ',
+        sourceUri: mockDoc.uri,
+      },
+      strategies: {
+        sendFn: expect.any(Function) as unknown,
+        isEligibleFn: expect.any(Function) as unknown,
+      },
+      contentName: expect.any(String) as unknown,
+      fnName: 'pasteSelectedTextToDestination',
+    });
     expect(mockLogger.debug).toHaveBeenCalledWith(
       {
         fn: 'TextSelectionPaster.pasteSelectedTextToDestination',

--- a/packages/rangelink-vscode-extension/src/__tests__/services/TextSelectionPaster.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/services/TextSelectionPaster.test.ts
@@ -89,7 +89,7 @@ describe('TextSelectionPaster', () => {
         sendFn: expect.any(Function) as unknown,
         isEligibleFn: expect.any(Function) as unknown,
       },
-      contentName: expect.any(String) as unknown,
+      contentName: 'Selected text',
       fnName: 'pasteSelectedTextToDestination',
     });
     expect(mockLogger.debug).toHaveBeenCalledWith(

--- a/packages/rangelink-vscode-extension/test-fixtures/dummy-ai-extension/extension.js
+++ b/packages/rangelink-vscode-extension/test-fixtures/dummy-ai-extension/extension.js
@@ -66,6 +66,12 @@ function activate(context) {
   );
 
   context.subscriptions.push(
+    vscode.commands.registerCommand('dummyAi.focusFail', () => {
+      throw new Error('Simulated focus failure for integration testing');
+    }),
+  );
+
+  context.subscriptions.push(
     vscode.commands.registerCommand('dummyAi.clearAll', () => {
       provider?.postMessage({ type: 'clearAll' });
     }),

--- a/packages/rangelink-vscode-extension/test-fixtures/dummy-ai-extension/extension.js
+++ b/packages/rangelink-vscode-extension/test-fixtures/dummy-ai-extension/extension.js
@@ -43,9 +43,7 @@ function activate(context) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand('dummyAi.focusFail', async () => {
-      throw new Error(
-        'dummyAi.focusFail: intentional failure for TC-010 clipboard-preservation test',
-      );
+      throw new Error('Simulated focus failure for integration testing');
     }),
   );
 
@@ -62,12 +60,6 @@ function activate(context) {
   context.subscriptions.push(
     vscode.commands.registerCommand('dummyAi.getText', () => {
       return provider?.requestText();
-    }),
-  );
-
-  context.subscriptions.push(
-    vscode.commands.registerCommand('dummyAi.focusFail', () => {
-      throw new Error('Simulated focus failure for integration testing');
     }),
   );
 


### PR DESCRIPTION
## Summary

Closes QA coverage gaps identified after PR #556's single-write clipboard architecture landed. Adds integration tests for text editor destination edge cases (hidden tabs, duplicate tab groups, stale view column), smart padding variants across all paste types, and built-in AI assistant binding. Fixes two pre-existing test failures caused by VS Code test-runner focus-steal and terminal line-ending normalization. Adds `--without-extensions` flag to `test-release-run.sh` to exclude tests requiring marketplace extensions in CI.

## Changes

- **Text editor destination tests** — New and fixed integration tests: hidden tab paste for R-L and R-V, duplicate tab group warning suppression, paste blocking when dest is in multiple tab groups, stale view column edge case, duplicate state clear/re-entry cycle
- **Smart padding tests** — Restructured `smart-padding-010` from verdict-based to `waitForHuman` + code assertion. Changed `smart-padding-009` from Claude Code to GitHub Copilot Chat binding (Copilot is built into VS Code, no marketplace extensions needed). Added multiline content preservation test (`smart-padding-003`) with terminal line-ending normalization fix
- **`openSourceWithSelection` helper** — New helper in `fileHelpers.ts` that opens a source file in a fresh view column with all text selected. Works around VS Code test-runner focus-steal where `showTextDocument` in an occupied column doesn't transfer `activeTextEditor` focus. Used by `duplicate-tab-group-003` and `stale-viewcolumn-001` to avoid selecting the dest editor by mistake
- **Terminal capturing fix** — `assertTerminalBufferEquals` now strips trailing `\n` after normalizing `\r` line endings, fixing `smart-padding-003` buffer mismatch
- **Test settings cleanup** — Removed `github.copilot-chat` override from `setup-integration-test-settings.js` that was redirecting Copilot Chat binding to the dummy AI extension's `insertText` command. The override mechanism is covered by unit tests. Repurposed `custom-ai-assistant-015` and `016` to verify normal built-in Copilot Chat registration
- **`--without-extensions` flag** — New `test-release-run.sh` flag that resolves `requires-extensions` QA labels and excludes those test IDs from the Mocha grep. `test:release:automated` now uses `--without-extensions` so CI skips tests needing marketplace extensions. Grep/exclusion composition handles `--grep`, `--automated`, and `--without-extensions` simultaneously via negative lookahead
- **Logging assertions** — Added log-level assertions to unit tests for `ClipboardRouter`, `FilePathPaster`, `LinkGenerator`, `TerminalSelectionService`, `TextSelectionPaster`, and insert factories (per T007 — logging is part of the method contract)
- **9 assisted→automated conversions** — Converted `core-send-commands-r-l-002`, `r-l-004`, `r-c-002` in `coreSendCommands.test.ts` and `send-file-path-002`, `004`, `005`, `006`, `010`, `011`, `012` in `sendFilePath.test.ts` from `[assisted]` (human presses chord, programmatic assertions verify) to fully automated: programmatic `vscode.commands.executeCommand()` dispatch replaces `waitForHuman`, exact content assertions (`assertTerminalBufferEquals`, `assert.strictEqual`) replace substring checks. All 9 run unattended and pass reliably in CI
- **`clearSelection(editor)` helper** — New helper in `editorHelpers.ts` that clears selection on an explicit editor reference instead of relying on `vscode.window.activeTextEditor`. Refactored `clearEditorSelection()` to delegate to it. Applied in `coreSendCommands.test.ts` and `contextMenuEditorContent.test.ts` to remove implicit `activeTextEditor` reliance during dest-editor setup
- **`ViewColumn.Beside` for source editors** — Fixes cross-suite focus-steal in 2 multi-column tests (`core-send-commands-r-l-002`, `send-file-path-006`) where source editors opened in numbered columns could silently lose focus to the dest editor, causing the extension to read the wrong editor's selection. `ViewColumn.Beside` always creates a brand-new editor group that reliably gets focus — tested and confirmed as the ONLY fix that works across suite boundaries (vs `closeAllGroups`, `joinAllGroups`, `focusFirstEditorGroup`)
- **Clipboard preservation test automation** — Converted `clipboard-preservation-001` and `005` from `[assisted]` (human selects text manually) to fully automated: programmatic `editor.selection` + direct `CMD_COPY_LINK_RELATIVE` invocation. Both now run unattended and pass reliably. Further converted `clipboard-preservation-011` through `016` (6 AI-assistant clipboard preservation tests) from `waitForHumanVerdict` (human verifies clipboard via manual paste) to fully automated: programmatic `writeClipboardSentinel()` + `CMD_COPY_LINK_RELATIVE` dispatch + `assertClipboardRestored()`. Clipboard content is programmatically inspectable via `vscode.env.clipboard.readText()` — human verification unnecessary. All 8 now run unattended and pass reliably
- **Custom AI paste verdict conversion** — Converted `custom-ai-assistant-012` and `013` paste-verification phases from `waitForHuman` (Cancel dismiss) to `waitForHumanVerdict` (explicit PASS/FAIL buttons), forcing the tester to confirm the paste outcome
- **Silent-pass trap closure (#560)** — Audited all 20 integration test files: 0 remaining `waitForHuman` calls without programmatic assertion backup. Every `waitForHuman` call is either a setup-only step with downstream assertions that fail if the action wasn't performed, or has been converted to `waitForHumanVerdict` + `assert.strictEqual(verdict, 'pass')`. Updated TESTING.md with a "Choosing between waitForHuman and waitForHumanVerdict" subsection documenting the contract distinction, correct usage patterns, and the warmup pattern
- **`clipboard-preservation-017` fix** — Test was impossible to run — "Dummy AI (Focus-Fail)" appeared nowhere in the R-D picker because no fixture command or settings registration existed. Added `dummyAi.focusFail` command (throws on invocation) to the dummy AI extension fixture and registered "Dummy AI (Focus-Fail)" in `setup-integration-test-settings.js` so it appears by default. Restructured from `waitForHumanVerdict` (human copy/paste + verdict) to `waitForHuman` (picker bind only) + programmatic `CMD_COPY_LINK_RELATIVE` + `assertClipboardChanged` — the machine verifies clipboard state, the human only does the picker bind
- **`clipboard-preservation-004` link format fix** — Updated expected link from `#L1-L3` to `#L1C1-L3C7` to match the new column-precision link format. Added programmatic `editor.selection` to eliminate manual line selection
- **QA YAML updates** — 17 tests changed from `automated: assisted` to `automated: true`: `clipboard-preservation-001`, `005`, `011`-`016`; `core-send-commands-r-l-002`, `r-l-004`, `r-c-002`; `send-file-path-002`, `004`, `005`, `006`, `010`, `011`, `012`; steps rewritten to reflect programmatic execution. `clipboard-preservation-017` steps updated to reflect picker bind + programmatic assertions
- **`test-release-run.sh` corner case fixes** — Empty label resolution now fails fast instead of silently running all tests. `--with-extensions` and `--without-extensions` are mutually exclusive (error if both). Removed misleading double `--grep` from report COMMAND display. `MOCHA_GREP`/`MOCHA_INVERT` are unset before composition to prevent environment leak
- Documentation: CHANGELOG not needed (internal test infrastructure); README not needed (no user-facing changes)

## Key Discoveries

- **VS Code test-runner focus-steal is a host limitation, not a production bug.** `showTextDocument(uri, ViewColumn.One)` reuses an existing editor group without reliably transferring focus in the automated test host. Any numbered column (One through Nine) can become contaminated — once a column has been used in a VS Code session, `showTextDocument` won't reliably transfer focus to it. `ViewColumn.Beside` (-2) always creates a brand-new group, bypassing the contamination entirely. Neither `closeAllGroups` nor `joinAllGroups` in `standardSuite.setup` resets column state. `focusFirstEditorGroup` before `showTextDocument` only works within a single suite, not across suite boundaries. The `ViewColumn.Beside` fix is applied to `core-send-commands-r-l-002` and `send-file-path-006` (source editors in multi-column tests). Full suite passes 185/185.
- **`terminal.sendText()` delivers `\r` line endings to Pseudoterminals.** The `assertTerminalBufferEquals` normalization chain needs `\r\n → \n`, `\r → \n`, AND trailing `\n` strip to match expected content exactly
- **Test-ordering interference is real in Mocha suites.** Tests that manipulate multi-column layouts contaminate the test runner's focus state for subsequent tests. `standardSuite`'s `closeAllEditors` + `unbind` setup isn't enough — column reuse matters. `closeAllGroups`, `joinAllGroups`, and `focusFirstEditorGroup` were all tested and found insufficient. Only `ViewColumn.Beside` reliably avoids the problem.

## Test Plan

- [x] All automated integration tests pass (`pnpm test:release:automated`)
- [x] QA validation passes (all automated and assisted markers match integration tests)
- [x] Unit test suite passes
- [x] Rebased on main (post PR #578 merge) — full suite passing, no regressions
- [x] `--without-extensions` correctly excludes tests requiring marketplace extensions
- [x] `--grep` composes correctly with `--automated`, `--without-extensions`, and `--assisted`/`--no-assisted`
- [x] Extension-required tests: `pnpm test:release:with-extensions --no-assisted --label requires-extensions` (4 passing: Claude Code + Cursor AI cold/warm)
- [x] Non-extension touched automated features: `pnpm test:release:grep "smart-padding|clipboard-preservation|custom-ai-assistant|duplicate-tab-group|stale-viewcolumn|hidden-tab-paste|text-editor-destination|github-copilot-chat|core-send-commands|send-file-path" --no-assisted --without-extensions`
- [x] 17 tests converted from assisted to automated (9 chord dispatch + 8 clipboard preservation), all pass reliably
- [x] custom-ai-assistant-012 and 013 paste phases converted to verdict tests
- [x] clipboard-preservation-017 now runnable — dummyAi.focusFail fixture + settings registration
- [x] TESTING.md updated with waitForHuman vs waitForHumanVerdict contract distinction
- [x] 0 silent-pass traps — all waitForHuman calls backed by programmatic assertions
- [x] clearSelection(editor) helper extracted, applied in 3 test files
- [x] ViewColumn.Beside fix applied to 2 multi-column tests, both pass across suite boundaries

Pre-push verification (run all from repo root):

```
pnpm test:release:with-extensions --no-assisted --label requires-extensions
```

```
pnpm test:release:grep "smart-padding|clipboard-preservation|custom-ai-assistant|duplicate-tab-group|stale-viewcolumn|hidden-tab-paste|text-editor-destination|github-copilot-chat|core-send-commands|send-file-path" --no-assisted --without-extensions
```

```
pnpm test:release:grep "claude-code|clipboard-preservation|custom-ai-assistant|smart-padding|hidden-tab-paste|text-editor-destination|url-exclusion|document-link-tooltip" --assisted
```

## Related

- Closes https://github.com/couimet/rangeLink/issues/563
- Closes https://github.com/couimet/rangeLink/issues/560


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded and automated many integration tests (clipboard preservation, send-file-path, smart-padding, AI assistant flows).
  * Added/updated test helpers for editor selection, terminal echoing, opening files with selection, and terminal buffer normalization.
  * Hardened unit tests with stricter assertions on clipboard routing and payload shapes.

* **Documentation**
  * Updated guidance for writing assisted integration tests with waitForHuman/ waitForHumanVerdict patterns and warmup recommendations.

* **Chores**
  * Improved test-run scripts and flags to control extension-inclusion and refined test filtering for release runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/rangeLink/pull/580?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->