### PR TITLE
[issues/584] Refactor standardSuite to provide OOP resource-tracking context

### DIFF
--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/index.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/index.ts
@@ -8,6 +8,7 @@ export * from './logBasedUiAssertions';
 export * from './logHelpers';
 export * from './navigationHelpers';
 export * from './settingsHelpers';
+export * from './ssContext';
 export * from './standardSuite';
 export * from './terminalHelpers';
 export * from './testEnv';

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/ssContext.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/ssContext.ts
@@ -8,8 +8,7 @@ import type { CapturingTerminal } from './capturingPtyHelpers';
 import { createAndBindCapturingTerminal, createCapturingTerminal } from './capturingPtyHelpers';
 import { cleanupFiles, createAndOpenFile, createWorkspaceFile, openEditor } from './fileHelpers';
 import { getLogCapture } from './getLogCapture';
-import { loadSettingsProfile } from './settingsHelpers';
-import { settle, TERMINAL_READY_MS, waitForExtensionActive } from './testEnv';
+import { SETTLE_MS, TERMINAL_READY_MS, waitForExtensionActive } from './testEnv';
 
 export interface SsContext {
   log: (msg: string) => void;
@@ -31,7 +30,7 @@ export interface SsContext {
   getLogCapture: () => LogCapture;
   openEditor: (uri: vscode.Uri, viewColumn?: vscode.ViewColumn) => Promise<vscode.TextEditor>;
   waitForExtensionActive: (extensionId: string, timeoutMs?: number) => Promise<void>;
-  loadSettingsProfile: (profileName: string) => Promise<void>;
+  trackFileUri: (uri: vscode.Uri) => void;
 }
 
 export class SsContextImpl implements SsContext {
@@ -47,7 +46,7 @@ export class SsContextImpl implements SsContext {
       }
       cleanupFiles(this.tmpFileUris);
       this.tmpFileUris.splice(0);
-      await settle();
+      await this.settle();
     });
   }
 
@@ -59,7 +58,7 @@ export class SsContextImpl implements SsContext {
     const t = vscode.window.createTerminal({ name });
     this.tmpTerminals.push(t);
     t.show(true);
-    await settle(TERMINAL_READY_MS);
+    await this.settle(TERMINAL_READY_MS);
     return t;
   }
 
