### PR TITLE
[issues/577] Cache VS Code marketplace extensions in CI

### DIFF
--- a/.github/actions/run-integration-tests-with-extensions/action.yml
+++ b/.github/actions/run-integration-tests-with-extensions/action.yml
@@ -22,7 +22,9 @@ runs:
     - name: Cache VS Code test binary
       uses: actions/cache@v4
       with:
-        path: ~/.vscode-test
+        path: |
+          ~/.vscode-test
+          !~/.vscode-test/extensions
         key: vscode-test-${{ runner.os }}-stable
         restore-keys: vscode-test-${{ runner.os }}-
 

--- a/.github/actions/run-integration-tests-with-extensions/action.yml
+++ b/.github/actions/run-integration-tests-with-extensions/action.yml
@@ -26,6 +26,13 @@ runs:
         key: vscode-test-${{ runner.os }}-stable
         restore-keys: vscode-test-${{ runner.os }}-
 
+    - name: Cache VS Code marketplace extensions
+      uses: actions/cache@v4
+      with:
+        path: ~/.vscode-test/extensions
+        key: vscode-extensions-${{ runner.os }}-${{ hashFiles('packages/rangelink-vscode-extension/.vscode-test.with-extensions.mjs') }}
+        restore-keys: vscode-extensions-${{ runner.os }}-
+
     - name: Run integration tests under Xvfb
       id: run
       shell: bash


### PR DESCRIPTION
## Summary

Speeds up the `run-integration-tests-with-extensions` CI job by caching `~/.vscode-test/extensions` (where `@vscode/test-cli` downloads marketplace extensions). Avoids re-downloading the same extensions on every CI run, reducing exposure to marketplace outages and rate limits.

## Changes

- Added `actions/cache@v4` step to `.github/actions/run-integration-tests-with-extensions/action.yml` for `~/.vscode-test/extensions`, keyed on a hash of `.vscode-test.with-extensions.mjs` so the cache auto-rotates when extensions are added, removed, or the config changes
- Documentation: CHANGELOG not needed (CI optimization, no user-facing change); README not needed

## Test Plan

- [ ] All existing tests pass at full coverage
- [ ] CI job `Integration Tests (with extensions)` uses the cache on next run

## Related

- Closes https://github.com/couimet/rangeLink/issues/577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved caching for integration test infrastructure by adding a dedicated cache for editor/IDE extensions and adjusting the existing test-binary cache to avoid duplicating those files. This reduces CI network usage and speeds up repeated test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/rangeLink/pull/582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->