### PR TITLE
[issues/494] Re-read editor selections after `Save & Generate`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ coverage/
 .claude-work/
 **/*.map
 pnpm-lock.yaml
+packages/rangelink-vscode-extension/qa/fixtures/workspace/format-on-save/unformatted.ts

--- a/packages/rangelink-vscode-extension/qa/fixtures/workspace/format-on-save/unformatted.ts
+++ b/packages/rangelink-vscode-extension/qa/fixtures/workspace/format-on-save/unformatted.ts
@@ -1,0 +1,12 @@
+// Fixture for dirty-buffer-warning-023:
+// Each declaration below has trailing whitespace (5 spaces) before the
+// newline. With `files.trimTrailingWhitespace` enabled, VS Code trims those
+// on save — shifting the end-of-line character offset for any selection
+// that extends to the trailing-whitespace region. This is built-in VS Code
+// behavior (no formatter required), so it reproduces deterministically in
+// any test host.
+//
+// This file is listed in .prettierignore so the trailing whitespace is
+// preserved across formatter runs.
+export const targetLine = 'shift me';     
+export const referenceLine = 'no trim';     

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
@@ -1662,6 +1662,25 @@ test_cases:
     expected_result: 'Clipboard still has sentinel (no send occurred). File still dirty. No Pasted log. handleDirtyBufferWarning logs "showing warning".'
     automated: assisted
 
+  - id: dirty-buffer-warning-023
+    feature: 'Dirty Buffer Warning — R-L Dialog'
+    scenario: 'R-L Save & Generate re-reads selections after save mutates the document'
+    preconditions:
+      - 'rangelink.warnOnDirtyBuffer = true (default)'
+      - 'files.trimTrailingWhitespace = true'
+      - 'A terminal is bound as destination'
+      - 'Fixture qa/fixtures/workspace/format-on-save/unformatted.ts opened — each `const` line has 5 trailing spaces before the newline'
+      - 'File made dirty by adding then removing a character'
+    steps:
+      - 'Place a multi-line selection that starts at the beginning of the `const targetLine = ...` line and extends to the END of the trailing whitespace on that same line (column ~36)'
+      - 'Press Cmd+R Cmd+L (Send RangeLink) — dialog appears'
+      - 'Click Save & Generate'
+    expected_result: |
+      File saved and trailing whitespace trimmed on the selected line (line length shrinks by 5 characters).
+      LinkGenerator logs "Re-read selections after Save & Continue to account for possible format-on-save shifts" with both preSaveSelections and postSaveSelections fields. The end character of postSaveSelections is smaller than preSaveSelections by ~5 (the trimmed whitespace).
+      Link sent to bound terminal correctly references the post-trim character range, not the stale pre-trim one.
+    automated: assisted
+
   # ---------------------------------------------------------------------------
   # Section 9 — R-V Send Terminal Selection
   # ---------------------------------------------------------------------------

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/logHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/logHelpers.ts
@@ -6,3 +6,28 @@ export const createLogger = (suiteName: string): ((msg: string) => void) => {
   const prefix = `[RL-integ:${suiteName}]`;
   return (msg: string) => nodeConsole.log(`${prefix} ${msg}`);
 };
+
+/**
+ * Extract the generated link from the "Sending link to destination" log line.
+ * Returns the `formattedLink.link` value, or undefined if the log line is
+ * missing or the link field cannot be parsed.
+ */
+export const extractSentLink = (lines: string[]): string | undefined => {
+  const sendingLog = lines.find((l) => l.includes('Sending link to destination'));
+  if (!sendingLog) return undefined;
+  const linkMatch = sendingLog.match(/"link":"([^"]+)"/);
+  return linkMatch?.[1];
+};
+
+/**
+ * Extract the generated link from the "Generated link:" log line.
+ * This log fires for ALL link generation paths (R-L, R-C, R-P) — not just
+ * send-to-destination. Returns the full link string (path + anchor), or
+ * undefined if the log line is missing or the link cannot be parsed.
+ */
+export const extractGeneratedLink = (lines: string[]): string | undefined => {
+  const generatedLog = lines.find((l) => l.includes('Generated link:'));
+  if (!generatedLog) return undefined;
+  const linkMatch = generatedLog.match(/"link":"([^"]+)"/);
+  return linkMatch?.[1];
+};

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/builtInAiAssistants.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/builtInAiAssistants.test.ts
@@ -24,6 +24,7 @@ import {
   assertClipboardChanged,
   assertClipboardRestored,
   assertStatusBarMsgLogged,
+  extractGeneratedLink,
   extractQuickPickItemsLogged,
   getLogCapture,
   openAndDismiss,
@@ -588,10 +589,20 @@ standardSuite('Built-in AI Assistants', (ss) => {
 
     await writeClipboardSentinel();
 
+    const logCapture = getLogCapture();
+    logCapture.mark('before-017');
+
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
     await ss.settle();
+    const lines017 = logCapture.getLinesSince('before-017');
+    const generatedLink017 = extractGeneratedLink(lines017);
+    assert.ok(generatedLink017, 'Expected "Generated link:" log line');
     const clipboard017 = await assertClipboardChanged('clipboard-preservation-017: failed paste');
-    assert.ok(clipboard017.includes('#L'), `Expected RangeLink on clipboard, got: ${clipboard017}`);
+    assert.strictEqual(
+      clipboard017,
+      generatedLink017,
+      `Expected clipboard to equal generated link, got: ${clipboard017}`,
+    );
     ss.log('✓ clipboard-preservation-017: failed paste — RangeLink stays on clipboard');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
@@ -13,6 +13,7 @@ import {
   assertClipboardChanged,
   assertClipboardRestored,
   assertTerminalBufferContains,
+  extractGeneratedLink,
   getLogCapture,
   openAndDismiss,
   standardSuite,
@@ -54,15 +55,25 @@ standardSuite('Clipboard Preservation', (ss) => {
       .getConfiguration('rangelink')
       .update('clipboard.preserve', 'never', vscode.ConfigurationTarget.Global);
 
+    const logCapture = getLogCapture();
+    logCapture.mark('before-006');
     capturing.clearCaptured();
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
+    await ss.settle();
+    const lines = logCapture.getLinesSince('before-006');
+    const generatedLink = extractGeneratedLink(lines);
+    assert.ok(generatedLink, 'Expected "Generated link:" log line');
     const clipboard = await assertClipboardChanged('R-L with preserve=never');
-    assert.ok(clipboard.includes('#L'), `Expected line reference but got: ${clipboard}`);
+    assert.strictEqual(
+      clipboard,
+      generatedLink,
+      `Expected clipboard to equal generated link, got: ${clipboard}`,
+    );
     const captured = capturing.getCapturedText();
     assertTerminalBufferContains(captured, 'clipboard');
     assert.ok(
-      captured.includes('#L'),
-      `Expected line reference in terminal buffer, got: ${captured}`,
+      captured.includes(generatedLink),
+      `Expected terminal buffer to contain generated link "${generatedLink}", got: ${captured}`,
     );
   });
 
@@ -71,15 +82,35 @@ standardSuite('Clipboard Preservation', (ss) => {
       .getConfiguration('rangelink')
       .update('clipboard.preserve', 'always', vscode.ConfigurationTarget.Global);
 
+    const logCapture = getLogCapture();
+    logCapture.mark('before-008a');
     await vscode.commands.executeCommand('rangelink.copyLinkOnlyWithRelativePath');
+    await ss.settle();
+    const lines = logCapture.getLinesSince('before-008a');
+    const generatedLink = extractGeneratedLink(lines);
+    assert.ok(generatedLink, 'Expected "Generated link:" log line');
     const clipboard = await assertClipboardChanged('R-C with preserve=always');
-    assert.ok(clipboard.includes('#L'), `Expected line reference but got: ${clipboard}`);
+    assert.strictEqual(
+      clipboard,
+      generatedLink,
+      `Expected clipboard to equal generated link, got: ${clipboard}`,
+    );
   });
 
   test('clipboard-preservation-008 (variant): R-C writes link to clipboard with default preserve setting', async () => {
+    const logCapture = getLogCapture();
+    logCapture.mark('before-008b');
     await vscode.commands.executeCommand('rangelink.copyLinkOnlyWithRelativePath');
+    await ss.settle();
+    const lines = logCapture.getLinesSince('before-008b');
+    const generatedLink = extractGeneratedLink(lines);
+    assert.ok(generatedLink, 'Expected "Generated link:" log line');
     const clipboard = await assertClipboardChanged('R-C with default preserve');
-    assert.ok(clipboard.includes('#L'), `Expected line reference but got: ${clipboard}`);
+    assert.strictEqual(
+      clipboard,
+      generatedLink,
+      `Expected clipboard to equal generated link, got: ${clipboard}`,
+    );
   });
 
   test('clipboard-preservation-008 (variant): R-C writes link to clipboard with preserve=never', async () => {
@@ -87,9 +118,19 @@ standardSuite('Clipboard Preservation', (ss) => {
       .getConfiguration('rangelink')
       .update('clipboard.preserve', 'never', vscode.ConfigurationTarget.Global);
 
+    const logCapture = getLogCapture();
+    logCapture.mark('before-008c');
     await vscode.commands.executeCommand('rangelink.copyLinkOnlyWithRelativePath');
+    await ss.settle();
+    const lines = logCapture.getLinesSince('before-008c');
+    const generatedLink = extractGeneratedLink(lines);
+    assert.ok(generatedLink, 'Expected "Generated link:" log line');
     const clipboard = await assertClipboardChanged('R-C with preserve=never');
-    assert.ok(clipboard.includes('#L'), `Expected line reference but got: ${clipboard}`);
+    assert.strictEqual(
+      clipboard,
+      generatedLink,
+      `Expected clipboard to equal generated link, got: ${clipboard}`,
+    );
   });
 });
 
@@ -108,12 +149,17 @@ standardSuite('Clipboard Preservation — Assisted', (ss) => {
     await ss.settle();
     await writeClipboardSentinel();
 
+    const logCapture = getLogCapture();
+    logCapture.mark('before-001');
     capturing.clearCaptured();
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
     await ss.settle();
+    const lines = logCapture.getLinesSince('before-001');
+    const generatedLink = extractGeneratedLink(lines);
+    assert.ok(generatedLink, 'Expected "Generated link:" log line');
 
     await assertClipboardRestored('clipboard-preservation-001: always + R-L');
-    assertTerminalBufferContains(capturing.getCapturedText(), '#L');
+    assertTerminalBufferContains(capturing.getCapturedText(), generatedLink);
     ss.log('✓ Clipboard restored to sentinel after R-L; terminal received link');
   });
 
@@ -203,12 +249,17 @@ standardSuite('Clipboard Preservation — Assisted', (ss) => {
     await ss.settle();
     await writeClipboardSentinel();
 
+    const logCapture = getLogCapture();
+    logCapture.mark('before-005');
     capturing.clearCaptured();
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
     await ss.settle();
+    const lines = logCapture.getLinesSince('before-005');
+    const generatedLink = extractGeneratedLink(lines);
+    assert.ok(generatedLink, 'Expected "Generated link:" log line');
 
     await assertClipboardRestored('clipboard-preservation-005: always + terminal paste');
-    assertTerminalBufferContains(capturing.getCapturedText(), '#L');
+    assertTerminalBufferContains(capturing.getCapturedText(), generatedLink);
     ss.log('✓ Clipboard restored to sentinel after terminal paste (preserve=always)');
   });
 
@@ -315,9 +366,12 @@ standardSuite('Clipboard Preservation — Assisted', (ss) => {
     const clipboardContent = await assertClipboardChanged(
       'clipboard-preservation-010: focus-fail — link must stay in clipboard',
     );
-    assert.ok(
-      clipboardContent.includes('#L'),
-      `Expected a RangeLink link in clipboard (with #L) but got: ${clipboardContent}`,
+    const generatedLink = extractGeneratedLink(lines010);
+    assert.ok(generatedLink, 'Expected "Generated link:" log line');
+    assert.strictEqual(
+      clipboardContent,
+      generatedLink,
+      `Expected clipboard to equal generated link "${generatedLink}", got: ${clipboardContent}`,
     );
     ss.log(
       '✓ Clipboard not restored after focus failure — link stays in clipboard for manual paste',

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
@@ -64,10 +64,9 @@ standardSuite('Clipboard Preservation', (ss) => {
     const generatedLink = extractGeneratedLink(lines);
     assert.ok(generatedLink, 'Expected "Generated link:" log line');
     const clipboard = await assertClipboardChanged('R-L with preserve=never');
-    assert.strictEqual(
-      clipboard,
-      generatedLink,
-      `Expected clipboard to equal generated link, got: ${clipboard}`,
+    assert.ok(
+      clipboard.includes(generatedLink),
+      `Expected clipboard to contain generated link "${generatedLink}", got: ${clipboard}`,
     );
     const captured = capturing.getCapturedText();
     assertTerminalBufferContains(captured, 'clipboard');

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
@@ -22,6 +22,7 @@ import {
   type CapturingTerminal,
   clearSelection,
   echoToTerminal,
+  extractGeneratedLink,
   extractQuickPickItemsLogged,
   getLogCapture,
   openAndDismiss,
@@ -147,9 +148,13 @@ standardSuite('Core Send Commands', (ss) => {
     await ss.settle();
 
     const clipboard = await assertClipboardChanged('R-C should write link to clipboard');
-    assert.ok(
-      clipboard.includes('#L'),
-      `Expected line-range link in clipboard, got: ${JSON.stringify(clipboard)}`,
+    const lines = logCapture.getLinesSince('before-r-c-001');
+    const generatedLink = extractGeneratedLink(lines);
+    assert.ok(generatedLink, 'Expected "Generated link:" log line');
+    assert.strictEqual(
+      clipboard,
+      generatedLink,
+      `Expected clipboard to equal generated link, got: ${JSON.stringify(clipboard)}`,
     );
 
     assert.strictEqual(
@@ -158,7 +163,7 @@ standardSuite('Core Send Commands', (ss) => {
       'Terminal should not have received anything from R-C',
     );
 
-    assertStatusBarMsgLogged(logCapture.getLinesSince('before-r-c-001'), {
+    assertStatusBarMsgLogged(lines, {
       message: '✓ RangeLink: RangeLink copied to clipboard',
     });
     ss.log('✓ R-C wrote link to clipboard; terminal received nothing');

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/dirtyBufferWarning.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/dirtyBufferWarning.test.ts
@@ -35,9 +35,15 @@ standardSuite('Dirty Buffer Warning', (ss) => {
       .getConfiguration('rangelink')
       .update('warnOnDirtyBuffer', false, vscode.ConfigurationTarget.Workspace);
 
+    const logCapture = getLogCapture();
+    logCapture.mark('before-004');
     await vscode.env.clipboard.writeText('rangelink-dirty-test-sentinel');
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_ONLY_RELATIVE);
+    await ss.settle();
+    const lines004 = logCapture.getLinesSince('before-004');
+    const generatedLink = extractGeneratedLink(lines004);
+    assert.ok(generatedLink, 'Expected "Generated link:" log line');
     const clipboard = await vscode.env.clipboard.readText();
 
     assert.notStrictEqual(
@@ -45,9 +51,10 @@ standardSuite('Dirty Buffer Warning', (ss) => {
       'rangelink-dirty-test-sentinel',
       'Expected clipboard to contain a generated link, not the sentinel — warnOnDirtyBuffer=false should bypass dialog',
     );
-    assert.ok(
-      clipboard.includes('#L'),
-      `Expected clipboard to contain a line reference but got: ${clipboard}`,
+    assert.strictEqual(
+      clipboard,
+      generatedLink,
+      `Expected clipboard to equal generated link, got: ${clipboard}`,
     );
     assert.ok(
       editor.document.isDirty,
@@ -270,7 +277,9 @@ standardSuite('Dirty Buffer Warning', (ss) => {
         'Expected no dialog log — setting should bypass dialog',
       );
 
-      assertTerminalBufferContains(capturing.getCapturedText(), '#L');
+      const generatedLink = extractGeneratedLink(lines);
+      assert.ok(generatedLink, 'Expected "Generated link:" log line');
+      assertTerminalBufferContains(capturing.getCapturedText(), generatedLink);
 
       assert.ok(
         editor.document.isDirty,
@@ -299,6 +308,10 @@ standardSuite('Dirty Buffer Warning', (ss) => {
     logCapture.mark('before-019');
 
     await vscode.commands.executeCommand(CMD_COPY_LINK_ONLY_RELATIVE);
+    await ss.settle();
+    const lines = logCapture.getLinesSince('before-019');
+    const generatedLink019 = extractGeneratedLink(lines);
+    assert.ok(generatedLink019, 'Expected "Generated link:" log line');
     const clipboard = await vscode.env.clipboard.readText();
 
     assert.notStrictEqual(
@@ -306,13 +319,13 @@ standardSuite('Dirty Buffer Warning', (ss) => {
       'rangelink-rc-clean-sentinel',
       'Expected clipboard to contain a generated link, not the sentinel',
     );
-    assert.ok(
-      clipboard.includes('#L'),
-      `Expected clipboard to contain a line reference but got: ${clipboard}`,
+    assert.strictEqual(
+      clipboard,
+      generatedLink019,
+      `Expected clipboard to equal generated link, got: ${clipboard}`,
     );
     assert.ok(!editor.document.isDirty, 'Expected document to remain clean');
 
-    const lines = logCapture.getLinesSince('before-019');
     const warningLog = lines.find((l) => l.includes('handleDirtyBufferWarning'));
     assert.strictEqual(
       warningLog,
@@ -645,7 +658,13 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
       'rc-save-sentinel',
       'Expected clipboard to change from sentinel',
     );
-    assert.ok(clipboard.includes('#L'), `Expected a RangeLink on clipboard but got: ${clipboard}`);
+    const generatedLink010 = extractGeneratedLink(lines);
+    assert.ok(generatedLink010, 'Expected "Generated link:" log line');
+    assert.strictEqual(
+      clipboard,
+      generatedLink010,
+      `Expected clipboard to equal generated link, got: ${clipboard}`,
+    );
     assert.ok(!editor.document.isDirty, 'Expected document to be saved after Save & Generate');
 
     ss.log('✓ R-C Save & Generate: file saved, link generated');
@@ -688,7 +707,13 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
     );
 
     assert.notStrictEqual(clipboard, 'rc-anyway-sentinel', 'Expected clipboard to change');
-    assert.ok(clipboard.includes('#L'), `Expected a RangeLink on clipboard but got: ${clipboard}`);
+    const generatedLink011 = extractGeneratedLink(lines);
+    assert.ok(generatedLink011, 'Expected "Generated link:" log line');
+    assert.strictEqual(
+      clipboard,
+      generatedLink011,
+      `Expected clipboard to equal generated link, got: ${clipboard}`,
+    );
     assert.ok(editor.document.isDirty, 'Expected document to remain dirty after Generate Anyway');
 
     ss.log('✓ R-C Generate Anyway: link generated, file still dirty');

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/dirtyBufferWarning.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/dirtyBufferWarning.test.ts
@@ -9,6 +9,9 @@ import {
   assertStatusBarMsgLogged,
   assertTerminalBufferContains,
   assertTerminalBufferEquals,
+  createFileAt,
+  extractGeneratedLink,
+  extractSentLink,
   getLogCapture,
   standardSuite,
   waitForHuman,
@@ -1117,6 +1120,139 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
       ss.log('✓ R-L dismiss: terminal buffer empty (no send occurred)');
     } finally {
       capturing.terminal.dispose();
+    }
+  });
+
+  test('[assisted] dirty-buffer-warning-023: R-L Save & Generate re-reads selections after save mutates document', async () => {
+    const TRAILING_SPACES = 5;
+    const TARGET_LINE_BASE = "export const targetLine = 'shift me';";
+    const REFERENCE_LINE_BASE = "export const referenceLine = 'no trim';";
+    const TARGET_LINE = `${TARGET_LINE_BASE}${' '.repeat(TRAILING_SPACES)}`;
+    const REFERENCE_LINE = `${REFERENCE_LINE_BASE}${' '.repeat(TRAILING_SPACES)}`;
+    const FIXTURE_CONTENT = `${TARGET_LINE}\n${REFERENCE_LINE}\n`;
+
+    const TARGET_LINE_BASE_LEN = TARGET_LINE_BASE.length;
+    const PRE_TRIM_LINE_LEN = TARGET_LINE.length;
+    const SELECTION_START_COL = 3;
+    const SELECTION_END_COL_PRE_TRIM = PRE_TRIM_LINE_LEN - 1;
+
+    const testFileUri = createFileAt('__rl-test-dirty-fmt-023.ts', FIXTURE_CONTENT);
+    const capturing = await ss.createAndBindCapturingTerminal('dirty-buffer-test');
+
+    const filesConfig = vscode.workspace.getConfiguration('files');
+    const originalTrimTrailingWhitespace =
+      filesConfig.inspect('trimTrailingWhitespace')?.workspaceValue;
+    await filesConfig.update(
+      'trimTrailingWhitespace',
+      true,
+      vscode.ConfigurationTarget.Workspace,
+    );
+
+    try {
+      const editor = await ss.openEditor(testFileUri);
+
+      await editor.edit((editBuilder) => {
+        editBuilder.insert(new vscode.Position(0, 0), '// 023\n');
+      });
+      assert.ok(editor.document.isDirty, 'Expected document to be dirty after edit');
+
+      const targetLineIdx = 1;
+      editor.selection = new vscode.Selection(
+        new vscode.Position(targetLineIdx, SELECTION_START_COL),
+        new vscode.Position(targetLineIdx, SELECTION_END_COL_PRE_TRIM),
+      );
+
+      await writeClipboardSentinel();
+
+      const logCapture = getLogCapture();
+      logCapture.mark('before-023');
+      capturing.clearCaptured();
+
+      await waitForHuman(
+        'dirty-buffer-warning-023-dialog',
+        'R-L on dirty file with trim-on-save → click "Save & Generate"',
+        [
+          'The editor is focused with a precise column range selected on line 2 (not the full line).',
+          'Press Cmd+R Cmd+L (Send RangeLink) — the dirty buffer dialog should appear.',
+          'Click "Save & Generate".',
+        ],
+      );
+
+      await ss.settle();
+
+      const lines = logCapture.getLinesSince('before-023');
+
+      const reReadLog = lines.find((l) =>
+        l.includes(
+          'Re-read selections after Save & Continue to account for possible format-on-save shifts',
+        ),
+      );
+      assert.ok(
+        reReadLog,
+        'Expected LinkGenerator to log the post-save re-read — the fix path was not taken',
+      );
+
+      const preMatch = reReadLog.match(/"preSaveSelections":(\[[^\]]*\])/);
+      const postMatch = reReadLog.match(/"postSaveSelections":(\[[^\]]*\])/);
+      assert.ok(preMatch && postMatch, `Expected pre/post selections in log, got: ${reReadLog}`);
+
+      const preSelections = JSON.parse(preMatch[1]) as Array<{
+        end: { line: number; char: number };
+      }>;
+      const postSelections = JSON.parse(postMatch[1]) as Array<{
+        end: { line: number; char: number };
+      }>;
+
+      assert.strictEqual(
+        preSelections[0].end.char,
+        SELECTION_END_COL_PRE_TRIM,
+        `Pre-save end column should be ${SELECTION_END_COL_PRE_TRIM} (within trailing whitespace)`,
+      );
+      assert.strictEqual(
+        preSelections[0].end.line,
+        targetLineIdx,
+        'Pre-save end line should match source line',
+      );
+
+      const postEndChar = postSelections[0].end.char;
+      const postEndLine = postSelections[0].end.line;
+      assert.ok(
+        postEndChar < SELECTION_END_COL_PRE_TRIM,
+        `Post-save end column (${postEndChar}) should be less than pre-save (${SELECTION_END_COL_PRE_TRIM}) after ${TRAILING_SPACES} spaces trimmed`,
+      );
+      assert.strictEqual(postEndLine, targetLineIdx, 'Post-save end line should be unchanged');
+      assert.ok(
+        postEndChar >= TARGET_LINE_BASE_LEN,
+        `Post-save end column (${postEndChar}) should be >= text-only line length (${TARGET_LINE_BASE_LEN})`,
+      );
+
+      assert.ok(!editor.document.isDirty, 'Expected document to be saved after Save & Generate');
+
+      const generatedLink = extractSentLink(lines);
+      assert.ok(generatedLink, 'Expected "Sending link to destination" log with formattedLink.link');
+
+      const L = targetLineIdx + 1;
+      const rangeRefPattern = new RegExp(
+        `#L${L}C${SELECTION_START_COL}-L${L}C${postEndChar}\\b`,
+      );
+      assert.ok(
+        rangeRefPattern.test(generatedLink),
+        `Expected link to contain #L${L}C${SELECTION_START_COL}-L${L}C${postEndChar}, got: ${generatedLink}`,
+      );
+
+      await assertClipboardRestored(
+        'R-L Save & Generate (trim-on-save): clipboard should be restored to sentinel after send',
+      );
+
+      ss.log('✓ R-L Save & Generate with trim-on-save: selections re-read, link coordinates correct');
+    } finally {
+      await vscode.workspace
+        .getConfiguration('files')
+        .update(
+          'trimTrailingWhitespace',
+          originalTrimTrailingWhitespace,
+          vscode.ConfigurationTarget.Workspace,
+        );
     }
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/dirtyBufferWarning.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/dirtyBufferWarning.test.ts
@@ -1167,11 +1167,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
     const filesConfig = vscode.workspace.getConfiguration('files');
     const originalTrimTrailingWhitespace =
       filesConfig.inspect('trimTrailingWhitespace')?.workspaceValue;
-    await filesConfig.update(
-      'trimTrailingWhitespace',
-      true,
-      vscode.ConfigurationTarget.Workspace,
-    );
+    await filesConfig.update('trimTrailingWhitespace', true, vscode.ConfigurationTarget.Workspace);
 
     try {
       const editor = await ss.openEditor(testFileUri);
@@ -1254,12 +1250,13 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
       assert.ok(!editor.document.isDirty, 'Expected document to be saved after Save & Generate');
 
       const generatedLink = extractSentLink(lines);
-      assert.ok(generatedLink, 'Expected "Sending link to destination" log with formattedLink.link');
+      assert.ok(
+        generatedLink,
+        'Expected "Sending link to destination" log with formattedLink.link',
+      );
 
       const L = targetLineIdx + 1;
-      const rangeRefPattern = new RegExp(
-        `#L${L}C${SELECTION_START_COL}-L${L}C${postEndChar}\\b`,
-      );
+      const rangeRefPattern = new RegExp(`#L${L}C${SELECTION_START_COL}-L${L}C${postEndChar}\\b`);
       assert.ok(
         rangeRefPattern.test(generatedLink),
         `Expected link to contain #L${L}C${SELECTION_START_COL}-L${L}C${postEndChar}, got: ${generatedLink}`,
@@ -1269,7 +1266,9 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
         'R-L Save & Generate (trim-on-save): clipboard should be restored to sentinel after send',
       );
 
-      ss.log('✓ R-L Save & Generate with trim-on-save: selections re-read, link coordinates correct');
+      ss.log(
+        '✓ R-L Save & Generate with trim-on-save: selections re-read, link coordinates correct',
+      );
     } finally {
       await vscode.workspace
         .getConfiguration('files')

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/unbind.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/unbind.test.ts
@@ -6,6 +6,7 @@ import {
   assertNoSetContextLogged,
   assertSetContextLogged,
   assertStatusBarMsgLogged,
+  extractGeneratedLink,
   getLogCapture,
   standardSuite,
   waitForHumanVerdict,
@@ -34,8 +35,13 @@ standardSuite('Unbind Destination', (ss) => {
     await vscode.window.showTextDocument(doc);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 7));
 
+    logCapture.mark('before-unbind-001-r-c');
     await vscode.env.clipboard.writeText('unbind-test-sentinel');
     await vscode.commands.executeCommand('rangelink.copyLinkOnlyWithRelativePath');
+    await ss.settle();
+    const linesRc = logCapture.getLinesSince('before-unbind-001-r-c');
+    const generatedLink = extractGeneratedLink(linesRc);
+    assert.ok(generatedLink, 'Expected "Generated link:" log line');
     const clipboard = await vscode.env.clipboard.readText();
 
     assert.notStrictEqual(
@@ -43,9 +49,10 @@ standardSuite('Unbind Destination', (ss) => {
       'unbind-test-sentinel',
       'Expected clipboard to contain the generated link after unbind + R-C, not the sentinel',
     );
-    assert.ok(
-      clipboard.includes('#L'),
-      `Expected clipboard to contain a line reference but got: ${clipboard}`,
+    assert.strictEqual(
+      clipboard,
+      generatedLink,
+      `Expected clipboard to equal generated link, got: ${clipboard}`,
     );
   });
 

--- a/packages/rangelink-vscode-extension/src/__tests__/services/LinkGenerator.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/services/LinkGenerator.test.ts
@@ -49,6 +49,7 @@ describe('LinkGenerator', () => {
   };
   let mockSelectionValidator: {
     validateSelectionsAndShowError: jest.Mock;
+    mapSelectionsForLogging: jest.Mock;
   };
   let mockGenLink: jest.SpyInstance;
 
@@ -66,6 +67,14 @@ describe('LinkGenerator', () => {
     };
     mockSelectionValidator = {
       validateSelectionsAndShowError: jest.fn(),
+      mapSelectionsForLogging: jest.fn((selections) =>
+        selections.map((s: any, i: number) => ({
+          index: i,
+          start: { line: s.start?.line, char: s.start?.character },
+          end: { line: s.end?.line, char: s.end?.character },
+          isEmpty: s.isEmpty,
+        })),
+      ),
     };
     generator = new LinkGenerator(
       getDelimiters,
@@ -285,6 +294,112 @@ describe('LinkGenerator', () => {
         { fn: 'generateLinkFromSelection', formattedLink: link },
         `Generated link: ${link.link}`,
       );
+    });
+
+    it('re-validates selections and uses post-save selections when warning returns SaveAndContinue', async () => {
+      const preSaveSel = createMockSelection({
+        isEmpty: false,
+        start: { line: 4, character: 0 } as any,
+        end: { line: 4, character: 10 } as any,
+      });
+      const postSaveSel = createMockSelection({
+        isEmpty: false,
+        start: { line: 3, character: 0 } as any,
+        end: { line: 3, character: 10 } as any,
+      });
+      const mockDoc = createMockDocument({
+        uri: createMockUri('/workspace/src/file.ts'),
+        isDirty: true,
+      });
+      const mockEditor = createMockEditor({ document: mockDoc, selections: [postSaveSel] });
+      mockSelectionValidator.validateSelectionsAndShowError
+        .mockReturnValueOnce({ editor: mockEditor, selections: [preSaveSel] })
+        .mockReturnValueOnce({ editor: mockEditor, selections: [postSaveSel] });
+      jest
+        .spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning')
+        .mockResolvedValue(DirtyBufferWarningResult.SaveAndContinue);
+      jest.spyOn(mockAdapter, 'getActiveTextEditorUri').mockReturnValue(mockDoc.uri);
+      jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(undefined);
+      mockGenLink.mockReturnValue(Result.ok(createMockFormattedLink('src/file.ts#L4C1-L4C11')));
+      mockClipboardRouter.resolveDestinationBehavior.mockResolvedValue(undefined);
+
+      await generator.createLink();
+
+      expect(mockSelectionValidator.validateSelectionsAndShowError).toHaveBeenCalledTimes(2);
+      expect(mockGenLink).toHaveBeenCalledWith({
+        referencePath: expect.any(String),
+        document: mockDoc,
+        selections: [postSaveSel],
+        delimiters: DELIMITERS,
+        linkType: 'regular',
+        logger: mockLogger,
+      });
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        {
+          fn: 'generateLinkFromSelection',
+          preSaveSelections: [
+            { index: 0, start: { line: 4, char: 0 }, end: { line: 4, char: 10 }, isEmpty: false },
+          ],
+          postSaveSelections: [
+            { index: 0, start: { line: 3, char: 0 }, end: { line: 3, char: 10 }, isEmpty: false },
+          ],
+        },
+        'Re-read selections after Save & Continue to account for possible format-on-save shifts',
+      );
+    });
+
+    it('aborts when post-save re-validation returns undefined', async () => {
+      const mockDoc = createMockDocument({
+        uri: createMockUri('/workspace/src/file.ts'),
+        isDirty: true,
+      });
+      const mockEditor = createMockEditor({
+        document: mockDoc,
+        selections: [createMockSelection({ isEmpty: false })],
+      });
+      mockSelectionValidator.validateSelectionsAndShowError
+        .mockReturnValueOnce({
+          editor: mockEditor,
+          selections: [createMockSelection({ isEmpty: false })],
+        })
+        .mockReturnValueOnce(undefined);
+      jest
+        .spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning')
+        .mockResolvedValue(DirtyBufferWarningResult.SaveAndContinue);
+
+      await generator.createLink();
+
+      expect(mockSelectionValidator.validateSelectionsAndShowError).toHaveBeenCalledTimes(2);
+      expect(mockGenLink).not.toHaveBeenCalled();
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        { fn: 'generateLinkFromSelection' },
+        'Post-save re-validation returned no selections, aborting',
+      );
+    });
+
+    it('does NOT re-validate selections when warning returns ContinueAnyway', async () => {
+      const mockDoc = createMockDocument({
+        uri: createMockUri('/workspace/src/file.ts'),
+        isDirty: true,
+      });
+      const sel = createMockSelection({ isEmpty: false });
+      const mockEditor = createMockEditor({ document: mockDoc, selections: [sel] });
+      mockSelectionValidator.validateSelectionsAndShowError.mockReturnValue({
+        editor: mockEditor,
+        selections: [sel],
+      });
+      jest
+        .spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning')
+        .mockResolvedValue(DirtyBufferWarningResult.ContinueAnyway);
+      jest.spyOn(mockAdapter, 'getActiveTextEditorUri').mockReturnValue(mockDoc.uri);
+      jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(undefined);
+      mockGenLink.mockReturnValue(Result.ok(createMockFormattedLink('src/file.ts#L1')));
+      mockClipboardRouter.resolveDestinationBehavior.mockResolvedValue(undefined);
+
+      await generator.createLink();
+
+      expect(mockSelectionValidator.validateSelectionsAndShowError).toHaveBeenCalledTimes(1);
+      expect(mockSelectionValidator.mapSelectionsForLogging).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/rangelink-vscode-extension/src/__tests__/services/LinkGenerator.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/services/LinkGenerator.test.ts
@@ -327,7 +327,7 @@ describe('LinkGenerator', () => {
 
       expect(mockSelectionValidator.validateSelectionsAndShowError).toHaveBeenCalledTimes(2);
       expect(mockGenLink).toHaveBeenCalledWith({
-        referencePath: expect.any(String),
+        referencePath: '/workspace/src/file.ts',
         document: mockDoc,
         selections: [postSaveSel],
         delimiters: DELIMITERS,

--- a/packages/rangelink-vscode-extension/src/services/LinkGenerator.ts
+++ b/packages/rangelink-vscode-extension/src/services/LinkGenerator.ts
@@ -112,8 +112,8 @@ export class LinkGenerator {
       return undefined;
     }
 
-    const { editor, selections } = validated;
-    const document = editor.document;
+    let { editor, selections } = validated;
+    let document = editor.document;
 
     const warningResult = await handleDirtyBufferWarning(
       document,
@@ -127,6 +127,28 @@ export class LinkGenerator {
       warningResult === DirtyBufferWarningResult.SaveFailed
     ) {
       return undefined;
+    }
+
+    if (warningResult === DirtyBufferWarningResult.SaveAndContinue) {
+      const preSaveSelections = selections;
+      const revalidated = this.selectionValidator.validateSelectionsAndShowError();
+      if (!revalidated) {
+        this.logger.debug(
+          { fn: 'generateLinkFromSelection' },
+          'Post-save re-validation returned no selections, aborting',
+        );
+        return undefined;
+      }
+      ({ editor, selections } = revalidated);
+      document = editor.document;
+      this.logger.debug(
+        {
+          fn: 'generateLinkFromSelection',
+          preSaveSelections: this.selectionValidator.mapSelectionsForLogging(preSaveSelections),
+          postSaveSelections: this.selectionValidator.mapSelectionsForLogging(selections),
+        },
+        'Re-read selections after Save & Continue to account for possible format-on-save shifts',
+      );
     }
 
     const referencePath = getReferencePath(this.ideAdapter, document.uri, pathFormat);


### PR DESCRIPTION
## Summary

`LinkGenerator.generateLinkFromSelection()` captured the editor selections before showing the dirty-buffer warning dialog. When the user chose "Save & Generate" and a save-time mutation occurred (format-on-save, `files.trimTrailingWhitespace`, etc.), the captured ranges referenced stale positions and link generation failed silently inside `toInputSelection`. After save, selections are now re-validated so the generated link reflects the post-save document.

## Changes

- `LinkGenerator.generateLinkFromSelection()` re-calls `selectionValidator.validateSelectionsAndShowError()` on the `SaveAndContinue` branch and replaces the cached `editor`, `selections`, and `document` references. Emits a debug log with pre/post selection coordinates so format-on-save shifts are diagnosable in the field. Aborts cleanly if re-validation returns `undefined` (e.g., the save collapsed the selection to empty).
- 3 new unit tests in `LinkGenerator.test.ts` covering the `SaveAndContinue` re-read, the abort-on-empty path, and a negative assertion that `ContinueAnyway` does NOT re-validate.
- New `extractSentLink()` utility in `logHelpers.ts` — parses the "Sending link to destination" log line and returns the generated link string, so integration tests can assert on exact link coordinates instead of fragile `includes('#L')` checks. 14 integration test files reference `#L`; most use only presence checks and could benefit from this utility in follow-up work.
- New `[assisted] dirty-buffer-warning-023` integration test that drives the same path through a real VS Code host using `files.trimTrailingWhitespace` to mutate the document during save. Selects a precise column range (not the full line), then parses the re-read log to verify pre/post selection coordinates and extracts the generated link via `extractSentLink()` to assert the link contains the correct post-trim character positions.
- New QA TC `dirty-buffer-warning-023` (assisted) plus matching fixture at `qa/fixtures/workspace/format-on-save/unformatted.ts`. The fixture is listed in `.prettierignore` so prettier doesn't strip the trailing whitespace that makes the test case deterministic.
- Documentation: CHANGELOG not updated — the Dirty Buffer Warning feature (and its "Save & Generate" branch) is already in `[Unreleased] > Added`, so this fix ships before any release ever exposed the bug. README not updated (no new user-facing surface).

## Test Plan

- [x] All existing unit tests pass (1928/1928)
- [x] New unit tests added in `LinkGenerator.test.ts` (3 new cases)
- [x] New `[assisted]` integration test compiles cleanly; runs via `packages/rangelink-vscode-extension/scripts/run-integration-tests.sh --grep "dirty-buffer-warning-023"`
- [x] QA validator: new TC matched on both YAML and integration test sides (assisted count 113 → 114)
- [ ] Manual QA walkthrough of `dirty-buffer-warning-023` during the next assisted QA pass

## Related

- Closes https://github.com/couimet/rangeLink/issues/494
- Surfaced by CodeRabbit on https://github.com/couimet/rangeLink/pull/493


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * "Save & Generate" now re-reads editor selections after format-on-save so generated links target the correct post-save ranges.

* **Tests**
  * Expanded integration and unit tests to validate post-save selection behavior and to assert exact generated/sent links via log-based checks.
  * Added a new test covering trimming trailing whitespace during Save & Generate.

* **Chores**
  * Added/updated test fixtures and housekeeping to keep those fixtures stable during formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/rangeLink/pull/588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->