@@ -100,7 +99,7 @@ export class SsContextImpl implements SsContext {
   }
 
   async settle(ms?: number): Promise<void> {
-    await settle(ms);
+    await new Promise<void>((resolve) => setTimeout(resolve, ms ?? SETTLE_MS));
   }
 
   getLogCapture(): LogCapture {
@@ -115,7 +114,7 @@ export class SsContextImpl implements SsContext {
     await waitForExtensionActive(extensionId, this.suiteLog, timeoutMs);
   }
 
-  async loadSettingsProfile(profileName: string): Promise<void> {
-    await loadSettingsProfile(profileName, this.suiteLog);
+  trackFileUri(uri: vscode.Uri): void {
+    this.tmpFileUris.push(uri);
   }
 }

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/ssContext.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/ssContext.ts
@@ -1,0 +1,121 @@
+import * as path from 'node:path';
+
+import * as vscode from 'vscode';
+
+import type { LogCapture } from '../../LogCapture';
+
+import type { CapturingTerminal } from './capturingPtyHelpers';
+import { createAndBindCapturingTerminal, createCapturingTerminal } from './capturingPtyHelpers';
+import { cleanupFiles, createAndOpenFile, createWorkspaceFile, openEditor } from './fileHelpers';
+import { getLogCapture } from './getLogCapture';
+import { loadSettingsProfile } from './settingsHelpers';
+import { settle, TERMINAL_READY_MS, waitForExtensionActive } from './testEnv';
+
+export interface SsContext {
+  log: (msg: string) => void;
+  createTerminal: (name: string) => Promise<vscode.Terminal>;
+  createCapturingTerminal: (name: string) => Promise<CapturingTerminal>;
+  createAndBindCapturingTerminal: (name: string) => Promise<CapturingTerminal>;
+  createContentFile: (
+    descriptor: string,
+    lineCount: number,
+    lineFactory: (index: number) => string,
+  ) => { uri: vscode.Uri; filename: string };
+  createWorkspaceFile: (descriptor: string, content: string) => vscode.Uri;
+  createAndOpenFile: (
+    descriptor: string,
+    content: string,
+    viewColumn?: vscode.ViewColumn,
+  ) => Promise<vscode.Uri>;
+  settle: (ms?: number) => Promise<void>;
+  getLogCapture: () => LogCapture;
+  openEditor: (uri: vscode.Uri, viewColumn?: vscode.ViewColumn) => Promise<vscode.TextEditor>;
+  waitForExtensionActive: (extensionId: string, timeoutMs?: number) => Promise<void>;
+  loadSettingsProfile: (profileName: string) => Promise<void>;
+}
+
+export class SsContextImpl implements SsContext {
+  private tmpFileUris: vscode.Uri[] = [];
+  private tmpTerminals: vscode.Terminal[] = [];
+  private suiteLog: (msg: string) => void;
+
+  constructor(suiteLog: (msg: string) => void) {
+    this.suiteLog = suiteLog;
+    teardown(async () => {
+      for (const t of this.tmpTerminals.splice(0)) {
+        t.dispose();
+      }
+      cleanupFiles(this.tmpFileUris);
+      this.tmpFileUris.splice(0);
+      await settle();
+    });
+  }
+
+  log(msg: string): void {
+    this.suiteLog(msg);
+  }
+
+  async createTerminal(name: string): Promise<vscode.Terminal> {
+    const t = vscode.window.createTerminal({ name });
+    this.tmpTerminals.push(t);
+    t.show(true);
+    await settle(TERMINAL_READY_MS);
+    return t;
+  }
+
+  async createCapturingTerminal(name: string): Promise<CapturingTerminal> {
+    const capturing = await createCapturingTerminal(name, this.tmpTerminals);
+    return capturing;
+  }
+
+  async createAndBindCapturingTerminal(name: string): Promise<CapturingTerminal> {
+    const capturing = await createAndBindCapturingTerminal(name, this.tmpTerminals);
+    return capturing;
+  }
+
+  createContentFile(
+    descriptor: string,
+    lineCount: number,
+    lineFactory: (index: number) => string,
+  ): { uri: vscode.Uri; filename: string } {
+    const lines = Array.from({ length: lineCount }, (_, i) => lineFactory(i));
+    const uri = createWorkspaceFile(descriptor, lines.join('\n') + '\n');
+    this.tmpFileUris.push(uri);
+    return { uri, filename: path.basename(uri.fsPath) };
+  }
+
+  createWorkspaceFile(descriptor: string, content: string): vscode.Uri {
+    const uri = createWorkspaceFile(descriptor, content);
+    this.tmpFileUris.push(uri);
+    return uri;
+  }
+
+  async createAndOpenFile(
+    descriptor: string,
+    content: string,
+    viewColumn?: vscode.ViewColumn,
+  ): Promise<vscode.Uri> {
+    const uri = await createAndOpenFile(descriptor, content, viewColumn, this.tmpFileUris);
+    return uri;
+  }
+
+  async settle(ms?: number): Promise<void> {
+    await settle(ms);
+  }
+
+  getLogCapture(): LogCapture {
+    return getLogCapture();
+  }
+
+  async openEditor(uri: vscode.Uri, viewColumn?: vscode.ViewColumn): Promise<vscode.TextEditor> {
+    return openEditor(uri, viewColumn);
+  }
+
+  async waitForExtensionActive(extensionId: string, timeoutMs?: number): Promise<void> {
+    await waitForExtensionActive(extensionId, this.suiteLog, timeoutMs);
+  }
+
+  async loadSettingsProfile(profileName: string): Promise<void> {
+    await loadSettingsProfile(profileName, this.suiteLog);
+  }
+}

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/standardSuite.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/standardSuite.ts
@@ -8,12 +8,14 @@ import { closeAllEditors } from './fileHelpers';
 import { getLogCapture } from './getLogCapture';
 import { createLogger } from './logHelpers';
 import { resetRangelinkSettings } from './settingsHelpers';
+import { SsContextImpl, type SsContext } from './ssContext';
 import { disposeAllTerminals } from './terminalHelpers';
 import { activateExtension, settle } from './testEnv';
 
-export const standardSuite = (name: string, fn: (log: (msg: string) => void) => void): void => {
+export const standardSuite = (name: string, fn: (ss: SsContext) => void): void => {
   suite(name, () => {
     const log = createLogger(name);
+    const ss = new SsContextImpl(log);
 
     suiteSetup(async () => {
       await activateExtension();
@@ -37,6 +39,6 @@ export const standardSuite = (name: string, fn: (log: (msg: string) => void) => 
       await closeAllEditors();
     });
 
-    fn(log);
+    fn(ss);
   });
 };

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
@@ -7,32 +7,19 @@ import { CMD_BIND_TO_DESTINATION } from '../../constants/commandIds';
 import {
   assertNoStatusBarMsgLogged,
   assertStatusBarMsgLogged,
-  cleanupFiles,
   closeAllEditors,
-  createAndOpenFile,
-  createTerminal,
-  createWorkspaceFile,
   extractQuickPickItemsLogged,
   findTerminalItems,
   findTestItemsByPrefix,
   getLogCapture,
   openAndDismiss,
   parseQuickPickItemsFromLogLine,
-  settle,
   standardSuite,
   waitForHuman,
   waitForHumanVerdict,
 } from '../helpers';
 
-standardSuite('R-D Bind to Destination', (log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-
-  teardown(async () => {
-    cleanupFiles(tmpFileUris);
-    tmpFileUris.length = 0;
-    await settle();
-  });
-
+standardSuite('R-D Bind to Destination', (ss) => {
   const findFileItems = (items: Record<string, unknown>[]): Record<string, unknown>[] =>
     findTestItemsByPrefix(items, '__rl-test-btd-');
 
@@ -44,7 +31,7 @@ standardSuite('R-D Bind to Destination', (log) => {
   ];
 
   test('[assisted] bind-to-destination-004: selecting a terminal destination binds it and shows success toast', async () => {
-    await createTerminal('rl-btd-004');
+    await ss.createTerminal('rl-btd-004');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-btd-004');
@@ -89,17 +76,12 @@ standardSuite('R-D Bind to Destination', (log) => {
       message: 'RangeLink: No destination bound',
     });
 
-    log('✓ Picker showed unbound terminal; bind succeeded with correct status bar toast');
+    ss.log('✓ Picker showed unbound terminal; bind succeeded with correct status bar toast');
   });
 
   test('[assisted] bind-to-destination-005: selecting a text editor destination binds it and shows success toast', async () => {
-    await createAndOpenFile('btd-005-a', 'line 1\n', undefined, tmpFileUris);
-    const uriB = await createAndOpenFile(
-      'btd-005-b',
-      'line 2\n',
-      vscode.ViewColumn.Two,
-      tmpFileUris,
-    );
+    await ss.createAndOpenFile('btd-005-a', 'line 1\n', undefined);
+    const uriB = await ss.createAndOpenFile('btd-005-b', 'line 2\n', vscode.ViewColumn.Two);
     const fnB = path.basename(uriB.fsPath);
 
     const logCapture = getLogCapture();
@@ -138,7 +120,7 @@ standardSuite('R-D Bind to Destination', (log) => {
       message: 'RangeLink: No destination bound',
     });
 
-    log('✓ Picker showed unbound file; bind succeeded with correct status bar toast');
+    ss.log('✓ Picker showed unbound file; bind succeeded with correct status bar toast');
   });
 
   test('[assisted] bind-to-destination-006: selecting a built-in AI assistant destination binds it and shows success toast', async () => {
@@ -160,14 +142,14 @@ standardSuite('R-D Bind to Destination', (log) => {
       `Expected status bar message "✓ RangeLink bound to <AI assistant>" for one of: ${AI_ASSISTANT_DISPLAY_NAMES.join(', ')}`,
     );
 
-    log('✓ AI assistant bind success toast logged');
+    ss.log('✓ AI assistant bind success toast logged');
   });
 
   test('[assisted] bind-to-destination-007: when already bound, destination picker shows smart-bind confirmation dialog', async () => {
-    await createTerminal('rl-btd-007-a');
+    await ss.createTerminal('rl-btd-007-a');
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
-    await settle();
-    await createTerminal('rl-btd-007-b');
+    await ss.settle();
+    await ss.createTerminal('rl-btd-007-b');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-btd-007');
@@ -213,14 +195,14 @@ standardSuite('R-D Bind to Destination', (log) => {
       message: 'Unbound Terminal ("rl-btd-007-a"), now bound to Terminal ("rl-btd-007-b")',
     });
 
-    log('✓ Confirmation dialog items validated; no bind/rebind toast after Escape');
+    ss.log('✓ Confirmation dialog items validated; no bind/rebind toast after Escape');
   });
 
   test('[assisted] bind-to-destination-008: smart-bind confirmation Yes replaces the binding', async () => {
-    await createTerminal('rl-btd-008-a');
+    await ss.createTerminal('rl-btd-008-a');
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
-    await settle();
-    await createTerminal('rl-btd-008-b');
+    await ss.settle();
+    await ss.createTerminal('rl-btd-008-b');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-btd-008');
@@ -245,14 +227,14 @@ standardSuite('R-D Bind to Destination', (log) => {
       message: '✓ RangeLink: Bound to Terminal ("rl-btd-008-a")',
     });
 
-    log('✓ Replacement binding toast logged; old binding not re-confirmed');
+    ss.log('✓ Replacement binding toast logged; old binding not re-confirmed');
   });
 
   test('[assisted] bind-to-destination-009: smart-bind confirmation No keeps existing binding', async () => {
-    await createTerminal('rl-btd-009-a');
+    await ss.createTerminal('rl-btd-009-a');
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
-    await settle();
-    await createTerminal('rl-btd-009-b');
+    await ss.settle();
+    await ss.createTerminal('rl-btd-009-b');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-btd-009');
@@ -283,13 +265,13 @@ standardSuite('R-D Bind to Destination', (log) => {
       'Human reported the original binding was NOT preserved when clicking "No, keep current binding"',
     );
 
-    log('✓ No rebind toast — original binding preserved (human verdict + state invariant)');
+    ss.log('✓ No rebind toast — original binding preserved (human verdict + state invariant)');
   });
 
   test('bind-to-destination-010: Escape from destination picker dismisses without changing binding', async () => {
-    await createTerminal('rl-btd-010');
+    await ss.createTerminal('rl-btd-010');
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-btd-010');
@@ -308,7 +290,7 @@ standardSuite('R-D Bind to Destination', (log) => {
       message: 'RangeLink: No destination bound',
     });
 
-    log('✓ No bind or unbind toast after Escape — binding state unchanged');
+    ss.log('✓ No bind or unbind toast after Escape — binding state unchanged');
   });
 
   test('[assisted] bind-to-destination-011: re-binding same built-in AI assistant shows already-bound message', async () => {
@@ -345,7 +327,7 @@ standardSuite('R-D Bind to Destination', (log) => {
       `Expected "Already bound to <AI assistant>" info toast for one of: ${AI_ASSISTANT_DISPLAY_NAMES.join(', ')}`,
     );
 
-    log('✓ Already-bound info toast logged; no confirmation dialog shown');
+    ss.log('✓ Already-bound info toast logged; no confirmation dialog shown');
   });
 
   test('[assisted] bind-to-destination-012: switching between different AI assistants shows confirmation dialog', async () => {
@@ -387,7 +369,7 @@ standardSuite('R-D Bind to Destination', (log) => {
     );
     assert.ok(reboundLogged, 'Expected rebound status bar message after "Yes, replace"');
 
-    log('✓ Confirmation dialog shown; rebind toast logged after "Yes, replace"');
+    ss.log('✓ Confirmation dialog shown; rebind toast logged after "Yes, replace"');
   });
 
   test('[assisted] bind-to-destination-014: Jump to Bound Destination with no bound destination opens picker', async () => {
@@ -408,20 +390,19 @@ standardSuite('R-D Bind to Destination', (log) => {
       'pass',
       'Jump to Bound Destination with no destination did not open picker',
     );
-    log('✓ Jump to Bound Destination with no destination opens picker (human verdict)');
+    ss.log('✓ Jump to Bound Destination with no destination opens picker (human verdict)');
   });
 
   test('[assisted] bind-to-destination-015: binding a text editor with a single tab group succeeds', async () => {
     await closeAllEditors();
 
-    const fileA = createWorkspaceFile('btd-015-a', 'file A content\n');
-    const fileB = createWorkspaceFile('btd-015-b', 'file B content\n');
-    tmpFileUris.push(fileA, fileB);
+    const fileA = ss.createWorkspaceFile('btd-015-a', 'file A content\n');
+    const fileB = ss.createWorkspaceFile('btd-015-b', 'file B content\n');
     const docA = await vscode.workspace.openTextDocument(fileA);
     const docB = await vscode.workspace.openTextDocument(fileB);
     await vscode.window.showTextDocument(docA, vscode.ViewColumn.One);
     await vscode.window.showTextDocument(docB, vscode.ViewColumn.One);
-    await settle();
+    await ss.settle();
 
     const verdict = await waitForHumanVerdict(
       'bind-to-destination-015',
@@ -441,6 +422,6 @@ standardSuite('R-D Bind to Destination', (log) => {
       'pass',
       'Binding a text editor in a single tab group failed or required a split',
     );
-    log('✓ Text editor binding works in single tab group — no split required (human verdict)');
+    ss.log('✓ Text editor binding works in single tab group — no split required (human verdict)');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/builtInAiAssistants.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/builtInAiAssistants.test.ts
@@ -24,15 +24,10 @@ import {
   assertClipboardChanged,
   assertClipboardRestored,
   assertStatusBarMsgLogged,
-  cleanupFiles,
-  createWorkspaceFile,
   extractQuickPickItemsLogged,
   getLogCapture,
   openAndDismiss,
-  openEditor,
-  settle,
   standardSuite,
-  waitForExtensionActive,
   waitForHuman,
   waitForHumanVerdict,
   writeClipboardSentinel,
@@ -44,26 +39,17 @@ const CLAUDE_CODE_BIND_STATUS_BAR_MESSAGE = '✓ RangeLink: Bound to Claude Code
 const GEMINI_CODE_ASSIST_DISPLAY_NAME = 'Gemini Code Assist';
 const GEMINI_BIND_STATUS_BAR_MESSAGE = '✓ RangeLink: Bound to Gemini Code Assist';
 
-standardSuite('Built-in AI Assistants', (log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-
-  teardown(async () => {
-    cleanupFiles(tmpFileUris);
-    tmpFileUris.length = 0;
-    await settle();
-  });
-
+standardSuite('Built-in AI Assistants', (ss) => {
   test('[assisted] claude-code-002: binding to Claude Code Chat and sending a link delivers content to chat', async () => {
-    const fileUri = createWorkspaceFile('cc-002', 'line 1\nline 2\nline 3\n');
-    tmpFileUris.push(fileUri);
-    await openEditor(fileUri);
-    await settle();
+    const fileUri = ss.createWorkspaceFile('cc-002', 'line 1\nline 2\nline 3\n');
+    await ss.openEditor(fileUri);
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-cc-002-bind');
 
     await vscode.commands.executeCommand(CMD_BIND_TO_CLAUDE_CODE);
-    await settle();
+    await ss.settle();
 
     const bindLines = logCapture.getLinesSince('before-cc-002-bind');
     assertStatusBarMsgLogged(bindLines, {
@@ -73,7 +59,7 @@ standardSuite('Built-in AI Assistants', (log) => {
     const doc = await vscode.workspace.openTextDocument(fileUri);
     const editor = await vscode.window.showTextDocument(doc);
     editor.selection = new vscode.Selection(0, 0, 1, 6);
-    await settle();
+    await ss.settle();
 
     logCapture.mark('before-cc-002-send');
 
@@ -82,7 +68,7 @@ standardSuite('Built-in AI Assistants', (log) => {
     // claude-code-004/005 cover). Programmatic invocation removes the focus-fragility
     // that bites when the editor hasn't received a real user click.
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const sendLines = logCapture.getLinesSince('before-cc-002-send');
 
@@ -117,25 +103,24 @@ standardSuite('Built-in AI Assistants', (log) => {
       'Human reported the RangeLink did not appear in Claude Code chat (code-side paste logs fired — the paste dispatched but did not reach the chat input)',
     );
 
-    log('✓ Bind status confirmed + content delivered to Claude Code chat');
+    ss.log('✓ Bind status confirmed + content delivered to Claude Code chat');
   });
 
   test('[assisted] claude-code-004: cold panel paste — content arrives in Claude Code chat after first R-L since bind', async () => {
-    const fileUri = createWorkspaceFile('cc-004', 'line 1\nline 2\nline 3\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('cc-004', 'line 1\nline 2\nline 3\n');
     const doc = await vscode.workspace.openTextDocument(fileUri);
     const editor = await vscode.window.showTextDocument(doc);
     editor.selection = new vscode.Selection(0, 0, 1, 6);
-    await settle();
+    await ss.settle();
 
     await vscode.commands.executeCommand(CMD_BIND_TO_CLAUDE_CODE);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-cc-004');
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-cc-004');
 
@@ -168,23 +153,22 @@ standardSuite('Built-in AI Assistants', (log) => {
       'Human reported the RangeLink did not appear in Claude Code chat (code-side paste logs fired — the paste dispatched but did not reach the chat input)',
     );
 
-    log('✓ Cold paste: content delivered to Claude Code (verdict PASS)');
+    ss.log('✓ Cold paste: content delivered to Claude Code (verdict PASS)');
   });
 
   test('[assisted] claude-code-005: warm panel paste — second R-L delivers content without cold-start refocus', async () => {
-    const fileUri = createWorkspaceFile('cc-005', 'line 1\nline 2\nline 3\nline 4\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('cc-005', 'line 1\nline 2\nline 3\nline 4\n');
     const doc = await vscode.workspace.openTextDocument(fileUri);
     const editor = await vscode.window.showTextDocument(doc);
     editor.selection = new vscode.Selection(0, 0, 1, 6);
-    await settle();
+    await ss.settle();
 
     await vscode.commands.executeCommand(CMD_BIND_TO_CLAUDE_CODE);
-    await settle();
+    await ss.settle();
 
     // First send (cold) — warms the panel
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const coldVerdict = await waitForHumanVerdict(
       'claude-code-005-cold',
@@ -206,13 +190,13 @@ standardSuite('Built-in AI Assistants', (log) => {
     // command to see the selection.
     await vscode.window.showTextDocument(doc);
     editor.selection = new vscode.Selection(2, 0, 3, 6);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-cc-005-warm');
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-cc-005-warm');
 
@@ -244,22 +228,21 @@ standardSuite('Built-in AI Assistants', (log) => {
       'Human reported the warm-send RangeLink did not appear cleanly in Claude Code chat',
     );
 
-    log('✓ Warm paste: content delivered to Claude Code (cold + warm both PASS)');
+    ss.log('✓ Warm paste: content delivered to Claude Code (cold + warm both PASS)');
   });
 
   test('[assisted] gemini-code-assist-002: binding to Gemini Code Assist and sending a link delivers content to chat', async () => {
-    const fileUri = createWorkspaceFile('gc-002', 'line 1\nline 2\nline 3\n');
-    tmpFileUris.push(fileUri);
-    await openEditor(fileUri);
-    await settle();
+    const fileUri = ss.createWorkspaceFile('gc-002', 'line 1\nline 2\nline 3\n');
+    await ss.openEditor(fileUri);
+    await ss.settle();
 
-    await waitForExtensionActive(EXTENSION_ID_GEMINI_CODE_ASSIST, log);
+    await ss.waitForExtensionActive(EXTENSION_ID_GEMINI_CODE_ASSIST);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-gc-002-bind');
 
     await vscode.commands.executeCommand(CMD_BIND_TO_GEMINI_CODE_ASSIST);
-    await settle();
+    await ss.settle();
 
     const bindLines = logCapture.getLinesSince('before-gc-002-bind');
     assertStatusBarMsgLogged(bindLines, {
@@ -277,12 +260,12 @@ standardSuite('Built-in AI Assistants', (log) => {
     const doc = await vscode.workspace.openTextDocument(fileUri);
     const editor = await vscode.window.showTextDocument(doc);
     editor.selection = new vscode.Selection(0, 0, 1, 6);
-    await settle();
+    await ss.settle();
 
     logCapture.mark('before-gc-002-send');
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const sendLines = logCapture.getLinesSince('before-gc-002-send');
 
@@ -317,27 +300,26 @@ standardSuite('Built-in AI Assistants', (log) => {
       'Human reported the RangeLink did not appear in Gemini Code Assist chat (code-side paste logs fired — the paste dispatched but did not reach the chat input)',
     );
 
-    log('✓ Bind status confirmed + content delivered to Gemini Code Assist chat');
+    ss.log('✓ Bind status confirmed + content delivered to Gemini Code Assist chat');
   });
 
   test('[assisted] gemini-code-assist-003: cold panel paste — content arrives in Gemini Code Assist chat after first R-L since bind', async () => {
-    const fileUri = createWorkspaceFile('gc-003', 'line 1\nline 2\nline 3\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('gc-003', 'line 1\nline 2\nline 3\n');
     const doc = await vscode.workspace.openTextDocument(fileUri);
     const editor = await vscode.window.showTextDocument(doc);
     editor.selection = new vscode.Selection(0, 0, 1, 6);
-    await settle();
+    await ss.settle();
 
-    await waitForExtensionActive(EXTENSION_ID_GEMINI_CODE_ASSIST, log);
+    await ss.waitForExtensionActive(EXTENSION_ID_GEMINI_CODE_ASSIST);
 
     await vscode.commands.executeCommand(CMD_BIND_TO_GEMINI_CODE_ASSIST);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-gc-003');
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-gc-003');
 
@@ -370,25 +352,24 @@ standardSuite('Built-in AI Assistants', (log) => {
       'Human reported the RangeLink did not appear in Gemini Code Assist chat (code-side paste logs fired — the paste dispatched but did not reach the chat input)',
     );
 
-    log('✓ Cold paste: content delivered to Gemini Code Assist (verdict PASS)');
+    ss.log('✓ Cold paste: content delivered to Gemini Code Assist (verdict PASS)');
   });
 
   test('[assisted] gemini-code-assist-004: warm panel paste — second R-L delivers content without cold-start refocus', async () => {
-    const fileUri = createWorkspaceFile('gc-004', 'line 1\nline 2\nline 3\nline 4\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('gc-004', 'line 1\nline 2\nline 3\nline 4\n');
     const doc = await vscode.workspace.openTextDocument(fileUri);
     const editor = await vscode.window.showTextDocument(doc);
     editor.selection = new vscode.Selection(0, 0, 1, 6);
-    await settle();
+    await ss.settle();
 
-    await waitForExtensionActive(EXTENSION_ID_GEMINI_CODE_ASSIST, log);
+    await ss.waitForExtensionActive(EXTENSION_ID_GEMINI_CODE_ASSIST);
 
     await vscode.commands.executeCommand(CMD_BIND_TO_GEMINI_CODE_ASSIST);
-    await settle();
+    await ss.settle();
 
     // First send (cold) — warms the panel
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const coldVerdict = await waitForHumanVerdict(
       'gemini-code-assist-004-cold',
@@ -408,13 +389,13 @@ standardSuite('Built-in AI Assistants', (log) => {
     // Select lines 3-4 for warm send
     await vscode.window.showTextDocument(doc);
     editor.selection = new vscode.Selection(2, 0, 3, 6);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-gc-004-warm');
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-gc-004-warm');
 
@@ -446,158 +427,151 @@ standardSuite('Built-in AI Assistants', (log) => {
       'Human reported the warm-send RangeLink did not appear cleanly in Gemini Code Assist chat',
     );
 
-    log('✓ Warm paste: content delivered to Gemini Code Assist (cold + warm both PASS)');
+    ss.log('✓ Warm paste: content delivered to Gemini Code Assist (cold + warm both PASS)');
   });
 
   test('clipboard-preservation-011: cold paste to Claude Code — prior clipboard restored', async () => {
-    const fileUri = createWorkspaceFile('cp-011', 'line 1\nline 2\nline 3\n');
-    tmpFileUris.push(fileUri);
-    const editor = await openEditor(fileUri);
-    await settle();
+    const fileUri = ss.createWorkspaceFile('cp-011', 'line 1\nline 2\nline 3\n');
+    const editor = await ss.openEditor(fileUri);
+    await ss.settle();
 
     await vscode.commands.executeCommand(CMD_BIND_TO_CLAUDE_CODE);
-    await settle();
+    await ss.settle();
 
     editor.selection = new vscode.Selection(0, 0, 1, 6);
-    await settle();
+    await ss.settle();
 
     await writeClipboardSentinel();
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
     await assertClipboardRestored('clipboard-preservation-011: always + Claude Code cold paste');
-    log('✓ clipboard-preservation-011: prior clipboard restored after cold paste');
+    ss.log('✓ clipboard-preservation-011: prior clipboard restored after cold paste');
   });
 
   test('clipboard-preservation-012: warm paste to Claude Code — prior clipboard restored', async () => {
-    const fileUri = createWorkspaceFile('cp-012', 'line 1\nline 2\nline 3\nline 4\n');
-    tmpFileUris.push(fileUri);
-    const editor = await openEditor(fileUri);
-    await settle();
+    const fileUri = ss.createWorkspaceFile('cp-012', 'line 1\nline 2\nline 3\nline 4\n');
+    const editor = await ss.openEditor(fileUri);
+    await ss.settle();
 
     await vscode.commands.executeCommand(CMD_BIND_TO_CLAUDE_CODE);
-    await settle();
+    await ss.settle();
 
     // Warmup: lines 1-2 pre-selected
     editor.selection = new vscode.Selection(0, 0, 1, 6);
-    await settle();
+    await ss.settle();
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     // Pre-select lines 3-4 for the warm send
     editor.selection = new vscode.Selection(2, 0, 3, 6);
-    await settle();
+    await ss.settle();
 
     await writeClipboardSentinel();
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
     await assertClipboardRestored('clipboard-preservation-012: always + Claude Code warm paste');
-    log('✓ clipboard-preservation-012: prior clipboard restored after warm paste');
+    ss.log('✓ clipboard-preservation-012: prior clipboard restored after warm paste');
   });
 
   test('clipboard-preservation-013: cold paste to Cursor AI — prior clipboard restored', async () => {
-    const fileUri = createWorkspaceFile('cp-013', 'line 1\nline 2\nline 3\n');
-    tmpFileUris.push(fileUri);
-    const editor = await openEditor(fileUri);
-    await settle();
+    const fileUri = ss.createWorkspaceFile('cp-013', 'line 1\nline 2\nline 3\n');
+    const editor = await ss.openEditor(fileUri);
+    await ss.settle();
 
     await vscode.commands.executeCommand(CMD_BIND_TO_CURSOR_AI);
-    await settle();
+    await ss.settle();
 
     editor.selection = new vscode.Selection(0, 0, 1, 6);
-    await settle();
+    await ss.settle();
 
     await writeClipboardSentinel();
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
     await assertClipboardRestored('clipboard-preservation-013: always + Cursor AI cold paste');
-    log('✓ clipboard-preservation-013: cold Cursor AI paste — clipboard restored');
+    ss.log('✓ clipboard-preservation-013: cold Cursor AI paste — clipboard restored');
   });
 
   test('clipboard-preservation-014: warm paste to Cursor AI — prior clipboard restored', async () => {
-    const fileUri = createWorkspaceFile('cp-014', 'line 1\nline 2\nline 3\nline 4\n');
-    tmpFileUris.push(fileUri);
-    const editor = await openEditor(fileUri);
-    await settle();
+    const fileUri = ss.createWorkspaceFile('cp-014', 'line 1\nline 2\nline 3\nline 4\n');
+    const editor = await ss.openEditor(fileUri);
+    await ss.settle();
 
     await vscode.commands.executeCommand(CMD_BIND_TO_CURSOR_AI);
-    await settle();
+    await ss.settle();
 
     // Warmup: lines 1-2 pre-selected
     editor.selection = new vscode.Selection(0, 0, 1, 6);
-    await settle();
+    await ss.settle();
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     // Pre-select lines 3-4 for the warm send
     editor.selection = new vscode.Selection(2, 0, 3, 6);
-    await settle();
+    await ss.settle();
 
     await writeClipboardSentinel();
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
     await assertClipboardRestored('clipboard-preservation-014: always + Cursor AI warm paste');
-    log('✓ clipboard-preservation-014: warm Cursor AI paste — clipboard restored');
+    ss.log('✓ clipboard-preservation-014: warm Cursor AI paste — clipboard restored');
   });
 
   test('clipboard-preservation-015: cold paste to Copilot Chat — prior clipboard restored', async () => {
-    const fileUri = createWorkspaceFile('cp-015', 'line 1\nline 2\nline 3\n');
-    tmpFileUris.push(fileUri);
-    const editor = await openEditor(fileUri);
-    await settle();
+    const fileUri = ss.createWorkspaceFile('cp-015', 'line 1\nline 2\nline 3\n');
+    const editor = await ss.openEditor(fileUri);
+    await ss.settle();
 
     await vscode.commands.executeCommand(CMD_BIND_TO_GITHUB_COPILOT_CHAT);
-    await settle();
+    await ss.settle();
 
     editor.selection = new vscode.Selection(0, 0, 1, 6);
-    await settle();
+    await ss.settle();
 
     await writeClipboardSentinel();
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
     await assertClipboardRestored('clipboard-preservation-015: always + Copilot Chat cold paste');
-    log('✓ clipboard-preservation-015: cold Copilot Chat paste — clipboard restored');
+    ss.log('✓ clipboard-preservation-015: cold Copilot Chat paste — clipboard restored');
   });
 
   test('clipboard-preservation-016: warm paste to Copilot Chat — prior clipboard restored', async () => {
-    const fileUri = createWorkspaceFile('cp-016', 'line 1\nline 2\nline 3\nline 4\n');
-    tmpFileUris.push(fileUri);
-    const editor = await openEditor(fileUri);
-    await settle();
+    const fileUri = ss.createWorkspaceFile('cp-016', 'line 1\nline 2\nline 3\nline 4\n');
+    const editor = await ss.openEditor(fileUri);
+    await ss.settle();
 
     await vscode.commands.executeCommand(CMD_BIND_TO_GITHUB_COPILOT_CHAT);
-    await settle();
+    await ss.settle();
 
     // Warmup: lines 1-2 pre-selected
     editor.selection = new vscode.Selection(0, 0, 1, 6);
-    await settle();
+    await ss.settle();
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     // Pre-select lines 3-4 for the warm send
     editor.selection = new vscode.Selection(2, 0, 3, 6);
-    await settle();
+    await ss.settle();
 
     await writeClipboardSentinel();
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
     await assertClipboardRestored('clipboard-preservation-016: always + Copilot Chat warm paste');
-    log('✓ clipboard-preservation-016: warm Copilot Chat paste — clipboard restored');
+    ss.log('✓ clipboard-preservation-016: warm Copilot Chat paste — clipboard restored');
   });
 
   test('[assisted] clipboard-preservation-017: failed paste — RangeLink stays on clipboard for manual paste', async () => {
-    const fileUri = createWorkspaceFile('cp-017', 'line 1\nline 2\nline 3\n');
-    tmpFileUris.push(fileUri);
-    const editor = await openEditor(fileUri);
-    await settle();
+    const fileUri = ss.createWorkspaceFile('cp-017', 'line 1\nline 2\nline 3\n');
+    const editor = await ss.openEditor(fileUri);
+    await ss.settle();
 
     await waitForHuman(
       'clipboard-preservation-017',
@@ -607,22 +581,22 @@ standardSuite('Built-in AI Assistants', (log) => {
         '2. Press Cancel to continue (assertions happen automatically)',
       ],
     );
-    await settle();
+    await ss.settle();
 
     editor.selection = new vscode.Selection(0, 0, 1, 6);
-    await settle();
+    await ss.settle();
 
     await writeClipboardSentinel();
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
     const clipboard017 = await assertClipboardChanged('clipboard-preservation-017: failed paste');
     assert.ok(clipboard017.includes('#L'), `Expected RangeLink on clipboard, got: ${clipboard017}`);
-    log('✓ clipboard-preservation-017: failed paste — RangeLink stays on clipboard');
+    ss.log('✓ clipboard-preservation-017: failed paste — RangeLink stays on clipboard');
   });
 });
 
-standardSuite('Built-in AI Assistants — Destination Picker', (log) => {
+standardSuite('Built-in AI Assistants — Destination Picker', (ss) => {
   test('claude-code-001: Claude Code Chat appears first in destination picker AI Assistants group', async function (this: MochaContext) {
     // Skip when the Claude Code marketplace extension isn't installed. The test asserts
     // on Claude Code's position in the AI Assistants group, which requires the extension
@@ -631,7 +605,7 @@ standardSuite('Built-in AI Assistants — Destination Picker', (log) => {
     // config does not. Without this guard, the test runs in both configs and fails in the
     // standard one because "GitHub Copilot Chat" takes the top slot when Claude Code is absent.
     if (!vscode.extensions.getExtension(EXTENSION_ID_CLAUDE_CODE)) {
-      log(
+      ss.log(
         `Skipping claude-code-001 — "${EXTENSION_ID_CLAUDE_CODE}" extension is not installed in this test config (expected in test:release:automated; runs only under test:release:with-extensions).`,
       );
       this.skip();
@@ -674,7 +648,7 @@ standardSuite('Built-in AI Assistants — Destination Picker', (log) => {
     );
     assert.strictEqual(aiSectionItems[0].itemKind, 'bindable');
 
-    log('✓ Claude Code Chat appears first in the AI Assistants group');
+    ss.log('✓ Claude Code Chat appears first in the AI Assistants group');
   });
 
   test('github-copilot-chat-001: GitHub Copilot Chat appears in destination picker when available', async () => {
@@ -691,7 +665,7 @@ standardSuite('Built-in AI Assistants — Destination Picker', (log) => {
     assert.ok(copilotItem, 'Expected "GitHub Copilot Chat" in the destination picker items');
     assert.strictEqual(copilotItem!.itemKind, 'bindable');
 
-    log('✓ github-copilot-chat-001 — log confirms "GitHub Copilot Chat" appears in R-D picker');
+    ss.log('✓ github-copilot-chat-001 — log confirms "GitHub Copilot Chat" appears in R-D picker');
   });
 
   test('claude-code-006: Cold-start default settings produce correct ColdRefocusConfig', async function (this: MochaContext) {
@@ -706,12 +680,12 @@ standardSuite('Built-in AI Assistants — Destination Picker', (log) => {
       `Expected coldStartDelayMs (${totalMs}) > coldRefocusIntervalMs (${intervalMs})`,
     );
 
-    log('✓ Default cold-start config produces valid ColdRefocusConfig');
+    ss.log('✓ Default cold-start config produces valid ColdRefocusConfig');
   });
 
   test('claude-code-007: Cold-start validation rejects invalid config and falls back to defaults', async function (this: MochaContext) {
     if (!vscode.extensions.getExtension(EXTENSION_ID_CLAUDE_CODE)) {
-      log('Skipping claude-code-007 — Claude Code extension not installed in this test config');
+      ss.log('Skipping claude-code-007 — Claude Code extension not installed in this test config');
       this.skip();
     }
 
@@ -720,16 +694,16 @@ standardSuite('Built-in AI Assistants — Destination Picker', (log) => {
     // Set invalid config: delay (100) <= interval (400)
     await config.update('coldStartDelayMs', 100, vscode.ConfigurationTarget.Workspace);
     await config.update('coldRefocusIntervalMs', 400, vscode.ConfigurationTarget.Workspace);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-cc-007');
 
     await vscode.commands.executeCommand(CMD_BIND_TO_CLAUDE_CODE);
-    await settle();
+    await ss.settle();
 
     await vscode.commands.executeCommand(CMD_JUMP_TO_DESTINATION);
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-cc-007');
     const warningLog = lines.find((line) =>
@@ -740,18 +714,18 @@ standardSuite('Built-in AI Assistants — Destination Picker', (log) => {
       'Expected validation warning log when coldStartDelayMs <= coldRefocusIntervalMs',
     );
 
-    log('✓ claude-code-007 — invalid config triggers fallback to defaults');
+    ss.log('✓ claude-code-007 — invalid config triggers fallback to defaults');
   });
 
   test('gemini-code-assist-001: Gemini Code Assist appears in destination picker when available', async function (this: MochaContext) {
     if (!vscode.extensions.getExtension(EXTENSION_ID_GEMINI_CODE_ASSIST)) {
-      log(
+      ss.log(
         `Skipping gemini-code-assist-001 — "${EXTENSION_ID_GEMINI_CODE_ASSIST}" extension is not installed in this test config.`,
       );
       this.skip();
     }
 
-    await waitForExtensionActive(EXTENSION_ID_GEMINI_CODE_ASSIST, log);
+    await ss.waitForExtensionActive(EXTENSION_ID_GEMINI_CODE_ASSIST);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-gc-001');
@@ -769,7 +743,7 @@ standardSuite('Built-in AI Assistants — Destination Picker', (log) => {
     );
     assert.strictEqual(geminiItem!.itemKind, 'bindable');
 
-    log('✓ gemini-code-assist-001 — Gemini Code Assist appears in the destination picker');
+    ss.log('✓ gemini-code-assist-001 — Gemini Code Assist appears in the destination picker');
   });
 
   test('gemini-code-assist-005: Cold-start default settings produce correct ColdRefocusConfig', async () => {
@@ -798,12 +772,12 @@ standardSuite('Built-in AI Assistants — Destination Picker', (log) => {
       `Expected coldStartDelayMs (${totalMs}) > coldRefocusIntervalMs (${intervalMs})`,
     );
 
-    log('✓ Default Gemini cold-start config produces valid ColdRefocusConfig');
+    ss.log('✓ Default Gemini cold-start config produces valid ColdRefocusConfig');
   });
 
   test('gemini-code-assist-006: Cold-start validation rejects invalid config and falls back to defaults', async function (this: MochaContext) {
     if (!vscode.extensions.getExtension(EXTENSION_ID_GEMINI_CODE_ASSIST)) {
-      log(
+      ss.log(
         'Skipping gemini-code-assist-006 — Gemini Code Assist extension not installed in this test config',
       );
       this.skip();
@@ -822,9 +796,9 @@ standardSuite('Built-in AI Assistants — Destination Picker', (log) => {
       INVALID_INTERVAL_MS,
       vscode.ConfigurationTarget.Workspace,
     );
-    await settle();
+    await ss.settle();
 
-    await waitForExtensionActive(EXTENSION_ID_GEMINI_CODE_ASSIST, log);
+    await ss.waitForExtensionActive(EXTENSION_ID_GEMINI_CODE_ASSIST);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-gc-006');
@@ -833,10 +807,10 @@ standardSuite('Built-in AI Assistants — Destination Picker', (log) => {
     // during focus() — not at bind() time. CMD_JUMP_TO_DESTINATION triggers
     // focusBoundDestination() → focus() → getColdRefocus() → validation warning.
     await vscode.commands.executeCommand(CMD_BIND_TO_GEMINI_CODE_ASSIST);
-    await settle();
+    await ss.settle();
 
     await vscode.commands.executeCommand(CMD_JUMP_TO_DESTINATION);
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-gc-006');
     const warningLog = lines.find(
@@ -849,6 +823,6 @@ standardSuite('Built-in AI Assistants — Destination Picker', (log) => {
       'Expected validation warning log with "using defaults" when coldStartDelayMs <= coldRefocusIntervalMs',
     );
 
-    log('✓ gemini-code-assist-006 — invalid config triggers fallback to defaults');
+    ss.log('✓ gemini-code-assist-006 — invalid config triggers fallback to defaults');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
@@ -13,43 +13,29 @@ import {
   assertClipboardChanged,
   assertClipboardRestored,
   assertTerminalBufferContains,
-  type CapturingTerminal,
-  cleanupFiles,
-  createAndBindCapturingTerminal,
-  createTerminal,
-  createWorkspaceFile,
   getLogCapture,
   openAndDismiss,
-  openEditor,
-  settle,
   standardSuite,
   TERMINAL_READY_MS,
   waitForHuman,
   CLIPBOARD_SENTINEL,
   writeClipboardSentinel,
 } from '../helpers';
+import type { CapturingTerminal } from '../helpers/capturingPtyHelpers';
 
-standardSuite('Clipboard Preservation', (_log) => {
+standardSuite('Clipboard Preservation', (ss) => {
   let testFileUri: vscode.Uri;
   let editor: vscode.TextEditor;
   let capturing: CapturingTerminal;
 
-  suiteSetup(async () => {
-    const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1} content`);
-    testFileUri = createWorkspaceFile('clipboard', lines.join('\n') + '\n');
-    editor = await openEditor(testFileUri);
-  });
-
-  suiteTeardown(async () => {
-    cleanupFiles([testFileUri]);
-  });
-
   setup(async () => {
-    capturing = await createAndBindCapturingTerminal('rl-clipboard-test');
-    await settle();
-    editor = await vscode.window.showTextDocument(editor.document);
-    await writeClipboardSentinel();
+    const { uri } = ss.createContentFile('clipboard', 10, (i) => `line ${i + 1} content`);
+    testFileUri = uri;
+    editor = await ss.openEditor(testFileUri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 7));
+    await writeClipboardSentinel();
+    capturing = await ss.createAndBindCapturingTerminal('rl-clipboard-test');
+    await ss.settle();
   });
 
   test('clipboard-preservation-003: R-F with preserve=always restores clipboard to sentinel after send', async () => {
@@ -107,66 +93,54 @@ standardSuite('Clipboard Preservation', (_log) => {
   });
 });
 
-standardSuite('Clipboard Preservation — Assisted', (log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-
-  teardown(async () => {
-    await vscode.commands.executeCommand('dummyAi.clearAll');
-    cleanupFiles(tmpFileUris);
-    tmpFileUris.splice(0);
-    await settle();
-  });
-
+standardSuite('Clipboard Preservation — Assisted', (ss) => {
   test('clipboard-preservation-001: always mode — R-L to terminal restores clipboard', async () => {
-    const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1} content`);
-    const fileUri = createWorkspaceFile('cbp-001', lines.join('\n') + '\n');
-    tmpFileUris.push(fileUri);
+    const { uri: fileUri } = ss.createContentFile('cbp-001', 10, (i) => `line ${i + 1} content`);
 
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal('cbp-001-dest');
+    const capturing = await ss.createAndBindCapturingTerminal('cbp-001-dest');
 
-    const editor001 = await openEditor(fileUri);
+    const editor001 = await ss.openEditor(fileUri);
     const lastSelectedLine = editor001.document.lineAt(3);
     editor001.selection = new vscode.Selection(
       new vscode.Position(1, 0),
       lastSelectedLine.range.end,
     );
-    await settle();
+    await ss.settle();
     await writeClipboardSentinel();
 
     capturing.clearCaptured();
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     await assertClipboardRestored('clipboard-preservation-001: always + R-L');
     assertTerminalBufferContains(capturing.getCapturedText(), '#L');
-    log('✓ Clipboard restored to sentinel after R-L; terminal received link');
+    ss.log('✓ Clipboard restored to sentinel after R-L; terminal received link');
   });
 
   test('clipboard-preservation-002: always mode — R-V from terminal restores clipboard', async () => {
     const PHRASE = 'hello world cbp-002';
 
-    const fileUri = createWorkspaceFile('cbp-002', '');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('cbp-002', '');
 
-    await openEditor(fileUri);
+    await ss.openEditor(fileUri);
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
-    await settle();
+    await ss.settle();
 
-    const srcTerminal = await createTerminal('cbp-002-src');
+    const srcTerminal = await ss.createTerminal('cbp-002-src');
     srcTerminal.show(true);
-    await settle();
+    await ss.settle();
 
     srcTerminal.sendText(PHRASE, false);
-    await settle(TERMINAL_READY_MS);
+    await ss.settle(TERMINAL_READY_MS);
 
     await vscode.commands.executeCommand(VSCODE_CMD_TERMINAL_SELECT_ALL);
-    await settle();
+    await ss.settle();
 
     // Sentinel written after selectAll so copyOnSelection cannot overwrite it
     await writeClipboardSentinel();
 
     await vscode.commands.executeCommand(CMD_TERMINAL_PASTE_SELECTED_TEXT);
-    await settle();
+    await ss.settle();
 
     const destContent = (await vscode.workspace.openTextDocument(fileUri)).getText();
     assert.ok(
@@ -174,22 +148,20 @@ standardSuite('Clipboard Preservation — Assisted', (log) => {
       `Expected "${PHRASE}" in destination file, got: ${JSON.stringify(destContent)}`,
     );
     await assertClipboardRestored('clipboard-preservation-002: always + R-V');
-    log('✓ Clipboard restored to sentinel and phrase landed in destination file after R-V');
+    ss.log('✓ Clipboard restored to sentinel and phrase landed in destination file after R-V');
   });
 
   test('[assisted] clipboard-preservation-004: always mode — AI assistant paste restores clipboard', async () => {
-    const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1} content`);
-    const fileUri = createWorkspaceFile('cbp-004', lines.join('\n') + '\n');
-    tmpFileUris.push(fileUri);
+    const { uri: fileUri } = ss.createContentFile('cbp-004', 10, (i) => `line ${i + 1} content`);
 
     const relPath = vscode.workspace.asRelativePath(fileUri);
     const expectedLink = `${relPath}#L1C1-L3C7`;
 
-    const editor = await openEditor(fileUri);
+    const editor = await ss.openEditor(fileUri);
     await writeClipboardSentinel();
 
     editor.selection = new vscode.Selection(0, 0, 2, 6);
-    await settle();
+    await ss.settle();
 
     await waitForHuman(
       'clipboard-preservation-004',
@@ -202,7 +174,7 @@ standardSuite('Clipboard Preservation — Assisted', (log) => {
       ],
     );
 
-    await settle();
+    await ss.settle();
     const dummyText = (await vscode.commands.executeCommand('dummyAi.getText')) as {
       tier1: string;
       tier2: string;
@@ -214,63 +186,58 @@ standardSuite('Clipboard Preservation — Assisted', (log) => {
       `Expected Dummy AI tier1="${expectedLink}", got: ${JSON.stringify(dummyText.tier1)}`,
     );
     await assertClipboardRestored('clipboard-preservation-004: always + AI paste');
-    log('✓ Clipboard restored to sentinel and link landed in Dummy AI after R-L');
+    ss.log('✓ Clipboard restored to sentinel and link landed in Dummy AI after R-L');
   });
 
   test('clipboard-preservation-005: always mode — terminal paste (fresh bind) restores clipboard', async () => {
-    const lines = Array.from({ length: 10 }, (_, i) => `entry ${i + 1}`);
-    const fileUri = createWorkspaceFile('cbp-005', lines.join('\n') + '\n');
-    tmpFileUris.push(fileUri);
+    const { uri: fileUri } = ss.createContentFile('cbp-005', 10, (i) => `entry ${i + 1}`);
 
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal('cbp-005-dest');
+    const capturing = await ss.createAndBindCapturingTerminal('cbp-005-dest');
 
-    const editor005 = await openEditor(fileUri);
+    const editor005 = await ss.openEditor(fileUri);
     const lastSelectedLine = editor005.document.lineAt(2);
     editor005.selection = new vscode.Selection(
       new vscode.Position(1, 0),
       lastSelectedLine.range.end,
     );
-    await settle();
+    await ss.settle();
     await writeClipboardSentinel();
 
     capturing.clearCaptured();
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     await assertClipboardRestored('clipboard-preservation-005: always + terminal paste');
     assertTerminalBufferContains(capturing.getCapturedText(), '#L');
-    log('✓ Clipboard restored to sentinel after terminal paste (preserve=always)');
+    ss.log('✓ Clipboard restored to sentinel after terminal paste (preserve=always)');
   });
 
   test('clipboard-preservation-007: never mode — R-V from terminal overwrites clipboard', async () => {
     const PHRASE = 'test phrase cbp-007';
 
-    const config = vscode.workspace.getConfiguration();
-    await config.update('rangelink.clipboard.preserve', 'never', vscode.ConfigurationTarget.Global);
-    log('set rangelink.clipboard.preserve to never');
+    await ss.loadSettingsProfile('clipboard-never');
 
-    const fileUri = createWorkspaceFile('cbp-007', '');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('cbp-007', '');
 
-    await openEditor(fileUri);
+    await ss.openEditor(fileUri);
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
-    await settle();
+    await ss.settle();
 
-    const srcTerminal = await createTerminal('cbp-007-src');
+    const srcTerminal = await ss.createTerminal('cbp-007-src');
     srcTerminal.show(true);
-    await settle();
+    await ss.settle();
 
     srcTerminal.sendText(PHRASE, false);
-    await settle(TERMINAL_READY_MS);
+    await ss.settle(TERMINAL_READY_MS);
 
     await vscode.commands.executeCommand(VSCODE_CMD_TERMINAL_SELECT_ALL);
-    await settle();
+    await ss.settle();
 
     // Sentinel written after selectAll so copyOnSelection cannot overwrite it
     await writeClipboardSentinel();
 
     await vscode.commands.executeCommand(CMD_TERMINAL_PASTE_SELECTED_TEXT);
-    await settle();
+    await ss.settle();
 
     const destContent = (await vscode.workspace.openTextDocument(fileUri)).getText();
     assert.ok(
@@ -278,40 +245,38 @@ standardSuite('Clipboard Preservation — Assisted', (log) => {
       `Expected "${PHRASE}" in destination file, got: ${JSON.stringify(destContent)}`,
     );
     await assertClipboardChanged('clipboard-preservation-007: never + R-V');
-    log('✓ Clipboard changed from sentinel and phrase landed in destination file after R-V');
+    ss.log('✓ Clipboard changed from sentinel and phrase landed in destination file after R-V');
   });
 
   test('clipboard-preservation-009: always mode — dismissed picker leaves clipboard unchanged', async () => {
-    const lines = Array.from({ length: 5 }, (_, i) => `line ${i + 1}`);
-    const fileUri = createWorkspaceFile('cbp-009', lines.join('\n') + '\n');
-    tmpFileUris.push(fileUri);
+    const { uri: fileUri } = ss.createContentFile('cbp-009', 5, (i) => `line ${i + 1}`);
 
     const SELECTION_START_LINE = 0;
     const SELECTION_END_LINE = 2;
     const SELECTION_COLUMN = 0;
 
-    const editor009 = await openEditor(fileUri);
+    const editor009 = await ss.openEditor(fileUri);
     editor009.selection = new vscode.Selection(
       new vscode.Position(SELECTION_START_LINE, SELECTION_COLUMN),
       new vscode.Position(SELECTION_END_LINE, SELECTION_COLUMN),
     );
-    await settle();
+    await ss.settle();
     await writeClipboardSentinel();
 
     await openAndDismiss(CMD_COPY_LINK_RELATIVE);
 
     await assertClipboardRestored('clipboard-preservation-009: always + picker dismissed');
-    log('✓ Clipboard unchanged after picker dismissed (no operation performed)');
+    ss.log('✓ Clipboard unchanged after picker dismissed (no operation performed)');
   });
 
   test('[assisted] clipboard-preservation-010: focus command failure preserves link in clipboard for manual paste', async () => {
-    const lines = Array.from({ length: 5 }, (_, i) => `line ${i + 1}`);
-    const fileUri = createWorkspaceFile('cbp-010', lines.join('\n') + '\n');
-    tmpFileUris.push(fileUri);
+    await ss.loadSettingsProfile('default');
+
+    const { uri: fileUri } = ss.createContentFile('cbp-010', 5, (i) => `line ${i + 1}`);
 
     const relPath = vscode.workspace.asRelativePath(fileUri);
-    await openEditor(fileUri);
-    await settle();
+    await ss.openEditor(fileUri);
+    await ss.settle();
     await writeClipboardSentinel();
 
     const logCapture = getLogCapture();
@@ -329,7 +294,7 @@ standardSuite('Clipboard Preservation — Assisted', (log) => {
       ],
     );
 
-    await settle();
+    await ss.settle();
 
     const lines010 = logCapture.getLinesSince('before-010');
     const focusFailLog = lines010.find((line) => line.includes('Focus failed, cannot paste link'));
@@ -354,6 +319,8 @@ standardSuite('Clipboard Preservation — Assisted', (log) => {
       clipboardContent.includes('#L'),
       `Expected a RangeLink link in clipboard (with #L) but got: ${clipboardContent}`,
     );
-    log('✓ Clipboard not restored after focus failure — link stays in clipboard for manual paste');
+    ss.log(
+      '✓ Clipboard not restored after focus failure — link stays in clipboard for manual paste',
+    );
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
@@ -215,7 +215,9 @@ standardSuite('Clipboard Preservation — Assisted', (ss) => {
   test('clipboard-preservation-007: never mode — R-V from terminal overwrites clipboard', async () => {
     const PHRASE = 'test phrase cbp-007';
 
-    await ss.loadSettingsProfile('clipboard-never');
+    const config = vscode.workspace.getConfiguration();
+    await config.update('rangelink.clipboard.preserve', 'never', vscode.ConfigurationTarget.Global);
+    ss.log('set rangelink.clipboard.preserve to never');
 
     const fileUri = ss.createWorkspaceFile('cbp-007', '');
 
@@ -270,8 +272,6 @@ standardSuite('Clipboard Preservation — Assisted', (ss) => {
   });
 
   test('[assisted] clipboard-preservation-010: focus command failure preserves link in clipboard for manual paste', async () => {
-    await ss.loadSettingsProfile('default');
-
     const { uri: fileUri } = ss.createContentFile('cbp-010', 5, (i) => `line ${i + 1}`);
 
     const relPath = vscode.workspace.asRelativePath(fileUri);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/commandRegistration.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/commandRegistration.test.ts
@@ -61,7 +61,7 @@ const EXPECTED_COMMAND_IDS = [
   'rangelink.handleFilePathClick',
 ] as const;
 
-standardSuite('Command Registration', (_log) => {
+standardSuite('Command Registration', (_ss) => {
   let registeredCommands: string[];
 
   suiteSetup(async () => {

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
@@ -10,13 +10,8 @@ import {
   assertSetContextLogged,
   assertStatusBarMsgLogged,
   assertTerminalBufferContains,
-  cleanupFiles,
   clearSelection,
-  createAndBindCapturingTerminal,
-  createAndOpenFile,
   getLogCapture,
-  openEditor,
-  settle,
   standardSuite,
   waitForHuman,
   waitForHumanVerdict,
@@ -25,8 +20,7 @@ import {
 const FILE_CONTENT = 'line 1\nline 2\nline 3\nline 4\n';
 const CONTEXT_IS_BOUND_KEY = 'rangelink.isBound';
 
-standardSuite('Context Menus — Editor Content', (log) => {
-  const tmpFileUris: vscode.Uri[] = [];
+standardSuite('Context Menus — Editor Content', (ss) => {
   let originalMultiLinePasteWarning: unknown;
 
   suiteSetup(async () => {
@@ -54,23 +48,17 @@ standardSuite('Context Menus — Editor Content', (log) => {
       );
   });
 
-  teardown(async () => {
-    cleanupFiles(tmpFileUris);
-    tmpFileUris.length = 0;
-    await settle();
-  });
-
   test('[assisted] context-menus-editor-content-001: Editor content "Send RangeLink" sends workspace-relative link to bound terminal', async () => {
-    const uri = await createAndOpenFile('ctxmenu-ed-001', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-ed-001', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
     const relativePath = vscode.workspace.asRelativePath(uri, false);
 
     const terminalName = 'rl-ctxmenu-ed-001';
-    const capturing = await createAndBindCapturingTerminal(terminalName);
+    const capturing = await ss.createAndBindCapturingTerminal(terminalName);
 
-    const editor = await openEditor(uri);
+    const editor = await ss.openEditor(uri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(1, 6));
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ed-001');
@@ -96,19 +84,19 @@ standardSuite('Context Menus — Editor Content', (log) => {
       message: `✓ RangeLink: RangeLink copied to clipboard & sent to Terminal ("${terminalName}")`,
     });
 
-    log('✓ Editor-content "Send RangeLink" delivered workspace-relative link to bound terminal');
+    ss.log('✓ Editor-content "Send RangeLink" delivered workspace-relative link to bound terminal');
   });
 
   test('[assisted] context-menus-editor-content-002: Editor content "Send RangeLink (Absolute)" sends absolute link to bound terminal', async () => {
-    const uri = await createAndOpenFile('ctxmenu-ed-002', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-ed-002', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
 
     const terminalName = 'rl-ctxmenu-ed-002';
-    const capturing = await createAndBindCapturingTerminal(terminalName);
+    const capturing = await ss.createAndBindCapturingTerminal(terminalName);
 
-    const editor = await openEditor(uri);
+    const editor = await ss.openEditor(uri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(1, 6));
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ed-002');
@@ -133,20 +121,22 @@ standardSuite('Context Menus — Editor Content', (log) => {
       message: `✓ RangeLink: RangeLink copied to clipboard & sent to Terminal ("${terminalName}")`,
     });
 
-    log('✓ Editor-content "Send RangeLink (Absolute)" delivered absolute link to bound terminal');
+    ss.log(
+      '✓ Editor-content "Send RangeLink (Absolute)" delivered absolute link to bound terminal',
+    );
   });
 
   test('[assisted] context-menus-editor-content-003: Editor content "Send Portable Link" sends portable link with workspace-relative path', async () => {
-    const uri = await createAndOpenFile('ctxmenu-ed-003', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-ed-003', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
     const relativePath = vscode.workspace.asRelativePath(uri, false);
 
     const terminalName = 'rl-ctxmenu-ed-003';
-    const capturing = await createAndBindCapturingTerminal(terminalName);
+    const capturing = await ss.createAndBindCapturingTerminal(terminalName);
 
-    const editor = await openEditor(uri);
+    const editor = await ss.openEditor(uri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(1, 6));
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ed-003');
@@ -171,19 +161,19 @@ standardSuite('Context Menus — Editor Content', (log) => {
       message: `✓ RangeLink: Portable RangeLink copied to clipboard & sent to Terminal ("${terminalName}")`,
     });
 
-    log('✓ Editor-content "Send Portable Link" delivered portable link to bound terminal');
+    ss.log('✓ Editor-content "Send Portable Link" delivered portable link to bound terminal');
   });
 
   test('[assisted] context-menus-editor-content-004: Editor content "Send Portable Link (Absolute)" sends portable link with absolute path', async () => {
-    const uri = await createAndOpenFile('ctxmenu-ed-004', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-ed-004', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
 
     const terminalName = 'rl-ctxmenu-ed-004';
-    const capturing = await createAndBindCapturingTerminal(terminalName);
+    const capturing = await ss.createAndBindCapturingTerminal(terminalName);
 
-    const editor = await openEditor(uri);
+    const editor = await ss.openEditor(uri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(1, 6));
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ed-004');
@@ -208,21 +198,21 @@ standardSuite('Context Menus — Editor Content', (log) => {
       message: `✓ RangeLink: Portable RangeLink copied to clipboard & sent to Terminal ("${terminalName}")`,
     });
 
-    log(
+    ss.log(
       '✓ Editor-content "Send Portable Link (Absolute)" delivered portable link with absolute path',
     );
   });
 
   test('[assisted] context-menus-editor-content-005: Editor content "Send Selected Text" sends raw selected text to bound terminal', async () => {
-    const uri = await createAndOpenFile('ctxmenu-ed-005', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-ed-005', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
 
     const terminalName = 'rl-ctxmenu-ed-005';
-    const capturing = await createAndBindCapturingTerminal(terminalName);
+    const capturing = await ss.createAndBindCapturingTerminal(terminalName);
 
-    const editor = await openEditor(uri);
+    const editor = await ss.openEditor(uri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(2, 6));
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ed-005');
@@ -251,17 +241,17 @@ standardSuite('Context Menus — Editor Content', (log) => {
     // sends `\r` between lines so a real shell treats each line as Enter-terminated;
     // our capturing pty preserves exactly what was sent.
     const normalizedCapture = capturing.getCapturedText().replace(/\r\n|\r/g, '\n');
-    log(`TC 005 captured (normalized): ${JSON.stringify(normalizedCapture)}`);
+    ss.log(`TC 005 captured (normalized): ${JSON.stringify(normalizedCapture)}`);
     assertTerminalBufferContains(normalizedCapture, 'line 1\nline 2\nline 3');
     assertStatusBarMsgLogged(lines, {
       message: `✓ RangeLink: Selected text copied to clipboard & sent to Terminal ("${terminalName}")`,
     });
 
-    log('✓ Editor-content "Send Selected Text" delivered raw selected text to bound terminal');
+    ss.log('✓ Editor-content "Send Selected Text" delivered raw selected text to bound terminal');
   });
 
   test('[assisted] context-menus-editor-content-006: Visual separator is visible between RangeLink commands and other menu items', async () => {
-    const uri = await createAndOpenFile('ctxmenu-ed-006', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-ed-006', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
 
     const verdict = await waitForHumanVerdict(
@@ -281,18 +271,18 @@ standardSuite('Context Menus — Editor Content', (log) => {
       'Human reported the RangeLink block has no visual separator — group prefixes in package.json may have drifted',
     );
 
-    log('✓ Editor-content context menu renders a visual separator for the RangeLink block');
+    ss.log('✓ Editor-content context menu renders a visual separator for the RangeLink block');
   });
 
   test('[assisted] context-menus-editor-content-007: Editor content "Send This File\'s Path" sends absolute path to bound terminal', async () => {
-    const uri = await createAndOpenFile('ctxmenu-ed-007', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-ed-007', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
 
     const terminalName = 'rl-ctxmenu-ed-007';
-    const capturing = await createAndBindCapturingTerminal(terminalName);
+    const capturing = await ss.createAndBindCapturingTerminal(terminalName);
 
-    await openEditor(uri);
-    await settle();
+    await ss.openEditor(uri);
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ed-007');
@@ -317,19 +307,19 @@ standardSuite('Context Menus — Editor Content', (log) => {
     assertClipboardWriteLogged(lines, { textLength: uri.fsPath.length });
     assertTerminalBufferContains(capturing.getCapturedText(), uri.fsPath);
 
-    log('✓ Editor-content "Send This File\'s Path" delivered absolute path to bound terminal');
+    ss.log('✓ Editor-content "Send This File\'s Path" delivered absolute path to bound terminal');
   });
 
   test('[assisted] context-menus-editor-content-008: Editor content "Send This File\'s Relative Path" sends workspace-relative path to bound terminal', async () => {
-    const uri = await createAndOpenFile('ctxmenu-ed-008', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-ed-008', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
     const relativePath = vscode.workspace.asRelativePath(uri, false);
 
     const terminalName = 'rl-ctxmenu-ed-008';
-    const capturing = await createAndBindCapturingTerminal(terminalName);
+    const capturing = await ss.createAndBindCapturingTerminal(terminalName);
 
-    await openEditor(uri);
-    await settle();
+    await ss.openEditor(uri);
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ed-008');
@@ -354,13 +344,13 @@ standardSuite('Context Menus — Editor Content', (log) => {
     assertClipboardWriteLogged(lines, { textLength: relativePath.length });
     assertTerminalBufferContains(capturing.getCapturedText(), relativePath);
 
-    log(
+    ss.log(
       '✓ Editor-content "Send This File\'s Relative Path" delivered relative path to bound terminal',
     );
   });
 
   test('[assisted] context-menus-editor-content-009: Editor content "Bind Here" binds the current file as the text editor destination', async () => {
-    const uri = await createAndOpenFile('ctxmenu-ed-009', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-ed-009', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
 
     const logCapture = getLogCapture();
@@ -383,18 +373,18 @@ standardSuite('Context Menus — Editor Content', (log) => {
       message: `✓ RangeLink: Bound to Text Editor ("${fn}")`,
     });
 
-    log('✓ Editor-content "Bind Here" committed a text-editor binding for the current file');
+    ss.log('✓ Editor-content "Bind Here" committed a text-editor binding for the current file');
   });
 
   test('[assisted] context-menus-editor-content-010: Editor content "Unbind" is visible when bound and unbinds on click', async () => {
-    const uri = await createAndOpenFile('ctxmenu-ed-010', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-ed-010', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
 
     const terminalName = 'rl-ctxmenu-ed-010';
-    await createAndBindCapturingTerminal(terminalName);
+    await ss.createAndBindCapturingTerminal(terminalName);
 
-    await openEditor(uri);
-    await settle();
+    await ss.openEditor(uri);
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ed-010');
@@ -424,19 +414,19 @@ standardSuite('Context Menus — Editor Content', (log) => {
       message: `✓ RangeLink: Unbound from Terminal ("${terminalName}")`,
     });
 
-    log('✓ Editor-content "Unbind" was visible (clicked it) and fired the unbind path');
+    ss.log('✓ Editor-content "Unbind" was visible (clicked it) and fired the unbind path');
   });
 
   test('[assisted] context-menus-editor-content-011: Selection-dependent RangeLink items are hidden when no text is selected', async () => {
-    const uri = await createAndOpenFile('ctxmenu-ed-011', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-ed-011', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
 
     const terminalName = 'rl-ctxmenu-ed-011';
-    await createAndBindCapturingTerminal(terminalName);
+    await ss.createAndBindCapturingTerminal(terminalName);
 
-    const editor = await openEditor(uri);
+    const editor = await ss.openEditor(uri);
     clearSelection(editor);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ed-011');
@@ -474,6 +464,8 @@ standardSuite('Context Menus — Editor Content', (log) => {
       'Expected no clipboard write log — nothing should have been sent during observation',
     );
 
-    log('✓ No-selection state: selection-dependent items hidden (human verdict + state invariant)');
+    ss.log(
+      '✓ No-selection state: selection-dependent items hidden (human verdict + state invariant)',
+    );
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorTab.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorTab.test.ts
@@ -10,11 +10,7 @@ import {
   assertSetContextLogged,
   assertStatusBarMsgLogged,
   assertTerminalBufferEquals,
-  cleanupFiles,
-  createAndOpenFile,
-  createCapturingTerminal,
   getLogCapture,
-  settle,
   standardSuite,
   waitForHuman,
 } from '../helpers';
@@ -22,23 +18,15 @@ import {
 const FILE_CONTENT = 'editor-tab context-menu test file\n';
 const CONTEXT_IS_BOUND_KEY = 'rangelink.isBound';
 
-standardSuite('Context Menus — Editor Tab', (log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-
-  teardown(async () => {
-    cleanupFiles(tmpFileUris);
-    tmpFileUris.length = 0;
-    await settle();
-  });
-
+standardSuite('Context Menus — Editor Tab', (ss) => {
   test('[assisted] context-menus-editor-tab-001: Editor tab "Send File Path" sends absolute path to bound terminal', async () => {
-    const uri = await createAndOpenFile('ctxmenu-tab-001', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-tab-001', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
 
     const terminalName = 'rl-ctxmenu-tab-001';
-    const capturing = await createCapturingTerminal(terminalName);
+    const capturing = await ss.createCapturingTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-tab-001');
@@ -64,20 +52,20 @@ standardSuite('Context Menus — Editor Tab', (log) => {
     assertClipboardWriteLogged(lines, { textLength: uri.fsPath.length });
     assertTerminalBufferEquals(capturing.getCapturedText(), ` ${uri.fsPath} `);
 
-    log(
+    ss.log(
       '✓ Editor-tab absolute path landed in bound terminal buffer (pty capture verified content)',
     );
   });
 
   test('[assisted] context-menus-editor-tab-002: Editor tab "Send Relative File Path" sends relative path to bound terminal', async () => {
-    const uri = await createAndOpenFile('ctxmenu-tab-002', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-tab-002', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
     const relativePath = vscode.workspace.asRelativePath(uri, false);
 
     const terminalName = 'rl-ctxmenu-tab-002';
-    const capturing = await createCapturingTerminal(terminalName);
+    const capturing = await ss.createCapturingTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-tab-002');
@@ -103,13 +91,13 @@ standardSuite('Context Menus — Editor Tab', (log) => {
     assertClipboardWriteLogged(lines, { textLength: relativePath.length });
     assertTerminalBufferEquals(capturing.getCapturedText(), ` ${relativePath} `);
 
-    log(
+    ss.log(
       '✓ Editor-tab relative path landed in bound terminal buffer (pty capture verified content)',
     );
   });
 
   test('[assisted] context-menus-editor-tab-003: Editor tab "Bind Here" binds that editor as text editor destination', async () => {
-    const uri = await createAndOpenFile('ctxmenu-tab-003', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-tab-003', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
 
     const logCapture = getLogCapture();
@@ -135,20 +123,17 @@ standardSuite('Context Menus — Editor Tab', (log) => {
 
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
 
-    log('✓ Editor-tab "Bind Here" committed a text-editor binding with correct displayName');
+    ss.log('✓ Editor-tab "Bind Here" committed a text-editor binding with correct displayName');
   });
 
   test('[assisted] context-menus-editor-tab-004: Editor tab "Unbind" is visible when bound and unbinds on click', async () => {
-    const uri = await createAndOpenFile('ctxmenu-tab-004', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-tab-004', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
 
     const terminalName = 'rl-ctxmenu-tab-004';
-    const terminal = vscode.window.createTerminal({ name: terminalName });
-
-    terminal.show(true);
-    await settle();
+    await ss.createTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-tab-004');
@@ -172,6 +157,6 @@ standardSuite('Context Menus — Editor Tab', (log) => {
 
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: false });
 
-    log('✓ Editor-tab "Unbind" fired the unbind path; context key flipped to false');
+    ss.log('✓ Editor-tab "Unbind" fired the unbind path; context key flipped to false');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuExplorer.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuExplorer.test.ts
@@ -12,11 +12,7 @@ import {
   assertSetContextLogged,
   assertStatusBarMsgLogged,
   assertTerminalBufferEquals,
-  cleanupFiles,
-  createAndOpenFile,
-  createCapturingTerminal,
   getLogCapture,
-  settle,
   standardSuite,
   waitForHuman,
   waitForHumanVerdict,
@@ -25,23 +21,15 @@ import {
 const FILE_CONTENT = 'explorer context-menu test file\n';
 const CONTEXT_IS_BOUND_KEY = 'rangelink.isBound';
 
-standardSuite('Context Menus — Explorer', (log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-
-  teardown(async () => {
-    cleanupFiles(tmpFileUris);
-    tmpFileUris.length = 0;
-    await settle();
-  });
-
+standardSuite('Context Menus — Explorer', (ss) => {
   test('[assisted] context-menus-explorer-001: Explorer "Send File Path" sends absolute path to bound terminal', async () => {
-    const uri = await createAndOpenFile('ctxmenu-exp-001', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-exp-001', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
 
     const terminalName = 'rl-ctxmenu-exp-001';
-    const capturing = await createCapturingTerminal(terminalName);
+    const capturing = await ss.createCapturingTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-exp-001');
@@ -67,18 +55,18 @@ standardSuite('Context Menus — Explorer', (log) => {
     assertClipboardWriteLogged(lines, { textLength: uri.fsPath.length });
     assertTerminalBufferEquals(capturing.getCapturedText(), ` ${uri.fsPath} `);
 
-    log('✓ Absolute path landed in bound terminal buffer (pty capture verified content)');
+    ss.log('✓ Absolute path landed in bound terminal buffer (pty capture verified content)');
   });
 
   test('[assisted] context-menus-explorer-002: Explorer "Send Relative File Path" sends relative path to bound terminal', async () => {
-    const uri = await createAndOpenFile('ctxmenu-exp-002', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-exp-002', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
     const relativePath = vscode.workspace.asRelativePath(uri, false);
 
     const terminalName = 'rl-ctxmenu-exp-002';
-    const capturing = await createCapturingTerminal(terminalName);
+    const capturing = await ss.createCapturingTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-exp-002');
@@ -104,11 +92,13 @@ standardSuite('Context Menus — Explorer', (log) => {
     assertClipboardWriteLogged(lines, { textLength: relativePath.length });
     assertTerminalBufferEquals(capturing.getCapturedText(), ` ${relativePath} `);
 
-    log('✓ Workspace-relative path landed in bound terminal buffer (pty capture verified content)');
+    ss.log(
+      '✓ Workspace-relative path landed in bound terminal buffer (pty capture verified content)',
+    );
   });
 
   test('[assisted] context-menus-explorer-003: Explorer "Bind Here" opens the file and binds it as text editor destination', async () => {
-    const uri = await createAndOpenFile('ctxmenu-exp-003', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-exp-003', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
 
     const logCapture = getLogCapture();
@@ -134,20 +124,17 @@ standardSuite('Context Menus — Explorer', (log) => {
 
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
 
-    log('✓ Explorer "Bind Here" committed a text-editor binding with correct displayName');
+    ss.log('✓ Explorer "Bind Here" committed a text-editor binding with correct displayName');
   });
 
   test('[assisted] context-menus-explorer-004: Explorer "Unbind" is visible when bound and unbinds on click', async () => {
-    const uri = await createAndOpenFile('ctxmenu-exp-004', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-exp-004', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
 
     const terminalName = 'rl-ctxmenu-exp-004';
-    const terminal = vscode.window.createTerminal({ name: terminalName });
-
-    terminal.show(true);
-    await settle();
+    await ss.createTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-exp-004');
@@ -171,11 +158,11 @@ standardSuite('Context Menus — Explorer', (log) => {
 
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: false });
 
-    log('✓ Explorer "Unbind" fired the unbind path; context key flipped to false');
+    ss.log('✓ Explorer "Unbind" fired the unbind path; context key flipped to false');
   });
 
   test('[assisted] context-menus-explorer-005: Explorer "Unbind" is hidden when no destination is bound', async () => {
-    const uri = await createAndOpenFile('ctxmenu-exp-005', FILE_CONTENT, undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('ctxmenu-exp-005', FILE_CONTENT);
     const fn = path.basename(uri.fsPath);
 
     const logCapture = getLogCapture();
@@ -201,7 +188,7 @@ standardSuite('Context Menus — Explorer', (log) => {
       'Human reported "RangeLink: Unbind" WAS visible in Explorer when unbound — the `when: rangelink.isBound` clause is not working',
     );
 
-    log(
+    ss.log(
       '✓ Unbound state: "Unbind" absent from Explorer context menu (human verdict + state invariant)',
     );
   });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
@@ -12,15 +12,9 @@ import {
   assertSetContextLogged,
   assertStatusBarMsgLogged,
   assertTerminalBufferContains,
-  cleanupFiles,
-  createAndBindCapturingTerminal,
-  createAndOpenFile,
-  createCapturingTerminal,
-  createTerminal,
   echoToTerminal,
   extractQuickPickItemsLogged,
   getLogCapture,
-  settle,
   standardSuite,
   waitForHuman,
   waitForHumanVerdict,
@@ -28,18 +22,10 @@ import {
 
 const CONTEXT_IS_BOUND_KEY = 'rangelink.isBound';
 
-standardSuite('Context Menus — Terminal', (log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-
-  teardown(async () => {
-    cleanupFiles(tmpFileUris);
-    tmpFileUris.length = 0;
-    await settle();
-  });
-
+standardSuite('Context Menus — Terminal', (ss) => {
   test('[assisted] context-menus-terminal-001: Terminal tab "Bind Here" binds that terminal', async () => {
     const terminalName = 'rl-ctxmenu-term-001';
-    await createTerminal(terminalName);
+    await ss.createTerminal(terminalName);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-term-001');
@@ -62,12 +48,12 @@ standardSuite('Context Menus — Terminal', (log) => {
 
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
 
-    log('✓ Terminal-tab context menu bound the terminal destination');
+    ss.log('✓ Terminal-tab context menu bound the terminal destination');
   });
 
   test('[assisted] context-menus-terminal-002: Terminal content-area "Bind Here" binds that terminal', async () => {
     const terminalName = 'rl-ctxmenu-term-002';
-    await createTerminal(terminalName);
+    await ss.createTerminal(terminalName);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-term-002');
@@ -90,14 +76,14 @@ standardSuite('Context Menus — Terminal', (log) => {
 
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: true });
 
-    log('✓ Terminal content-area context menu bound the terminal destination');
+    ss.log('✓ Terminal content-area context menu bound the terminal destination');
   });
 
   test('[assisted] context-menus-terminal-003: Terminal content-area "Unbind" is visible when bound and unbinds on click', async () => {
     const terminalName = 'rl-ctxmenu-term-003';
-    await createTerminal(terminalName);
+    await ss.createTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-term-003');
@@ -121,14 +107,14 @@ standardSuite('Context Menus — Terminal', (log) => {
 
     assertSetContextLogged(lines, { key: CONTEXT_IS_BOUND_KEY, value: false });
 
-    log('✓ Terminal content-area "Unbind" was visible (clicked it) and fired the unbind path');
+    ss.log('✓ Terminal content-area "Unbind" was visible (clicked it) and fired the unbind path');
   });
 
   test('[assisted] context-menus-terminal-004: Right-clicking a specific terminal TAB binds THAT terminal (multi-terminal disambiguation)', async () => {
     const targetName = 'rl-ctxmenu-term-004-TARGET';
     const otherName = 'rl-ctxmenu-term-004-OTHER';
-    await createTerminal(otherName);
-    await createTerminal(targetName);
+    await ss.createTerminal(otherName);
+    await ss.createTerminal(targetName);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-term-004');
@@ -163,14 +149,14 @@ standardSuite('Context Menus — Terminal', (log) => {
       `Expected direct-bind log for "${targetName}" from context-menu source`,
     );
 
-    log('✓ Right-clicked TAB bound the target terminal directly (picker bypassed)');
+    ss.log('✓ Right-clicked TAB bound the target terminal directly (picker bypassed)');
   });
 
   test('[assisted] context-menus-terminal-005: Right-clicking a specific terminal CONTENT AREA binds THAT terminal (multi-terminal disambiguation)', async () => {
     const targetName = 'rl-ctxmenu-term-005-TARGET';
     const otherName = 'rl-ctxmenu-term-005-OTHER';
-    await createTerminal(otherName);
-    await createTerminal(targetName);
+    await ss.createTerminal(otherName);
+    await ss.createTerminal(targetName);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-term-005');
@@ -205,7 +191,7 @@ standardSuite('Context Menus — Terminal', (log) => {
       `Expected direct-bind log for "${targetName}" from context-menu source`,
     );
 
-    log('✓ Right-clicked CONTENT AREA bound the target terminal directly (picker bypassed)');
+    ss.log('✓ Right-clicked CONTENT AREA bound the target terminal directly (picker bypassed)');
   });
 
   // ---------------------------------------------------------------------------
@@ -216,23 +202,21 @@ standardSuite('Context Menus — Terminal', (log) => {
   // ---------------------------------------------------------------------------
 
   test('[assisted] send-terminal-selection-005: Terminal content-area "Send Selection to Destination" sends selected text to bound editor', async () => {
-    const editorUri = await createAndOpenFile(
+    const editorUri = await ss.createAndOpenFile(
       'ctxmenu-term-sts-005',
       'destination file — terminal selection arrives here\n',
-      undefined,
-      tmpFileUris,
     );
     const editorFn = path.basename(editorUri.fsPath);
 
     await vscode.commands.executeCommand(CMD_CONTEXT_EDITOR_CONTENT_BIND, editorUri);
-    await settle();
+    await ss.settle();
 
     const terminalName = 'rl-ctxmenu-term-sts-005';
-    const terminal = await createTerminal(terminalName);
+    const terminal = await ss.createTerminal(terminalName);
 
     const markerText = 'STS_005_MARKER_TEXT';
     echoToTerminal(terminal, markerText);
-    await settle(TERMINAL_READY_MS);
+    await ss.settle(TERMINAL_READY_MS);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-sts-005');
@@ -265,7 +249,9 @@ standardSuite('Context Menus — Terminal', (log) => {
       message: `✓ RangeLink: Selected text copied to clipboard & sent to Text Editor ("${editorFn}")`,
     });
 
-    log('✓ Terminal context-menu "Send Selection to Destination" routed selection to bound editor');
+    ss.log(
+      '✓ Terminal context-menu "Send Selection to Destination" routed selection to bound editor',
+    );
   });
 
   // ---------------------------------------------------------------------------
@@ -277,12 +263,12 @@ standardSuite('Context Menus — Terminal', (log) => {
     const boundName = 'rl-sts-008-BOUND';
     const sourceName = 'rl-sts-008-SOURCE';
 
-    const capturingBound = await createAndBindCapturingTerminal(boundName);
+    const capturingBound = await ss.createAndBindCapturingTerminal(boundName);
 
-    const sourceTerminal = await createTerminal(sourceName);
+    const sourceTerminal = await ss.createTerminal(sourceName);
     const markerText = 'STS_008_CROSS_TERMINAL_MARKER';
     echoToTerminal(sourceTerminal, markerText);
-    await settle(TERMINAL_READY_MS);
+    await ss.settle(TERMINAL_READY_MS);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-sts-008');
@@ -322,18 +308,18 @@ standardSuite('Context Menus — Terminal', (log) => {
 
     assertTerminalBufferContains(capturingBound.getCapturedText(), markerText);
 
-    log(
+    ss.log(
       '✓ Cross-terminal send: source selection landed in bound terminal buffer (pty-captured) with focus shift',
     );
   });
 
   test('[assisted] send-terminal-selection-009: "Send Selection to Destination" is NOT in the terminal TAB menu', async () => {
     const terminalName = 'rl-sts-009';
-    const terminal = await createTerminal(terminalName);
+    const terminal = await ss.createTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
-    await settle();
+    await ss.settle();
     echoToTerminal(terminal, 'STS_009_MARKER_TEXT');
-    await settle(TERMINAL_READY_MS);
+    await ss.settle(TERMINAL_READY_MS);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-sts-009');
@@ -365,7 +351,7 @@ standardSuite('Context Menus — Terminal', (log) => {
       'Expected no TerminalSelectionService log — nothing should have triggered a paste during observation',
     );
 
-    log('✓ Tab menu did NOT offer "Send Selection" (human verdict + no paste log)');
+    ss.log('✓ Tab menu did NOT offer "Send Selection" (human verdict + no paste log)');
   });
 
   // ---------------------------------------------------------------------------
@@ -376,10 +362,10 @@ standardSuite('Context Menus — Terminal', (log) => {
 
   test('[assisted] send-terminal-selection-010: Self-paste — bound terminal selection is sent back to itself (current behavior, no guard)', async () => {
     const terminalName = 'rl-sts-010';
-    const capturing = await createAndBindCapturingTerminal(terminalName);
+    const capturing = await ss.createAndBindCapturingTerminal(terminalName);
     const markerText = 'STS_010_SELF_PASTE_MARKER';
     capturing.terminal.sendText(markerText, false);
-    await settle(TERMINAL_READY_MS);
+    await ss.settle(TERMINAL_READY_MS);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-sts-010');
@@ -405,7 +391,7 @@ standardSuite('Context Menus — Terminal', (log) => {
 
     assertTerminalBufferContains(capturing.getCapturedText(), markerText);
 
-    log(
+    ss.log(
       '✓ Self-paste: selection echoed back into bound terminal buffer (pty-captured; follow-up issue worth filing for guard)',
     );
   });
@@ -420,12 +406,12 @@ standardSuite('Context Menus — Terminal', (log) => {
     const sourceName = 'rl-sts-011-SOURCE';
     const destName = 'rl-sts-011-DEST';
 
-    const capturingDest = await createCapturingTerminal(destName);
+    const capturingDest = await ss.createCapturingTerminal(destName);
 
-    const sourceTerminal = await createTerminal(sourceName);
+    const sourceTerminal = await ss.createTerminal(sourceName);
     const markerText = 'STS_011_MARKER_TEXT';
     echoToTerminal(sourceTerminal, markerText);
-    await settle(TERMINAL_READY_MS);
+    await ss.settle(TERMINAL_READY_MS);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-sts-011');
@@ -470,7 +456,7 @@ standardSuite('Context Menus — Terminal', (log) => {
 
     assertTerminalBufferContains(capturingDest.getCapturedText(), markerText);
 
-    log(
+    ss.log(
       '✓ Unbound state: menu item shown; click opened picker; selection landed in picked destination buffer (pty-captured)',
     );
   });
@@ -482,11 +468,11 @@ standardSuite('Context Menus — Terminal', (log) => {
 
   test('[assisted] send-terminal-selection-012: "Send Selection" is hidden when no terminal text is selected', async () => {
     const terminalName = 'rl-sts-012';
-    const terminal = await createTerminal(terminalName);
+    const terminal = await ss.createTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
-    await settle();
+    await ss.settle();
     echoToTerminal(terminal, 'STS_012_MARKER_TEXT');
-    await settle(TERMINAL_READY_MS);
+    await ss.settle(TERMINAL_READY_MS);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-sts-012');
@@ -518,7 +504,7 @@ standardSuite('Context Menus — Terminal', (log) => {
       'Expected no paste log — nothing should have triggered a paste during observation',
     );
 
-    log('✓ No-selection state: "Send Selection" absent (human verdict + no paste log)');
+    ss.log('✓ No-selection state: "Send Selection" absent (human verdict + no paste log)');
   });
 
   // ---------------------------------------------------------------------------
@@ -538,10 +524,10 @@ standardSuite('Context Menus — Terminal', (log) => {
     );
 
     const terminalName = 'rl-sts-013';
-    const terminal = await createTerminal(terminalName);
+    const terminal = await ss.createTerminal(terminalName);
     const markerText = 'STS_013_AI_DELIVERY_MARKER';
     echoToTerminal(terminal, markerText);
-    await settle(TERMINAL_READY_MS);
+    await ss.settle(TERMINAL_READY_MS);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-sts-013');
@@ -585,7 +571,7 @@ standardSuite('Context Menus — Terminal', (log) => {
       `Expected Dummy AI tier1 textarea to contain "${markerText}" but got: ${textResult!.tier1}`,
     );
 
-    log(
+    ss.log(
       '✓ Terminal context-menu "Send Selection" delivered selection to Dummy AI via Tier 1 direct insert',
     );
   });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
@@ -20,50 +20,36 @@ import {
   assertTerminalBufferEquals,
   assertToastLogged,
   type CapturingTerminal,
-  cleanupFiles,
   clearSelection,
-  createAndBindCapturingTerminal,
-  createTerminal,
-  createWorkspaceFile,
+  echoToTerminal,
   extractQuickPickItemsLogged,
   getLogCapture,
   openAndDismiss,
-  openEditor,
-  settle,
   standardSuite,
   TERMINAL_READY_MS,
   waitForHuman,
-  echoToTerminal,
   writeClipboardSentinel,
 } from '../helpers';
 
 const NO_TERMINAL_SELECTION_MSG = 'No text selected in the terminal. Select text and try again.';
 
-standardSuite('Core Send Commands', (log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-  const tmpTerminals: vscode.Terminal[] = [];
-
+standardSuite('Core Send Commands', (ss) => {
   teardown(async () => {
-    for (const t of tmpTerminals.splice(0)) t.dispose();
     await vscode.commands.executeCommand('dummyAi.clearAll');
-    cleanupFiles(tmpFileUris);
-    tmpFileUris.splice(0);
-    await settle();
   });
 
   test('core-send-commands-r-l-002: R-L sends RangeLink to bound text editor destination', async () => {
-    const srcUri = createWorkspaceFile(
+    const srcUri = ss.createWorkspaceFile(
       'csc-r-l-002-src',
       'line 1\nline 2\nline 3\nline 4\nline 5\n',
     );
-    const destUri = createWorkspaceFile('csc-r-l-002-dest', '');
-    tmpFileUris.push(srcUri, destUri);
+    const destUri = ss.createWorkspaceFile('csc-r-l-002-dest', '');
 
     const destDoc = await vscode.workspace.openTextDocument(destUri);
     const destEditor = await vscode.window.showTextDocument(destDoc, vscode.ViewColumn.Two);
     clearSelection(destEditor);
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
-    await settle();
+    await ss.settle();
 
     const srcDoc = await vscode.workspace.openTextDocument(srcUri);
     const srcEditor = await vscode.window.showTextDocument(srcDoc, vscode.ViewColumn.Beside);
@@ -71,13 +57,13 @@ standardSuite('Core Send Commands', (log) => {
       new vscode.Position(1, 0),
       new vscode.Position(3, 0),
     );
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-r-l-002');
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-r-l-002');
 
@@ -95,19 +81,21 @@ standardSuite('Core Send Commands', (log) => {
     assertStatusBarMsgLogged(lines, {
       message: `✓ RangeLink: RangeLink copied to clipboard & sent to Text Editor ("${destBasename}")`,
     });
-    log('✓ R-L sent exact RangeLink to bound text editor destination');
+    ss.log('✓ R-L sent exact RangeLink to bound text editor destination');
   });
 
   test('[assisted] core-send-commands-r-l-003: R-L sends RangeLink to bound AI assistant destination', async () => {
-    const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1} content`);
-    const fileUri = createWorkspaceFile('csc-r-l-003', lines.join('\n') + '\n');
-    tmpFileUris.push(fileUri);
+    const { uri: fileUri } = ss.createContentFile(
+      'csc-r-l-003',
+      10,
+      (i) => `line ${i + 1} content`,
+    );
 
     const relPath = vscode.workspace.asRelativePath(fileUri);
     const expectedLink = `${relPath}#L1-L3`;
 
-    await openEditor(fileUri);
-    await settle();
+    await ss.openEditor(fileUri);
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-r-l-003');
@@ -122,7 +110,7 @@ standardSuite('Core Send Commands', (log) => {
       ],
     );
 
-    await settle();
+    await ss.settle();
     const dummyText = (await vscode.commands.executeCommand('dummyAi.getText')) as {
       tier1: string;
       tier2: string;
@@ -137,25 +125,25 @@ standardSuite('Core Send Commands', (log) => {
       logCapture.getLinesSince('before-r-l-003').some((l) => l.includes('sent to')),
       'Expected "sent to" log line after R-L to AI destination',
     );
-    log('✓ R-L sent RangeLink to Dummy AI (Tier 1) destination');
+    ss.log('✓ R-L sent RangeLink to Dummy AI (Tier 1) destination');
   });
 
   test('core-send-commands-r-c-001: R-C copies RangeLink to clipboard and does NOT send to terminal', async () => {
-    const fileUri = createWorkspaceFile('csc-r-c-001', 'line 1\nline 2\nline 3\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('csc-r-c-001', 'line 1\nline 2\nline 3\n');
 
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal('csc-r-c-001-dest');
+    const capturing: CapturingTerminal =
+      await ss.createAndBindCapturingTerminal('csc-r-c-001-dest');
 
-    const editor = await openEditor(fileUri);
+    const editor = await ss.openEditor(fileUri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(2, 0));
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-r-c-001');
 
     await writeClipboardSentinel();
     await vscode.commands.executeCommand(CMD_COPY_LINK_ONLY_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const clipboard = await assertClipboardChanged('R-C should write link to clipboard');
     assert.ok(
@@ -172,24 +160,24 @@ standardSuite('Core Send Commands', (log) => {
     assertStatusBarMsgLogged(logCapture.getLinesSince('before-r-c-001'), {
       message: '✓ RangeLink: RangeLink copied to clipboard',
     });
-    log('✓ R-C wrote link to clipboard; terminal received nothing');
+    ss.log('✓ R-C wrote link to clipboard; terminal received nothing');
   });
 
   test('core-send-commands-r-l-004: Command dispatch "Send RangeLink" behaves identically to R-L keybinding', async () => {
-    const fileUri = createWorkspaceFile('csc-r-l-004', 'line 1\nline 2\nline 3\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('csc-r-l-004', 'line 1\nline 2\nline 3\n');
 
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal('csc-r-l-004-dest');
+    const capturing: CapturingTerminal =
+      await ss.createAndBindCapturingTerminal('csc-r-l-004-dest');
 
-    const editor = await openEditor(fileUri);
+    const editor = await ss.openEditor(fileUri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(2, 0));
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-r-l-004');
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const relPath = vscode.workspace.asRelativePath(fileUri);
     const expectedContent = ` ${relPath}#L1-L2 `;
@@ -198,18 +186,20 @@ standardSuite('Core Send Commands', (log) => {
     assertStatusBarMsgLogged(logCapture.getLinesSince('before-r-l-004'), {
       message: '✓ RangeLink: RangeLink copied to clipboard & sent to Terminal ("csc-r-l-004-dest")',
     });
-    log('✓ Command dispatch "Send RangeLink" delivered exact link to bound terminal destination');
+    ss.log(
+      '✓ Command dispatch "Send RangeLink" delivered exact link to bound terminal destination',
+    );
   });
 
   test('core-send-commands-r-c-002: Command dispatch "Copy RangeLink" behaves identically to R-C keybinding', async () => {
-    const fileUri = createWorkspaceFile('csc-r-c-002', 'line 1\nline 2\nline 3\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('csc-r-c-002', 'line 1\nline 2\nline 3\n');
 
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal('csc-r-c-002-dest');
+    const capturing: CapturingTerminal =
+      await ss.createAndBindCapturingTerminal('csc-r-c-002-dest');
 
-    const editor = await openEditor(fileUri);
+    const editor = await ss.openEditor(fileUri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(2, 0));
-    await settle();
+    await ss.settle();
 
     await writeClipboardSentinel();
 
@@ -217,7 +207,7 @@ standardSuite('Core Send Commands', (log) => {
     logCapture.mark('before-r-c-002');
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_ONLY_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const relPath = vscode.workspace.asRelativePath(fileUri);
     const expectedContent = `${relPath}#L1-L2`;
@@ -238,7 +228,7 @@ standardSuite('Core Send Commands', (log) => {
     assertStatusBarMsgLogged(logCapture.getLinesSince('before-r-c-002'), {
       message: '✓ RangeLink: RangeLink copied to clipboard',
     });
-    log(
+    ss.log(
       '✓ Command dispatch "Copy RangeLink" wrote exact link to clipboard; terminal received nothing',
     );
   });
@@ -246,13 +236,14 @@ standardSuite('Core Send Commands', (log) => {
   test('[assisted] send-terminal-selection-001: Cmd+R Cmd+V with terminal text selected sends to bound destination', async () => {
     const MARKER = 'rl-sts-001-marker';
 
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal('csc-sts-001-dest');
-    await settle();
+    const capturing: CapturingTerminal =
+      await ss.createAndBindCapturingTerminal('csc-sts-001-dest');
+    await ss.settle();
 
-    const srcTerminal = await createTerminal('csc-sts-001-src', tmpTerminals);
+    const srcTerminal = await ss.createTerminal('csc-sts-001-src');
 
     echoToTerminal(srcTerminal, MARKER);
-    await settle(TERMINAL_READY_MS);
+    await ss.settle(TERMINAL_READY_MS);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-sts-001');
@@ -269,11 +260,11 @@ standardSuite('Core Send Commands', (log) => {
       message:
         '✓ RangeLink: Selected text copied to clipboard & sent to Terminal ("csc-sts-001-dest")',
     });
-    log('✓ R-V sent selected terminal text to bound destination');
+    ss.log('✓ R-V sent selected terminal text to bound destination');
   });
 
   test('send-terminal-selection-003: R-V with no text selected in terminal shows error message', async () => {
-    await createTerminal('csc-sts-003', tmpTerminals);
+    await ss.createTerminal('csc-sts-003');
 
     // On macOS, terminal.copySelection leaves the clipboard unchanged when nothing
     // is selected — so we prime the clipboard to empty so the preserve/read roundtrip
@@ -284,22 +275,22 @@ standardSuite('Core Send Commands', (log) => {
     logCapture.mark('before-sts-003');
 
     await vscode.commands.executeCommand(CMD_TERMINAL_PASTE_SELECTED_TEXT);
-    await settle();
+    await ss.settle();
 
     assertToastLogged(logCapture.getLinesSince('before-sts-003'), {
       type: 'error',
       message: NO_TERMINAL_SELECTION_MSG,
     });
-    log('✓ R-V with no selection shows "no text selected" error toast');
+    ss.log('✓ R-V with no selection shows "no text selected" error toast');
   });
 
   test('[assisted] send-terminal-selection-004: R-V with no bound destination opens destination picker', async () => {
     const MARKER = 'rl-sts-004-marker';
 
-    const srcTerminal = await createTerminal('csc-sts-004-src', tmpTerminals);
+    const srcTerminal = await ss.createTerminal('csc-sts-004-src');
 
     echoToTerminal(srcTerminal, MARKER);
-    await settle(TERMINAL_READY_MS);
+    await ss.settle(TERMINAL_READY_MS);
 
     const logCapture004 = getLogCapture();
     logCapture004.mark('before-sts-004');
@@ -320,16 +311,15 @@ standardSuite('Core Send Commands', (log) => {
       'Expected destination picker to open (no showQuickPick log entry found)',
     );
     assert.ok(items004.length > 0, 'Expected destination picker to contain at least one item');
-    log('✓ R-V with no bound destination opens picker (log-based)');
+    ss.log('✓ R-V with no bound destination opens picker (log-based)');
   });
 
   test('core-send-commands-r-l-005: R-L with no bound destination opens picker', async () => {
-    const fileUri = createWorkspaceFile('csc-r-l-005', 'test content\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('csc-r-l-005', 'test content\n');
     const doc = await vscode.workspace.openTextDocument(fileUri);
     const editor = await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 4));
-    await settle();
+    await ss.settle();
 
     const logCaptureRl005 = getLogCapture();
     logCaptureRl005.mark('before-r-l-005');
@@ -342,16 +332,15 @@ standardSuite('Core Send Commands', (log) => {
       'Expected destination picker to open (no showQuickPick log entry found)',
     );
     assert.ok(itemsRl005.length > 0, 'Expected destination picker to contain at least one item');
-    log('✓ R-L with no destination opens picker (log-based)');
+    ss.log('✓ R-L with no destination opens picker (log-based)');
   });
 
   test('core-send-commands-r-p-001: Send Portable Link with no bound destination opens picker', async () => {
-    const fileUri = createWorkspaceFile('csc-r-p-001', 'test content\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('csc-r-p-001', 'test content\n');
     const doc = await vscode.workspace.openTextDocument(fileUri);
     const editor = await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 4));
-    await settle();
+    await ss.settle();
 
     const logCaptureRp001 = getLogCapture();
     logCaptureRp001.mark('before-r-p-001');
@@ -364,16 +353,15 @@ standardSuite('Core Send Commands', (log) => {
       'Expected destination picker to open (no showQuickPick log entry found)',
     );
     assert.ok(itemsRp001.length > 0, 'Expected destination picker to contain at least one item');
-    log('✓ Send Portable Link with no destination opens picker (log-based)');
+    ss.log('✓ Send Portable Link with no destination opens picker (log-based)');
   });
 
   test('core-send-commands-r-v-001: Send Selected Text with no bound destination opens picker', async () => {
-    const fileUri = createWorkspaceFile('csc-r-v-001', 'test content\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('csc-r-v-001', 'test content\n');
     const doc = await vscode.workspace.openTextDocument(fileUri);
     const editor = await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 4));
-    await settle();
+    await ss.settle();
 
     const logCaptureRv001 = getLogCapture();
     logCaptureRv001.mark('before-r-v-001');
@@ -386,19 +374,20 @@ standardSuite('Core Send Commands', (log) => {
       'Expected destination picker to open (no showQuickPick log entry found)',
     );
     assert.ok(itemsRv001.length > 0, 'Expected destination picker to contain at least one item');
-    log('✓ Send Selected Text with no destination opens picker (log-based)');
+    ss.log('✓ Send Selected Text with no destination opens picker (log-based)');
   });
 
   test('send-terminal-selection-006: R-L with terminal focus shows no-active-editor error', async () => {
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal('csc-sts-006-dest');
+    const capturing: CapturingTerminal =
+      await ss.createAndBindCapturingTerminal('csc-sts-006-dest');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-sts-006');
 
     capturing.terminal.show();
-    await settle();
+    await ss.settle();
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-sts-006');
     assertToastLogged(lines, {
@@ -412,19 +401,20 @@ standardSuite('Core Send Commands', (log) => {
     assertNoStatusBarMsgLogged(lines, {
       message: '✓ RangeLink: RangeLink copied to clipboard & sent to Terminal ("csc-sts-006-dest")',
     });
-    log('✓ R-L from terminal focus shows no-active-editor error');
+    ss.log('✓ R-L from terminal focus shows no-active-editor error');
   });
 
   test('send-terminal-selection-007: R-C with terminal focus shows no-active-editor error', async () => {
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal('csc-sts-007-dest');
+    const capturing: CapturingTerminal =
+      await ss.createAndBindCapturingTerminal('csc-sts-007-dest');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-sts-007');
 
     capturing.terminal.show();
-    await settle();
+    await ss.settle();
     await vscode.commands.executeCommand(CMD_COPY_LINK_ONLY_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-sts-007');
     assertToastLogged(lines, {
@@ -435,24 +425,27 @@ standardSuite('Core Send Commands', (log) => {
       !lines.some((line) => line.includes('VscodeAdapter.writeTextToClipboard')),
       'Expected no clipboard write when R-C invoked from terminal focus',
     );
-    log('✓ R-C from terminal focus shows no-active-editor error');
+    ss.log('✓ R-C from terminal focus shows no-active-editor error');
   });
 
   test('core-send-commands-r-l-001: R-L sends RangeLink to bound terminal', async () => {
-    const capturing: CapturingTerminal = await createAndBindCapturingTerminal('csc-r-l-001-dest');
+    const capturing: CapturingTerminal =
+      await ss.createAndBindCapturingTerminal('csc-r-l-001-dest');
 
-    const fileUri = createWorkspaceFile('csc-r-l-001', 'line 1\nline 2\nline 3\nline 4\nline 5\n');
-    tmpFileUris.push(fileUri);
-    const editor = await openEditor(fileUri);
+    const fileUri = ss.createWorkspaceFile(
+      'csc-r-l-001',
+      'line 1\nline 2\nline 3\nline 4\nline 5\n',
+    );
+    const editor = await ss.openEditor(fileUri);
     editor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(4, 0));
-    await settle();
+    await ss.settle();
     capturing.clearCaptured();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-r-l-001');
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-r-l-001');
     assertStatusBarMsgLogged(lines, {
@@ -464,27 +457,26 @@ standardSuite('Core Send Commands', (log) => {
       captured.startsWith(' ') && captured.endsWith(' '),
       `Expected padded (space-bracketed) link in terminal buffer, got: ${JSON.stringify(captured)}`,
     );
-    log('✓ R-L sent padded RangeLink to bound terminal');
+    ss.log('✓ R-L sent padded RangeLink to bound terminal');
   });
 
   test('full-line-selection-validation-001: R-L after expandLineSelection generates link without error', async () => {
     const capturing: CapturingTerminal =
-      await createAndBindCapturingTerminal('csc-fullline-001-dest');
+      await ss.createAndBindCapturingTerminal('csc-fullline-001-dest');
 
-    const fileUri = createWorkspaceFile('csc-fullline-001', 'line 1\nline 2\nline 3\n');
-    tmpFileUris.push(fileUri);
-    await openEditor(fileUri);
-    await settle();
+    const fileUri = ss.createWorkspaceFile('csc-fullline-001', 'line 1\nline 2\nline 3\n');
+    await ss.openEditor(fileUri);
+    await ss.settle();
 
     await vscode.commands.executeCommand('expandLineSelection');
-    await settle();
+    await ss.settle();
     capturing.clearCaptured();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-fullline-001');
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-fullline-001');
     assertStatusBarMsgLogged(lines, {
@@ -501,6 +493,6 @@ standardSuite('Core Send Commands', (log) => {
       captured.startsWith(' ') && captured.endsWith(' '),
       `Expected padded link in terminal buffer, got: ${JSON.stringify(captured)}`,
     );
-    log('✓ Full-line selection → R-L: link generated, no error');
+    ss.log('✓ Full-line selection → R-L: link generated, no error');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
@@ -85,9 +85,10 @@ standardSuite('Core Send Commands', (ss) => {
   });
 
   test('[assisted] core-send-commands-r-l-003: R-L sends RangeLink to bound AI assistant destination', async () => {
+    const CSC_R_L_003_LINE_COUNT = 10;
     const { uri: fileUri } = ss.createContentFile(
       'csc-r-l-003',
-      10,
+      CSC_R_L_003_LINE_COUNT,
       (i) => `line ${i + 1} content`,
     );
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/customAiAssistants.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/customAiAssistants.test.ts
@@ -7,12 +7,9 @@ import {
   assertClipboardChanged,
   assertClipboardRestored,
   assertToastLogged,
-  cleanupFiles,
-  createAndOpenFile,
   extractQuickPickItemsLogged,
   getLogCapture,
   openAndDismiss,
-  settle,
   standardSuite,
   waitForHuman,
   waitForHumanVerdict,
@@ -22,7 +19,7 @@ import {
 const EXPECTED_CUSTOM_ASSISTANTS_COUNT = 7;
 const EXPECTED_CUSTOM_AI_REGISTRATIONS = 6;
 
-standardSuite('Custom AI Assistants', (_log) => {
+standardSuite('Custom AI Assistants', (_ss) => {
   test('custom-ai-assistant-001: three-tier config is parsed and logged at activation', () => {
     const logCapture = getLogCapture();
     const allLines = logCapture.getAllLines();
@@ -204,7 +201,7 @@ standardSuite('Custom AI Assistants', (_log) => {
   });
 });
 
-standardSuite('Custom AI Assistants — Destination Picker', (log) => {
+standardSuite('Custom AI Assistants — Destination Picker', (ss) => {
   test('custom-ai-assistant-003: custom AI assistant appears in R-D destination picker with configured display name', async () => {
     const logCapture = getLogCapture();
     logCapture.mark('before-003');
@@ -219,7 +216,7 @@ standardSuite('Custom AI Assistants — Destination Picker', (log) => {
     assert.ok(tier1, 'Expected "Dummy AI (Tier 1)" in the destination picker items');
     assert.strictEqual(tier1!.itemKind, 'bindable');
 
-    log('✓ custom-ai-assistant-003 — log confirms "Dummy AI (Tier 1)" appears in R-D picker');
+    ss.log('✓ custom-ai-assistant-003 — log confirms "Dummy AI (Tier 1)" appears in R-D picker');
   });
 
   test('custom-ai-assistant-007: multiple custom AI assistants listed in user-defined order', async () => {
@@ -255,26 +252,20 @@ standardSuite('Custom AI Assistants — Destination Picker', (log) => {
       );
     }
 
-    log(
+    ss.log(
       '✓ custom-ai-assistant-007 — log confirms custom AI assistants appear in settings.json order',
     );
   });
 });
 
-standardSuite('Custom AI Assistants — Cold Start', (log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-
+standardSuite('Custom AI Assistants — Cold Start', (ss) => {
   teardown(async () => {
     await vscode.commands.executeCommand('dummyAi.clearAll');
-    cleanupFiles(tmpFileUris);
-    tmpFileUris.length = 0;
-    await settle();
   });
 
   test('[assisted] custom-ai-assistant-017: Tier 1 direct insert works when panel is not yet visible', async () => {
-    const uri = await createAndOpenFile('__rl-test-cold-start', 'cold start test');
-    tmpFileUris.push(uri);
-    await settle();
+    await ss.createAndOpenFile('__rl-test-cold-start', 'cold start test');
+    await ss.settle();
 
     await waitForHuman(
       'custom-ai-assistant-017',
@@ -287,7 +278,7 @@ standardSuite('Custom AI Assistants — Cold Start', (log) => {
 
     await vscode.commands.executeCommand('editor.action.selectAll');
     await vscode.commands.executeCommand('rangelink.copyLinkWithRelativePath');
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-cold-start');
 
@@ -311,30 +302,24 @@ standardSuite('Custom AI Assistants — Cold Start', (log) => {
       'Expected tier2 textarea to be empty (no cross-contamination)',
     );
 
-    log('✓ Tier 1 cold start — panel auto-initialized, text delivered');
+    ss.log('✓ Tier 1 cold start — panel auto-initialized, text delivered');
   });
 });
 
-standardSuite('Custom AI Assistants — Paste Flow', (log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-
+standardSuite('Custom AI Assistants — Paste Flow', (ss) => {
   suiteSetup(async () => {
     await vscode.commands.executeCommand('dummyAi.focusPanel');
-    await settle();
+    await ss.settle();
     await vscode.commands.executeCommand('dummyAi.getText');
   });
 
   teardown(async () => {
     await vscode.commands.executeCommand('dummyAi.clearAll');
-    cleanupFiles(tmpFileUris);
-    tmpFileUris.length = 0;
-    await settle();
   });
 
   test('[assisted] custom-ai-assistant-010: Tier 1 direct insert delivers text to dummy textarea', async () => {
-    const uri = await createAndOpenFile('__rl-test-tier1', 'hello world\nline two\nline three');
-    tmpFileUris.push(uri);
-    await settle();
+    await ss.createAndOpenFile('__rl-test-tier1', 'hello world\nline two\nline three');
+    await ss.settle();
 
     await waitForHuman('custom-ai-assistant-010', "Cmd+R Cmd+D → select 'Dummy AI (Tier 1)'", [
       'Press Cmd+R Cmd+D and select "Dummy AI (Tier 1)" from the picker.',
@@ -345,7 +330,7 @@ standardSuite('Custom AI Assistants — Paste Flow', (log) => {
 
     await vscode.commands.executeCommand('editor.action.selectAll');
     await vscode.commands.executeCommand('rangelink.copyLinkWithRelativePath');
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-tier1-paste');
 
@@ -369,13 +354,12 @@ standardSuite('Custom AI Assistants — Paste Flow', (log) => {
       'Expected tier2 textarea to be empty (no cross-contamination)',
     );
 
-    log('✓ Tier 1 direct insert delivered text to dummy textarea');
+    ss.log('✓ Tier 1 direct insert delivered text to dummy textarea');
   });
 
   test('[assisted] custom-ai-assistant-011: Tier 1 clipboard isolation — sentinel preserved', async () => {
-    const uri = await createAndOpenFile('__rl-test-tier1-clip', 'clipboard test');
-    tmpFileUris.push(uri);
-    await settle();
+    await ss.createAndOpenFile('__rl-test-tier1-clip', 'clipboard test');
+    await ss.settle();
 
     await waitForHuman('custom-ai-assistant-011', "Cmd+R Cmd+D → select 'Dummy AI (Tier 1)'", [
       'Press Cmd+R Cmd+D and select "Dummy AI (Tier 1)" from the picker.',
@@ -387,19 +371,18 @@ standardSuite('Custom AI Assistants — Paste Flow', (log) => {
 
     await vscode.commands.executeCommand('editor.action.selectAll');
     await vscode.commands.executeCommand('rangelink.copyLinkWithRelativePath');
-    await settle();
+    await ss.settle();
 
     await assertClipboardRestored(
       'Tier 1 should not disturb clipboard — outer preserve restores sentinel',
     );
 
-    log('✓ Tier 1 clipboard isolation — sentinel preserved after R-L');
+    ss.log('✓ Tier 1 clipboard isolation — sentinel preserved after R-L');
   });
 
   test('[assisted] custom-ai-assistant-012: Tier 3 shows manual-paste toast and clipboard not restored', async () => {
-    const uri = await createAndOpenFile('__rl-test-tier3', 'tier three test');
-    tmpFileUris.push(uri);
-    await settle();
+    await ss.createAndOpenFile('__rl-test-tier3', 'tier three test');
+    await ss.settle();
 
     await waitForHuman('custom-ai-assistant-012', "Cmd+R Cmd+D → select 'Dummy AI (Tier 3)'", [
       'Press Cmd+R Cmd+D and select "Dummy AI (Tier 3)" from the picker.',
@@ -411,7 +394,7 @@ standardSuite('Custom AI Assistants — Paste Flow', (log) => {
 
     await vscode.commands.executeCommand('editor.action.selectAll');
     await vscode.commands.executeCommand('rangelink.copyLinkWithRelativePath');
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-tier3-paste');
 
@@ -463,15 +446,14 @@ standardSuite('Custom AI Assistants — Paste Flow', (log) => {
       'Expected tier1 textarea to be empty (Tier 3 uses manual paste, not direct insert)',
     );
 
-    log(
+    ss.log(
       '✓ Tier 3 shows manual-paste toast, clipboard not restored (link stays), manual paste verified',
     );
   });
 
   test('[assisted] custom-ai-assistant-013: Tier 2→3 fallback — clipboard not restored and manual paste works', async () => {
-    const uri = await createAndOpenFile('__rl-test-fallback', 'fallback test');
-    tmpFileUris.push(uri);
-    await settle();
+    await ss.createAndOpenFile('__rl-test-fallback', 'fallback test');
+    await ss.settle();
 
     await waitForHuman('custom-ai-assistant-013', "Cmd+R Cmd+D → select 'Dummy AI (Fallback)'", [
       'Press Cmd+R Cmd+D and select "Dummy AI (Fallback)" from the picker.',
@@ -483,7 +465,7 @@ standardSuite('Custom AI Assistants — Paste Flow', (log) => {
 
     await vscode.commands.executeCommand('editor.action.selectAll');
     await vscode.commands.executeCommand('rangelink.copyLinkWithRelativePath');
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-fallback-paste');
 
@@ -544,13 +526,12 @@ standardSuite('Custom AI Assistants — Paste Flow', (log) => {
       'Expected tier1 textarea to be empty (fallback resolved to focusCommands, not direct insert)',
     );
 
-    log('✓ Tier 2→3 fallback: clipboard not restored, manual paste verified');
+    ss.log('✓ Tier 2→3 fallback: clipboard not restored, manual paste verified');
   });
 
   test('[assisted] custom-ai-assistant-014: ${content} template delivers text via insertWithArgs', async () => {
-    const uri = await createAndOpenFile('__rl-test-template', 'template test content');
-    tmpFileUris.push(uri);
-    await settle();
+    await ss.createAndOpenFile('__rl-test-template', 'template test content');
+    await ss.settle();
 
     await waitForHuman('custom-ai-assistant-014', "Cmd+R Cmd+D → select 'Dummy AI (Template)'", [
       'Press Cmd+R Cmd+D and select "Dummy AI (Template)" from the picker.',
@@ -561,7 +542,7 @@ standardSuite('Custom AI Assistants — Paste Flow', (log) => {
 
     await vscode.commands.executeCommand('editor.action.selectAll');
     await vscode.commands.executeCommand('rangelink.copyLinkWithRelativePath');
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-template-paste');
 
@@ -580,6 +561,8 @@ standardSuite('Custom AI Assistants — Paste Flow', (log) => {
       'Expected tier1 textarea to contain the link via template interpolation',
     );
 
-    log('✓ ${content} template interpolation delivered text to dummy textarea via insertWithArgs');
+    ss.log(
+      '✓ ${content} template interpolation delivered text to dummy textarea via insertWithArgs',
+    );
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/dirtyBufferWarning.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/dirtyBufferWarning.test.ts
@@ -9,33 +9,17 @@ import {
   assertStatusBarMsgLogged,
   assertTerminalBufferContains,
   assertTerminalBufferEquals,
-  cleanupFiles,
-  closeAllEditors,
-  createAndBindCapturingTerminal,
-  createCapturingTerminal,
-  createWorkspaceFile,
   getLogCapture,
-  openEditor,
-  settle,
   standardSuite,
   waitForHuman,
   waitForHumanVerdict,
   writeClipboardSentinel,
 } from '../helpers';
 
-standardSuite('Dirty Buffer Warning', (_log) => {
-  let testFileUri: vscode.Uri;
-
-  suiteSetup(async () => {
-    testFileUri = createWorkspaceFile('dirty', 'const x = 1;\n');
-  });
-
-  suiteTeardown(async () => {
-    cleanupFiles([testFileUri]);
-  });
-
+standardSuite('Dirty Buffer Warning', (ss) => {
   test('dirty-buffer-warning-004: warnOnDirtyBuffer=false — R-C generates link without showing warning dialog', async () => {
-    const editor = await openEditor(testFileUri);
+    const testFileUri = ss.createWorkspaceFile('dirty', 'const x = 1;\n');
+    const editor = await ss.openEditor(testFileUri);
 
     await editor.edit((editBuilder) => {
       editBuilder.insert(new vscode.Position(0, 0), '// dirty\n');
@@ -69,10 +53,11 @@ standardSuite('Dirty Buffer Warning', (_log) => {
   });
 
   test('[assisted] dirty-buffer-warning-008: warnOnDirtyBuffer=false — R-F sends file path without showing warning dialog', async () => {
-    const capturing = await createCapturingTerminal('dirty-buffer-test');
+    const testFileUri = ss.createWorkspaceFile('dirty', 'const x = 1;\n');
+    const capturing = await ss.createCapturingTerminal('dirty-buffer-test');
 
     try {
-      const editor = await openEditor(testFileUri);
+      const editor = await ss.openEditor(testFileUri);
 
       await editor.edit((editBuilder) => {
         editBuilder.insert(new vscode.Position(0, 0), '// rf-dirty\n');
@@ -96,7 +81,7 @@ standardSuite('Dirty Buffer Warning', (_log) => {
         ],
       );
 
-      await settle();
+      await ss.settle();
 
       assert.ok(
         editor.document.isDirty,
@@ -132,12 +117,12 @@ standardSuite('Dirty Buffer Warning', (_log) => {
   });
 
   test('[assisted] dirty-buffer-warning-009: R-F on clean file sends path without warning', async () => {
-    const capturing = await createCapturingTerminal('dirty-buffer-test');
+    const capturing = await ss.createCapturingTerminal('dirty-buffer-test');
 
-    const cleanUri = createWorkspaceFile('clean-rf', 'clean content\n');
+    const cleanUri = ss.createWorkspaceFile('clean-rf', 'clean content\n');
 
     try {
-      const editor = await openEditor(cleanUri);
+      const editor = await ss.openEditor(cleanUri);
       assert.ok(!editor.document.isDirty, 'Expected document to be clean');
 
       const logCapture = getLogCapture();
@@ -153,7 +138,7 @@ standardSuite('Dirty Buffer Warning', (_log) => {
         ],
       );
 
-      await settle();
+      await ss.settle();
 
       assert.ok(!editor.document.isDirty, 'Expected document to remain clean');
 
@@ -169,16 +154,15 @@ standardSuite('Dirty Buffer Warning', (_log) => {
       );
     } finally {
       capturing.terminal.dispose();
-      await closeAllEditors();
-      cleanupFiles([cleanUri]);
     }
   });
 
   test('[assisted] dirty-buffer-warning-018: warnOnDirtyBuffer=false — R-L sends link to bound destination without warning dialog', async () => {
-    const capturing = await createAndBindCapturingTerminal('dirty-buffer-test');
+    const testFileUri = ss.createWorkspaceFile('dirty', 'const x = 1;\n');
+    const capturing = await ss.createAndBindCapturingTerminal('dirty-buffer-test');
 
     try {
-      const editor = await openEditor(testFileUri);
+      const editor = await ss.openEditor(testFileUri);
 
       await editor.edit((editBuilder) => {
         editBuilder.insert(new vscode.Position(0, 0), '// rl-bypass\n');
@@ -206,7 +190,7 @@ standardSuite('Dirty Buffer Warning', (_log) => {
         ],
       );
 
-      await settle();
+      await ss.settle();
 
       const lines = logCapture.getLinesSince('before-018');
       const disabledLog = lines.find(
@@ -235,10 +219,11 @@ standardSuite('Dirty Buffer Warning', (_log) => {
   });
 
   test('dirty-buffer-warning-006: warnOnDirtyBuffer=false — R-L sends link to bound destination without dialog', async () => {
-    const capturing = await createAndBindCapturingTerminal('dirty-buffer-test');
+    const testFileUri = ss.createWorkspaceFile('dirty', 'const x = 1;\n');
+    const capturing = await ss.createAndBindCapturingTerminal('dirty-buffer-test');
 
     try {
-      const editor = await openEditor(testFileUri);
+      const editor = await ss.openEditor(testFileUri);
 
       await editor.edit((editBuilder) => {
         editBuilder.insert(new vscode.Position(0, 0), '// dirty-006\n');
@@ -258,7 +243,7 @@ standardSuite('Dirty Buffer Warning', (_log) => {
       capturing.clearCaptured();
 
       await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-      await settle();
+      await ss.settle();
 
       const lines = logCapture.getLinesSince('before-006');
       const disabledLog = lines.find(
@@ -298,63 +283,58 @@ standardSuite('Dirty Buffer Warning', (_log) => {
   });
 
   test('dirty-buffer-warning-019: R-C on clean file generates link without warning dialog', async () => {
-    const cleanUri = createWorkspaceFile('clean-rc', 'clean rc content\n');
+    const cleanUri = ss.createWorkspaceFile('clean-rc', 'clean rc content\n');
 
-    try {
-      const editor = await openEditor(cleanUri);
-      assert.ok(!editor.document.isDirty, 'Expected document to be clean');
+    const editor = await ss.openEditor(cleanUri);
+    assert.ok(!editor.document.isDirty, 'Expected document to be clean');
 
-      editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 5));
+    editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 5));
 
-      await vscode.env.clipboard.writeText('rangelink-rc-clean-sentinel');
+    await vscode.env.clipboard.writeText('rangelink-rc-clean-sentinel');
 
-      const logCapture = getLogCapture();
-      logCapture.mark('before-019');
+    const logCapture = getLogCapture();
+    logCapture.mark('before-019');
 
-      await vscode.commands.executeCommand(CMD_COPY_LINK_ONLY_RELATIVE);
-      const clipboard = await vscode.env.clipboard.readText();
+    await vscode.commands.executeCommand(CMD_COPY_LINK_ONLY_RELATIVE);
+    const clipboard = await vscode.env.clipboard.readText();
 
-      assert.notStrictEqual(
-        clipboard,
-        'rangelink-rc-clean-sentinel',
-        'Expected clipboard to contain a generated link, not the sentinel',
-      );
-      assert.ok(
-        clipboard.includes('#L'),
-        `Expected clipboard to contain a line reference but got: ${clipboard}`,
-      );
-      assert.ok(!editor.document.isDirty, 'Expected document to remain clean');
+    assert.notStrictEqual(
+      clipboard,
+      'rangelink-rc-clean-sentinel',
+      'Expected clipboard to contain a generated link, not the sentinel',
+    );
+    assert.ok(
+      clipboard.includes('#L'),
+      `Expected clipboard to contain a line reference but got: ${clipboard}`,
+    );
+    assert.ok(!editor.document.isDirty, 'Expected document to remain clean');
 
-      const lines = logCapture.getLinesSince('before-019');
-      const warningLog = lines.find((l) => l.includes('handleDirtyBufferWarning'));
-      assert.strictEqual(
-        warningLog,
-        undefined,
-        'Expected no dirty buffer warning log for clean file — Clean early-return must not emit logs',
-      );
-    } finally {
-      await closeAllEditors();
-      cleanupFiles([cleanUri]);
-    }
+    const lines = logCapture.getLinesSince('before-019');
+    const warningLog = lines.find((l) => l.includes('handleDirtyBufferWarning'));
+    assert.strictEqual(
+      warningLog,
+      undefined,
+      'Expected no dirty buffer warning log for clean file — Clean early-return must not emit logs',
+    );
   });
 
   test('dirty-buffer-warning-007: clean file generates link immediately without dialog', async () => {
-    const capturing = await createAndBindCapturingTerminal('dirty-buffer-test');
+    const capturing = await ss.createAndBindCapturingTerminal('dirty-buffer-test');
 
-    const cleanUri = createWorkspaceFile('clean-rl-007', 'line 1\nline 2\nline 3\nline 4\n');
+    const cleanUri = ss.createWorkspaceFile('clean-rl-007', 'line 1\nline 2\nline 3\nline 4\n');
 
     try {
-      const editor = await openEditor(cleanUri);
+      const editor = await ss.openEditor(cleanUri);
       editor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(3, 0));
       await editor.document.save();
-      await settle();
+      await ss.settle();
       capturing.clearCaptured();
 
       const logCapture = getLogCapture();
       logCapture.mark('before-007');
 
       await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-      await settle();
+      await ss.settle();
 
       const lines = logCapture.getLinesSince('before-007');
       assertStatusBarMsgLogged(lines, {
@@ -373,28 +353,17 @@ standardSuite('Dirty Buffer Warning', (_log) => {
       );
     } finally {
       capturing.terminal.dispose();
-      await closeAllEditors();
-      cleanupFiles([cleanUri]);
     }
   });
 });
 
-standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
-  let testFileUri: vscode.Uri;
-
-  suiteSetup(async () => {
-    testFileUri = createWorkspaceFile('dirty-dialog', 'original content\n');
-  });
-
-  suiteTeardown(async () => {
-    cleanupFiles([testFileUri]);
-  });
-
+standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
   test('[assisted] dirty-buffer-warning-001: warnOnDirtyBuffer=true — R-L on dirty file shows warning dialog', async () => {
-    const capturing = await createAndBindCapturingTerminal('dirty-buffer-test');
+    const testFileUri = ss.createWorkspaceFile('dirty-dialog', 'original content\n');
+    const capturing = await ss.createAndBindCapturingTerminal('dirty-buffer-test');
 
     try {
-      const editor = await openEditor(testFileUri);
+      const editor = await ss.openEditor(testFileUri);
 
       await editor.edit((editBuilder) => {
         editBuilder.insert(new vscode.Position(0, 0), '// dirty-001\n');
@@ -425,7 +394,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
         'Human confirmed: warning dialog did NOT appear when R-L on dirty file',
       );
 
-      await settle();
+      await ss.settle();
 
       const lines = logCapture.getLinesSince('before-001');
       const showingWarningLog = lines.find(
@@ -440,17 +409,18 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
 
       assertTerminalBufferEquals(capturing.getCapturedText(), '');
 
-      log('✓ Warning dialog appeared when R-L on dirty file (default warnOnDirtyBuffer=true)');
+      ss.log('✓ Warning dialog appeared when R-L on dirty file (default warnOnDirtyBuffer=true)');
     } finally {
       capturing.terminal.dispose();
     }
   });
 
   test('[assisted] dirty-buffer-warning-002: dirty buffer dialog shows Save & Generate, Generate Anyway, and dismiss options', async () => {
-    const capturing = await createAndBindCapturingTerminal('dirty-buffer-test');
+    const testFileUri = ss.createWorkspaceFile('dirty-dialog', 'original content\n');
+    const capturing = await ss.createAndBindCapturingTerminal('dirty-buffer-test');
 
     try {
-      const editor = await openEditor(testFileUri);
+      const editor = await ss.openEditor(testFileUri);
 
       await editor.edit((editBuilder) => {
         editBuilder.insert(new vscode.Position(0, 0), '// dirty-002\n');
@@ -481,7 +451,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
         'Human confirmed: dialog options did not match expected (Save & Generate / Generate Anyway / dismiss)',
       );
 
-      await settle();
+      await ss.settle();
 
       const lines = logCapture.getLinesSince('before-002');
       const showingWarningLog = lines.find(
@@ -505,17 +475,18 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
 
       assertTerminalBufferEquals(capturing.getCapturedText(), '');
 
-      log('✓ Dialog showed 3 options: Save & Generate, Generate Anyway, and dismiss');
+      ss.log('✓ Dialog showed 3 options: Save & Generate, Generate Anyway, and dismiss');
     } finally {
       capturing.terminal.dispose();
     }
   });
 
   test('[assisted] dirty-buffer-warning-003: R-L Save & Generate saves file and sends link to bound destination', async () => {
-    const capturing = await createAndBindCapturingTerminal('dirty-buffer-test');
+    const testFileUri = ss.createWorkspaceFile('dirty-dialog', 'original content\n');
+    const capturing = await ss.createAndBindCapturingTerminal('dirty-buffer-test');
 
     try {
-      const editor = await openEditor(testFileUri);
+      const editor = await ss.openEditor(testFileUri);
 
       await editor.edit((editBuilder) => {
         editBuilder.insert(new vscode.Position(0, 0), '// dirty-003\n');
@@ -543,7 +514,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
         ],
       );
 
-      await settle();
+      await ss.settle();
 
       const lines = logCapture.getLinesSince('before-003');
       const showingWarningLog = lines.find(
@@ -565,17 +536,18 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
 
       await assertClipboardRestored('R-L Save & Generate: clipboard should be restored after send');
 
-      log('✓ R-L Save & Generate: file saved, link sent to terminal');
+      ss.log('✓ R-L Save & Generate: file saved, link sent to terminal');
     } finally {
       capturing.terminal.dispose();
     }
   });
 
   test('[assisted] dirty-buffer-warning-005: R-L dismiss aborts link generation, terminal unchanged', async () => {
-    const capturing = await createAndBindCapturingTerminal('dirty-buffer-test');
+    const testFileUri = ss.createWorkspaceFile('dirty-dialog', 'original content\n');
+    const capturing = await ss.createAndBindCapturingTerminal('dirty-buffer-test');
 
     try {
-      const editor = await openEditor(testFileUri);
+      const editor = await ss.openEditor(testFileUri);
 
       await editor.edit((editBuilder) => {
         editBuilder.insert(new vscode.Position(0, 0), '// dirty-005\n');
@@ -600,7 +572,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
         ],
       );
 
-      await settle();
+      await ss.settle();
 
       const lines = logCapture.getLinesSince('before-005');
       const showingWarningLog = lines.find(
@@ -623,14 +595,15 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
         'R-L dismiss: clipboard should still have sentinel (no send occurred)',
       );
 
-      log('✓ R-L dismiss: terminal unchanged, file still dirty');
+      ss.log('✓ R-L dismiss: terminal unchanged, file still dirty');
     } finally {
       capturing.terminal.dispose();
     }
   });
 
   test('[assisted] dirty-buffer-warning-010: R-C Save & Generate saves file and generates link', async () => {
-    const editor = await openEditor(testFileUri);
+    const testFileUri = ss.createWorkspaceFile('dirty-dialog', 'original content\n');
+    const editor = await ss.openEditor(testFileUri);
 
     await editor.edit((editBuilder) => {
       editBuilder.insert(new vscode.Position(0, 0), '// assisted-rc-save\n');
@@ -650,7 +623,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
       'Click "Save & Generate".',
     ]);
 
-    await settle();
+    await ss.settle();
     const clipboard = await vscode.env.clipboard.readText();
 
     const lines = logCapture.getLinesSince('before-010');
@@ -672,11 +645,12 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
     assert.ok(clipboard.includes('#L'), `Expected a RangeLink on clipboard but got: ${clipboard}`);
     assert.ok(!editor.document.isDirty, 'Expected document to be saved after Save & Generate');
 
-    log('✓ R-C Save & Generate: file saved, link generated');
+    ss.log('✓ R-C Save & Generate: file saved, link generated');
   });
 
   test('[assisted] dirty-buffer-warning-011: R-C Generate Anyway sends link without saving', async () => {
-    const editor = await openEditor(testFileUri);
+    const testFileUri = ss.createWorkspaceFile('dirty-dialog', 'original content\n');
+    const editor = await ss.openEditor(testFileUri);
 
     await editor.edit((editBuilder) => {
       editBuilder.insert(new vscode.Position(0, 0), '// assisted-rc-anyway\n');
@@ -696,7 +670,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
       'Click "Generate Anyway".',
     ]);
 
-    await settle();
+    await ss.settle();
     const clipboard = await vscode.env.clipboard.readText();
 
     const lines = logCapture.getLinesSince('before-011');
@@ -714,11 +688,12 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
     assert.ok(clipboard.includes('#L'), `Expected a RangeLink on clipboard but got: ${clipboard}`);
     assert.ok(editor.document.isDirty, 'Expected document to remain dirty after Generate Anyway');
 
-    log('✓ R-C Generate Anyway: link generated, file still dirty');
+    ss.log('✓ R-C Generate Anyway: link generated, file still dirty');
   });
 
   test('[assisted] dirty-buffer-warning-012: R-C dismiss aborts link generation', async () => {
-    const editor = await openEditor(testFileUri);
+    const testFileUri = ss.createWorkspaceFile('dirty-dialog', 'original content\n');
+    const editor = await ss.openEditor(testFileUri);
 
     await editor.edit((editBuilder) => {
       editBuilder.insert(new vscode.Position(0, 0), '// assisted-rc-dismiss\n');
@@ -742,7 +717,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
       ],
     );
 
-    await settle();
+    await ss.settle();
     const clipboard = await vscode.env.clipboard.readText();
 
     const lines = logCapture.getLinesSince('before-012');
@@ -763,14 +738,15 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
     );
     assert.ok(editor.document.isDirty, 'Expected document to remain dirty');
 
-    log('✓ R-C dismiss: no link generated, clipboard unchanged');
+    ss.log('✓ R-C dismiss: no link generated, clipboard unchanged');
   });
 
   test('[assisted] dirty-buffer-warning-013: R-F Save & Send saves file and sends path', async () => {
-    const capturing = await createCapturingTerminal('dirty-buffer-test');
+    const testFileUri = ss.createWorkspaceFile('dirty-dialog', 'original content\n');
+    const capturing = await ss.createCapturingTerminal('dirty-buffer-test');
 
     try {
-      const editor = await openEditor(testFileUri);
+      const editor = await ss.openEditor(testFileUri);
 
       await editor.edit((editBuilder) => {
         editBuilder.insert(new vscode.Position(0, 0), '// assisted-rf-save\n');
@@ -791,24 +767,25 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
         ],
       );
 
-      await settle();
+      await ss.settle();
 
       assert.ok(!editor.document.isDirty, 'Expected document to be saved after Save & Send');
 
       const relativePath = vscode.workspace.asRelativePath(testFileUri, false);
       assertTerminalBufferEquals(capturing.getCapturedText(), ` ${relativePath} `);
 
-      log('✓ R-F Save & Send: file saved, path sent (pty capture verified content)');
+      ss.log('✓ R-F Save & Send: file saved, path sent (pty capture verified content)');
     } finally {
       capturing.terminal.dispose();
     }
   });
 
   test('[assisted] dirty-buffer-warning-014: R-F Send Anyway sends path without saving', async () => {
-    const capturing = await createCapturingTerminal('dirty-buffer-test');
+    const testFileUri = ss.createWorkspaceFile('dirty-dialog', 'original content\n');
+    const capturing = await ss.createCapturingTerminal('dirty-buffer-test');
 
     try {
-      const editor = await openEditor(testFileUri);
+      const editor = await ss.openEditor(testFileUri);
 
       await editor.edit((editBuilder) => {
         editBuilder.insert(new vscode.Position(0, 0), '// assisted-rf-anyway\n');
@@ -829,21 +806,22 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
         ],
       );
 
-      await settle();
+      await ss.settle();
 
       assert.ok(editor.document.isDirty, 'Expected document to remain dirty after Send Anyway');
 
       const relativePath = vscode.workspace.asRelativePath(testFileUri, false);
       assertTerminalBufferEquals(capturing.getCapturedText(), ` ${relativePath} `);
 
-      log('✓ R-F Send Anyway: path sent, file still dirty (pty capture verified content)');
+      ss.log('✓ R-F Send Anyway: path sent, file still dirty (pty capture verified content)');
     } finally {
       capturing.terminal.dispose();
     }
   });
 
   test('[assisted] dirty-buffer-warning-015: R-F dismiss aborts file path send', async () => {
-    const editor = await openEditor(testFileUri);
+    const testFileUri = ss.createWorkspaceFile('dirty-dialog', 'original content\n');
+    const editor = await ss.openEditor(testFileUri);
 
     await editor.edit((editBuilder) => {
       editBuilder.insert(new vscode.Position(0, 0), '// assisted-rf-dismiss\n');
@@ -861,7 +839,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
       ],
     );
 
-    await settle();
+    await ss.settle();
     const clipboard = await vscode.env.clipboard.readText();
 
     assert.strictEqual(
@@ -871,14 +849,15 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
     );
     assert.ok(editor.document.isDirty, 'Expected document to remain dirty');
 
-    log('✓ R-F dismiss: no path sent, clipboard unchanged');
+    ss.log('✓ R-F dismiss: no path sent, clipboard unchanged');
   });
 
   test('[assisted] dirty-buffer-warning-016: R-L clipboard preserved after dirty buffer dialog with bound destination', async () => {
-    const capturing = await createAndBindCapturingTerminal('dirty-buffer-test');
+    const testFileUri = ss.createWorkspaceFile('dirty-dialog', 'original content\n');
+    const capturing = await ss.createAndBindCapturingTerminal('dirty-buffer-test');
 
     try {
-      const editor = await openEditor(testFileUri);
+      const editor = await ss.openEditor(testFileUri);
 
       await editor.edit((editBuilder) => {
         editBuilder.insert(new vscode.Position(0, 0), '// clipboard-preserve-rl\n');
@@ -902,7 +881,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
         ['Press Cmd+R Cmd+L — the dirty buffer dialog should appear.', 'Click "Generate Anyway".'],
       );
 
-      await settle();
+      await ss.settle();
 
       await assertClipboardRestored(
         'R-L with bound destination + dirty buffer dialog: clipboard should be restored after send',
@@ -912,7 +891,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
 
       assert.ok(editor.document.isDirty, 'Expected document to remain dirty after Generate Anyway');
 
-      log(
+      ss.log(
         '✓ R-L dirty + bound destination: link landed in terminal; clipboard preserved after Generate Anyway',
       );
     } finally {
@@ -921,10 +900,11 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
   });
 
   test('[assisted] dirty-buffer-warning-017: R-F clipboard preserved after dirty buffer dialog with bound destination', async () => {
-    const capturing = await createAndBindCapturingTerminal('dirty-buffer-test');
+    const testFileUri = ss.createWorkspaceFile('dirty-dialog', 'original content\n');
+    const capturing = await ss.createAndBindCapturingTerminal('dirty-buffer-test');
 
     try {
-      const editor = await openEditor(testFileUri);
+      const editor = await ss.openEditor(testFileUri);
 
       await editor.edit((editBuilder) => {
         editBuilder.insert(new vscode.Position(0, 0), '// clipboard-preserve-rf\n');
@@ -941,7 +921,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
         ['Press Cmd+R Cmd+F — the dirty buffer dialog should appear.', 'Click "Send Anyway".'],
       );
 
-      await settle();
+      await ss.settle();
 
       await assertClipboardRestored(
         'R-F with bound destination + dirty buffer dialog: clipboard should be restored after send',
@@ -952,7 +932,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
 
       assert.ok(editor.document.isDirty, 'Expected document to remain dirty after Send Anyway');
 
-      log(
+      ss.log(
         '✓ R-F dirty + bound destination: path landed in terminal; clipboard preserved after Send Anyway',
       );
     } finally {
@@ -961,10 +941,11 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
   });
 
   test('[assisted] dirty-buffer-warning-020: R-L Save & Generate saves file and sends link to bound destination', async () => {
-    const capturing = await createAndBindCapturingTerminal('dirty-buffer-test');
+    const testFileUri = ss.createWorkspaceFile('dirty-dialog', 'original content\n');
+    const capturing = await ss.createAndBindCapturingTerminal('dirty-buffer-test');
 
     try {
-      const editor = await openEditor(testFileUri);
+      const editor = await ss.openEditor(testFileUri);
 
       await editor.edit((editBuilder) => {
         editBuilder.insert(new vscode.Position(0, 0), '// assisted-rl-save\n');
@@ -992,7 +973,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
         ],
       );
 
-      await settle();
+      await ss.settle();
 
       const lines = logCapture.getLinesSince('before-020');
       const showingWarningLog = lines.find(
@@ -1013,17 +994,18 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
 
       assert.ok(!editor.document.isDirty, 'Expected document to be saved after Save & Generate');
 
-      log('✓ R-L Save & Generate: file saved, link landed in terminal');
+      ss.log('✓ R-L Save & Generate: file saved, link landed in terminal');
     } finally {
       capturing.terminal.dispose();
     }
   });
 
   test('[assisted] dirty-buffer-warning-021: R-L Generate Anyway sends link without saving', async () => {
-    const capturing = await createAndBindCapturingTerminal('dirty-buffer-test');
+    const testFileUri = ss.createWorkspaceFile('dirty-dialog', 'original content\n');
+    const capturing = await ss.createAndBindCapturingTerminal('dirty-buffer-test');
 
     try {
-      const editor = await openEditor(testFileUri);
+      const editor = await ss.openEditor(testFileUri);
 
       await editor.edit((editBuilder) => {
         editBuilder.insert(new vscode.Position(0, 0), '// assisted-rl-anyway\n');
@@ -1051,7 +1033,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
         ],
       );
 
-      await settle();
+      await ss.settle();
 
       const lines = logCapture.getLinesSince('before-021');
       const showingWarningLog = lines.find(
@@ -1072,17 +1054,18 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
 
       assert.ok(editor.document.isDirty, 'Expected document to remain dirty after Generate Anyway');
 
-      log('✓ R-L Generate Anyway: link landed in terminal, file still dirty');
+      ss.log('✓ R-L Generate Anyway: link landed in terminal, file still dirty');
     } finally {
       capturing.terminal.dispose();
     }
   });
 
   test('[assisted] dirty-buffer-warning-022: R-L dismiss aborts link generation', async () => {
-    const capturing = await createAndBindCapturingTerminal('dirty-buffer-test');
+    const testFileUri = ss.createWorkspaceFile('dirty-dialog', 'original content\n');
+    const capturing = await ss.createAndBindCapturingTerminal('dirty-buffer-test');
 
     try {
-      const editor = await openEditor(testFileUri);
+      const editor = await ss.openEditor(testFileUri);
 
       await editor.edit((editBuilder) => {
         editBuilder.insert(new vscode.Position(0, 0), '// assisted-rl-dismiss\n');
@@ -1110,7 +1093,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
         ],
       );
 
-      await settle();
+      await ss.settle();
 
       const lines = logCapture.getLinesSince('before-022');
       const showingWarningLog = lines.find(
@@ -1131,7 +1114,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (log) => {
 
       assert.ok(editor.document.isDirty, 'Expected document to remain dirty');
 
-      log('✓ R-L dismiss: terminal buffer empty (no send occurred)');
+      ss.log('✓ R-L dismiss: terminal buffer empty (no send occurred)');
     } finally {
       capturing.terminal.dispose();
     }

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/editorBindingValidation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/editorBindingValidation.test.ts
@@ -9,7 +9,6 @@ import {
   extractQuickPickItemsLogged,
   findTestItemsByPrefix,
   getLogCapture,
-  getWorkspaceRoot,
   openAndDismiss,
   standardSuite,
   waitForHumanVerdict,
@@ -82,9 +81,8 @@ standardSuite('Editor Binding Validation', (ss) => {
   test('editor-binding-validation-004: binary .png file is excluded from R-D destination picker', async () => {
     // Minimal PNG magic bytes — enough for VSCode to detect as binary
     const PNG_MAGIC = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-    const pngPath = path.join(getWorkspaceRoot(), `__rl-test-ebv-004-${Date.now()}.png`);
-    fs.writeFileSync(pngPath, PNG_MAGIC);
-    const pngUri = vscode.Uri.file(pngPath);
+    const pngUri = ss.createWorkspaceFile('ebv-004-png', '');
+    fs.writeFileSync(pngUri.fsPath, PNG_MAGIC);
 
     const txtUri = ss.createWorkspaceFile('ebv-004-txt', 'control file\n');
 
@@ -107,7 +105,7 @@ standardSuite('Editor Binding Validation', (ss) => {
     const items = extractQuickPickItemsLogged(lines);
     assert.ok(items, 'Expected showQuickPick log entry from R-D picker');
 
-    const pngFileName = path.basename(pngPath);
+    const pngFileName = path.basename(pngUri.fsPath);
     const txtFileName = path.basename(txtUri.fsPath);
 
     const pngItems = findTestItemsByPrefix(items!, pngFileName);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/editorBindingValidation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/editorBindingValidation.test.ts
@@ -9,6 +9,7 @@ import {
   extractQuickPickItemsLogged,
   findTestItemsByPrefix,
   getLogCapture,
+  getWorkspaceRoot,
   openAndDismiss,
   standardSuite,
   waitForHumanVerdict,
@@ -81,8 +82,10 @@ standardSuite('Editor Binding Validation', (ss) => {
   test('editor-binding-validation-004: binary .png file is excluded from R-D destination picker', async () => {
     // Minimal PNG magic bytes — enough for VSCode to detect as binary
     const PNG_MAGIC = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-    const pngUri = ss.createWorkspaceFile('ebv-004-png', '');
-    fs.writeFileSync(pngUri.fsPath, PNG_MAGIC);
+    const pngPath = path.join(getWorkspaceRoot(), `__rl-test-ebv-004-${Date.now()}.png`);
+    fs.writeFileSync(pngPath, PNG_MAGIC);
+    const pngUri = vscode.Uri.file(pngPath);
+    ss.trackFileUri(pngUri);
 
     const txtUri = ss.createWorkspaceFile('ebv-004-txt', 'control file\n');
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/editorBindingValidation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/editorBindingValidation.test.ts
@@ -6,26 +6,16 @@ import * as vscode from 'vscode';
 
 import { CMD_BIND_TO_DESTINATION } from '../../constants/commandIds';
 import {
-  cleanupFiles,
-  createWorkspaceFile,
   extractQuickPickItemsLogged,
   findTestItemsByPrefix,
   getLogCapture,
   getWorkspaceRoot,
   openAndDismiss,
-  settle,
   standardSuite,
   waitForHumanVerdict,
 } from '../helpers';
 
-standardSuite('Editor Binding Validation', (log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-
-  teardown(async () => {
-    cleanupFiles(tmpFileUris);
-    await settle();
-  });
-
+standardSuite('Editor Binding Validation', (ss) => {
   test('[assisted] editor-binding-validation-001: search editor content hides link and bind commands', async () => {
     const verdict = await waitForHumanVerdict(
       'editor-binding-validation-001',
@@ -44,7 +34,7 @@ standardSuite('Editor Binding Validation', (log) => {
       'pass',
       'Link or bind commands were visible in the search editor content area context menu',
     );
-    log('✓ Search editor content hides link/bind commands (human verdict)');
+    ss.log('✓ Search editor content hides link/bind commands (human verdict)');
   });
 
   test('[assisted] editor-binding-validation-002: output panel hides file path and bind commands', async () => {
@@ -66,7 +56,7 @@ standardSuite('Editor Binding Validation', (log) => {
       'pass',
       'File path or bind commands were visible in the output panel context menu',
     );
-    log('✓ Output panel hides file path/bind commands (human verdict)');
+    ss.log('✓ Output panel hides file path/bind commands (human verdict)');
   });
 
   test('[assisted] editor-binding-validation-003: Settings UI hides file path and bind commands', async () => {
@@ -86,7 +76,7 @@ standardSuite('Editor Binding Validation', (log) => {
     );
 
     assert.strictEqual(verdict, 'pass', 'File path or bind commands appeared for the Settings UI');
-    log('✓ Settings UI hides file path/bind commands (human verdict)');
+    ss.log('✓ Settings UI hides file path/bind commands (human verdict)');
   });
 
   test('editor-binding-validation-004: binary .png file is excluded from R-D destination picker', async () => {
@@ -95,10 +85,8 @@ standardSuite('Editor Binding Validation', (log) => {
     const pngPath = path.join(getWorkspaceRoot(), `__rl-test-ebv-004-${Date.now()}.png`);
     fs.writeFileSync(pngPath, PNG_MAGIC);
     const pngUri = vscode.Uri.file(pngPath);
-    tmpFileUris.push(pngUri);
 
-    const txtUri = createWorkspaceFile('ebv-004-txt', 'control file\n');
-    tmpFileUris.push(txtUri);
+    const txtUri = ss.createWorkspaceFile('ebv-004-txt', 'control file\n');
 
     const txtDoc = await vscode.workspace.openTextDocument(txtUri);
     await vscode.window.showTextDocument(txtDoc, vscode.ViewColumn.One);
@@ -108,7 +96,7 @@ standardSuite('Editor Binding Validation', (log) => {
     const pngDoc = await vscode.workspace.openTextDocument(pngUri);
     await vscode.window.showTextDocument(pngDoc, vscode.ViewColumn.Two);
 
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ebv-004');
@@ -135,7 +123,7 @@ standardSuite('Editor Binding Validation', (log) => {
       `Plain .txt file "${txtFileName}" must appear in R-D picker as positive control`,
     );
 
-    log('✓ Binary .png excluded from R-D picker; .txt control file present (log verified)');
+    ss.log('✓ Binary .png excluded from R-D picker; .txt control file present (log verified)');
   });
 
   test('[assisted] editor-binding-validation-005: search editor TAB hides file path commands', async () => {
@@ -156,6 +144,6 @@ standardSuite('Editor Binding Validation', (log) => {
       'pass',
       'File path commands were visible in the search editor tab context menu',
     );
-    log('✓ Search editor tab hides file path commands (human verdict)');
+    ss.log('✓ Search editor tab hides file path commands (human verdict)');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filePathNavigation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filePathNavigation.test.ts
@@ -5,32 +5,18 @@ import * as vscode from 'vscode';
 
 import {
   assertToastLogged,
-  cleanupFiles,
-  createWorkspaceFile,
   getLogCapture,
   getWorkspaceRoot,
   openEditor,
-  settle,
   standardSuite,
 } from '../helpers';
 
 const NON_EXISTENT_PATH_SETTLE_MS = 1000;
 
-standardSuite('File Path Navigation', (_log) => {
-  let testFileUri: vscode.Uri;
-  let anchorFileUri: vscode.Uri;
-
-  suiteSetup(async () => {
-    testFileUri = createWorkspaceFile('filepath', '// rangelink file path nav test\n');
-    anchorFileUri = createWorkspaceFile('filepath-anchor', '// anchor\n');
-    await openEditor(anchorFileUri);
-  });
-
-  suiteTeardown(async () => {
-    cleanupFiles([testFileUri, anchorFileUri]);
-  });
-
+standardSuite('File Path Navigation', (ss) => {
   test('clickable-file-paths-010: handleFilePathClick opens the file in the active editor', async () => {
+    const testFileUri = ss.createWorkspaceFile('filepath', '// rangelink file path nav test\n');
+
     await vscode.commands.executeCommand('rangelink.handleFilePathClick', {
       filePath: testFileUri.fsPath,
     });
@@ -44,6 +30,7 @@ standardSuite('File Path Navigation', (_log) => {
   });
 
   test('clickable-file-paths-011: handleFilePathClick with non-existent path does not change active editor', async () => {
+    const anchorFileUri = ss.createWorkspaceFile('filepath-anchor', '// anchor\n');
     await openEditor(anchorFileUri);
     const editorBefore = vscode.window.activeTextEditor?.document.uri.fsPath;
 
@@ -56,7 +43,7 @@ standardSuite('File Path Navigation', (_log) => {
       filePath: nonExistentPath,
     });
 
-    await settle(NON_EXISTENT_PATH_SETTLE_MS);
+    await ss.settle(NON_EXISTENT_PATH_SETTLE_MS);
 
     const editorAfter = vscode.window.activeTextEditor?.document.uri.fsPath;
     assert.strictEqual(

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filePicker.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filePicker.test.ts
@@ -6,15 +6,12 @@ import * as vscode from 'vscode';
 
 import { CMD_BIND_TO_DESTINATION, CMD_OPEN_STATUS_BAR_MENU } from '../../constants/commandIds';
 import {
-  cleanupFiles,
-  createAndOpenFile,
   extractQuickPickItemsLogged,
   findTestItemsByPrefix,
   getLogCapture,
   getWorkspaceRoot,
   openAndDismiss,
   parseQuickPickItemsFromLogLine,
-  settle,
   standardSuite,
   waitForHuman,
 } from '../helpers';
@@ -22,34 +19,16 @@ import {
 const SEPARATOR_KIND = -1;
 const FILE_OVERFLOW_THRESHOLD = 5;
 
-standardSuite('File Picker', (log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-
-  teardown(async () => {
-    cleanupFiles(tmpFileUris);
-    tmpFileUris.length = 0;
-    await settle();
-  });
-
+standardSuite('File Picker', (ss) => {
   const findTestFileItems = (items: Record<string, unknown>[]): Record<string, unknown>[] =>
     findTestItemsByPrefix(items, '__rl-test-fp-');
 
   test('file-picker-001: bound file appears first with bound badge', async () => {
-    const uriA = await createAndOpenFile(
-      'fp-001-a',
-      'line 1\nline 2\n',
-      vscode.ViewColumn.One,
-      tmpFileUris,
-    );
+    const uriA = await ss.createAndOpenFile('fp-001-a', 'line 1\nline 2\n', vscode.ViewColumn.One);
     const fnA = path.basename(uriA.fsPath);
     await vscode.commands.executeCommand('rangelink.bindToTextEditorHere');
-    await settle();
-    const uriB = await createAndOpenFile(
-      'fp-001-b',
-      'other file\n',
-      vscode.ViewColumn.Two,
-      tmpFileUris,
-    );
+    await ss.settle();
+    const uriB = await ss.createAndOpenFile('fp-001-b', 'other file\n', vscode.ViewColumn.Two);
     const fnB = path.basename(uriB.fsPath);
 
     const logCapture = getLogCapture();
@@ -88,23 +67,13 @@ standardSuite('File Picker', (log) => {
       ],
     );
 
-    log('✓ Bound file first with full semantic state + description');
+    ss.log('✓ Bound file first with full semantic state + description');
   });
 
   test('file-picker-002: active file appears before others in its group', async () => {
-    const uriA = await createAndOpenFile(
-      'fp-002-a',
-      'file a\n',
-      vscode.ViewColumn.One,
-      tmpFileUris,
-    );
+    const uriA = await ss.createAndOpenFile('fp-002-a', 'file a\n', vscode.ViewColumn.One);
     const fnA = path.basename(uriA.fsPath);
-    const uriB = await createAndOpenFile(
-      'fp-002-b',
-      'file b\n',
-      vscode.ViewColumn.Two,
-      tmpFileUris,
-    );
+    const uriB = await ss.createAndOpenFile('fp-002-b', 'file b\n', vscode.ViewColumn.Two);
     const fnB = path.basename(uriB.fsPath);
 
     const logCapture = getLogCapture();
@@ -143,7 +112,7 @@ standardSuite('File Picker', (log) => {
       ],
     );
 
-    log('✓ Files ordered by ViewColumn (Tab Group 1 before Tab Group 2)');
+    ss.log('✓ Files ordered by ViewColumn (Tab Group 1 before Tab Group 2)');
   });
 
   test('file-picker-003: same base name shows path disambiguation', async () => {
@@ -159,18 +128,17 @@ standardSuite('File Picker', (log) => {
     fs.writeFileSync(fileB, 'file B\n', 'utf8');
     const uriA = vscode.Uri.file(fileA);
     const uriB = vscode.Uri.file(fileB);
-    tmpFileUris.push(uriA, uriB);
 
     await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(uriA), {
       viewColumn: vscode.ViewColumn.One,
       preview: false,
     });
-    await settle();
+    await ss.settle();
     await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(uriB), {
       viewColumn: vscode.ViewColumn.Two,
       preview: false,
     });
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-fp-003');
@@ -220,11 +188,11 @@ standardSuite('File Picker', (log) => {
       ],
     );
 
-    log('✓ Path disambiguation validated with disambiguator in descriptions');
+    ss.log('✓ Path disambiguation validated with disambiguator in descriptions');
   });
 
   test('file-picker-004: open files appear as inline items in destination picker', async () => {
-    const uri = await createAndOpenFile('fp-004', 'content\n', undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('fp-004', 'content\n', undefined);
     const fn = path.basename(uri.fsPath);
 
     const logCapture = getLogCapture();
@@ -256,12 +224,12 @@ standardSuite('File Picker', (log) => {
       ],
     );
 
-    log('✓ File appears inline in R-D picker — full assertion');
+    ss.log('✓ File appears inline in R-D picker — full assertion');
   });
 
   test('file-picker-005: overflow shows "More files..." when exceeding inline limit', async () => {
     for (let i = 1; i <= FILE_OVERFLOW_THRESHOLD; i++) {
-      await createAndOpenFile(`fp-005-${i}`, `file ${i}\n`, undefined, tmpFileUris);
+      await ss.createAndOpenFile(`fp-005-${i}`, `file ${i}\n`, undefined);
     }
 
     const logCapture = getLogCapture();
@@ -295,13 +263,13 @@ standardSuite('File Picker', (log) => {
       },
     );
 
-    log('✓ File overflow fully validated with concrete expected count');
+    ss.log('✓ File overflow fully validated with concrete expected count');
   });
 
   test('[assisted] file-picker-006: secondary picker shows Active Files section', async () => {
     const fileNames: string[] = [];
     for (let i = 1; i <= FILE_OVERFLOW_THRESHOLD; i++) {
-      const uri = await createAndOpenFile(`fp-006-${i}`, `file ${i}\n`, undefined, tmpFileUris);
+      const uri = await ss.createAndOpenFile(`fp-006-${i}`, `file ${i}\n`, undefined);
       fileNames.push(path.basename(uri.fsPath));
     }
     const lastFileName = fileNames[fileNames.length - 1];
@@ -367,24 +335,23 @@ standardSuite('File Picker', (log) => {
       'Non-active file should have no description badge',
     );
 
-    log('✓ Secondary picker: active file has "active" badge, non-active has none');
+    ss.log('✓ Secondary picker: active file has "active" badge, non-active has none');
   });
 
   test('[assisted] file-picker-007: secondary picker shows Tab Group sections', async () => {
-    await createAndOpenFile('fp-007-g1', 'group 1\n', vscode.ViewColumn.One, tmpFileUris);
-    await createAndOpenFile('fp-007-g2', 'group 2\n', vscode.ViewColumn.Two, tmpFileUris);
+    await ss.createAndOpenFile('fp-007-g1', 'group 1\n', vscode.ViewColumn.One);
+    await ss.createAndOpenFile('fp-007-g2', 'group 2\n', vscode.ViewColumn.Two);
 
     const extraNames: string[] = [];
     for (let i = 1; i <= 3; i++) {
-      const uri = await createAndOpenFile(
+      const uri = await ss.createAndOpenFile(
         `fp-007-extra-${i}`,
         `extra ${i}\n`,
         vscode.ViewColumn.One,
-        tmpFileUris,
       );
       extraNames.push(path.basename(uri.fsPath));
     }
-    await createAndOpenFile('fp-007-g2b', 'group 2 extra\n', vscode.ViewColumn.Two, tmpFileUris);
+    await ss.createAndOpenFile('fp-007-g2b', 'group 2 extra\n', vscode.ViewColumn.Two);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-fp-007');
@@ -428,12 +395,12 @@ standardSuite('File Picker', (log) => {
       'Expected all test files to be bindable and not-bound',
     );
 
-    log('✓ Tab Group 1 + Tab Group 2 separators + test files validated');
+    ss.log('✓ Tab Group 1 + Tab Group 2 separators + test files validated');
   });
 
   test('[assisted] file-picker-008: escaping secondary file picker returns to parent', async () => {
     for (let i = 1; i <= FILE_OVERFLOW_THRESHOLD; i++) {
-      await createAndOpenFile(`fp-008-${i}`, `file ${i}\n`, undefined, tmpFileUris);
+      await ss.createAndOpenFile(`fp-008-${i}`, `file ${i}\n`, undefined);
     }
 
     const logCapture = getLogCapture();
@@ -466,7 +433,7 @@ standardSuite('File Picker', (log) => {
     });
     assert.deepStrictEqual(reopenedItems.map(mapFields), firstItems.map(mapFields));
 
-    log('✓ Reopened parent picker has identical items');
+    ss.log('✓ Reopened parent picker has identical items');
   });
 
   test('[assisted] file-picker-010: secondary picker shows path disambiguation for same-name files', async () => {
@@ -483,21 +450,20 @@ standardSuite('File Picker', (log) => {
     fs.writeFileSync(fileB, 'file B\n', 'utf8');
     const uriA = vscode.Uri.file(fileA);
     const uriB = vscode.Uri.file(fileB);
-    tmpFileUris.push(uriA, uriB);
 
     await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(uriA), {
       viewColumn: vscode.ViewColumn.One,
       preview: false,
     });
-    await settle();
+    await ss.settle();
     await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(uriB), {
       viewColumn: vscode.ViewColumn.Two,
       preview: false,
     });
-    await settle();
+    await ss.settle();
 
     for (let i = 1; i <= FILE_OVERFLOW_THRESHOLD; i++) {
-      await createAndOpenFile(`fp-010-filler-${i}`, `filler ${i}\n`, undefined, tmpFileUris);
+      await ss.createAndOpenFile(`fp-010-filler-${i}`, `filler ${i}\n`, undefined);
     }
 
     const logCapture = getLogCapture();
@@ -533,7 +499,7 @@ standardSuite('File Picker', (log) => {
       `Expected disambiguator paths in secondary picker descriptions but got: ${JSON.stringify(descriptions)}`,
     );
 
-    log('✓ Secondary picker shows path disambiguation');
+    ss.log('✓ Secondary picker shows path disambiguation');
   });
 
   test('file-picker-011: three files with same name show deeper disambiguation paths', async () => {
@@ -555,23 +521,22 @@ standardSuite('File Picker', (log) => {
       fs.writeFileSync(f, 'content\n', 'utf8');
       return vscode.Uri.file(f);
     });
-    tmpFileUris.push(...uris);
 
     await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(uris[0]), {
       viewColumn: vscode.ViewColumn.One,
       preview: false,
     });
-    await settle();
+    await ss.settle();
     await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(uris[1]), {
       viewColumn: vscode.ViewColumn.Two,
       preview: false,
     });
-    await settle();
+    await ss.settle();
     await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(uris[2]), {
       viewColumn: vscode.ViewColumn.Three,
       preview: false,
     });
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-fp-011');
@@ -628,23 +593,13 @@ standardSuite('File Picker', (log) => {
       `Expected 3 unique descriptions for disambiguation but got ${uniqueDescriptions.size}: ${JSON.stringify(descriptions)}`,
     );
 
-    log('✓ Three same-name files: same label/displayName, unique disambiguated descriptions');
+    ss.log('✓ Three same-name files: same label/displayName, unique disambiguated descriptions');
   });
 
   test('file-picker-012: unique file names have no disambiguator in description', async () => {
-    const uriA = await createAndOpenFile(
-      'fp-012-alpha',
-      'file a\n',
-      vscode.ViewColumn.One,
-      tmpFileUris,
-    );
+    const uriA = await ss.createAndOpenFile('fp-012-alpha', 'file a\n', vscode.ViewColumn.One);
     const fnA = path.basename(uriA.fsPath);
-    const uriB = await createAndOpenFile(
-      'fp-012-beta',
-      'file b\n',
-      vscode.ViewColumn.Two,
-      tmpFileUris,
-    );
+    const uriB = await ss.createAndOpenFile('fp-012-beta', 'file b\n', vscode.ViewColumn.Two);
     const fnB = path.basename(uriB.fsPath);
 
     const logCapture = getLogCapture();
@@ -683,11 +638,11 @@ standardSuite('File Picker', (log) => {
       ],
     );
 
-    log('✓ Unique file names: no disambiguator, ordered by ViewColumn');
+    ss.log('✓ Unique file names: no disambiguator, ordered by ViewColumn');
   });
 
   test('file-picker-009: file picker appears inline in R-M menu when unbound', async () => {
-    const uri = await createAndOpenFile('fp-009', 'content\n', undefined, tmpFileUris);
+    const uri = await ss.createAndOpenFile('fp-009', 'content\n', undefined);
     const fn = path.basename(uri.fsPath);
 
     const logCapture = getLogCapture();
@@ -722,6 +677,6 @@ standardSuite('File Picker', (log) => {
       ],
     );
 
-    log('✓ File appears inline in R-M menu — full assertion');
+    ss.log('✓ File appears inline in R-M menu — full assertion');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filePicker.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filePicker.test.ts
@@ -129,6 +129,9 @@ standardSuite('File Picker', (ss) => {
     const uriA = vscode.Uri.file(fileA);
     const uriB = vscode.Uri.file(fileB);
 
+    ss.trackFileUri(uriA);
+    ss.trackFileUri(uriB);
+
     await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(uriA), {
       viewColumn: vscode.ViewColumn.One,
       preview: false,
@@ -451,6 +454,9 @@ standardSuite('File Picker', (ss) => {
     const uriA = vscode.Uri.file(fileA);
     const uriB = vscode.Uri.file(fileB);
 
+    ss.trackFileUri(uriA);
+    ss.trackFileUri(uriB);
+
     await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(uriA), {
       viewColumn: vscode.ViewColumn.One,
       preview: false,
@@ -519,7 +525,9 @@ standardSuite('File Picker', (ss) => {
     ];
     const uris = files.map((f) => {
       fs.writeFileSync(f, 'content\n', 'utf8');
-      return vscode.Uri.file(f);
+      const uri = vscode.Uri.file(f);
+      ss.trackFileUri(uri);
+      return uri;
     });
 
     await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(uris[0]), {

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filenameOnlyNavigation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filenameOnlyNavigation.test.ts
@@ -18,7 +18,7 @@ import {
 
 const DUPLICATE_FILE_CONTENT = 'duplicate file content\n';
 
-standardSuite('Filename-Only Navigation Fallback', (_log) => {
+standardSuite('Filename-Only Navigation Fallback', (_ss) => {
   let uniqueFilename: string;
   let uniqueFilePath: string;
   let relativeFilePath: string;

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filenameOnlyNavigation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filenameOnlyNavigation.test.ts
@@ -12,13 +12,12 @@ import {
   getLogCapture,
   getWorkspaceRoot,
   navigateViaHandleLinkClick,
-  settle,
   standardSuite,
 } from '../helpers';
 
 const DUPLICATE_FILE_CONTENT = 'duplicate file content\n';
 
-standardSuite('Filename-Only Navigation Fallback', (_ss) => {
+standardSuite('Filename-Only Navigation Fallback', (ss) => {
   let uniqueFilename: string;
   let uniqueFilePath: string;
   let relativeFilePath: string;
@@ -115,7 +114,7 @@ standardSuite('Filename-Only Navigation Fallback', (_ss) => {
       linkText,
       parsed: parseResult.value,
     });
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-fallback-002');
     assertToastLogged(lines, {
@@ -139,7 +138,7 @@ standardSuite('Filename-Only Navigation Fallback', (_ss) => {
       linkText,
       parsed: parseResult.value,
     });
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-fallback-003');
     assertToastLogged(lines, {

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/goToRangeLink.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/goToRangeLink.test.ts
@@ -7,12 +7,9 @@ import { CMD_GO_TO_RANGELINK } from '../../constants/commandIds';
 import {
   assertInputBoxLogged,
   assertToastLogged,
-  cleanupFiles,
-  createAndOpenFile,
   extractQuickPickItemsLogged,
   getLogCapture,
   openAndDismiss,
-  settle,
   standardSuite,
   waitForHuman,
 } from '../helpers';
@@ -37,15 +34,7 @@ const assertUserCancelledInputLogged = (lines: string[]): void => {
   assert.ok(found, 'Expected GoToRangeLinkCommand.execute "User cancelled input" debug log');
 };
 
-standardSuite('R-G Go to Link', (log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-
-  teardown(async () => {
-    cleanupFiles(tmpFileUris);
-    tmpFileUris.length = 0;
-    await settle();
-  });
-
+standardSuite('R-G Go to Link', (ss) => {
   test('go-to-link-001: Cmd+R Cmd+G opens the Go to Link input box', async () => {
     const logCapture = getLogCapture();
     logCapture.mark('before-gtl-001');
@@ -57,16 +46,11 @@ standardSuite('R-G Go to Link', (log) => {
     assertInputBoxLogged(lines, INPUT_BOX_OPTS);
     assertUserCancelledInputLogged(lines);
 
-    log('✓ Input box opened with correct prompt/placeholder; cancellation logged');
+    ss.log('✓ Input box opened with correct prompt/placeholder; cancellation logged');
   });
 
   test('[assisted] go-to-link-003: valid link navigates to file and selects the range', async () => {
-    const uri = await createAndOpenFile(
-      'gtl-003',
-      buildFileContent(TEST_FILE_LINE_COUNT),
-      undefined,
-      tmpFileUris,
-    );
+    const uri = await ss.createAndOpenFile('gtl-003', buildFileContent(TEST_FILE_LINE_COUNT));
     const fn = path.basename(uri.fsPath);
     const linkText = `${fn}#L3-L7`;
 
@@ -107,16 +91,11 @@ standardSuite('R-G Go to Link', (log) => {
       { anchorLine: 2, anchorChar: 0, activeLine: 6, activeChar: endLineLength },
     );
 
-    log('✓ Navigation toast logged; editor selection spans lines 3-7 of the target file');
+    ss.log('✓ Navigation toast logged; editor selection spans lines 3-7 of the target file');
   });
 
   test('[assisted] go-to-link-004: character-level precision link selects the exact column range', async () => {
-    const uri = await createAndOpenFile(
-      'gtl-004',
-      buildFileContent(TEST_FILE_LINE_COUNT),
-      undefined,
-      tmpFileUris,
-    );
+    const uri = await ss.createAndOpenFile('gtl-004', buildFileContent(TEST_FILE_LINE_COUNT));
     const fn = path.basename(uri.fsPath);
     const linkText = `${fn}#L3C5-L3C20`;
 
@@ -156,7 +135,7 @@ standardSuite('R-G Go to Link', (log) => {
       { anchorLine: 2, anchorChar: 4, activeLine: 2, activeChar: 19 },
     );
 
-    log('✓ Character-precision navigation logged; selection spans col 5 to col 20 on line 3');
+    ss.log('✓ Character-precision navigation logged; selection spans col 5 to col 20 on line 3');
   });
 
   test('[assisted] go-to-link-005: invalid link format shows error toast', async () => {
@@ -195,7 +174,7 @@ standardSuite('R-G Go to Link', (log) => {
       'Expected active editor URI to be unchanged (no navigation occurred)',
     );
 
-    log('✓ Invalid input produced error toast with exact message; no navigation occurred');
+    ss.log('✓ Invalid input produced error toast with exact message; no navigation occurred');
   });
 
   test('[assisted] go-to-link-006: empty input shows error toast', async () => {
@@ -233,7 +212,7 @@ standardSuite('R-G Go to Link', (log) => {
       'Expected active editor URI to be unchanged (no navigation occurred)',
     );
 
-    log('✓ Empty input produced the empty-input error toast; no parse attempted');
+    ss.log('✓ Empty input produced the empty-input error toast; no parse attempted');
   });
 
   test('[assisted] go-to-link-007: nonexistent file path shows warning toast', async () => {
@@ -264,7 +243,7 @@ standardSuite('R-G Go to Link', (log) => {
       'Expected active editor URI to be unchanged (no navigation occurred)',
     );
 
-    log('✓ Nonexistent file produced the file-not-found warning toast with exact path');
+    ss.log('✓ Nonexistent file produced the file-not-found warning toast with exact path');
   });
 
   test('[assisted] go-to-link-008: Command Palette "RangeLink: Go to Link" opens the same input box', async () => {
@@ -287,7 +266,7 @@ standardSuite('R-G Go to Link', (log) => {
     assertInputBoxLogged(lines, INPUT_BOX_OPTS);
     assertUserCancelledInputLogged(lines);
 
-    log('✓ Command Palette entry opened the same Go to Link input box');
+    ss.log('✓ Command Palette entry opened the same Go to Link input box');
   });
 
   test('[assisted] go-to-link-009: R-M menu "Go to Link" item opens the same input box', async () => {
@@ -316,6 +295,6 @@ standardSuite('R-G Go to Link', (log) => {
     assertInputBoxLogged(lines, INPUT_BOX_OPTS);
     assertUserCancelledInputLogged(lines);
 
-    log('✓ R-M menu item routed to the Go to Link input box (same prompt/placeholder as R-G)');
+    ss.log('✓ R-M menu item routed to the Go to Link input box (same prompt/placeholder as R-G)');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/linkGeneration.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/linkGeneration.test.ts
@@ -4,7 +4,7 @@ import { NoOpLogger } from 'barebone-logger';
 import { DEFAULT_DELIMITERS, findLinksInText } from 'rangelink-core-ts';
 import * as vscode from 'vscode';
 
-import { openEditor, settle, standardSuite, waitForHumanVerdict } from '../helpers';
+import { standardSuite, waitForHumanVerdict } from '../helpers';
 
 const LOGGER = new NoOpLogger();
 
@@ -12,7 +12,7 @@ standardSuite('Link Generation', (ss) => {
   test('full-line-link-generation-001: selecting line + trailing newline generates #L20 not #L20-L21', async () => {
     const { uri } = ss.createContentFile('tc132', 25, (i) => `line ${i + 1} content`);
 
-    const editor = await openEditor(uri);
+    const editor = await ss.openEditor(uri);
 
     editor.selection = new vscode.Selection(new vscode.Position(19, 0), new vscode.Position(20, 0));
 
@@ -146,7 +146,7 @@ standardSuite('Link Generation — Clickable Links (Assisted)', (ss) => {
       '__rl-test-url-exclusion',
       'Some text\nhttps://example.com/path/file.ts#L10\nMore text\n',
     );
-    await settle();
+    await ss.settle();
 
     const verdict = await waitForHumanVerdict(
       'url-exclusion-002',
@@ -172,7 +172,7 @@ standardSuite('Link Generation — Clickable Links (Assisted)', (ss) => {
       '__rl-test-doc-link-tooltip',
       'See code at src/utils/helper.ts#L5 for details\n',
     );
-    await settle();
+    await ss.settle();
 
     const verdict = await waitForHumanVerdict(
       'document-link-tooltip-001',

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/linkGeneration.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/linkGeneration.test.ts
@@ -4,29 +4,13 @@ import { NoOpLogger } from 'barebone-logger';
 import { DEFAULT_DELIMITERS, findLinksInText } from 'rangelink-core-ts';
 import * as vscode from 'vscode';
 
-import {
-  cleanupFiles,
-  createAndOpenFile,
-  createWorkspaceFile,
-  openEditor,
-  settle,
-  standardSuite,
-  waitForHumanVerdict,
-} from '../helpers';
+import { openEditor, settle, standardSuite, waitForHumanVerdict } from '../helpers';
 
 const LOGGER = new NoOpLogger();
 
-standardSuite('Link Generation', (_log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-
-  suiteTeardown(async () => {
-    cleanupFiles(tmpFileUris);
-  });
-
+standardSuite('Link Generation', (ss) => {
   test('full-line-link-generation-001: selecting line + trailing newline generates #L20 not #L20-L21', async () => {
-    const lines = Array.from({ length: 25 }, (_, i) => `line ${i + 1} content`);
-    const uri = createWorkspaceFile('tc132', lines.join('\n') + '\n');
-    tmpFileUris.push(uri);
+    const { uri } = ss.createContentFile('tc132', 25, (i) => `line ${i + 1} content`);
 
     const editor = await openEditor(uri);
 
@@ -156,21 +140,12 @@ standardSuite('Link Generation', (_log) => {
   });
 });
 
-standardSuite('Link Generation — Clickable Links (Assisted)', (log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-
-  teardown(async () => {
-    cleanupFiles(tmpFileUris);
-    tmpFileUris.length = 0;
-    await settle();
-  });
-
+standardSuite('Link Generation — Clickable Links (Assisted)', (ss) => {
   test('[assisted] url-exclusion-002: https:// URL in document does not receive a RangeLink document link', async () => {
-    const uri = await createAndOpenFile(
+    await ss.createAndOpenFile(
       '__rl-test-url-exclusion',
       'Some text\nhttps://example.com/path/file.ts#L10\nMore text\n',
     );
-    tmpFileUris.push(uri);
     await settle();
 
     const verdict = await waitForHumanVerdict(
@@ -189,15 +164,14 @@ standardSuite('Link Generation — Clickable Links (Assisted)', (log) => {
       'pass',
       'Human reported FAIL: RangeLink document link appeared on https:// URL',
     );
-    log('✓ url-exclusion-002 — no RangeLink document link on https:// URL (human verified)');
+    ss.log('✓ url-exclusion-002 — no RangeLink document link on https:// URL (human verified)');
   });
 
   test('[assisted] document-link-tooltip-001: hovering a clickable RangeLink shows clean tooltip', async () => {
-    const uri = await createAndOpenFile(
+    await ss.createAndOpenFile(
       '__rl-test-doc-link-tooltip',
       'See code at src/utils/helper.ts#L5 for details\n',
     );
-    tmpFileUris.push(uri);
     await settle();
 
     const verdict = await waitForHumanVerdict(
@@ -212,6 +186,8 @@ standardSuite('Link Generation — Clickable Links (Assisted)', (log) => {
     );
 
     assert.strictEqual(verdict, 'pass', 'Human reported FAIL: document link tooltip was not clean');
-    log('✓ document-link-tooltip-001 — clean tooltip on RangeLink document link (human verified)');
+    ss.log(
+      '✓ document-link-tooltip-001 — clean tooltip on RangeLink document link (human verified)',
+    );
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationClamping.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationClamping.test.ts
@@ -1,16 +1,11 @@
 import assert from 'node:assert';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 
 import { DEFAULT_DELIMITERS, parseLink } from 'rangelink-core-ts';
-import * as vscode from 'vscode';
 
 import {
   assertToastLogged,
-  cleanupFiles,
   clearEditorSelection,
   getLogCapture,
-  getWorkspaceRoot,
   navigateViaHandleLinkClick,
   standardSuite,
 } from '../helpers';
@@ -18,23 +13,14 @@ import {
 const LINE_COUNT = 10;
 const LINE_CONTENT = 'abcdefghijklmnopqrst';
 
-standardSuite('Navigation Clamping', (_log) => {
-  let testFilename: string;
-  let testFileUri: vscode.Uri;
-
-  suiteSetup(async () => {
-    const lines = Array.from({ length: LINE_COUNT }, () => LINE_CONTENT);
-    testFilename = `__rl-test-clamp-${Date.now()}.ts`;
-    const testFilePath = path.join(getWorkspaceRoot(), testFilename);
-    fs.writeFileSync(testFilePath, lines.join('\n') + '\n', 'utf8');
-    testFileUri = vscode.Uri.file(testFilePath);
-  });
-
-  suiteTeardown(async () => {
-    cleanupFiles([testFileUri]);
-  });
-
+standardSuite('Navigation Clamping', (ss) => {
   test('navigation-clamping-001: #L50 on 10-line file — selection clamped to last line', async () => {
+    const { filename: testFilename } = ss.createContentFile(
+      'clamp-001',
+      LINE_COUNT,
+      () => LINE_CONTENT,
+    );
+
     const logCapture = getLogCapture();
     logCapture.mark('before-clamping-001');
 
@@ -69,6 +55,12 @@ standardSuite('Navigation Clamping', (_log) => {
   });
 
   test('navigation-clamping-002: #L1C200 on 20-char line — character clamped to line length', async () => {
+    const { filename: testFilename } = ss.createContentFile(
+      'clamp-002',
+      LINE_COUNT,
+      () => LINE_CONTENT,
+    );
+
     const logCapture = getLogCapture();
     logCapture.mark('before-clamping-002');
 
@@ -102,6 +94,12 @@ standardSuite('Navigation Clamping', (_log) => {
   });
 
   test('navigation-clamping-003: #L5C10 within bounds — selection at exact position', async () => {
+    const { filename: testFilename } = ss.createContentFile(
+      'clamp-003',
+      LINE_COUNT,
+      () => LINE_CONTENT,
+    );
+
     const logCapture = getLogCapture();
     logCapture.mark('before-clamping-003');
 
@@ -130,6 +128,12 @@ standardSuite('Navigation Clamping', (_log) => {
   });
 
   test('navigation-clamping-004: #L50C200 — both line and column clamped', async () => {
+    const { filename: testFilename } = ss.createContentFile(
+      'clamp-004',
+      LINE_COUNT,
+      () => LINE_CONTENT,
+    );
+
     const logCapture = getLogCapture();
     logCapture.mark('before-clamping-004');
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationPrecision.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationPrecision.test.ts
@@ -1,37 +1,23 @@
 import assert from 'node:assert';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 
 import { DEFAULT_DELIMITERS, parseLink } from 'rangelink-core-ts';
-import * as vscode from 'vscode';
 
 import {
   assertToastLogged,
-  cleanupFiles,
   clearEditorSelection,
   getLogCapture,
-  getWorkspaceRoot,
   navigateViaHandleLinkClick,
   standardSuite,
 } from '../helpers';
 
-standardSuite('Navigation Precision', (_log) => {
-  let testFilename: string;
-  let testFileUri: vscode.Uri;
-
-  suiteSetup(async () => {
-    const lines = Array.from({ length: 25 }, (_, i) => `line ${i + 1} content`);
-    testFilename = `__rl-test-nav-${Date.now()}.ts`;
-    const testFilePath = path.join(getWorkspaceRoot(), testFilename);
-    fs.writeFileSync(testFilePath, lines.join('\n') + '\n', 'utf8');
-    testFileUri = vscode.Uri.file(testFilePath);
-  });
-
-  suiteTeardown(async () => {
-    cleanupFiles([testFileUri]);
-  });
-
+standardSuite('Navigation Precision', (ss) => {
   test('full-line-navigation-001: #L10 navigates to full line 10 — selection spans col 0 to end of line', async () => {
+    const { filename: testFilename } = ss.createContentFile(
+      'nav-001',
+      25,
+      (i) => `line ${i + 1} content`,
+    );
+
     const linkText = `${testFilename}#L10`;
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
     assert.ok(parseResult.success, `Expected parseLink to succeed for: ${linkText}`);
@@ -65,6 +51,12 @@ standardSuite('Navigation Precision', (_log) => {
   });
 
   test('full-line-navigation-002: #L10-L15 navigates to range — anchor (9,0), active at end of line 15', async () => {
+    const { filename: testFilename } = ss.createContentFile(
+      'nav-002',
+      25,
+      (i) => `line ${i + 1} content`,
+    );
+
     const linkText = `${testFilename}#L10-L15`;
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
     assert.ok(parseResult.success, `Expected parseLink to succeed for: ${linkText}`);
@@ -98,6 +90,12 @@ standardSuite('Navigation Precision', (_log) => {
   });
 
   test('char-navigation-001: #L10C5 navigates to cursor position (9,4)', async () => {
+    const { filename: testFilename } = ss.createContentFile(
+      'nav-003',
+      25,
+      (i) => `line ${i + 1} content`,
+    );
+
     const linkText = `${testFilename}#L10C5`;
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
     assert.ok(parseResult.success, `Expected parseLink to succeed for: ${linkText}`);
@@ -126,6 +124,12 @@ standardSuite('Navigation Precision', (_log) => {
   });
 
   test('char-navigation-002: #L10C5-L15C10 navigates to range (9,4)→(14,9)', async () => {
+    const { filename: testFilename } = ss.createContentFile(
+      'nav-004',
+      25,
+      (i) => `line ${i + 1} content`,
+    );
+
     const linkText = `${testFilename}#L10C5-L15C10`;
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
     assert.ok(parseResult.success, `Expected parseLink to succeed for: ${linkText}`);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationPrecision.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationPrecision.test.ts
@@ -11,10 +11,12 @@ import {
 } from '../helpers';
 
 standardSuite('Navigation Precision', (ss) => {
+  const NAV_TEST_LINE_COUNT = 25;
+
   test('full-line-navigation-001: #L10 navigates to full line 10 — selection spans col 0 to end of line', async () => {
     const { filename: testFilename } = ss.createContentFile(
       'nav-001',
-      25,
+      NAV_TEST_LINE_COUNT,
       (i) => `line ${i + 1} content`,
     );
 
@@ -53,7 +55,7 @@ standardSuite('Navigation Precision', (ss) => {
   test('full-line-navigation-002: #L10-L15 navigates to range — anchor (9,0), active at end of line 15', async () => {
     const { filename: testFilename } = ss.createContentFile(
       'nav-002',
-      25,
+      NAV_TEST_LINE_COUNT,
       (i) => `line ${i + 1} content`,
     );
 
@@ -92,7 +94,7 @@ standardSuite('Navigation Precision', (ss) => {
   test('char-navigation-001: #L10C5 navigates to cursor position (9,4)', async () => {
     const { filename: testFilename } = ss.createContentFile(
       'nav-003',
-      25,
+      NAV_TEST_LINE_COUNT,
       (i) => `line ${i + 1} content`,
     );
 
@@ -126,7 +128,7 @@ standardSuite('Navigation Precision', (ss) => {
   test('char-navigation-002: #L10C5-L15C10 navigates to range (9,4)→(14,9)', async () => {
     const { filename: testFilename } = ss.createContentFile(
       'nav-004',
-      25,
+      NAV_TEST_LINE_COUNT,
       (i) => `line ${i + 1} content`,
     );
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationToastSettings.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationToastSettings.test.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert';
-import * as path from 'node:path';
 
 import { DEFAULT_DELIMITERS, parseLink } from 'rangelink-core-ts';
 import * as vscode from 'vscode';
@@ -8,28 +7,13 @@ import {
   assertNoToastLogged,
   assertSuppressionLogged,
   assertToastLogged,
-  cleanupFiles,
-  createWorkspaceFile,
   getLogCapture,
   navigateViaHandleLinkClick,
   settle,
   standardSuite,
 } from '../helpers';
 
-standardSuite('Navigation Toast Settings', (_log) => {
-  let testFilename: string;
-  let testFileUri: vscode.Uri;
-
-  suiteSetup(async () => {
-    const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1} content here`);
-    testFileUri = createWorkspaceFile('toast settings', lines.join('\n') + '\n');
-    testFilename = path.basename(testFileUri.fsPath);
-  });
-
-  suiteTeardown(async () => {
-    cleanupFiles([testFileUri]);
-  });
-
+standardSuite('Navigation Toast Settings', (ss) => {
   teardown(async () => {
     const config = vscode.workspace.getConfiguration('rangelink');
     await config.update(
@@ -45,6 +29,12 @@ standardSuite('Navigation Toast Settings', (_log) => {
   });
 
   test('navigation-toast-settings-001: showNavigatedToast=false suppresses info toast but navigation still works', async () => {
+    const { filename: testFilename } = ss.createContentFile(
+      'toast-settings-001',
+      10,
+      (i) => `line ${i + 1} content here`,
+    );
+
     await vscode.workspace
       .getConfiguration('rangelink')
       .update('navigation.showNavigatedToast', false, vscode.ConfigurationTarget.Workspace);
@@ -73,6 +63,12 @@ standardSuite('Navigation Toast Settings', (_log) => {
   });
 
   test('navigation-toast-settings-002: showClampingWarning=false suppresses clamping warning but navigation still works', async () => {
+    const { filename: testFilename } = ss.createContentFile(
+      'toast-settings-002',
+      10,
+      (i) => `line ${i + 1} content here`,
+    );
+
     await vscode.workspace
       .getConfiguration('rangelink')
       .update('navigation.showClampingWarning', false, vscode.ConfigurationTarget.Workspace);
@@ -106,6 +102,12 @@ standardSuite('Navigation Toast Settings', (_log) => {
   });
 
   test('navigation-toast-settings-003: default settings show info toast after successful navigation', async () => {
+    const { filename: testFilename } = ss.createContentFile(
+      'toast-settings-003',
+      10,
+      (i) => `line ${i + 1} content here`,
+    );
+
     const linkText = `${testFilename}#L3`;
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
     assert.ok(parseResult.success, `Expected parseLink to succeed for: ${linkText}`);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationToastSettings.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationToastSettings.test.ts
@@ -9,7 +9,6 @@ import {
   assertToastLogged,
   getLogCapture,
   navigateViaHandleLinkClick,
-  settle,
   standardSuite,
 } from '../helpers';
 
@@ -47,7 +46,7 @@ standardSuite('Navigation Toast Settings', (ss) => {
     logCapture.mark('before-toast-settings-001');
 
     const { sel } = await navigateViaHandleLinkClick(linkText, parseResult.value, testFilename);
-    await settle();
+    await ss.settle();
 
     assert.strictEqual(sel.anchor.line, 4, `Expected anchor line 4 but got ${sel.anchor.line}`);
 
@@ -85,7 +84,7 @@ standardSuite('Navigation Toast Settings', (ss) => {
       parseResult.value,
       testFilename,
     );
-    await settle();
+    await ss.settle();
 
     const lastLine = doc.lineCount - 1;
     assert.strictEqual(sel.anchor.line, lastLine, `Expected clamped to last line ${lastLine}`);
@@ -116,7 +115,7 @@ standardSuite('Navigation Toast Settings', (ss) => {
     logCapture.mark('before-toast-settings-003');
 
     const { sel } = await navigateViaHandleLinkClick(linkText, parseResult.value, testFilename);
-    await settle();
+    await ss.settle();
 
     assert.strictEqual(sel.anchor.line, 2, `Expected anchor line 2 but got ${sel.anchor.line}`);
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/platformKeybindings.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/platformKeybindings.test.ts
@@ -2,30 +2,17 @@ import assert from 'node:assert';
 
 import * as vscode from 'vscode';
 
-import {
-  cleanupFiles,
-  createWorkspaceFile,
-  settle,
-  standardSuite,
-  waitForHumanVerdict,
-} from '../helpers';
+import { standardSuite, waitForHumanVerdict } from '../helpers';
 
-standardSuite('Platform Keybindings', (_log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-
-  suiteTeardown(async () => {
-    cleanupFiles(tmpFileUris);
-  });
-
+standardSuite('Platform Keybindings', (ss) => {
   test('[assisted] ubuntu-ctrl-keybindings-001: Ctrl+R chords work on Ubuntu/Linux', async () => {
-    const testFileUri = createWorkspaceFile(
+    const testFileUri = ss.createWorkspaceFile(
       'ubuntu-ctrl-test',
       'line 1\nline 2\nline 3\nline 4\nline 5\n',
     );
-    tmpFileUris.push(testFileUri);
     const doc = await vscode.workspace.openTextDocument(testFileUri);
     await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
-    await settle();
+    await ss.settle();
 
     const verdict = await waitForHumanVerdict(
       'ubuntu-ctrl-keybindings-001',

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/releaseNotifier.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/releaseNotifier.test.ts
@@ -13,7 +13,7 @@ const getReleaseNotifier = () => {
   return ext.exports.releaseNotifier;
 };
 
-standardSuite('Release Notifier', (log) => {
+standardSuite('Release Notifier', (ss) => {
   test('release-notifier-001: first install stores version silently without notification', async () => {
     const notifier = getReleaseNotifier();
     await notifier.setLastNotifiedVersion(undefined);
@@ -37,7 +37,7 @@ standardSuite('Release Notifier', (log) => {
       undefined,
       'Expected version to be stored in globalState after first install',
     );
-    log('✓ First install: version stored silently, no notification shown');
+    ss.log('✓ First install: version stored silently, no notification shown');
   });
 
   test('release-notifier-002: same version stored — skips silently', async () => {
@@ -66,7 +66,7 @@ standardSuite('Release Notifier', (log) => {
       versionAfterFirstInstall,
       'Expected stored version to remain unchanged after same-version skip',
     );
-    log('✓ Same version: notification skipped, globalState unchanged');
+    ss.log('✓ Same version: notification skipped, globalState unchanged');
   });
 
   test('[assisted] release-notifier-003: upgrade detected — dismiss is temporary, version not stored', async () => {
@@ -109,7 +109,7 @@ standardSuite('Release Notifier', (log) => {
       '0.0.0',
       'Expected globalState to remain at "0.0.0" — dismiss must not store the new version',
     );
-    log(
+    ss.log(
       '✓ Upgrade notification dismissed; version not stored (still "0.0.0"), will reappear on next activation',
     );
   });
@@ -161,7 +161,7 @@ standardSuite('Release Notifier', (log) => {
       undefined,
       'Expected no second upgrade notification — version must have been stored',
     );
-    log(
+    ss.log(
       '✓ Upgrade notification: "What\'s New" stored version and opened browser; re-run confirmed no second popup',
     );
   });
@@ -218,7 +218,7 @@ standardSuite('Release Notifier', (log) => {
       undefined,
       'Expected no second upgrade notification — version must have been stored',
     );
-    log(
+    ss.log(
       '✓ Upgrade notification: "Skip for this version" stored version without opening browser; re-run confirmed no second popup',
     );
   });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/sendFilePath.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/sendFilePath.test.ts
@@ -13,6 +13,7 @@ import {
   assertTerminalBufferContains,
   assertTerminalBufferEquals,
   assertToastLogged,
+  createFileAt,
   extractQuickPickItemsLogged,
   getLogCapture,
   openEditor,
@@ -78,7 +79,8 @@ standardSuite('Send File Path', (ss) => {
   test('send-file-path-004: terminal destination — path with spaces is auto-quoted in single quotes', async () => {
     const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
 
-    const fileUri = ss.createWorkspaceFile('sfp-004', 'content\n');
+    const fileUri = createFileAt('__rl-test-my folder.ts', 'content\n');
+    ss.trackFileUri(fileUri);
     await openEditor(fileUri);
     await ss.settle();
 
@@ -110,7 +112,8 @@ standardSuite('Send File Path', (ss) => {
   test('send-file-path-005: terminal destination — path with parentheses is auto-quoted in single quotes', async () => {
     const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
 
-    const fileUri = ss.createWorkspaceFile('sfp-005', 'content\n');
+    const fileUri = createFileAt('__rl-test-utils (v2).ts', 'content\n');
+    ss.trackFileUri(fileUri);
     await openEditor(fileUri);
     await ss.settle();
 
@@ -143,7 +146,8 @@ standardSuite('Send File Path', (ss) => {
     const ANCHOR_START = 'ANCHOR_START';
     const ANCHOR_END = 'ANCHOR_END';
     const destUri = ss.createWorkspaceFile('sfp-006-dest', `${ANCHOR_START}\n${ANCHOR_END}\n`);
-    const sourceUri = ss.createWorkspaceFile('sfp-006-source', 'content\n');
+    const sourceUri = createFileAt('__rl-test-source with spaces.ts', 'content\n');
+    ss.trackFileUri(sourceUri);
 
     const destEditor = await openEditor(destUri, vscode.ViewColumn.Two);
     destEditor.selection = new vscode.Selection(
@@ -195,7 +199,8 @@ standardSuite('Send File Path', (ss) => {
 
     const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
 
-    const fileUri = ss.createWorkspaceFile('sfp-008', 'content\n');
+    const fileUri = createFileAt('__rl-test-clipboard check.ts', 'content\n');
+    ss.trackFileUri(fileUri);
     await openEditor(fileUri);
     await ss.settle();
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/sendFilePath.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/sendFilePath.test.ts
@@ -13,42 +13,29 @@ import {
   assertTerminalBufferContains,
   assertTerminalBufferEquals,
   assertToastLogged,
-  cleanupFiles,
-  createAndBindCapturingTerminal,
-  createCapturingTerminal,
   createFileAt,
-  createWorkspaceFile,
   extractQuickPickItemsLogged,
   getLogCapture,
   openEditor,
-  settle,
   standardSuite,
   waitForHuman,
   writeClipboardSentinel,
 } from '../helpers';
 
-standardSuite('Send File Path', (log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-
-  teardown(async () => {
-    cleanupFiles(tmpFileUris.splice(0));
-    await settle();
-  });
-
+standardSuite('Send File Path', (ss) => {
   test('send-file-path-001: R-F sends workspace-relative path to bound terminal', async () => {
-    const capturing = await createAndBindCapturingTerminal('sfp-test');
+    const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
 
-    const fileUri = createWorkspaceFile('sfp-001', 'content\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('sfp-001', 'content\n');
     await openEditor(fileUri);
-    await settle();
+    await ss.settle();
     capturing.clearCaptured();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-001');
 
     await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const relativePath = vscode.workspace.asRelativePath(fileUri, false);
     const lines = logCapture.getLinesSince('before-001');
@@ -61,23 +48,22 @@ standardSuite('Send File Path', (log) => {
       uriSource: 'command-palette',
       filePath: relativePath,
     });
-    log('✓ R-F sends workspace-relative path to terminal');
+    ss.log('✓ R-F sends workspace-relative path to terminal');
   });
 
   test('send-file-path-002: Cmd+R Cmd+Shift+F sends absolute path to bound terminal', async () => {
-    const capturing = await createAndBindCapturingTerminal('sfp-test');
+    const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
 
-    const fileUri = createWorkspaceFile('sfp-002', 'content\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('sfp-002', 'content\n');
     await openEditor(fileUri);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-002');
     capturing.clearCaptured();
 
     await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_ABSOLUTE);
-    await settle();
+    await ss.settle();
 
     const absolutePath = fileUri.fsPath;
     const lines = logCapture.getLinesSince('before-002');
@@ -87,23 +73,22 @@ standardSuite('Send File Path', (log) => {
       filePath: absolutePath,
     });
     assertTerminalBufferEquals(capturing.getCapturedText(), ` ${absolutePath} `);
-    log('✓ Cmd+R Cmd+Shift+F sends exact absolute path to terminal');
+    ss.log('✓ Cmd+R Cmd+Shift+F sends exact absolute path to terminal');
   });
 
   test('send-file-path-004: terminal destination — path with spaces is auto-quoted in single quotes', async () => {
-    const capturing = await createAndBindCapturingTerminal('sfp-test');
+    const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
 
     const fileUri = createFileAt('__rl-test-my folder.ts', 'content\n');
-    tmpFileUris.push(fileUri);
     await openEditor(fileUri);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-004');
     capturing.clearCaptured();
 
     await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const relativePath = vscode.workspace.asRelativePath(fileUri, false);
     const lines = logCapture.getLinesSince('before-004');
@@ -120,23 +105,22 @@ standardSuite('Send File Path', (log) => {
       'Expected "Quoted path for unsafe characters" log — path with spaces must be quoted before terminal send',
     );
     assertTerminalBufferEquals(capturing.getCapturedText(), ` '${relativePath}' `);
-    log('✓ Path with spaces auto-quoted for terminal destination');
+    ss.log('✓ Path with spaces auto-quoted for terminal destination');
   });
 
   test('send-file-path-005: terminal destination — path with parentheses is auto-quoted in single quotes', async () => {
-    const capturing = await createAndBindCapturingTerminal('sfp-test');
+    const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
 
     const fileUri = createFileAt('__rl-test-utils (v2).ts', 'content\n');
-    tmpFileUris.push(fileUri);
     await openEditor(fileUri);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-005');
     capturing.clearCaptured();
 
     await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const relativePath = vscode.workspace.asRelativePath(fileUri, false);
     const lines = logCapture.getLinesSince('before-005');
@@ -153,16 +137,14 @@ standardSuite('Send File Path', (log) => {
       'Expected "Quoted path for unsafe characters" log — path with parentheses must be quoted before terminal send',
     );
     assertTerminalBufferEquals(capturing.getCapturedText(), ` '${relativePath}' `);
-    log('✓ Path with parentheses auto-quoted for terminal destination');
+    ss.log('✓ Path with parentheses auto-quoted for terminal destination');
   });
 
   test('send-file-path-006: text editor destination — path with spaces is auto-quoted', async () => {
     const ANCHOR_START = 'ANCHOR_START';
     const ANCHOR_END = 'ANCHOR_END';
-    const destUri = createWorkspaceFile('sfp-006-dest', `${ANCHOR_START}\n${ANCHOR_END}\n`);
-    tmpFileUris.push(destUri);
+    const destUri = ss.createWorkspaceFile('sfp-006-dest', `${ANCHOR_START}\n${ANCHOR_END}\n`);
     const sourceUri = createFileAt('__rl-test-source with spaces.ts', 'content\n');
-    tmpFileUris.push(sourceUri);
 
     const destEditor = await openEditor(destUri, vscode.ViewColumn.Two);
     destEditor.selection = new vscode.Selection(
@@ -170,19 +152,19 @@ standardSuite('Send File Path', (log) => {
       new vscode.Position(1, 0),
     );
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
-    await settle();
+    await ss.settle();
 
     await vscode.window.showTextDocument(
       await vscode.workspace.openTextDocument(sourceUri),
       vscode.ViewColumn.Beside,
     );
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-006');
 
     await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const relativePath = vscode.workspace.asRelativePath(sourceUri, false);
     const lines = logCapture.getLinesSince('before-006');
@@ -204,7 +186,7 @@ standardSuite('Send File Path', (log) => {
       content.includes(`${ANCHOR_START}\n '${relativePath}' ${ANCHOR_END}`),
       `Expected single-quoted path inserted between anchors, got: ${JSON.stringify(content)}`,
     );
-    log('✓ Text editor destination receives auto-quoted path (spaces → single quotes)');
+    ss.log('✓ Text editor destination receives auto-quoted path (spaces → single quotes)');
   });
 
   test('send-file-path-007: clipboard and terminal both receive the quoted path (single clipboard write)', async () => {
@@ -212,12 +194,11 @@ standardSuite('Send File Path', (log) => {
       .getConfiguration('rangelink')
       .update('clipboard.preserve', 'never', vscode.ConfigurationTarget.Global);
 
-    const capturing = await createAndBindCapturingTerminal('sfp-test');
+    const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
 
     const fileUri = createFileAt('__rl-test-clipboard check.ts', 'content\n');
-    tmpFileUris.push(fileUri);
     await openEditor(fileUri);
-    await settle();
+    await ss.settle();
 
     capturing.clearCaptured();
 
@@ -225,7 +206,7 @@ standardSuite('Send File Path', (log) => {
     logCapture.mark('before-007');
 
     await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const relativePath = vscode.workspace.asRelativePath(fileUri, false);
     const clipboard = await vscode.env.clipboard.readText();
@@ -247,7 +228,7 @@ standardSuite('Send File Path', (log) => {
       clipboard.includes(relativePath),
       `Expected clipboard to include the file path, got: ${JSON.stringify(clipboard)}`,
     );
-    log('✓ Both terminal and clipboard receive the quoted path (single clipboard write)');
+    ss.log('✓ Both terminal and clipboard receive the quoted path (single clipboard write)');
   });
 
   test('send-file-path-008: self-paste shows info notification and copies smart-padded path to clipboard without modifying file', async () => {
@@ -258,11 +239,10 @@ standardSuite('Send File Path', (log) => {
       .getConfiguration('rangelink')
       .update('smartPadding.pasteFilePath', 'both', vscode.ConfigurationTarget.Global);
 
-    const fileUri = createWorkspaceFile('sfp-008-self', 'original content\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('sfp-008-self', 'original content\n');
     await openEditor(fileUri);
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
-    await settle();
+    await ss.settle();
 
     await writeClipboardSentinel();
 
@@ -270,7 +250,7 @@ standardSuite('Send File Path', (log) => {
     logCapture.mark('before-008');
 
     await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const relativePath = vscode.workspace.asRelativePath(fileUri, false);
     const lines = logCapture.getLinesSince('before-008');
@@ -287,16 +267,15 @@ standardSuite('Send File Path', (log) => {
     );
     const doc = await vscode.workspace.openTextDocument(fileUri);
     assert.ok(!doc.isDirty, 'Expected file to remain unmodified after self-paste');
-    log('✓ Self-paste: info notification shown, smart-padded path on clipboard, file unchanged');
+    ss.log('✓ Self-paste: info notification shown, smart-padded path on clipboard, file unchanged');
   });
 
   test('[assisted] send-file-path-009: unbound — R-F opens destination picker before sending', async () => {
-    const capturing = await createCapturingTerminal('sfp-picker-test');
+    const capturing = await ss.createCapturingTerminal('sfp-picker-test');
 
-    const fileUri = createWorkspaceFile('sfp-009', 'content\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('sfp-009', 'content\n');
     await openEditor(fileUri);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-009');
@@ -313,7 +292,7 @@ standardSuite('Send File Path', (log) => {
       ],
     );
 
-    await settle();
+    await ss.settle();
 
     const relativePath = vscode.workspace.asRelativePath(fileUri, false);
     const lines = logCapture.getLinesSince('before-009');
@@ -325,23 +304,22 @@ standardSuite('Send File Path', (log) => {
     );
     assert.ok(terminalItem !== undefined, 'Expected "sfp-picker-test" to appear in the picker');
     assertTerminalBufferContains(capturing.getCapturedText(), relativePath);
-    log('✓ Unbound R-F opens picker; path sent after selection');
+    ss.log('✓ Unbound R-F opens picker; path sent after selection');
   });
 
   test('send-file-path-010: Command Palette "Send Current File Path" sends workspace-relative path', async () => {
-    const capturing = await createAndBindCapturingTerminal('sfp-test');
+    const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
 
-    const fileUri = createWorkspaceFile('sfp-010', 'content\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('sfp-010', 'content\n');
     await openEditor(fileUri);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-010');
     capturing.clearCaptured();
 
     await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const relativePath = vscode.workspace.asRelativePath(fileUri, false);
     const lines = logCapture.getLinesSince('before-010');
@@ -351,23 +329,22 @@ standardSuite('Send File Path', (log) => {
       filePath: relativePath,
     });
     assertTerminalBufferEquals(capturing.getCapturedText(), ` ${relativePath} `);
-    log('✓ Command Palette "Send Current File Path" sends workspace-relative path');
+    ss.log('✓ Command Palette "Send Current File Path" sends workspace-relative path');
   });
 
   test('send-file-path-011: Command Palette "Send Current File Path (Absolute)" sends absolute path', async () => {
-    const capturing = await createAndBindCapturingTerminal('sfp-test');
+    const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
 
-    const fileUri = createWorkspaceFile('sfp-011', 'content\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('sfp-011', 'content\n');
     await openEditor(fileUri);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-011');
     capturing.clearCaptured();
 
     await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_ABSOLUTE);
-    await settle();
+    await ss.settle();
 
     const absolutePath = fileUri.fsPath;
     const lines = logCapture.getLinesSince('before-011');
@@ -377,16 +354,14 @@ standardSuite('Send File Path', (log) => {
       filePath: absolutePath,
     });
     assertTerminalBufferEquals(capturing.getCapturedText(), ` ${absolutePath} `);
-    log('✓ Command Palette "Send Current File Path (Absolute)" sends absolute path');
+    ss.log('✓ Command Palette "Send Current File Path (Absolute)" sends absolute path');
   });
 
   test('send-file-path-012: bound text editor hidden behind another tab — paste still lands in bound editor', async () => {
     const ANCHOR_START = 'ANCHOR_START';
     const ANCHOR_END = 'ANCHOR_END';
-    const destUri = createWorkspaceFile('sfp-012-dest', `${ANCHOR_START}\n${ANCHOR_END}\n`);
-    tmpFileUris.push(destUri);
-    const sourceUri = createWorkspaceFile('sfp-012-source', 'content\n');
-    tmpFileUris.push(sourceUri);
+    const destUri = ss.createWorkspaceFile('sfp-012-dest', `${ANCHOR_START}\n${ANCHOR_END}\n`);
+    const sourceUri = ss.createWorkspaceFile('sfp-012-source', 'content\n');
 
     const destEditor = await vscode.window.showTextDocument(
       await vscode.workspace.openTextDocument(destUri),
@@ -397,19 +372,19 @@ standardSuite('Send File Path', (log) => {
       new vscode.Position(1, 0),
     );
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
-    await settle();
+    await ss.settle();
 
     await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(sourceUri), {
       viewColumn: vscode.ViewColumn.One,
       preview: false,
     });
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-012');
 
     await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE);
-    await settle();
+    await ss.settle();
 
     assert.strictEqual(
       vscode.window.activeTextEditor?.document.uri.toString(),
@@ -431,6 +406,6 @@ standardSuite('Send File Path', (log) => {
       expectedContent,
       `Expected exact dest content, got: ${JSON.stringify(destDoc.getText())}`,
     );
-    log('✓ Bound editor brought to foreground and received exact file path');
+    ss.log('✓ Bound editor brought to foreground and received exact file path');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/sendFilePath.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/sendFilePath.test.ts
@@ -13,7 +13,6 @@ import {
   assertTerminalBufferContains,
   assertTerminalBufferEquals,
   assertToastLogged,
-  createFileAt,
   extractQuickPickItemsLogged,
   getLogCapture,
   openEditor,
@@ -79,7 +78,7 @@ standardSuite('Send File Path', (ss) => {
   test('send-file-path-004: terminal destination — path with spaces is auto-quoted in single quotes', async () => {
     const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
 
-    const fileUri = createFileAt('__rl-test-my folder.ts', 'content\n');
+    const fileUri = ss.createWorkspaceFile('sfp-004', 'content\n');
     await openEditor(fileUri);
     await ss.settle();
 
@@ -111,7 +110,7 @@ standardSuite('Send File Path', (ss) => {
   test('send-file-path-005: terminal destination — path with parentheses is auto-quoted in single quotes', async () => {
     const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
 
-    const fileUri = createFileAt('__rl-test-utils (v2).ts', 'content\n');
+    const fileUri = ss.createWorkspaceFile('sfp-005', 'content\n');
     await openEditor(fileUri);
     await ss.settle();
 
@@ -144,7 +143,7 @@ standardSuite('Send File Path', (ss) => {
     const ANCHOR_START = 'ANCHOR_START';
     const ANCHOR_END = 'ANCHOR_END';
     const destUri = ss.createWorkspaceFile('sfp-006-dest', `${ANCHOR_START}\n${ANCHOR_END}\n`);
-    const sourceUri = createFileAt('__rl-test-source with spaces.ts', 'content\n');
+    const sourceUri = ss.createWorkspaceFile('sfp-006-source', 'content\n');
 
     const destEditor = await openEditor(destUri, vscode.ViewColumn.Two);
     destEditor.selection = new vscode.Selection(
@@ -196,7 +195,7 @@ standardSuite('Send File Path', (ss) => {
 
     const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
 
-    const fileUri = createFileAt('__rl-test-clipboard check.ts', 'content\n');
+    const fileUri = ss.createWorkspaceFile('sfp-008', 'content\n');
     await openEditor(fileUri);
     await ss.settle();
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/smartPadding.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/smartPadding.test.ts
@@ -14,9 +14,6 @@ import {
 import {
   assertTerminalBufferEquals,
   cleanupFiles,
-  createAndBindCapturingTerminal,
-  createTerminal,
-  createWorkspaceFile,
   echoToTerminal,
   getWorkspaceRoot,
   openEditor,
@@ -35,7 +32,7 @@ import {
 // documents are particularly susceptible to cross-test contamination.
 // ---------------------------------------------------------------------------
 
-standardSuite('Smart Padding — Editor-to-Editor R-V: 001-untitled', (log) => {
+standardSuite('Smart Padding — Editor-to-Editor R-V: 001-untitled', (ss) => {
   let sourceFileUri: vscode.Uri;
 
   setup(async () => {
@@ -51,7 +48,7 @@ standardSuite('Smart Padding — Editor-to-Editor R-V: 001-untitled', (log) => {
 
   test('smart-padding-001-untitled: whitespace-only text sent to untitled editor destination', async () => {
     const whitespaceContent = '   \t   ';
-    log('smart-padding-001-untitled: starting — default profile');
+    ss.log('smart-padding-001-untitled: starting — default profile');
 
     fs.writeFileSync(sourceFileUri.fsPath, whitespaceContent, 'utf8');
 
@@ -83,7 +80,7 @@ standardSuite('Smart Padding — Editor-to-Editor R-V: 001-untitled', (log) => {
   });
 });
 
-standardSuite('Smart Padding — Editor-to-Editor R-V: langswitch', (log) => {
+standardSuite('Smart Padding — Editor-to-Editor R-V: langswitch', (ss) => {
   let sourceFileUri001: vscode.Uri;
   let sourceFileUri002: vscode.Uri;
 
@@ -103,7 +100,7 @@ standardSuite('Smart Padding — Editor-to-Editor R-V: langswitch', (log) => {
 
   test('langswitch-binding-001: binding survives manual language-mode change on untitled file', async () => {
     const sourceContent = 'hello world';
-    log('langswitch-001: starting');
+    ss.log('langswitch-001: starting');
 
     fs.writeFileSync(sourceFileUri001.fsPath, sourceContent, 'utf8');
 
@@ -182,24 +179,13 @@ standardSuite('Smart Padding — Editor-to-Editor R-V: langswitch', (log) => {
 // Suite — Single-Write Architecture (CapturingTerminal + assisted tests)
 // ---------------------------------------------------------------------------
 
-standardSuite('Smart Padding — Single-Write Architecture', (log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-  const tmpTerminals: vscode.Terminal[] = [];
-
-  teardown(async () => {
-    for (const t of tmpTerminals.splice(0)) t.dispose();
-    cleanupFiles(tmpFileUris);
-    tmpFileUris.length = 0;
-    await settle();
-  });
-
+standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
   test('smart-padding-001: whitespace-only text preserved when sent to destination', async () => {
     const whitespaceContent = '   \t   ';
 
-    const sourceUri = createWorkspaceFile('pad-001', whitespaceContent);
-    tmpFileUris.push(sourceUri);
+    const sourceUri = ss.createWorkspaceFile('pad-001', whitespaceContent);
 
-    const capturing = await createAndBindCapturingTerminal('pad-001-dest', tmpTerminals);
+    const capturing = await ss.createAndBindCapturingTerminal('pad-001-dest');
     await settle();
 
     const sourceEditor = await openEditor(sourceUri);
@@ -224,14 +210,13 @@ standardSuite('Smart Padding — Single-Write Architecture', (log) => {
       captured.includes('\t'),
       `Expected captured content to contain tab, got: ${JSON.stringify(captured)}`,
     );
-    log('✓ smart-padding-001: whitespace preserved');
+    ss.log('✓ smart-padding-001: whitespace preserved');
   });
 
   test('smart-padding-003: multiline content preserved through destination', async () => {
     const expected = 'line 1\nline 2\nline 3';
 
-    const sourceUri = createWorkspaceFile('pad-003', expected + '\n');
-    tmpFileUris.push(sourceUri);
+    const sourceUri = ss.createWorkspaceFile('pad-003', expected + '\n');
 
     const destDoc = await vscode.workspace.openTextDocument({ content: '', language: 'plaintext' });
     await vscode.window.showTextDocument(destDoc, vscode.ViewColumn.Two);
@@ -254,7 +239,7 @@ standardSuite('Smart Padding — Single-Write Architecture', (log) => {
       expected,
       `Expected multiline content to arrive intact, got: ${JSON.stringify(destContent)}`,
     );
-    log('✓ smart-padding-003: multiline content preserved through destination');
+    ss.log('✓ smart-padding-003: multiline content preserved through destination');
   });
 
   test('smart-padding-005: pasteContent=before adds leading space only', async () => {
@@ -262,10 +247,9 @@ standardSuite('Smart Padding — Single-Write Architecture', (log) => {
       .getConfiguration('rangelink')
       .update('smartPadding.pasteContent', 'before', vscode.ConfigurationTarget.Global);
 
-    const sourceUri = createWorkspaceFile('pad-005', 'hello\n');
-    tmpFileUris.push(sourceUri);
+    const sourceUri = ss.createWorkspaceFile('pad-005', 'hello\n');
 
-    const capturing = await createAndBindCapturingTerminal('pad-005-dest', tmpTerminals);
+    const capturing = await ss.createAndBindCapturingTerminal('pad-005-dest');
     await settle();
 
     const sourceEditor = await openEditor(sourceUri);
@@ -277,7 +261,7 @@ standardSuite('Smart Padding — Single-Write Architecture', (log) => {
     await settle();
 
     assertTerminalBufferEquals(capturing.getCapturedText(), ' hello');
-    log('✓ smart-padding-005: leading space applied');
+    ss.log('✓ smart-padding-005: leading space applied');
   });
 
   test('smart-padding-006: pasteContent=after adds trailing space only', async () => {
@@ -285,10 +269,9 @@ standardSuite('Smart Padding — Single-Write Architecture', (log) => {
       .getConfiguration('rangelink')
       .update('smartPadding.pasteContent', 'after', vscode.ConfigurationTarget.Global);
 
-    const sourceUri = createWorkspaceFile('pad-006', 'hello\n');
-    tmpFileUris.push(sourceUri);
+    const sourceUri = ss.createWorkspaceFile('pad-006', 'hello\n');
 
-    const capturing = await createAndBindCapturingTerminal('pad-006-dest', tmpTerminals);
+    const capturing = await ss.createAndBindCapturingTerminal('pad-006-dest');
     await settle();
 
     const sourceEditor = await openEditor(sourceUri);
@@ -300,7 +283,7 @@ standardSuite('Smart Padding — Single-Write Architecture', (log) => {
     await settle();
 
     assertTerminalBufferEquals(capturing.getCapturedText(), 'hello ');
-    log('✓ smart-padding-006: trailing space applied');
+    ss.log('✓ smart-padding-006: trailing space applied');
   });
 
   test('smart-padding-007: pasteContent=both — text selection sent to destination has leading and trailing space', async () => {
@@ -308,10 +291,9 @@ standardSuite('Smart Padding — Single-Write Architecture', (log) => {
       .getConfiguration('rangelink')
       .update('smartPadding.pasteContent', 'both', vscode.ConfigurationTarget.Global);
 
-    const sourceUri = createWorkspaceFile('pad-007', 'hello world\n');
-    tmpFileUris.push(sourceUri);
+    const sourceUri = ss.createWorkspaceFile('pad-007', 'hello world\n');
 
-    const capturing = await createAndBindCapturingTerminal('pad-007-dest', tmpTerminals);
+    const capturing = await ss.createAndBindCapturingTerminal('pad-007-dest');
     await settle();
 
     const sourceEditor = await openEditor(sourceUri);
@@ -323,7 +305,7 @@ standardSuite('Smart Padding — Single-Write Architecture', (log) => {
     await settle();
 
     assertTerminalBufferEquals(capturing.getCapturedText(), ' hello world ');
-    log('✓ smart-padding-007: padded text selection sent to destination');
+    ss.log('✓ smart-padding-007: padded text selection sent to destination');
   });
 
   test('smart-padding-008: pasteFilePath=both — file path sent to terminal has leading and trailing space', async () => {
@@ -331,10 +313,9 @@ standardSuite('Smart Padding — Single-Write Architecture', (log) => {
       .getConfiguration('rangelink')
       .update('smartPadding.pasteFilePath', 'both', vscode.ConfigurationTarget.Global);
 
-    const fileUri = createWorkspaceFile('pad-008', 'content\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('pad-008', 'content\n');
 
-    const capturing = await createAndBindCapturingTerminal('pad-008-dest', tmpTerminals);
+    const capturing = await ss.createAndBindCapturingTerminal('pad-008-dest');
     await settle();
 
     await openEditor(fileUri);
@@ -346,12 +327,11 @@ standardSuite('Smart Padding — Single-Write Architecture', (log) => {
 
     const relativePath = vscode.workspace.asRelativePath(fileUri, false);
     assertTerminalBufferEquals(capturing.getCapturedText(), ` ${relativePath} `);
-    log('✓ smart-padding-008: padded file path sent to terminal');
+    ss.log('✓ smart-padding-008: padded file path sent to terminal');
   });
 
   test('[assisted] smart-padding-009: pasteLink=both — RangeLink sent to AI assistant has leading and trailing space', async () => {
-    const fileUri = createWorkspaceFile('pad-009', 'line 1\nline 2\nline 3\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('pad-009', 'line 1\nline 2\nline 3\n');
     const editor = await openEditor(fileUri);
     await settle();
 
@@ -375,7 +355,7 @@ standardSuite('Smart Padding — Single-Write Architecture', (log) => {
     );
 
     assert.strictEqual(verdict, 'pass');
-    log('✓ smart-padding-009: RangeLink sent to Copilot with padding (human verified)');
+    ss.log('✓ smart-padding-009: RangeLink sent to Copilot with padding (human verified)');
   });
 
   test('[assisted] smart-padding-010: terminal selection sent to editor with padding=both', async () => {
@@ -383,15 +363,14 @@ standardSuite('Smart Padding — Single-Write Architecture', (log) => {
       .getConfiguration('rangelink')
       .update('smartPadding.pasteContent', 'both', vscode.ConfigurationTarget.Global);
 
-    const destUri = createWorkspaceFile('pad-010-dest', '');
-    tmpFileUris.push(destUri);
+    const destUri = ss.createWorkspaceFile('pad-010-dest', '');
 
     const destDoc = await vscode.workspace.openTextDocument(destUri);
     await vscode.window.showTextDocument(destDoc, vscode.ViewColumn.Two);
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE, destUri);
     await settle();
 
-    const terminal = await createTerminal('pad-010-src', tmpTerminals);
+    const terminal = await ss.createTerminal('pad-010-src');
     echoToTerminal(terminal, 'hello');
     await settle();
 
@@ -411,7 +390,7 @@ standardSuite('Smart Padding — Single-Write Architecture', (log) => {
       destContent.includes(' hello '),
       `Expected dest to contain padded text " hello ", got: "${destContent}"`,
     );
-    log('✓ smart-padding-010: terminal selection sent to editor with padding (code verified)');
+    ss.log('✓ smart-padding-010: terminal selection sent to editor with padding (code verified)');
   });
 
   test('smart-padding-011: pasteContent=none — no padding applied when setting is off', async () => {
@@ -419,10 +398,9 @@ standardSuite('Smart Padding — Single-Write Architecture', (log) => {
       .getConfiguration('rangelink')
       .update('smartPadding.pasteContent', 'none', vscode.ConfigurationTarget.Global);
 
-    const sourceUri = createWorkspaceFile('pad-011', 'hello\n');
-    tmpFileUris.push(sourceUri);
+    const sourceUri = ss.createWorkspaceFile('pad-011', 'hello\n');
 
-    const capturing = await createAndBindCapturingTerminal('pad-011-dest', tmpTerminals);
+    const capturing = await ss.createAndBindCapturingTerminal('pad-011-dest');
     await settle();
 
     const sourceEditor = await openEditor(sourceUri);
@@ -434,6 +412,6 @@ standardSuite('Smart Padding — Single-Write Architecture', (log) => {
     await settle();
 
     assertTerminalBufferEquals(capturing.getCapturedText(), 'hello');
-    log('✓ smart-padding-011: no padding when disabled');
+    ss.log('✓ smart-padding-011: no padding when disabled');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/smartPadding.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/smartPadding.test.ts
@@ -18,7 +18,6 @@ import {
   getWorkspaceRoot,
   openEditor,
   openUntitledDoc,
-  settle,
   standardSuite,
   waitForHuman,
   waitForHumanVerdict,
@@ -56,11 +55,11 @@ standardSuite('Smart Padding — Editor-to-Editor R-V: 001-untitled', (ss) => {
     await vscode.window.showTextDocument(destDoc, vscode.ViewColumn.Two);
 
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE, destDoc.uri);
-    await settle();
+    await ss.settle();
 
     const sourceDoc = await vscode.workspace.openTextDocument(sourceFileUri);
     const sourceEditor = await vscode.window.showTextDocument(sourceDoc, vscode.ViewColumn.Three);
-    await settle();
+    await ss.settle();
 
     const lastLine = sourceEditor.document.lineCount - 1;
     const lastChar = sourceEditor.document.lineAt(lastLine).text.length;
@@ -70,7 +69,7 @@ standardSuite('Smart Padding — Editor-to-Editor R-V: 001-untitled', (ss) => {
     );
 
     await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
-    await settle();
+    await ss.settle();
 
     const destContent = destDoc.getText();
     assert.ok(
@@ -108,14 +107,14 @@ standardSuite('Smart Padding — Editor-to-Editor R-V: langswitch', (ss) => {
     const originalLanguage = destDoc.languageId;
 
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE, destDoc.uri);
-    await settle();
+    await ss.settle();
 
     const updatedDestDoc = await vscode.languages.setTextDocumentLanguage(destDoc, 'markdown');
-    await settle();
+    await ss.settle();
 
     const sourceDoc = await vscode.workspace.openTextDocument(sourceFileUri001);
     const sourceEditor = await vscode.window.showTextDocument(sourceDoc, vscode.ViewColumn.Three);
-    await settle();
+    await ss.settle();
 
     sourceEditor.selection = new vscode.Selection(
       new vscode.Position(0, 0),
@@ -123,7 +122,7 @@ standardSuite('Smart Padding — Editor-to-Editor R-V: langswitch', (ss) => {
     );
 
     await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
-    await settle();
+    await ss.settle();
 
     const destContent = updatedDestDoc.getText();
     assert.ok(
@@ -141,23 +140,23 @@ standardSuite('Smart Padding — Editor-to-Editor R-V: langswitch', (ss) => {
     await vscode.window.showTextDocument(destDoc, vscode.ViewColumn.Two);
 
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE, destDoc.uri);
-    await settle();
+    await ss.settle();
 
     const mdContent = '```typescript\nconst x = 1;\n```\n';
     const edit = new vscode.WorkspaceEdit();
     edit.insert(destDoc.uri, new vscode.Position(0, 0), mdContent);
     await vscode.workspace.applyEdit(edit);
-    await settle();
+    await ss.settle();
 
     let currentDestDoc = destDoc;
     if (destDoc.languageId === 'plaintext') {
       currentDestDoc = await vscode.languages.setTextDocumentLanguage(destDoc, 'markdown');
-      await settle();
+      await ss.settle();
     }
 
     const sourceDoc = await vscode.workspace.openTextDocument(sourceFileUri002);
     const sourceEditor = await vscode.window.showTextDocument(sourceDoc, vscode.ViewColumn.Three);
-    await settle();
+    await ss.settle();
 
     sourceEditor.selection = new vscode.Selection(
       new vscode.Position(0, 0),
@@ -165,7 +164,7 @@ standardSuite('Smart Padding — Editor-to-Editor R-V: langswitch', (ss) => {
     );
 
     await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
-    await settle();
+    await ss.settle();
 
     const destContent = currentDestDoc.getText();
     assert.ok(
@@ -186,7 +185,7 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
     const sourceUri = ss.createWorkspaceFile('pad-001', whitespaceContent);
 
     const capturing = await ss.createAndBindCapturingTerminal('pad-001-dest');
-    await settle();
+    await ss.settle();
 
     const sourceEditor = await openEditor(sourceUri);
     const lastLine = sourceEditor.document.lineCount - 1;
@@ -195,11 +194,11 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
       new vscode.Position(0, 0),
       new vscode.Position(lastLine, lastChar),
     );
-    await settle();
+    await ss.settle();
 
     capturing.clearCaptured();
     await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
-    await settle();
+    await ss.settle();
 
     const captured = capturing.getCapturedText();
     assert.ok(
@@ -221,17 +220,17 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
     const destDoc = await vscode.workspace.openTextDocument({ content: '', language: 'plaintext' });
     await vscode.window.showTextDocument(destDoc, vscode.ViewColumn.Two);
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
-    await settle();
+    await ss.settle();
 
     const sourceEditor = await openEditor(sourceUri, vscode.ViewColumn.Beside);
     sourceEditor.selection = new vscode.Selection(
       new vscode.Position(0, 0),
       new vscode.Position(2, 6),
     );
-    await settle();
+    await ss.settle();
 
     await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
-    await settle();
+    await ss.settle();
 
     const destContent = destDoc.getText();
     assert.strictEqual(
@@ -250,15 +249,15 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
     const sourceUri = ss.createWorkspaceFile('pad-005', 'hello\n');
 
     const capturing = await ss.createAndBindCapturingTerminal('pad-005-dest');
-    await settle();
+    await ss.settle();
 
     const sourceEditor = await openEditor(sourceUri);
     sourceEditor.selection = new vscode.Selection(0, 0, 0, 5);
-    await settle();
+    await ss.settle();
 
     capturing.clearCaptured();
     await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
-    await settle();
+    await ss.settle();
 
     assertTerminalBufferEquals(capturing.getCapturedText(), ' hello');
     ss.log('✓ smart-padding-005: leading space applied');
@@ -272,15 +271,15 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
     const sourceUri = ss.createWorkspaceFile('pad-006', 'hello\n');
 
     const capturing = await ss.createAndBindCapturingTerminal('pad-006-dest');
-    await settle();
+    await ss.settle();
 
     const sourceEditor = await openEditor(sourceUri);
     sourceEditor.selection = new vscode.Selection(0, 0, 0, 5);
-    await settle();
+    await ss.settle();
 
     capturing.clearCaptured();
     await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
-    await settle();
+    await ss.settle();
 
     assertTerminalBufferEquals(capturing.getCapturedText(), 'hello ');
     ss.log('✓ smart-padding-006: trailing space applied');
@@ -294,15 +293,15 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
     const sourceUri = ss.createWorkspaceFile('pad-007', 'hello world\n');
 
     const capturing = await ss.createAndBindCapturingTerminal('pad-007-dest');
-    await settle();
+    await ss.settle();
 
     const sourceEditor = await openEditor(sourceUri);
     sourceEditor.selection = new vscode.Selection(0, 0, 0, 11);
-    await settle();
+    await ss.settle();
 
     capturing.clearCaptured();
     await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
-    await settle();
+    await ss.settle();
 
     assertTerminalBufferEquals(capturing.getCapturedText(), ' hello world ');
     ss.log('✓ smart-padding-007: padded text selection sent to destination');
@@ -316,14 +315,14 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
     const fileUri = ss.createWorkspaceFile('pad-008', 'content\n');
 
     const capturing = await ss.createAndBindCapturingTerminal('pad-008-dest');
-    await settle();
+    await ss.settle();
 
     await openEditor(fileUri);
-    await settle();
+    await ss.settle();
 
     capturing.clearCaptured();
     await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const relativePath = vscode.workspace.asRelativePath(fileUri, false);
     assertTerminalBufferEquals(capturing.getCapturedText(), ` ${relativePath} `);
@@ -333,15 +332,15 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
   test('[assisted] smart-padding-009: pasteLink=both — RangeLink sent to AI assistant has leading and trailing space', async () => {
     const fileUri = ss.createWorkspaceFile('pad-009', 'line 1\nline 2\nline 3\n');
     const editor = await openEditor(fileUri);
-    await settle();
+    await ss.settle();
 
     await vscode.commands.executeCommand(CMD_BIND_TO_GITHUB_COPILOT_CHAT);
-    await settle();
+    await ss.settle();
 
     editor.selection = new vscode.Selection(0, 0, 1, 6);
-    await settle();
+    await ss.settle();
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const verdict = await waitForHumanVerdict(
       'smart-padding-009',
@@ -368,11 +367,11 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
     const destDoc = await vscode.workspace.openTextDocument(destUri);
     await vscode.window.showTextDocument(destDoc, vscode.ViewColumn.Two);
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE, destUri);
-    await settle();
+    await ss.settle();
 
     const terminal = await ss.createTerminal('pad-010-src');
     echoToTerminal(terminal, 'hello');
-    await settle();
+    await ss.settle();
 
     await waitForHuman(
       'smart-padding-010',
@@ -401,15 +400,15 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
     const sourceUri = ss.createWorkspaceFile('pad-011', 'hello\n');
 
     const capturing = await ss.createAndBindCapturingTerminal('pad-011-dest');
-    await settle();
+    await ss.settle();
 
     const sourceEditor = await openEditor(sourceUri);
     sourceEditor.selection = new vscode.Selection(0, 0, 0, 5);
-    await settle();
+    await ss.settle();
 
     capturing.clearCaptured();
     await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
-    await settle();
+    await ss.settle();
 
     assertTerminalBufferEquals(capturing.getCapturedText(), 'hello');
     ss.log('✓ smart-padding-011: no padding when disabled');

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/statusBarMenu.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/statusBarMenu.test.ts
@@ -5,27 +5,17 @@ import * as vscode from 'vscode';
 import { CMD_BIND_TO_TERMINAL_HERE, CMD_OPEN_STATUS_BAR_MENU } from '../../constants/commandIds';
 import {
   assertQuickPickItemsLogged,
-  cleanupFiles,
-  createWorkspaceFile,
   extractQuickPickItemsLogged,
   getLogCapture,
   openAndDismiss,
-  settle,
   standardSuite,
-  TERMINAL_READY_MS,
   waitForHuman,
   waitForHumanVerdict,
 } from '../helpers';
 
 const SEPARATOR_KIND = -1;
 
-standardSuite('R-M Status Bar Menu', (log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-
-  suiteTeardown(async () => {
-    cleanupFiles(tmpFileUris);
-  });
-
+standardSuite('R-M Status Bar Menu', (ss) => {
   test('status-bar-menu-002: invoking openStatusBarMenu command opens the R-M menu', async () => {
     const logCapture = getLogCapture();
     logCapture.mark('before-menu-002');
@@ -57,15 +47,14 @@ standardSuite('R-M Status Bar Menu', (log) => {
       ],
     );
 
-    log('✓ Unbound menu: no Jump item, correct structure');
+    ss.log('✓ Unbound menu: no Jump item, correct structure');
   });
 
   test('status-bar-menu-003: invoking openStatusBarMenu command opens the R-M menu', async () => {
-    const testFileUri = createWorkspaceFile('menu-003', 'line 1\nline 2\n');
-    tmpFileUris.push(testFileUri);
-    const doc = await vscode.workspace.openTextDocument(testFileUri);
+    const fileUri = ss.createWorkspaceFile('menu-003', 'line 1\nline 2\n');
+    const doc = await vscode.workspace.openTextDocument(fileUri);
     await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-menu-003');
@@ -97,16 +86,14 @@ standardSuite('R-M Status Bar Menu', (log) => {
       ],
     );
 
-    log('✓ Direct command menu: no Jump item, correct structure');
+    ss.log('✓ Direct command menu: no Jump item, correct structure');
   });
 
   test('status-bar-menu-005: R-M menu shows Jump to Bound Destination when bound', async () => {
-    const terminal = vscode.window.createTerminal({ name: 'rl-menu-test' });
-    terminal.show(true);
-    await settle(TERMINAL_READY_MS);
+    await ss.createTerminal('rl-menu-test');
 
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-menu-005');
@@ -126,7 +113,7 @@ standardSuite('R-M Status Bar Menu', (log) => {
       { label: '$(info) Show Version Info', itemKind: 'command' },
     ]);
 
-    log('✓ Bound-state menu items validated via log capture');
+    ss.log('✓ Bound-state menu items validated via log capture');
   });
 
   test('[assisted] status-bar-menu-001: status bar item visible with correct text and tooltip', async () => {
@@ -141,7 +128,7 @@ standardSuite('R-M Status Bar Menu', (log) => {
       ],
     );
     assert.strictEqual(verdict, 'pass', 'Human reported status bar text or tooltip was incorrect');
-    log('✓ Status bar item shows correct text and tooltip');
+    ss.log('✓ Status bar item shows correct text and tooltip');
   });
 
   test('status-bar-menu-006: R-M menu shows destination picker items when no destination is bound', async () => {
@@ -162,15 +149,13 @@ standardSuite('R-M Status Bar Menu', (log) => {
       undefined,
       'Expected no Jump item in unbound state',
     );
-    log('✓ Unbound menu shows "choose below" info item and no Jump item');
+    ss.log('✓ Unbound menu shows "choose below" info item and no Jump item');
   });
 
   test('[assisted] status-bar-menu-007: R-M menu Unbind Destination item unbinds the destination when selected', async () => {
-    const terminal = vscode.window.createTerminal({ name: 'rl-sbm-007' });
-    terminal.show(true);
-    await settle(TERMINAL_READY_MS);
+    await ss.createTerminal('rl-sbm-007');
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-007');
@@ -222,7 +207,7 @@ standardSuite('R-M Status Bar Menu', (log) => {
       undefined,
       'Expected no Jump item after unbind',
     );
-    log(
+    ss.log(
       '✓ Bound menu showed Jump + Unbind; human selected Unbind; post-unbind menu confirmed Jump absent',
     );
   });
@@ -257,7 +242,7 @@ standardSuite('R-M Status Bar Menu', (log) => {
       (l) => l.includes('GoToRangeLinkCommand.execute') && l.includes('Showing input box'),
     );
     assert.ok(inputBoxLog, 'Expected GoToRangeLinkCommand to log input box presentation');
-    log('✓ R-M menu "Go to Link" dispatched the R-G command and input box was shown');
+    ss.log('✓ R-M menu "Go to Link" dispatched the R-G command and input box was shown');
   });
 
   test('[assisted] status-bar-menu-009: R-M menu Show Version Info displays version, commit, branch, and build date', async () => {
@@ -292,7 +277,7 @@ standardSuite('R-M Status Bar Menu', (log) => {
       'pass',
       'Human reported version info notification was missing fields',
     );
-    log(
+    ss.log(
       '✓ Show Version Info dispatched and notification displayed all required fields (human verified)',
     );
   });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/terminalPicker.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/terminalPicker.test.ts
@@ -4,16 +4,12 @@ import * as vscode from 'vscode';
 
 import { CMD_BIND_TO_DESTINATION, CMD_OPEN_STATUS_BAR_MENU } from '../../constants/commandIds';
 import {
-  cleanupFiles,
-  closeAllEditors,
-  createTerminal,
-  createWorkspaceFile,
   extractQuickPickItemsLogged,
   findTerminalItems,
   getLogCapture,
+  loadSettingsProfile,
   openAndDismiss,
   parseQuickPickItemsFromLogLine,
-  settle,
   standardSuite,
   waitForHuman,
 } from '../helpers';
@@ -23,12 +19,12 @@ const TERMINAL_OVERFLOW_COUNT = 6;
 const MAX_INLINE_DEFAULT = 5;
 const FILE_OVERFLOW_THRESHOLD = 5;
 
-standardSuite('Terminal Picker', (log) => {
+standardSuite('Terminal Picker', (ss) => {
   test('terminal-picker-001: active terminal is marked with active badge', async () => {
-    const t1 = await createTerminal('rl-tp-001-a');
-    await createTerminal('rl-tp-001-b');
+    const t1 = await ss.createTerminal('rl-tp-001-a');
+    await ss.createTerminal('rl-tp-001-b');
     t1.show(true);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-001');
@@ -69,16 +65,16 @@ standardSuite('Terminal Picker', (log) => {
       ],
     );
 
-    log('✓ Active terminal: all 6 fields. Non-active: no badge, no isActive');
+    ss.log('✓ Active terminal: all 6 fields. Non-active: no badge, no isActive');
   });
 
   test('terminal-picker-002: bound terminal is marked with bound badge', async () => {
-    await createTerminal('rl-tp-002');
+    await ss.createTerminal('rl-tp-002');
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
-    await settle();
-    const t2 = await createTerminal('rl-tp-002-other');
+    await ss.settle();
+    const t2 = await ss.createTerminal('rl-tp-002-other');
     t2.show(true);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-002');
@@ -119,14 +115,14 @@ standardSuite('Terminal Picker', (log) => {
       ],
     );
 
-    log('✓ Bound first (all 6 fields), active other second');
+    ss.log('✓ Bound first (all 6 fields), active other second');
   });
 
   test('terminal-picker-003: terminal that is both active and bound shows dual badge', async () => {
-    const t = await createTerminal('rl-tp-003');
+    const t = await ss.createTerminal('rl-tp-003');
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
     t.show(true);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-003');
@@ -159,14 +155,14 @@ standardSuite('Terminal Picker', (log) => {
       ],
     );
 
-    log('✓ Dual badge: all 6 fields validated');
+    ss.log('✓ Dual badge: all 6 fields validated');
   });
 
   test('terminal-picker-004: bound terminal always appears first in the list', async () => {
-    await createTerminal('rl-tp-004-b');
+    await ss.createTerminal('rl-tp-004-b');
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
-    await settle();
-    await createTerminal('rl-tp-004-a');
+    await ss.settle();
+    await ss.createTerminal('rl-tp-004-a');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-004');
@@ -207,16 +203,16 @@ standardSuite('Terminal Picker', (log) => {
       ],
     );
 
-    log('✓ Bound terminal first — all 6 fields');
+    ss.log('✓ Bound terminal first — all 6 fields');
   });
 
   test('terminal-picker-005: active non-bound terminal appears second', async () => {
-    await createTerminal('rl-tp-005-a');
+    await ss.createTerminal('rl-tp-005-a');
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
-    await settle();
-    const t2 = await createTerminal('rl-tp-005-b');
+    await ss.settle();
+    const t2 = await ss.createTerminal('rl-tp-005-b');
     t2.show(true);
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-005');
@@ -257,11 +253,11 @@ standardSuite('Terminal Picker', (log) => {
       ],
     );
 
-    log('✓ Bound first, active second — all 6 fields');
+    ss.log('✓ Bound first, active second — all 6 fields');
   });
 
   test('terminal-picker-006: hidden IDE terminals are absent from the picker', async () => {
-    await createTerminal('rl-tp-006');
+    await ss.createTerminal('rl-tp-006');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-006');
@@ -294,12 +290,12 @@ standardSuite('Terminal Picker', (log) => {
       ],
     );
 
-    log('✓ Only the test terminal appears — full field validation');
+    ss.log('✓ Only the test terminal appears — full field validation');
   });
 
   test('terminal-picker-007: all terminals shown inline when within maxInline limit', async () => {
-    await createTerminal('rl-tp-007-a');
-    await createTerminal('rl-tp-007-b');
+    await ss.createTerminal('rl-tp-007-a');
+    await ss.createTerminal('rl-tp-007-b');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-007');
@@ -346,12 +342,12 @@ standardSuite('Terminal Picker', (log) => {
       ],
     );
 
-    log('✓ Both terminals inline, full field validation');
+    ss.log('✓ Both terminals inline, full field validation');
   });
 
   test('terminal-picker-008: overflow shows "More terminals..." when exceeding maxInline', async () => {
     for (let i = 1; i <= TERMINAL_OVERFLOW_COUNT; i++) {
-      await createTerminal(`rl-tp-008-${i}`);
+      await ss.createTerminal(`rl-tp-008-${i}`);
     }
 
     const logCapture = getLogCapture();
@@ -407,12 +403,12 @@ standardSuite('Terminal Picker', (log) => {
       },
     );
 
-    log('✓ Overflow item + active inline terminal fully validated');
+    ss.log('✓ Overflow item + active inline terminal fully validated');
   });
 
   test('[assisted] terminal-picker-009: selecting "More terminals..." opens secondary full picker', async () => {
     for (let i = 1; i <= TERMINAL_OVERFLOW_COUNT; i++) {
-      await createTerminal(`rl-tp-009-${i}`);
+      await ss.createTerminal(`rl-tp-009-${i}`);
     }
 
     const logCapture = getLogCapture();
@@ -472,12 +468,12 @@ standardSuite('Terminal Picker', (log) => {
       { description: undefined, isActive: false, boundState: 'not-bound', itemKind: 'bindable' },
     );
 
-    log('✓ Secondary picker: all terminals + active/non-active field validation');
+    ss.log('✓ Secondary picker: all terminals + active/non-active field validation');
   });
 
   test('[assisted] terminal-picker-010: escaping secondary picker returns to parent destination picker', async () => {
     for (let i = 1; i <= TERMINAL_OVERFLOW_COUNT; i++) {
-      await createTerminal(`rl-tp-010-${i}`);
+      await ss.createTerminal(`rl-tp-010-${i}`);
     }
 
     const logCapture = getLogCapture();
@@ -511,22 +507,16 @@ standardSuite('Terminal Picker', (log) => {
     });
     assert.deepStrictEqual(reopenedItems.map(mapFields), firstItems.map(mapFields));
 
-    log('✓ Parent picker reopened with identical items');
+    ss.log('✓ Parent picker reopened with identical items');
   });
 
   test('terminal-picker-011: maxInline setting changes overflow threshold', async () => {
+    await loadSettingsProfile('terminal-picker-low', ss.log);
     const LOW_MAX_INLINE = 2;
-    const config = vscode.workspace.getConfiguration();
-    await config.update(
-      'rangelink.terminalPicker.maxInline',
-      LOW_MAX_INLINE,
-      vscode.ConfigurationTarget.Global,
-    );
-    log(`set rangelink.terminalPicker.maxInline to ${LOW_MAX_INLINE}`);
     const TC_TERMINAL_COUNT = 3;
 
     for (let i = 1; i <= TC_TERMINAL_COUNT; i++) {
-      await createTerminal(`rl-tp-011-${i}`);
+      await ss.createTerminal(`rl-tp-011-${i}`);
     }
 
     const logCapture = getLogCapture();
@@ -578,11 +568,11 @@ standardSuite('Terminal Picker', (log) => {
       },
     );
 
-    log('✓ maxInline=2: overflow + active inline terminal fully validated');
+    ss.log('✓ maxInline=2: overflow + active inline terminal fully validated');
   });
 
   test('terminal-picker-012: terminal picker appears inline in R-M menu when unbound', async () => {
-    await createTerminal('rl-tp-012');
+    await ss.createTerminal('rl-tp-012');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-012');
@@ -620,11 +610,11 @@ standardSuite('Terminal Picker', (log) => {
       ],
     );
 
-    log('✓ Terminal inline in R-M menu with full description');
+    ss.log('✓ Terminal inline in R-M menu with full description');
   });
 
   test('terminal-picker-013: terminal picker appears inline in R-D destination picker', async () => {
-    await createTerminal('rl-tp-013');
+    await ss.createTerminal('rl-tp-013');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-013');
@@ -657,84 +647,77 @@ standardSuite('Terminal Picker', (log) => {
       ],
     );
 
-    log('✓ Terminal inline in R-D picker — full fields');
+    ss.log('✓ Terminal inline in R-D picker — full fields');
   });
 
   test('bind-to-destination-013: R-D picker shows both overflow items when many terminals and files are open', async () => {
     for (let i = 1; i <= TERMINAL_OVERFLOW_COUNT; i++) {
-      await createTerminal(`rl-btd-013-${i}`);
+      await ss.createTerminal(`rl-btd-013-${i}`);
     }
 
-    const tmpFileUris: vscode.Uri[] = [];
     for (let i = 1; i <= FILE_OVERFLOW_THRESHOLD; i++) {
-      const uri = createWorkspaceFile(`btd-013-${i}`, `file ${i}\n`);
-      tmpFileUris.push(uri);
+      const uri = ss.createWorkspaceFile(`btd-013-${i}`, `file ${i}\n`);
       const doc = await vscode.workspace.openTextDocument(uri);
       await vscode.window.showTextDocument(doc, {
         viewColumn: vscode.ViewColumn.One,
         preview: false,
       });
-      await settle();
+      await ss.settle();
     }
 
-    try {
-      const logCapture = getLogCapture();
-      logCapture.mark('before-btd-013');
+    const logCapture = getLogCapture();
+    logCapture.mark('before-btd-013');
 
-      await openAndDismiss(CMD_BIND_TO_DESTINATION);
+    await openAndDismiss(CMD_BIND_TO_DESTINATION);
 
-      const lines = logCapture.getLinesSince('before-btd-013');
-      const items = extractQuickPickItemsLogged(lines);
-      assert.ok(items, 'Expected showQuickPick log entry');
+    const lines = logCapture.getLinesSince('before-btd-013');
+    const items = extractQuickPickItemsLogged(lines);
+    assert.ok(items, 'Expected showQuickPick log entry');
 
-      const moreTerminals = items!.find((i) => i.label === 'More terminals...');
-      assert.ok(moreTerminals, 'Expected "More terminals..." overflow item');
-      assert.deepStrictEqual(
-        {
-          label: moreTerminals!.label,
-          displayName: moreTerminals!.displayName,
-          description: moreTerminals!.description,
-          remainingCount: moreTerminals!.remainingCount,
-          itemKind: moreTerminals!.itemKind,
-        },
-        {
-          label: 'More terminals...',
-          displayName: 'More terminals...',
-          description: `${TERMINAL_OVERFLOW_COUNT - MAX_INLINE_DEFAULT} more`,
-          remainingCount: TERMINAL_OVERFLOW_COUNT - MAX_INLINE_DEFAULT,
-          itemKind: 'terminal-more',
-        },
-      );
+    const moreTerminals = items!.find((i) => i.label === 'More terminals...');
+    assert.ok(moreTerminals, 'Expected "More terminals..." overflow item');
+    assert.deepStrictEqual(
+      {
+        label: moreTerminals!.label,
+        displayName: moreTerminals!.displayName,
+        description: moreTerminals!.description,
+        remainingCount: moreTerminals!.remainingCount,
+        itemKind: moreTerminals!.itemKind,
+      },
+      {
+        label: 'More terminals...',
+        displayName: 'More terminals...',
+        description: `${TERMINAL_OVERFLOW_COUNT - MAX_INLINE_DEFAULT} more`,
+        remainingCount: TERMINAL_OVERFLOW_COUNT - MAX_INLINE_DEFAULT,
+        itemKind: 'terminal-more',
+      },
+    );
 
-      const moreFiles = items!.find(
-        (i) => typeof i.label === 'string' && (i.label as string).includes('More files...'),
-      );
-      assert.ok(moreFiles, 'Expected "More files..." overflow item');
-      assert.deepStrictEqual(
-        {
-          label: moreFiles!.label,
-          displayName: moreFiles!.displayName,
-          description: moreFiles!.description,
-          remainingCount: moreFiles!.remainingCount,
-          itemKind: moreFiles!.itemKind,
-        },
-        {
-          label: 'More files...',
-          displayName: 'More files...',
-          description: `${FILE_OVERFLOW_THRESHOLD - 1} more`,
-          remainingCount: FILE_OVERFLOW_THRESHOLD - 1,
-          itemKind: 'file-more',
-        },
-      );
+    const moreFiles = items!.find(
+      (i) => typeof i.label === 'string' && (i.label as string).includes('More files...'),
+    );
+    assert.ok(moreFiles, 'Expected "More files..." overflow item');
+    assert.deepStrictEqual(
+      {
+        label: moreFiles!.label,
+        displayName: moreFiles!.displayName,
+        description: moreFiles!.description,
+        remainingCount: moreFiles!.remainingCount,
+        itemKind: moreFiles!.itemKind,
+      },
+      {
+        label: 'More files...',
+        displayName: 'More files...',
+        description: `${FILE_OVERFLOW_THRESHOLD - 1} more`,
+        remainingCount: FILE_OVERFLOW_THRESHOLD - 1,
+        itemKind: 'file-more',
+      },
+    );
 
-      const activeTerminal = findTerminalItems(items!).find((i) => i.isActive === true);
-      assert.ok(activeTerminal, 'Expected one active terminal in inline items');
-      assert.strictEqual(activeTerminal!.boundState, 'not-bound');
+    const activeTerminal = findTerminalItems(items!).find((i) => i.isActive === true);
+    assert.ok(activeTerminal, 'Expected one active terminal in inline items');
+    assert.strictEqual(activeTerminal!.boundState, 'not-bound');
 
-      log('✓ Both overflow items + active inline terminal validated');
-    } finally {
-      await closeAllEditors();
-      cleanupFiles(tmpFileUris);
-    }
+    ss.log('✓ Both overflow items + active inline terminal validated');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/terminalPicker.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/terminalPicker.test.ts
@@ -7,7 +7,6 @@ import {
   extractQuickPickItemsLogged,
   findTerminalItems,
   getLogCapture,
-  loadSettingsProfile,
   openAndDismiss,
   parseQuickPickItemsFromLogLine,
   standardSuite,
@@ -511,7 +510,9 @@ standardSuite('Terminal Picker', (ss) => {
   });
 
   test('terminal-picker-011: maxInline setting changes overflow threshold', async () => {
-    await loadSettingsProfile('terminal-picker-low', ss.log);
+    const config = vscode.workspace.getConfiguration();
+    await config.update('rangelink.terminalPicker.maxInline', 2, vscode.ConfigurationTarget.Global);
+    ss.log('set rangelink.terminalPicker.maxInline to 2');
     const LOW_MAX_INLINE = 2;
     const TC_TERMINAL_COUNT = 3;
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/textEditorDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/textEditorDestination.test.ts
@@ -10,41 +10,30 @@ import {
 import {
   assertNoToastLogged,
   assertToastLogged,
-  cleanupFiles,
-  createWorkspaceFile,
   getLogCapture,
   openSourceWithSelection,
-  settle,
   standardSuite,
   waitForHumanVerdict,
 } from '../helpers';
 
-standardSuite('Text Editor Destination', (log) => {
-  const tmpFileUris: vscode.Uri[] = [];
-
-  teardown(async () => {
-    cleanupFiles(tmpFileUris);
-    await settle();
-  });
-
+standardSuite('Text Editor Destination', (ss) => {
   test('[assisted] text-editor-destination-001: self-paste R-L copies to clipboard and shows info message', async () => {
-    const fileUri = createWorkspaceFile('ted-001', 'self-paste test\n');
-    tmpFileUris.push(fileUri);
+    const fileUri = ss.createWorkspaceFile('ted-001', 'self-paste test\n');
     const doc = await vscode.workspace.openTextDocument(fileUri);
     const editor = await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
-    await settle();
+    await ss.settle();
 
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
-    await settle();
+    await ss.settle();
 
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 10));
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ted-001');
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-ted-001');
 
@@ -65,16 +54,15 @@ standardSuite('Text Editor Destination', (log) => {
     );
     assert.strictEqual(verdict, 'pass');
 
-    log('✓ Self-paste R-L: info toast shown, file unchanged (log verified)');
+    ss.log('✓ Self-paste R-L: info toast shown, file unchanged (log verified)');
   });
 
   test('[assisted] hidden-tab-paste-001: R-L with bound editor hidden behind another tab — paste still lands in bound editor', async () => {
     const ANCHOR_START = 'ANCHOR_START';
     const ANCHOR_END = 'ANCHOR_END';
     const SOURCE_CONTENT = 'source-for-rangelink';
-    const destUri = createWorkspaceFile('htl-001-dest', `${ANCHOR_START}\n${ANCHOR_END}\n`);
-    const sourceUri = createWorkspaceFile('htl-001-source', `${SOURCE_CONTENT}\n`);
-    tmpFileUris.push(destUri, sourceUri);
+    const destUri = ss.createWorkspaceFile('htl-001-dest', `${ANCHOR_START}\n${ANCHOR_END}\n`);
+    const sourceUri = ss.createWorkspaceFile('htl-001-source', `${SOURCE_CONTENT}\n`);
 
     const destEditor = await vscode.window.showTextDocument(
       await vscode.workspace.openTextDocument(destUri),
@@ -85,7 +73,7 @@ standardSuite('Text Editor Destination', (log) => {
       new vscode.Position(1, 0),
     );
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
-    await settle();
+    await ss.settle();
 
     const sourceEditor = await vscode.window.showTextDocument(
       await vscode.workspace.openTextDocument(sourceUri),
@@ -95,13 +83,13 @@ standardSuite('Text Editor Destination', (log) => {
       new vscode.Position(0, 0),
       new vscode.Position(0, SOURCE_CONTENT.length),
     );
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-htl-001');
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-htl-001');
 
@@ -124,16 +112,15 @@ standardSuite('Text Editor Destination', (log) => {
       `Expected line reference "#L1" in bound editor, got: "${destContent}"`,
     );
 
-    log('✓ Bound editor brought to foreground and received RangeLink');
+    ss.log('✓ Bound editor brought to foreground and received RangeLink');
   });
 
   test('[assisted] hidden-tab-paste-002: R-V with bound editor hidden behind another tab — paste still lands in bound editor', async () => {
     const ANCHOR_START = 'ANCHOR_START';
     const ANCHOR_END = 'ANCHOR_END';
     const SELECTED_TEXT = 'text-to-paste';
-    const destUri = createWorkspaceFile('htl-002-dest', `${ANCHOR_START}\n${ANCHOR_END}\n`);
-    const sourceUri = createWorkspaceFile('htl-002-source', `${SELECTED_TEXT}\n`);
-    tmpFileUris.push(destUri, sourceUri);
+    const destUri = ss.createWorkspaceFile('htl-002-dest', `${ANCHOR_START}\n${ANCHOR_END}\n`);
+    const sourceUri = ss.createWorkspaceFile('htl-002-source', `${SELECTED_TEXT}\n`);
 
     const destEditor = await vscode.window.showTextDocument(
       await vscode.workspace.openTextDocument(destUri),
@@ -144,7 +131,7 @@ standardSuite('Text Editor Destination', (log) => {
       new vscode.Position(1, 0),
     );
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
-    await settle();
+    await ss.settle();
 
     const sourceEditor = await vscode.window.showTextDocument(
       await vscode.workspace.openTextDocument(sourceUri),
@@ -154,13 +141,13 @@ standardSuite('Text Editor Destination', (log) => {
       new vscode.Position(0, 0),
       new vscode.Position(0, SELECTED_TEXT.length),
     );
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-htl-002');
 
     await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-htl-002');
 
@@ -178,16 +165,15 @@ standardSuite('Text Editor Destination', (log) => {
       `Expected selected text inserted in bound editor at cursor position, got: "${destContent}"`,
     );
 
-    log('✓ Bound editor brought to foreground and received selected text');
+    ss.log('✓ Bound editor brought to foreground and received selected text');
   });
 
   const WARN_DUPLICATE_TAB_GROUPS =
     'Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed.';
 
   test('duplicate-tab-group-001: warning toast fires when bound file is opened in a second editor group', async () => {
-    const destUri = createWorkspaceFile('dtg-001-dest', 'destination file\n');
-    const triggerUri = createWorkspaceFile('dtg-001-trigger', '');
-    tmpFileUris.push(destUri, triggerUri);
+    const destUri = ss.createWorkspaceFile('dtg-001-dest', 'destination file\n');
+    const triggerUri = ss.createWorkspaceFile('dtg-001-trigger', '');
 
     const destDoc = await vscode.workspace.openTextDocument(destUri);
     await vscode.window.showTextDocument(destDoc, {
@@ -195,7 +181,7 @@ standardSuite('Text Editor Destination', (log) => {
       preview: false,
     });
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
-    await settle();
+    await ss.settle();
 
     // Open same file in col 2 so both instances are visible. onDidChangeTabs fires
     // during this call but visibleTextEditors may not include col 2 yet.
@@ -203,7 +189,7 @@ standardSuite('Text Editor Destination', (log) => {
       viewColumn: vscode.ViewColumn.Two,
       preview: false,
     });
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-dtg-001');
@@ -215,21 +201,20 @@ standardSuite('Text Editor Destination', (log) => {
       viewColumn: vscode.ViewColumn.Three,
       preview: false,
     });
-    await settle();
+    await ss.settle();
 
     assertToastLogged(logCapture.getLinesSince('before-dtg-001'), {
       type: 'warning',
       message: WARN_DUPLICATE_TAB_GROUPS,
     });
 
-    log('✓ Warning toast fired when bound file open in multiple editor groups');
+    ss.log('✓ Warning toast fired when bound file open in multiple editor groups');
   });
 
   test('duplicate-tab-group-002: warning is not repeated when duplicate state is already active', async () => {
-    const destUri = createWorkspaceFile('dtg-002-dest', 'destination file\n');
-    const trigger1Uri = createWorkspaceFile('dtg-002-trigger1', '');
-    const trigger2Uri = createWorkspaceFile('dtg-002-trigger2', '');
-    tmpFileUris.push(destUri, trigger1Uri, trigger2Uri);
+    const destUri = ss.createWorkspaceFile('dtg-002-dest', 'destination file\n');
+    const trigger1Uri = ss.createWorkspaceFile('dtg-002-trigger1', '');
+    const trigger2Uri = ss.createWorkspaceFile('dtg-002-trigger2', '');
 
     const destDoc = await vscode.workspace.openTextDocument(destUri);
     await vscode.window.showTextDocument(destDoc, {
@@ -237,20 +222,20 @@ standardSuite('Text Editor Destination', (log) => {
       preview: false,
     });
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
-    await settle();
+    await ss.settle();
 
     await vscode.window.showTextDocument(destDoc, {
       viewColumn: vscode.ViewColumn.Two,
       preview: false,
     });
-    await settle();
+    await ss.settle();
 
     // Open trigger1 in col 3 — fires onDidChangeTabs with both dest instances visible → first warning.
     await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(trigger1Uri), {
       viewColumn: vscode.ViewColumn.Three,
       preview: false,
     });
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-dtg-002');
@@ -261,21 +246,20 @@ standardSuite('Text Editor Destination', (log) => {
       viewColumn: vscode.ViewColumn.Four,
       preview: false,
     });
-    await settle();
+    await ss.settle();
 
     assertNoToastLogged(logCapture.getLinesSince('before-dtg-002'), {
       type: 'warning',
       message: WARN_DUPLICATE_TAB_GROUPS,
     });
 
-    log('✓ No second warning fired while already in duplicate tab state');
+    ss.log('✓ No second warning fired while already in duplicate tab state');
   });
 
   test('duplicate-tab-group-003: paste is blocked with error when bound file is visible in multiple tab groups', async () => {
     const SOURCE_TEXT = 'dtg-003-source-text';
-    const destUri = createWorkspaceFile('dtg-003-dest', 'ANCHOR\n');
-    const sourceUri = createWorkspaceFile('dtg-003-source', `${SOURCE_TEXT}\n`);
-    tmpFileUris.push(destUri, sourceUri);
+    const destUri = ss.createWorkspaceFile('dtg-003-dest', 'ANCHOR\n');
+    const sourceUri = ss.createWorkspaceFile('dtg-003-source', `${SOURCE_TEXT}\n`);
 
     const destDoc = await vscode.workspace.openTextDocument(destUri);
 
@@ -285,14 +269,14 @@ standardSuite('Text Editor Destination', (log) => {
       preview: false,
     });
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
-    await settle();
+    await ss.settle();
 
     // Open dest in col 3 as well (both instances now visible).
     await vscode.window.showTextDocument(destDoc, {
       viewColumn: vscode.ViewColumn.Three,
       preview: false,
     });
-    await settle();
+    await ss.settle();
 
     // Open source in col 4 — a fresh column that reliably gets focus in the
     // test runner (col 2 and 3 are occupied by dest; col 1 is unreliable
@@ -303,7 +287,7 @@ standardSuite('Text Editor Destination', (log) => {
     logCapture.mark('before-dtg-003');
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     assertToastLogged(logCapture.getLinesSince('before-dtg-003'), {
       type: 'error',
@@ -318,15 +302,14 @@ standardSuite('Text Editor Destination', (log) => {
       `Expected destination to remain unchanged when duplicate-tab guard blocks paste, got: "${destContentAfter}"`,
     );
 
-    log('✓ Paste blocked with ambiguous-columns error when dest is in multiple tab groups');
+    ss.log('✓ Paste blocked with ambiguous-columns error when dest is in multiple tab groups');
   });
 
   test('duplicate-tab-group-004: duplicate state clears when conflict resolves and re-entry triggers a fresh warning', async () => {
-    const destUri = createWorkspaceFile('dtg-004-dest', 'destination file\n');
-    const trigger1Uri = createWorkspaceFile('dtg-004-trigger1', '');
-    const trigger2Uri = createWorkspaceFile('dtg-004-trigger2', '');
-    const trigger3Uri = createWorkspaceFile('dtg-004-trigger3', '');
-    tmpFileUris.push(destUri, trigger1Uri, trigger2Uri, trigger3Uri);
+    const destUri = ss.createWorkspaceFile('dtg-004-dest', 'destination file\n');
+    const trigger1Uri = ss.createWorkspaceFile('dtg-004-trigger1', '');
+    const trigger2Uri = ss.createWorkspaceFile('dtg-004-trigger2', '');
+    const trigger3Uri = ss.createWorkspaceFile('dtg-004-trigger3', '');
 
     const destDoc = await vscode.workspace.openTextDocument(destUri);
     await vscode.window.showTextDocument(destDoc, {
@@ -334,20 +317,20 @@ standardSuite('Text Editor Destination', (log) => {
       preview: false,
     });
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
-    await settle();
+    await ss.settle();
 
     await vscode.window.showTextDocument(destDoc, {
       viewColumn: vscode.ViewColumn.Two,
       preview: false,
     });
-    await settle();
+    await ss.settle();
 
     // Open trigger1 in col 3 → first warning fires, isInDuplicateTabState becomes true.
     await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(trigger1Uri), {
       viewColumn: vscode.ViewColumn.Three,
       preview: false,
     });
-    await settle();
+    await ss.settle();
 
     const logCapture = getLogCapture();
     logCapture.mark('before-dtg-004-close');
@@ -355,7 +338,7 @@ standardSuite('Text Editor Destination', (log) => {
     // Close col 2 dest: focus it first, then close the active editor.
     await vscode.window.showTextDocument(destDoc, { viewColumn: vscode.ViewColumn.Two });
     await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
-    await settle();
+    await ss.settle();
 
     // Open trigger2 in col 2 to force onDidChangeTabs — visibleTextEditors now has only
     // one dest instance (col 1), so the listener clears the duplicate state.
@@ -363,7 +346,7 @@ standardSuite('Text Editor Destination', (log) => {
       viewColumn: vscode.ViewColumn.Two,
       preview: false,
     });
-    await settle();
+    await ss.settle();
 
     const linesSinceClose = logCapture.getLinesSince('before-dtg-004-close');
     const stateCleared = linesSinceClose.some((l) =>
@@ -376,7 +359,7 @@ standardSuite('Text Editor Destination', (log) => {
       viewColumn: vscode.ViewColumn.Two,
       preview: false,
     });
-    await settle();
+    await ss.settle();
 
     logCapture.mark('before-dtg-004-rewarn');
 
@@ -385,22 +368,21 @@ standardSuite('Text Editor Destination', (log) => {
       viewColumn: vscode.ViewColumn.Three,
       preview: false,
     });
-    await settle();
+    await ss.settle();
 
     assertToastLogged(logCapture.getLinesSince('before-dtg-004-rewarn'), {
       type: 'warning',
       message: WARN_DUPLICATE_TAB_GROUPS,
     });
 
-    log('✓ Duplicate state cleared on resolve; re-entry triggered a fresh warning');
+    ss.log('✓ Duplicate state cleared on resolve; re-entry triggered a fresh warning');
   });
 
   test('stale-viewcolumn-001: paste targets the correct new column after bound editor is moved', async () => {
     const SOURCE_TEXT = 'stale-vc-001-source-text';
-    const destUri = createWorkspaceFile('svc-001-dest', 'ANCHOR\n');
-    const sourceUri = createWorkspaceFile('svc-001-source', `${SOURCE_TEXT}\n`);
-    const dummyUri = createWorkspaceFile('svc-001-dummy', '');
-    tmpFileUris.push(destUri, sourceUri, dummyUri);
+    const destUri = ss.createWorkspaceFile('svc-001-dest', 'ANCHOR\n');
+    const sourceUri = ss.createWorkspaceFile('svc-001-source', `${SOURCE_TEXT}\n`);
+    const dummyUri = ss.createWorkspaceFile('svc-001-dummy', '');
 
     const destDoc = await vscode.workspace.openTextDocument(destUri);
 
@@ -414,14 +396,14 @@ standardSuite('Text Editor Destination', (log) => {
       new vscode.Position(1, 0),
     );
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
-    await settle();
+    await ss.settle();
 
     // Open dest in col 3 — dest is now visible in col 2 AND col 3.
     await vscode.window.showTextDocument(destDoc, {
       viewColumn: vscode.ViewColumn.Three,
       preview: false,
     });
-    await settle();
+    await ss.settle();
 
     // Open dummy in col 2 (active) — dest in col 2 is now HIDDEN behind dummy.
     // After this: col 2 shows dummy (visible), dest (hidden). Col 3 shows dest (visible).
@@ -431,7 +413,7 @@ standardSuite('Text Editor Destination', (log) => {
       viewColumn: vscode.ViewColumn.Two,
       preview: false,
     });
-    await settle();
+    await ss.settle();
 
     // Open source in col 4 — a fresh column that reliably gets focus.
     // Col 2 is occupied by dummy (dest hidden behind it), col 3 by dest.
@@ -441,7 +423,7 @@ standardSuite('Text Editor Destination', (log) => {
     logCapture.mark('before-svc-001');
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-svc-001');
     const movedLog = lines.some((l) =>
@@ -456,6 +438,6 @@ standardSuite('Text Editor Destination', (log) => {
       `Expected RangeLink referencing "${relativeSourcePath}" in dest, got: "${destContent}"`,
     );
 
-    log('✓ Paste followed bound editor to new view column');
+    ss.log('✓ Paste followed bound editor to new view column');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/unbind.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/unbind.test.ts
@@ -3,36 +3,21 @@ import assert from 'node:assert';
 import * as vscode from 'vscode';
 
 import {
-  TERMINAL_READY_MS,
   assertNoSetContextLogged,
   assertSetContextLogged,
   assertStatusBarMsgLogged,
-  cleanupFiles,
-  createWorkspaceFile,
   getLogCapture,
-  settle,
   standardSuite,
   waitForHumanVerdict,
 } from '../helpers';
 
-standardSuite('Unbind Destination', (_log) => {
-  let testFileUri: vscode.Uri;
-
-  suiteSetup(async () => {
-    testFileUri = createWorkspaceFile('unbind', 'line 1 content\nline 2 content\n');
-  });
-
-  suiteTeardown(async () => {
-    cleanupFiles([testFileUri]);
-  });
-
+standardSuite('Unbind Destination', (ss) => {
   test('unbind-001: unbindDestination unbinds a currently bound terminal destination', async () => {
-    const doc = await vscode.workspace.openTextDocument(testFileUri);
+    const fileUri = ss.createWorkspaceFile('unbind-001', 'line 1 content\nline 2 content\n');
+    const doc = await vscode.workspace.openTextDocument(fileUri);
     const editor = await vscode.window.showTextDocument(doc);
 
-    const terminal = vscode.window.createTerminal({ name: 'rl-unbind-test' });
-    terminal.show(true);
-    await settle(TERMINAL_READY_MS);
+    await ss.createTerminal('rl-unbind-test');
 
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
 
@@ -65,9 +50,7 @@ standardSuite('Unbind Destination', (_log) => {
   });
 
   test('unbind-004: RangeLink: Unbind Destination available in Command Palette', async () => {
-    const terminal = vscode.window.createTerminal({ name: 'rl-unbind-004-test' });
-    terminal.show(true);
-    await settle(TERMINAL_READY_MS);
+    await ss.createTerminal('rl-unbind-004-test');
 
     await vscode.commands.executeCommand('rangelink.bindToTerminalHere');
 
@@ -112,9 +95,7 @@ standardSuite('Unbind Destination', (_log) => {
   test('[assisted] unbind-006: "RangeLink: Unbind" visible in command palette when a destination is bound', async () => {
     const CONTEXT_IS_BOUND_KEY = 'rangelink.isBound';
 
-    const terminal = vscode.window.createTerminal({ name: 'rl-unbind-006-test' });
-    terminal.show(true);
-    await settle(TERMINAL_READY_MS);
+    await ss.createTerminal('rl-unbind-006-test');
 
     const logCapture = getLogCapture();
     logCapture.mark('before-unbind-006');
@@ -149,7 +130,7 @@ standardSuite('Unbind Destination', (_log) => {
     logCapture.mark('before-unbind-003-noop');
 
     await vscode.commands.executeCommand('rangelink.unbindDestination');
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-unbind-003-noop');
     assertStatusBarMsgLogged(lines, {

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/untitledNavigation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/untitledNavigation.test.ts
@@ -11,7 +11,6 @@ import {
   clearEditorSelection,
   getLogCapture,
   openUntitledDoc,
-  settle,
   standardSuite,
 } from '../helpers';
 
@@ -76,7 +75,7 @@ const UNTITLED_CONTENT = Array.from(
   (_, i) => `untitled line ${i + 1} content here`,
 ).join('\n');
 
-standardSuite('Untitled File Navigation', (_ss) => {
+standardSuite('Untitled File Navigation', (ss) => {
   let untitledDoc: vscode.TextDocument;
   let untitledDisplayName: string;
 
@@ -84,7 +83,7 @@ standardSuite('Untitled File Navigation', (_ss) => {
     untitledDoc = await openUntitledDoc({ content: UNTITLED_CONTENT });
     assert.strictEqual(untitledDoc.uri.scheme, 'untitled', 'Expected untitled document');
     untitledDisplayName = getUntitledDisplayName(untitledDoc.uri);
-    await settle();
+    await ss.settle();
   });
 
   // untitled-navigation-001: Navigate to single line in untitled file
@@ -98,7 +97,7 @@ standardSuite('Untitled File Navigation', (_ss) => {
 
     await clearEditorSelection();
     const { sel, doc } = await navigateToUntitledLink(linkText, parseResult.value, untitledDoc.uri);
-    await settle();
+    await ss.settle();
 
     assert.strictEqual(doc.uri.scheme, 'untitled', 'Expected navigation to untitled document');
     const lineLength = doc.lineAt(4).text.length;
@@ -138,7 +137,7 @@ standardSuite('Untitled File Navigation', (_ss) => {
 
     await clearEditorSelection();
     const { sel, doc } = await navigateToUntitledLink(linkText, parseResult.value, untitledDoc.uri);
-    await settle();
+    await ss.settle();
 
     assert.strictEqual(doc.uri.scheme, 'untitled', 'Expected navigation to untitled document');
     const endLineLength = doc.lineAt(6).text.length;
@@ -179,7 +178,7 @@ standardSuite('Untitled File Navigation', (_ss) => {
       linkText,
       parsed: parseResult.value,
     });
-    await settle();
+    await ss.settle();
 
     const lines = logCapture.getLinesSince('before-untitled-nav-003');
     assertToastLogged(lines, {
@@ -203,7 +202,7 @@ standardSuite('Untitled File Navigation', (_ss) => {
 
     await clearEditorSelection();
     const { sel, doc } = await navigateToUntitledLink(linkText, parseResult.value, untitledDoc.uri);
-    await settle();
+    await ss.settle();
 
     assert.strictEqual(doc.uri.scheme, 'untitled', 'Expected navigation to untitled document');
     assert.deepStrictEqual(
@@ -238,7 +237,7 @@ standardSuite('Untitled File Navigation', (_ss) => {
 
     await clearEditorSelection();
     const { sel, doc } = await navigateToUntitledLink(linkText, parseResult.value, untitledDoc.uri);
-    await settle();
+    await ss.settle();
 
     assert.strictEqual(doc.uri.scheme, 'untitled', 'Expected navigation to untitled document');
     const lastLine = doc.lineCount - 1;
@@ -276,7 +275,7 @@ standardSuite('Untitled File Navigation', (_ss) => {
 
     await clearEditorSelection();
     const { sel, doc } = await navigateToUntitledLink(linkText, parseResult.value, untitledDoc.uri);
-    await settle();
+    await ss.settle();
 
     assert.strictEqual(doc.uri.scheme, 'untitled', 'Expected navigation to untitled document');
     const lineLength = doc.lineAt(4).text.length;

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/untitledNavigation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/untitledNavigation.test.ts
@@ -76,7 +76,7 @@ const UNTITLED_CONTENT = Array.from(
   (_, i) => `untitled line ${i + 1} content here`,
 ).join('\n');
 
-standardSuite('Untitled File Navigation', (_log) => {
+standardSuite('Untitled File Navigation', (_ss) => {
   let untitledDoc: vscode.TextDocument;
   let untitledDisplayName: string;
 


### PR DESCRIPTION
## Summary

Replaces duplicated resource-tracking boilerplate (`tmpFileUris` arrays, `teardown` hooks, manual `vscode.window.createTerminal()` calls) with an `ss` context object that auto-tracks resources and registers per-test cleanup. Every `standardSuite` callback now receives an `SsContext` instead of a raw `log` function. Adds a `createContentFile` helper that collapses the repeated `Array.from → join → createWorkspaceFile → path.basename` pattern into a single call.

## Changes

- New `SsContext` interface and `SsContextImpl` class in `src/__integration-tests__/helpers/ssContext.ts` with 12 factory methods that auto-track created resources (files, terminals) and register per-test teardown
- `standardSuite` signature changed from `(log: (msg: string) => void) => void` to `(ss: SsContext) => void`; the wrapper instantiates `SsContextImpl` and passes it to the callback
- All ~36 `standardSuite` callbacks across ~24 test files converted: `(log)` → `(ss)`, `log(...)` → `ss.log(...)`, free-function calls → `ss.*` methods
- Removed all `tmpFileUris` arrays and per-test `teardown` blocks from 11 suites (auto-tracked by `ss`)
- Replaced 10 manual `vscode.window.createTerminal()` calls with `ss.createTerminal()` (disposal tracked automatically)
- Eliminated 4 `suiteSetup`/`suiteTeardown` blocks (unbind, clipboardPreservation, dirtyBufferWarning) — resources moved to per-test creation
- Added `waitForExtensionActive` and `loadSettingsProfile` as `ss` methods for consistency
- Added `createContentFile` helper to SsContext; converted 15+ call sites across 7 test files, eliminating the 3-line Array.from + join + createWorkspaceFile + path.basename boilerplate
- Free-function helpers remain as the implementation layer that `ss` methods delegate to; test call sites no longer import them directly

## Test Plan

- [x] All 1925 unit tests pass (98.46% coverage)
- [x] Sampled integration tests from 5 suites pass (navigationClamping, navigationPrecision, filePathNavigation, navigationToastSettings, smartPadding)
- [x] No remaining `tmpFileUris` or `tmpTerminals` references in suite files
- [x] TS compilation clean for all suite/helper files (18 pre-existing unit test errors from base branch, none in integration code)
- [x] Lint and format clean

## Related

- Closes https://github.com/couimet/rangeLink/issues/584

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized and consolidated integration test harness into a suite-scoped context object.
  * Replaced many ad-hoc helpers with unified per-suite APIs for file/terminal creation, logging, settling, and cleanup.
  * Simplified teardown and resource tracking across numerous tests, improving test reliability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/rangeLink/pull/587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->