### PR TITLE
[issues/541] Fix Go to RangeLink falsely reporting "Multiple files match" when root-level file matches

### DIFF
--- a/packages/rangelink-vscode-extension/src/__tests__/utils/resolveWorkspacePath.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/utils/resolveWorkspacePath.test.ts
@@ -181,7 +181,7 @@ describe('resolveWorkspacePath', () => {
       const resolved = expectResolvedPath(result);
       expect(resolved.uri.fsPath).toBe('/Users/name/project/src/deep/auth.ts');
       expect(resolved.resolvedVia).toBe('filename-fallback');
-      expect(mockFindFiles).toHaveBeenCalledWith('**/auth.ts', undefined, 2);
+      expect(mockFindFiles).toHaveBeenCalledWith('**/auth.ts', '{**/node_modules/**}', 2);
     });
 
     it('should return FILENAME_AMBIGUOUS when bare filename matches multiple files', async () => {
@@ -192,7 +192,7 @@ describe('resolveWorkspacePath', () => {
       const result = await resolveWorkspacePath('auth.ts', mockVscode);
 
       expect(result).toBe(FILENAME_AMBIGUOUS);
-      expect(mockFindFiles).toHaveBeenCalledWith('**/auth.ts', undefined, 2);
+      expect(mockFindFiles).toHaveBeenCalledWith('**/auth.ts', '{**/node_modules/**}', 2);
     });
 
     it('should return undefined when bare filename matches no files', async () => {
@@ -201,7 +201,7 @@ describe('resolveWorkspacePath', () => {
       const result = await resolveWorkspacePath('nonexistent.ts', mockVscode);
 
       expect(result).toBeUndefined();
-      expect(mockFindFiles).toHaveBeenCalledWith('**/nonexistent.ts', undefined, 2);
+      expect(mockFindFiles).toHaveBeenCalledWith('**/nonexistent.ts', '{**/node_modules/**}', 2);
     });
 
     it('should skip fallback for paths with forward slash separators', async () => {
@@ -218,13 +218,30 @@ describe('resolveWorkspacePath', () => {
       expect(mockFindFiles).not.toHaveBeenCalled();
     });
 
-    it('should return undefined when findFiles rejects', async () => {
+    it('should return undefined when findFiles rejects (file not at root)', async () => {
       mockFindFiles.mockRejectedValueOnce(new Error('workspace error'));
 
       const result = await resolveWorkspacePath('auth.ts', mockVscode);
 
       expect(result).toBeUndefined();
-      expect(mockFindFiles).toHaveBeenCalledWith('**/auth.ts', undefined, 2);
+      expect(mockStat).toHaveBeenCalledTimes(1);
+      expect(mockFindFiles).toHaveBeenCalledWith('**/auth.ts', '{**/node_modules/**}', 2);
+    });
+
+    it('should return FILENAME_AMBIGUOUS when bare filename exists at multiple workspace roots', async () => {
+      const workspace1 = '/Users/name/project1';
+      const workspace2 = '/Users/name/project2';
+      mockVscode.workspace.workspaceFolders = [
+        createMockWorkspaceFolder(workspace1),
+        createMockWorkspaceFolder(workspace2),
+      ];
+      mockStat.mockResolvedValue({} as any);
+
+      const result = await resolveWorkspacePath('package.json', mockVscode);
+
+      expect(result).toBe(FILENAME_AMBIGUOUS);
+      expect(mockStat).toHaveBeenCalledTimes(2);
+      expect(mockFindFiles).not.toHaveBeenCalled();
     });
 
     it('should escape square brackets in bare filename', async () => {
@@ -236,7 +253,7 @@ describe('resolveWorkspacePath', () => {
       const resolved = expectResolvedPath(result);
       expect(resolved.uri.fsPath).toBe('/Users/name/project/src/routes/[id].ts');
       expect(resolved.resolvedVia).toBe('filename-fallback');
-      expect(mockFindFiles).toHaveBeenCalledWith('**/[[]id[]].ts', undefined, 2);
+      expect(mockFindFiles).toHaveBeenCalledWith('**/[[]id[]].ts', '{**/node_modules/**}', 2);
     });
 
     it('should escape asterisk in bare filename', async () => {
@@ -247,7 +264,7 @@ describe('resolveWorkspacePath', () => {
 
       const resolved = expectResolvedPath(result);
       expect(resolved.resolvedVia).toBe('filename-fallback');
-      expect(mockFindFiles).toHaveBeenCalledWith('**/file[*].ts', undefined, 2);
+      expect(mockFindFiles).toHaveBeenCalledWith('**/file[*].ts', '{**/node_modules/**}', 2);
     });
 
     it('should escape question mark in bare filename', async () => {
@@ -258,7 +275,7 @@ describe('resolveWorkspacePath', () => {
 
       const resolved = expectResolvedPath(result);
       expect(resolved.resolvedVia).toBe('filename-fallback');
-      expect(mockFindFiles).toHaveBeenCalledWith('**/foo[?].ts', undefined, 2);
+      expect(mockFindFiles).toHaveBeenCalledWith('**/foo[?].ts', '{**/node_modules/**}', 2);
     });
 
     it('should escape curly braces in bare filename', async () => {
@@ -269,10 +286,10 @@ describe('resolveWorkspacePath', () => {
 
       const resolved = expectResolvedPath(result);
       expect(resolved.resolvedVia).toBe('filename-fallback');
-      expect(mockFindFiles).toHaveBeenCalledWith('**/[{]slug[}].ts', undefined, 2);
+      expect(mockFindFiles).toHaveBeenCalledWith('**/[{]slug[}].ts', '{**/node_modules/**}', 2);
     });
 
-    it('should return FILENAME_AMBIGUOUS when bare filename exists at workspace root and subdirectory', async () => {
+    it('should return root match when bare filename exists at both workspace root and subdirectory', async () => {
       const rootMatch = createMockUri('/Users/name/project/index.ts');
       const subMatch = createMockUri('/Users/name/project/src/index.ts');
       mockFindFiles.mockResolvedValueOnce([rootMatch, subMatch]);
@@ -280,40 +297,45 @@ describe('resolveWorkspacePath', () => {
 
       const result = await resolveWorkspacePath('index.ts', mockVscode);
 
-      expect(result).toBe(FILENAME_AMBIGUOUS);
-      expect(mockStat).not.toHaveBeenCalled();
+      const resolved = expectResolvedPath(result);
+      expect(resolved.uri.fsPath).toBe('/Users/name/project/index.ts');
+      expect(resolved.resolvedVia).toBe('workspace-relative');
+      expect(mockStat).toHaveBeenCalledTimes(1);
+      expect(mockFindFiles).not.toHaveBeenCalled();
     });
 
-    it('should return filename-fallback when bare filename exists only at workspace root', async () => {
-      const rootMatch = createMockUri('/Users/name/project/auth.ts');
-      mockFindFiles.mockResolvedValueOnce([rootMatch]);
+    it('should return workspace-relative when bare filename exists only at workspace root', async () => {
+      mockStat.mockResolvedValue({} as any);
 
       const result = await resolveWorkspacePath('auth.ts', mockVscode);
 
       const resolved = expectResolvedPath(result);
-      expect(resolved.resolvedVia).toBe('filename-fallback');
+      expect(resolved.resolvedVia).toBe('workspace-relative');
       expect(resolved.uri.fsPath).toBe('/Users/name/project/auth.ts');
-      expect(mockStat).not.toHaveBeenCalled();
+      expect(mockStat).toHaveBeenCalledTimes(1);
+      expect(mockFindFiles).not.toHaveBeenCalled();
     });
 
-    it('should return undefined when findFiles rejects even if file exists at workspace root', async () => {
-      mockFindFiles.mockRejectedValueOnce(new Error('workspace error'));
+    it('should return root match when bare filename exists at workspace root even if findFiles would fail', async () => {
       mockStat.mockResolvedValue({} as any);
 
       const result = await resolveWorkspacePath('auth.ts', mockVscode);
 
-      expect(result).toBeUndefined();
-      expect(mockStat).not.toHaveBeenCalled();
+      const resolved = expectResolvedPath(result);
+      expect(resolved.resolvedVia).toBe('workspace-relative');
+      expect(resolved.uri.fsPath).toBe('/Users/name/project/auth.ts');
+      expect(mockStat).toHaveBeenCalledTimes(1);
+      expect(mockFindFiles).not.toHaveBeenCalled();
     });
 
-    it('should return undefined when findFiles returns empty even if workspace-relative would match', async () => {
+    it('should return undefined when bare filename not at workspace root and findFiles returns empty', async () => {
+      // Root fs.stat fails (file not at root), findFiles returns empty
       mockFindFiles.mockResolvedValueOnce([]);
-      mockStat.mockResolvedValue({} as any);
 
       const result = await resolveWorkspacePath('auth.ts', mockVscode);
 
       expect(result).toBeUndefined();
-      expect(mockStat).not.toHaveBeenCalled();
+      expect(mockStat).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/rangelink-vscode-extension/src/__tests__/utils/resolveWorkspacePath.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/utils/resolveWorkspacePath.test.ts
@@ -316,18 +316,6 @@ describe('resolveWorkspacePath', () => {
       expect(mockFindFiles).not.toHaveBeenCalled();
     });
 
-    it('should return root match when bare filename exists at workspace root even if findFiles would fail', async () => {
-      mockStat.mockResolvedValue({} as any);
-
-      const result = await resolveWorkspacePath('auth.ts', mockVscode);
-
-      const resolved = expectResolvedPath(result);
-      expect(resolved.resolvedVia).toBe('workspace-relative');
-      expect(resolved.uri.fsPath).toBe('/Users/name/project/auth.ts');
-      expect(mockStat).toHaveBeenCalledTimes(1);
-      expect(mockFindFiles).not.toHaveBeenCalled();
-    });
-
     it('should return undefined when bare filename not at workspace root and findFiles returns empty', async () => {
       // Root fs.stat fails (file not at root), findFiles returns empty
       mockFindFiles.mockResolvedValueOnce([]);

--- a/packages/rangelink-vscode-extension/src/utils/resolveWorkspacePath.ts
+++ b/packages/rangelink-vscode-extension/src/utils/resolveWorkspacePath.ts
@@ -29,9 +29,10 @@ const escapeGlobPattern = (filename: string): string => {
  *
  * Attempts to resolve the path in the following order:
  * 1. If path is absolute and exists, use it directly
- * 2. If path is a bare filename (no directory separators), search workspace
- *    via findFiles — return the URI only when exactly one match exists,
- *    return FILENAME_AMBIGUOUS when multiple matches exist
+ * 2. If path is a bare filename (no directory separators):
+ *    a. Check workspace root(s) via fs.stat — return match if exactly one root has it
+ *    b. If multiple roots have it, return FILENAME_AMBIGUOUS
+ *    c. Fall back to findFiles across workspace (node_modules excluded) to check uniqueness
  * 3. Try resolving relative to each workspace folder
  * 4. If no workspace or file not found, return undefined
  *
@@ -62,16 +63,35 @@ export const resolveWorkspacePath = async (
     return undefined;
   }
 
-  // Bare-filename resolution: if the path has no directory separators,
-  // use findFiles to check for ambiguity BEFORE the workspace-relative
-  // loop — otherwise a root-level match would silently win (Issue #342)
+  // Bare-filename resolution: check workspace root(s) first via fs.stat,
+  // then fall back to findFiles with node_modules excluded (Issue #541).
   const isBareFilename = !linkPath.includes('/') && !linkPath.includes('\\');
   if (isBareFilename) {
+    let rootMatchCount = 0;
+    let rootMatch: vscode.Uri | undefined;
+    for (const folder of workspaceFolders) {
+      const rootPath = path.join(folder.uri.fsPath, linkPath);
+      const rootUri = ideInstance.Uri.file(rootPath);
+      try {
+        await ideInstance.workspace.fs.stat(rootUri);
+        rootMatchCount++;
+        rootMatch = rootUri;
+      } catch {
+        // Not at this root
+      }
+    }
+    if (rootMatchCount === 1) {
+      return { uri: rootMatch!, resolvedVia: 'workspace-relative' };
+    }
+    if (rootMatchCount >= AMBIGUITY_THRESHOLD) {
+      return FILENAME_AMBIGUOUS;
+    }
+
     const pattern = `**/${escapeGlobPattern(linkPath)}`;
     try {
       const matches = await ideInstance.workspace.findFiles(
         pattern,
-        undefined,
+        '{**/node_modules/**}',
         AMBIGUITY_THRESHOLD,
       );
       if (matches.length === 1) {


### PR DESCRIPTION
## Summary

The bare filename resolution path in `resolveWorkspacePath()` always delegated to `findFiles('**/filename', undefined, 2)`, returning `FILENAME_AMBIGUOUS` as soon as 2 matches existed anywhere in the workspace. In monorepos, common root-level files like `package.json` appear in multiple subdirectories, so typing a bare filename always triggered the ambiguity warning. This fix checks workspace root(s) via `fs.stat` before falling back to `findFiles`, matching the most likely user intent. `node_modules` is now excluded from the findFiles fallback to avoid dependency-directory noise.

## Changes

- Reordered bare-filename resolution in `resolveWorkspacePath.ts`: check workspace root(s) via `fs.stat` before `findFiles`. Single root match returns `workspace-relative`; multiple root matches across workspace folders returns `FILENAME_AMBIGUOUS`
- Added `{**/node_modules/**}` exclude pattern to `findFiles` fallback
- Updated 5 test assertions to reflect new resolution order and node_modules exclusion
- Added multi-root ambiguity test for bare filename existing at multiple workspace roots
- Documentation: CHANGELOG added; README not needed (no new feature or setting)

## Test Plan

- [x] All existing tests pass (1923)
- [x] New tests added for: root-first resolution, multi-root ambiguity, findFiles node_modules exclusion
- [ ] Manual testing: test `package.json` bare filename navigation in monorepo workspace

## Related

Closes https://github.com/couimet/rangeLink/issues/541

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace file path resolution to prioritize direct root directory checks before falling back to broader searches, enabling more efficient and accurate file disambiguation.

* **Tests**
  * Enhanced test coverage for workspace path resolution edge cases, including ambiguous filenames across multiple workspace roots and various fallback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/rangeLink/pull/585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->