### PR TITLE
[issues/542] Drop `preconditions:` and `steps:` from automated QA YAML entries

### DIFF
--- a/.claude/skills/qa-suggest/SKILL.md
+++ b/.claude/skills/qa-suggest/SKILL.md
@@ -48,7 +48,7 @@ Read both YAML files in parallel.
 Read these in parallel:
 
 1. `packages/rangelink-vscode-extension/CHANGELOG.md` — extract only the `## [Unreleased]` section (stop at the next `## [` header)
-2. `packages/rangelink-vscode-extension/src/__integration-tests__/suite/` — Glob for `*.test.ts` files and scan their `suite()`/`test()` names to understand what is already automated
+2. `packages/rangelink-vscode-extension/src/__integration-tests__/suite/` — Glob for `*.test.ts` files and scan two things: (a) `suite()`/`test()` names to map scenarios to TC IDs, and (b) which tests call `waitForHuman` or `waitForHumanVerdict` — those are the assisted ones (see "Choosing the automated value" in Step 6 for why this is the canonical signal)
 
 ## Step 4: Diff TCs Between Versions
 
@@ -59,6 +59,8 @@ Compare the current YAML against the previous YAML:
 - **Changed**: TCs whose `automated:` field flipped between versions, or whose `scenario:` text was updated
 
 Record these for the change summary output.
+
+**Schema-migration noise to ignore.** Starting in v1.1.0 the YAML schema dropped `preconditions:` and `steps:` from every `automated: true` and `automated: assisted` entry — the integration test is canonical for those. When diffing against a pre-v1.1.0 YAML, do NOT treat the removal of `preconditions:`/`steps:` as a "Changed" event, whether it appears alone or alongside an `automated: false → true|assisted` flip. Only flag genuine semantic changes (the automated flip itself, or scenario text edits).
 
 ## Step 5: Cross-Reference CHANGELOG Against TC Coverage
 
@@ -77,7 +79,21 @@ For each entry under `## [Unreleased]` in the CHANGELOG:
 
 ## Step 6: Draft New TC Entries
 
-For each uncovered CHANGELOG entry, draft one or more TC entries following the YAML schema:
+For each uncovered CHANGELOG entry, draft one or more TC entries following the YAML schema. The shape of the entry depends on whether an integration test already covers the scenario — see [Choosing the automated value](#choosing-the-automated-value) below to pick first, then use the matching template from [YAML templates](#yaml-templates).
+
+### Choosing the `automated` value
+
+Look at the integration tests loaded in Step 3 and find any test whose scenario matches the CHANGELOG entry. Then:
+
+- A test exists and it calls `waitForHuman` or `waitForHumanVerdict` (it pauses for a human action at runtime) → set `automated: assisted`
+- A test exists and it does NOT call either of those (fully programmatic, no human in the loop) → set `automated: true`
+- No test covers the scenario → set `automated: false`
+
+The presence of `waitForHuman` / `waitForHumanVerdict` is the canonical signal because it is the actual runtime mechanism that pauses the test for a human. Naming conventions like an `[assisted]` prefix in the test title are a secondary signal layered on top of the functional behaviour; treat the prefix as a hint, but always confirm by looking for the `waitForHuman*` call.
+
+### YAML templates
+
+**Full template (`automated: false`)** — used when no integration test covers the scenario. `preconditions:` and `steps:` are required because the YAML is the only source of instructions:
 
 <!-- prettier-ignore -->
 ```yaml
@@ -90,6 +106,17 @@ For each uncovered CHANGELOG entry, draft one or more TC entries following the Y
       - '<test action>'
     expected_result: '<what passing looks like>'
     automated: false
+```
+
+**Compact template (`automated: true` or `automated: assisted`)** — used when an integration test in `src/__integration-tests__/suite/` already covers the scenario. Omit `preconditions:` and `steps:` because the integration test is canonical and duplicating instructions invites drift:
+
+<!-- prettier-ignore -->
+```yaml
+  - id: <feature-slug>-NNN
+    feature: '<CHANGELOG section name>'
+    scenario: '<one-line description of the specific scenario>'
+    expected_result: '<what passing looks like>'
+    automated: true   # or: assisted
 ```
 
 ### TC ID scheme: feature-slug IDs
@@ -107,9 +134,9 @@ IDs are derived from the `feature:` field value using this algorithm:
 
 **To find the next available number**: scan the current YAML for all `id:` values that start with the derived slug prefix, extract the highest NNN, and use `max + 1`.
 
-**`automated` field**: set to `true` only if you confirmed an integration test already covers this exact scenario in Step 3. Otherwise set `false`.
+### Section placement
 
-**Section placement**: new TCs go at the end of their feature's section in the YAML. If no section exists for the feature yet, create a new section comment block following the existing pattern.
+New TCs go at the end of their feature's section in the YAML. If no section exists for the feature yet, create a new section comment block following the existing pattern.
 
 ## Step 7: Write Scratchpad Report
 

--- a/packages/rangelink-vscode-extension/TESTING.md
+++ b/packages/rangelink-vscode-extension/TESTING.md
@@ -265,6 +265,10 @@ Each test case has an `automated` field with three possible values:
 
 When you implement an integration test for a TC, update its `automated` field to `true` or `assisted` in the YAML.
 
+#### `preconditions:` and `steps:` are only on manual TCs
+
+`preconditions:` and `steps:` appear only on `automated: false` entries. For `automated: true` and `automated: assisted` TCs the integration test in `src/__integration-tests__/suite/` is the canonical source — setup code, `waitForHuman()`/`waitForHumanVerdict()` action prompts, and assertions all live there. Duplicating them in YAML invites drift, so they are omitted. When flipping a TC from `false` to `true` or `assisted`, delete the `preconditions:` and `steps:` blocks at the same time.
+
 ### When to add new test cases
 
 Add at least one TC to the QA YAML for every:

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
@@ -10,10 +10,20 @@
 #   id:              Unique test case identifier (<feature-slug>-NNN)
 #   feature:         Feature area
 #   scenario:        One-line description of the specific scenario being tested
-#   preconditions:   List of required setup steps before executing
-#   steps:           Ordered list of test actions
+#   labels:          Optional tags (e.g., cursor, ubuntu, requires-extensions)
+#   preconditions:   Required setup steps — only on `automated: false` entries
+#   steps:           Ordered test actions — only on `automated: false` entries
 #   expected_result: What a passing run looks like
-#   automated:       false (manual) | true (covered by TypeScript integration tests)
+#   automated:       Coverage status:
+#                      true     — covered by a non-[assisted] integration test in
+#                                 src/__integration-tests__/suite/ (runs in CI)
+#                      assisted — covered by an [assisted]-tagged integration test
+#                                 that pauses for a human UI action
+#                      false    — fully manual; preconditions and steps are required
+#
+# For `automated: true` and `automated: assisted` entries the integration test in
+# src/__integration-tests__/suite/ is the canonical source of setup and actions —
+# `preconditions:` and `steps:` are omitted to prevent duplication and drift.
 
 test_cases:
   # ---------------------------------------------------------------------------
@@ -45,10 +55,6 @@ test_cases:
   - id: status-bar-menu-003
     feature: 'R-M Status Bar Menu'
     scenario: 'Cmd+R Cmd+M keybinding opens the R-M menu'
-    preconditions:
-      - 'Any workspace open with editor focus'
-    steps:
-      - 'Press Cmd+R Cmd+M'
     expected_result: 'Same QuickPick menu opens as clicking the status bar item.'
     automated: true
 
@@ -67,22 +73,12 @@ test_cases:
   - id: status-bar-menu-005
     feature: 'R-M Status Bar Menu'
     scenario: 'R-M menu shows Jump to Bound Destination when a destination is bound'
-    preconditions:
-      - 'A destination (terminal or file) is currently bound'
-    steps:
-      - 'Open the R-M menu (keybinding or status bar click)'
-      - 'Observe the menu items'
     expected_result: "Menu contains 'Jump to Bound Destination' with the destination name shown. 'Unbind Destination' is also visible."
     automated: true
 
   - id: status-bar-menu-006
     feature: 'R-M Status Bar Menu'
     scenario: 'R-M menu shows destination picker when no destination is bound'
-    preconditions:
-      - 'No destination is bound (fresh install or after R-U unbind)'
-    steps:
-      - 'Open the R-M menu'
-      - 'Observe the first item'
     expected_result: "Menu shows a bind item that opens the destination picker. 'Jump to Bound Destination' is absent."
     automated: true
 
@@ -192,11 +188,6 @@ test_cases:
   - id: bind-to-destination-010
     feature: 'R-D Bind to Destination'
     scenario: 'Escape from destination picker dismisses without changing binding'
-    preconditions:
-      - 'Any binding state (bound or unbound)'
-    steps:
-      - 'Open R-D picker'
-      - 'Press Escape without selecting anything'
     expected_result: 'Picker closes. Binding state is unchanged.'
     automated: true
 
@@ -228,13 +219,6 @@ test_cases:
   - id: bind-to-destination-013
     feature: 'R-D Bind to Destination'
     scenario: 'R-D picker shows both "More terminals..." and "More files..." overflow items when many terminals and files are open'
-    preconditions:
-      - 'More terminals than maxInline (default 5) are open'
-      - 'Multiple files are open across tab groups'
-      - 'No destination is bound'
-    steps:
-      - 'Open R-D destination picker (Cmd+R Cmd+D or Ctrl+R Ctrl+D)'
-      - 'Observe the picker items'
     expected_result: 'Picker shows inline terminal items up to maxInline limit, "More terminals..." overflow item, inline file items (current-in-group), "More files..." overflow item, and standard command items (Go to Link, Show Version Info).'
     automated: true
 
@@ -268,56 +252,30 @@ test_cases:
   - id: terminal-picker-001
     feature: 'Terminal Picker'
     scenario: 'Active terminal is marked with active badge'
-    preconditions:
-      - 'Two or more terminals open'
-      - 'No terminal is bound'
-    steps:
-      - "Click a terminal tab (e.g., 'Gamma') to make it the active terminal"
-      - 'Open the terminal picker via R-D or R-M'
     expected_result: "'Gamma' shows an 'active' badge in the picker. Other terminals have no badge."
     automated: true
 
   - id: terminal-picker-002
     feature: 'Terminal Picker'
     scenario: 'Bound terminal is marked with bound badge'
-    preconditions:
-      - "'Beta' terminal is bound"
-      - "'Gamma' is the active terminal (not bound)"
-    steps:
-      - 'Open the terminal picker'
     expected_result: "'Beta' shows a 'bound' badge. 'Gamma' shows an 'active' badge."
     automated: true
 
   - id: terminal-picker-003
     feature: 'Terminal Picker'
     scenario: 'Terminal that is both active and bound shows dual bound · active badge'
-    preconditions:
-      - "'Beta' terminal is both bound and the currently active (focused) terminal"
-    steps:
-      - "Click the 'Beta' terminal tab to make it active"
-      - 'Open the terminal picker'
     expected_result: "'Beta' shows a combined 'bound · active' badge (both indicators present on the same item)."
     automated: true
 
   - id: terminal-picker-004
     feature: 'Terminal Picker'
     scenario: 'Bound terminal always appears first in the terminal picker list'
-    preconditions:
-      - "'Beta' terminal is bound"
-      - 'Multiple other terminals open'
-    steps:
-      - 'Open the terminal picker'
     expected_result: "'Beta' is the first item in the terminal list, regardless of the order terminals were opened."
     automated: true
 
   - id: terminal-picker-005
     feature: 'Terminal Picker'
     scenario: 'Active (non-bound) terminal appears second in the list'
-    preconditions:
-      - "'Beta' is bound"
-      - "'Gamma' is active but not bound"
-    steps:
-      - 'Open the terminal picker'
     expected_result: "'Beta' (bound) is first. 'Gamma' (active, not bound) is second. Remaining terminals follow in any order."
     automated: true
 
@@ -337,22 +295,12 @@ test_cases:
   - id: terminal-picker-007
     feature: 'Terminal Picker'
     scenario: 'With maxInline or fewer terminals, all are shown inline with no overflow item'
-    preconditions:
-      - 'rangelink.terminalPicker.maxInline = 5 (default)'
-      - 'Exactly 5 or fewer terminals open'
-    steps:
-      - 'Open R-D picker'
     expected_result: "All terminals appear inline. No 'More terminals...' item is visible."
     automated: true
 
   - id: terminal-picker-008
     feature: 'Terminal Picker'
     scenario: 'With more terminals than maxInline, extras collapse into More terminals...'
-    preconditions:
-      - 'rangelink.terminalPicker.maxInline = 2'
-      - '5 or more terminals open'
-    steps:
-      - 'Open R-D picker or terminal sub-section of R-M'
     expected_result: "Only 3 terminals shown inline. A 'More terminals...' item appears at the bottom of the terminal section."
     automated: true
 
@@ -379,34 +327,18 @@ test_cases:
   - id: terminal-picker-011
     feature: 'Terminal Picker'
     scenario: 'rangelink.terminalPicker.maxInline setting changes the overflow threshold'
-    preconditions:
-      - '4 terminals open'
-    steps:
-      - 'Set rangelink.terminalPicker.maxInline = 2 in VS Code settings'
-      - 'Open R-D picker'
     expected_result: "Only 2 terminals shown inline. 'More terminals...' appears. Previously all 4 were inline with higher maxInline."
     automated: true
 
   - id: terminal-picker-012
     feature: 'Terminal Picker'
     scenario: 'Terminal picker appears inline in the R-M menu when unbound'
-    preconditions:
-      - 'No destination bound'
-      - 'Terminals are open'
-    steps:
-      - 'Open R-M menu'
-      - 'Observe the terminal entries in the menu'
     expected_result: 'Terminal picker items appear inline within the R-M menu. Selecting one binds that terminal.'
     automated: true
 
   - id: terminal-picker-013
     feature: 'Terminal Picker'
     scenario: 'Terminal picker appears inline in the R-D destination picker'
-    preconditions:
-      - 'R-D picker is open'
-    steps:
-      - 'Press Cmd+R Cmd+D'
-      - 'Observe that terminal entries are part of the combined destination picker'
     expected_result: 'Terminal entries appear in the R-D picker with the same badges and ordering as when accessed from R-M.'
     automated: true
 
@@ -417,55 +349,30 @@ test_cases:
   - id: file-picker-001
     feature: 'File Picker'
     scenario: 'Bound file appears first in the list with bound badge'
-    preconditions:
-      - 'src/utils/helper.ts is bound as destination'
-      - 'Multiple other files are open'
-    steps:
-      - 'Open R-D picker'
     expected_result: "src/utils/helper.ts appears at the top of the file list with a 'bound' badge."
     automated: true
 
   - id: file-picker-002
     feature: 'File Picker'
     scenario: 'Active (frontmost) file per tab group appears before other files in that group'
-    preconditions:
-      - 'Two tab groups open'
-      - 'src/index.ts is the frontmost tab in tab group 1'
-      - 'No binding active'
-    steps:
-      - 'Click src/index.ts to make it active in tab group 1'
-      - 'Open R-D picker'
     expected_result: 'src/index.ts appears before other files in tab group 1 within the picker.'
     automated: true
 
   - id: file-picker-003
     feature: 'File Picker'
     scenario: 'Files with the same base name show path disambiguation'
-    preconditions:
-      - 'Two files with the same base name are open: e.g., src/utils/index.ts and src/types/index.ts'
-    steps:
-      - 'Open both files in the editor'
-      - 'Open R-D picker (file section)'
     expected_result: 'Both index.ts files appear with enough path context to distinguish them (e.g., utils/index.ts and types/index.ts).'
     automated: true
 
   - id: file-picker-004
     feature: 'File Picker'
     scenario: 'Open files appear as inline items in the destination picker'
-    preconditions:
-      - '3 or fewer files open (within inline limit)'
-    steps:
-      - 'Open R-D picker'
     expected_result: "The open file entries appear inline in the picker. No 'More files...' item."
     automated: true
 
   - id: file-picker-005
     feature: 'File Picker'
     scenario: 'With more open files than the inline limit, extras collapse into More files...'
-    preconditions:
-      - 'More files open than the inline limit (e.g., 6+ files)'
-    steps:
-      - 'Open R-D picker'
     expected_result: "Only the inline limit of files is shown. A 'More files...' item appears at the bottom of the file section."
     automated: true
 
@@ -504,11 +411,6 @@ test_cases:
   - id: file-picker-009
     feature: 'File Picker'
     scenario: 'File picker appears inline in the R-M menu when unbound'
-    preconditions:
-      - 'No destination bound'
-      - 'Files are open'
-    steps:
-      - 'Open R-M menu'
     expected_result: 'File entries appear inline within the R-M menu. Selecting one binds the file as the destination.'
     automated: true
 
@@ -527,20 +429,12 @@ test_cases:
   - id: file-picker-011
     feature: 'File Picker'
     scenario: 'Three files with same name show deeper disambiguation paths'
-    preconditions:
-      - 'Three files with the same base name exist in different directory trees'
-    steps:
-      - 'Open R-D destination picker'
     expected_result: 'All three files appear with unique disambiguating path fragments that distinguish their locations.'
     automated: true
 
   - id: file-picker-012
     feature: 'File Picker'
     scenario: 'Unique file names have no disambiguator in their description'
-    preconditions:
-      - 'Multiple files with different names are open'
-    steps:
-      - 'Open R-D destination picker'
     expected_result: 'File descriptions contain only badges and tab group labels — no disambiguation path prefix.'
     automated: true
 
@@ -553,14 +447,6 @@ test_cases:
       - clipboard
     feature: 'Clipboard Preservation'
     scenario: 'always mode: clipboard content before R-L is restored after the operation'
-    preconditions:
-      - 'rangelink.clipboard.preserve = "always" (loaded automatically by test)'
-      - 'Test file with 10 lines open in editor'
-      - 'Terminal "cbp-001-dest" pre-bound by the test'
-    steps:
-      - 'Test writes sentinel to clipboard automatically'
-      - 'Test programmatically selects lines 2-4 and invokes R-L'
-      - 'Test asserts clipboard restored to sentinel and terminal buffer contains link'
     expected_result: 'Clipboard contains the sentinel value (not the RangeLink). assertClipboardRestored passes — preserve=always silently restored the clipboard after delivery.'
     automated: true
 
@@ -569,15 +455,6 @@ test_cases:
       - clipboard
     feature: 'Clipboard Preservation'
     scenario: 'always mode: clipboard content before R-V from terminal is restored after the operation'
-    preconditions:
-      - 'rangelink.clipboard.preserve = "always" (loaded automatically by test)'
-      - 'Empty text editor file pre-bound as destination (cbp-002-...)'
-      - 'Terminal "cbp-002-src" created and focused by test'
-    steps:
-      - 'Test types "hello world cbp-002" into terminal via sendText and selects all via selectAll'
-      - 'Test writes sentinel to clipboard (after selection to prevent copyOnSelection interference)'
-      - 'Test invokes R-V command directly — phrase lands in bound file'
-      - 'Test asserts phrase in dest file and clipboard restored to sentinel'
     expected_result: 'Destination file contains "hello world cbp-002". Clipboard contains the sentinel value. assertClipboardRestored passes — preserve=always silently restored the clipboard after R-V delivery.'
     automated: true
 
@@ -586,15 +463,6 @@ test_cases:
       - clipboard
     feature: 'Clipboard Preservation'
     scenario: 'always mode: clipboard content before R-F is restored after the operation'
-    preconditions:
-      - 'rangelink.clipboard.preserve = "always"'
-      - 'Terminal bound, any file active'
-    steps:
-      - 'Copy CLIPBOARD_SENTINEL to clipboard'
-      - 'Focus the active editor'
-      - 'Press Cmd+R Cmd+F'
-      - 'Verify terminal received the file path'
-      - 'Press Cmd+V anywhere'
     expected_result: 'Clipboard contains CLIPBOARD_SENTINEL. File path sent to terminal; clipboard preserved.'
     automated: true
 
@@ -620,14 +488,6 @@ test_cases:
       - clipboard
     feature: 'Clipboard Preservation'
     scenario: 'always mode: clipboard content before terminal paste is restored after'
-    preconditions:
-      - 'rangelink.clipboard.preserve = "always" (loaded automatically by test)'
-      - 'Test file with 10 lines open in editor'
-      - 'Terminal "cbp-005-dest" pre-bound by the test'
-    steps:
-      - 'Test writes sentinel to clipboard automatically'
-      - 'Test programmatically selects lines 2-3 and invokes R-L'
-      - 'Test asserts clipboard restored to sentinel and terminal buffer contains link'
     expected_result: 'Clipboard contains the sentinel value (not the RangeLink). assertClipboardRestored passes — preserve=always silently restored the clipboard after delivery.'
     automated: true
 
@@ -636,14 +496,6 @@ test_cases:
       - clipboard
     feature: 'Clipboard Preservation'
     scenario: 'never mode: clipboard contains the last RangeLink output after R-L'
-    preconditions:
-      - 'rangelink.clipboard.preserve = "never"'
-      - 'Terminal bound as destination'
-    steps:
-      - 'Copy CLIPBOARD_SENTINEL to clipboard'
-      - 'Select 3 lines of code'
-      - 'Press Cmd+R Cmd+L'
-      - 'Press Cmd+V anywhere'
     expected_result: 'Clipboard contains the RangeLink (e.g. src/utils/helper.ts#L2-L4). CLIPBOARD_SENTINEL is gone.'
     automated: true
 
@@ -652,15 +504,6 @@ test_cases:
       - clipboard
     feature: 'Clipboard Preservation'
     scenario: 'never mode: clipboard contains last output after R-V (sentinel is gone)'
-    preconditions:
-      - 'rangelink.clipboard.preserve = "never" (loaded automatically by test)'
-      - 'Empty text editor file pre-bound as destination (cbp-007-...)'
-      - 'Terminal "cbp-007-src" created and focused by test'
-    steps:
-      - 'Test types "test phrase cbp-007" into terminal via sendText and selects all via selectAll'
-      - 'Test writes sentinel to clipboard (after selection to prevent copyOnSelection interference)'
-      - 'Test invokes R-V command directly — phrase lands in bound file'
-      - 'Test asserts phrase in dest file and clipboard changed (sentinel is gone)'
     expected_result: 'Destination file contains "test phrase cbp-007". Clipboard contains the selected terminal text, NOT the sentinel. assertClipboardChanged passes — preserve=never overwrites clipboard with the transported content.'
     automated: true
 
@@ -669,14 +512,6 @@ test_cases:
       - clipboard
     feature: 'Clipboard Preservation'
     scenario: 'R-C (Copy RangeLink) always writes to clipboard regardless of preserve setting'
-    preconditions:
-      - 'rangelink.clipboard.preserve = "always"'
-      - 'Terminal bound'
-    steps:
-      - 'Copy CLIPBOARD_SENTINEL to clipboard'
-      - 'Select 3 lines of code'
-      - 'Press Cmd+R Cmd+C (Copy RangeLink)'
-      - 'Press Cmd+V anywhere'
     expected_result: 'Clipboard contains the RangeLink, NOT CLIPBOARD_SENTINEL. R-C is clipboard-only; preserve does not apply.'
     automated: true
 
@@ -685,15 +520,6 @@ test_cases:
       - clipboard
     feature: 'Clipboard Preservation'
     scenario: 'always mode: dismissed picker leaves clipboard unchanged (no operation performed)'
-    preconditions:
-      - 'rangelink.clipboard.preserve = "always" (loaded automatically by test)'
-      - 'No destination bound (ensured by test teardown)'
-    steps:
-      - 'Test writes sentinel to clipboard automatically'
-      - 'Click into any file and select a few lines'
-      - 'Press Cmd+R Cmd+L — destination picker opens (no destination bound)'
-      - 'Press Escape to dismiss without selecting anything'
-      - 'Press Cancel — test reads clipboard and asserts it still equals the sentinel'
     expected_result: 'Clipboard contains the sentinel value. assertClipboardRestored passes — no preserve cycle was triggered because the operation was cancelled before any transport.'
     automated: true
 
@@ -723,14 +549,6 @@ test_cases:
       - requires-extensions
     feature: 'Clipboard Preservation — AI Assistant Lifecycle'
     scenario: 'Cold paste to Claude Code: prior clipboard content is restored after paste'
-    preconditions:
-      - 'Claude Code bound as destination (not already open)'
-      - 'rangelink.clipboard.preserve = "always" (default)'
-      - 'Prior clipboard content exists (e.g., "prior-content")'
-    steps:
-      - 'Sentinel written to clipboard programmatically'
-      - 'R-L dispatched programmatically to cold-bound Claude Code'
-      - 'assertClipboardRestored verifies sentinel is back on clipboard'
     expected_result: 'Prior clipboard content is restored after the paste operation completes.'
     automated: true
 
@@ -740,15 +558,6 @@ test_cases:
       - requires-extensions
     feature: 'Clipboard Preservation — AI Assistant Lifecycle'
     scenario: 'Warm paste to Claude Code: prior clipboard content is restored (panel already open)'
-    preconditions:
-      - 'Claude Code bound and panel is already open (warm)'
-      - 'rangelink.clipboard.preserve = "always" (default)'
-      - 'Prior clipboard content exists'
-    steps:
-      - 'Warmup R-L dispatched programmatically'
-      - 'Sentinel written to clipboard programmatically'
-      - 'Second R-L dispatched programmatically to warm-bound Claude Code'
-      - 'assertClipboardRestored verifies sentinel is back on clipboard'
     expected_result: 'Single clipboard write. Prior content restored without cold-start refocus overhead.'
     automated: true
 
@@ -758,14 +567,6 @@ test_cases:
       - cursor
     feature: 'Clipboard Preservation — AI Assistant Lifecycle'
     scenario: 'Cold paste to Cursor AI: prior clipboard content is restored after paste'
-    preconditions:
-      - 'Cursor AI bound as destination (not already open)'
-      - 'rangelink.clipboard.preserve = "always" (default)'
-      - 'Prior clipboard content exists'
-    steps:
-      - 'Sentinel written to clipboard programmatically'
-      - 'R-L dispatched programmatically to cold-bound Cursor AI'
-      - 'assertClipboardRestored verifies sentinel is back on clipboard'
     expected_result: 'Prior clipboard content is restored after paste completes.'
     automated: true
 
@@ -775,15 +576,6 @@ test_cases:
       - cursor
     feature: 'Clipboard Preservation — AI Assistant Lifecycle'
     scenario: 'Warm paste to Cursor AI: prior clipboard content is restored (panel already open)'
-    preconditions:
-      - 'Cursor AI bound and panel is already open (warm)'
-      - 'rangelink.clipboard.preserve = "always" (default)'
-      - 'Prior clipboard content exists'
-    steps:
-      - 'Warmup R-L dispatched programmatically'
-      - 'Sentinel written to clipboard programmatically'
-      - 'Second R-L dispatched programmatically to warm-bound Cursor AI'
-      - 'assertClipboardRestored verifies sentinel is back on clipboard'
     expected_result: 'Prior clipboard content restored after warm paste.'
     automated: true
 
@@ -792,14 +584,6 @@ test_cases:
       - clipboard
     feature: 'Clipboard Preservation — AI Assistant Lifecycle'
     scenario: 'Cold paste to GitHub Copilot Chat: prior clipboard content is restored after paste'
-    preconditions:
-      - 'GitHub Copilot Chat bound as destination (not already open)'
-      - 'rangelink.clipboard.preserve = "always" (default)'
-      - 'Prior clipboard content exists'
-    steps:
-      - 'Sentinel written to clipboard programmatically'
-      - 'R-L dispatched programmatically to cold-bound Copilot Chat'
-      - 'assertClipboardRestored verifies sentinel is back on clipboard'
     expected_result: 'Prior clipboard content is restored after paste completes.'
     automated: true
 
@@ -808,15 +592,6 @@ test_cases:
       - clipboard
     feature: 'Clipboard Preservation — AI Assistant Lifecycle'
     scenario: 'Warm paste to GitHub Copilot Chat: prior clipboard content is restored (panel already open)'
-    preconditions:
-      - 'GitHub Copilot Chat bound and panel is already open (warm)'
-      - 'rangelink.clipboard.preserve = "always" (default)'
-      - 'Prior clipboard content exists'
-    steps:
-      - 'Warmup R-L dispatched programmatically'
-      - 'Sentinel written to clipboard programmatically'
-      - 'Second R-L dispatched programmatically to warm-bound Copilot Chat'
-      - 'assertClipboardRestored verifies sentinel is back on clipboard'
     expected_result: 'Prior clipboard content restored after warm paste.'
     automated: true
 
@@ -862,14 +637,6 @@ test_cases:
       - clipboard
     feature: 'Send File Path'
     scenario: 'Cmd+R Cmd+F sends workspace-relative path to bound terminal destination'
-    preconditions:
-      - 'Workspace open at known root'
-      - 'Terminal bound'
-      - 'File active at e.g. src/utils/helper.ts'
-    steps:
-      - 'Focus the file in the editor'
-      - 'Press Cmd+R Cmd+F (Mac) / Ctrl+R Ctrl+F (Win/Linux)'
-      - 'Observe terminal output'
     expected_result: 'Terminal receives src/utils/helper.ts (workspace-relative). Success toast confirms send.'
     automated: true
 
@@ -878,14 +645,6 @@ test_cases:
       - clipboard
     feature: 'Send File Path'
     scenario: 'Cmd+R Cmd+Shift+F sends absolute path to bound terminal destination'
-    preconditions:
-      - 'Workspace open'
-      - 'Terminal bound'
-      - 'Any file active'
-    steps:
-      - 'Focus the file'
-      - 'Press Cmd+R Cmd+Shift+F'
-      - 'Observe terminal'
     expected_result: 'Terminal receives full absolute path (e.g. /Users/you/project/src/utils/helper.ts).'
     automated: true
 
@@ -911,13 +670,6 @@ test_cases:
       - clipboard
     feature: 'Send File Path'
     scenario: 'Terminal destination: path with spaces is auto-quoted in single quotes'
-    preconditions:
-      - 'Terminal bound'
-      - 'Active file has spaces in its path (e.g. src/my folder/helper.ts)'
-    steps:
-      - 'Focus the file with spaces in its path'
-      - 'Press Cmd+R Cmd+F'
-      - 'Observe terminal output'
     expected_result: "Terminal receives 'src/my folder/helper.ts' — single-quoted."
     automated: true
 
@@ -926,13 +678,6 @@ test_cases:
       - clipboard
     feature: 'Send File Path'
     scenario: 'Terminal destination: path with parentheses is auto-quoted in single quotes'
-    preconditions:
-      - 'Terminal bound'
-      - 'Active file has parentheses in path (e.g. src/utils (v2)/helper.ts)'
-    steps:
-      - 'Focus the file with parens in path'
-      - 'Press Cmd+R Cmd+F'
-      - 'Observe terminal'
     expected_result: "Terminal receives 'src/utils (v2)/helper.ts' — single-quoted."
     automated: true
 
@@ -941,13 +686,6 @@ test_cases:
       - clipboard
     feature: 'Send File Path'
     scenario: 'Text editor destination: path with spaces is auto-quoted'
-    preconditions:
-      - 'Text editor (not terminal) bound as destination'
-      - 'Active file has spaces in path'
-    steps:
-      - 'Focus the file with spaces'
-      - 'Press Cmd+R Cmd+F'
-      - 'Observe bound text editor'
     expected_result: "Text editor receives single-quoted path (e.g. 'my folder/file.ts'). Shell-quoting applies to all destinations."
     automated: true
 
@@ -956,13 +694,6 @@ test_cases:
       - clipboard
     feature: 'Send File Path'
     scenario: 'Clipboard always contains the unquoted path regardless of destination type'
-    preconditions:
-      - 'Terminal bound'
-      - 'Active file has spaces in path'
-    steps:
-      - 'Press Cmd+R Cmd+F'
-      - 'Observe terminal (receives quoted path)'
-      - 'Press Cmd+V in any text field'
     expected_result: 'Clipboard contains unquoted path. Terminal received quoted version.'
     automated: true
 
@@ -971,13 +702,6 @@ test_cases:
       - clipboard
     feature: 'Send File Path'
     scenario: 'Self-paste: sending path of the currently active file to that same file shows info + clipboard copy'
-    preconditions:
-      - 'Active file is bound as text editor destination (same file as source)'
-    steps:
-      - 'With bound file focused, press Cmd+R Cmd+F'
-      - 'Observe notifications'
-      - 'Verify file not modified'
-      - 'Press Cmd+V anywhere'
     expected_result: 'Info notification appears. Clipboard contains path. File not modified.'
     automated: true
 
@@ -999,12 +723,6 @@ test_cases:
       - clipboard
     feature: 'Send File Path'
     scenario: 'RangeLink: Send Current File Path in Command Palette'
-    preconditions:
-      - 'Terminal bound, workspace open'
-    steps:
-      - 'Open Command Palette (Cmd+Shift+P)'
-      - 'Type Send Current File Path, press Enter'
-      - 'Observe terminal'
     expected_result: 'Terminal receives workspace-relative path. Same as Cmd+R Cmd+F.'
     automated: true
 
@@ -1013,12 +731,6 @@ test_cases:
       - clipboard
     feature: 'Send File Path'
     scenario: 'RangeLink: Send Current File Path (Absolute) in Command Palette'
-    preconditions:
-      - 'Terminal bound, workspace open'
-    steps:
-      - 'Open Command Palette (Cmd+Shift+P)'
-      - 'Type Send Current File Path (Absolute), press Enter'
-      - 'Observe terminal'
     expected_result: 'Terminal receives absolute path. Same as Cmd+R Cmd+Shift+F.'
     automated: true
 
@@ -1027,13 +739,6 @@ test_cases:
       - clipboard
     feature: 'Send File Path'
     scenario: 'Bound text editor hidden behind another tab — paste still lands in bound editor'
-    preconditions:
-      - 'Text editor bound as destination in single column'
-      - 'Source file opened in same column (hides bound editor)'
-    steps:
-      - 'With source file active (bound editor hidden behind it), press Cmd+R Cmd+F'
-      - 'Observe that the bound editor is brought to the foreground'
-      - 'Confirm file path appears in the bound editor at cursor position'
     expected_result: 'Bound editor is surfaced automatically and receives the file path. Source editor had focus; paste still landed in bound editor.'
     automated: true
 
@@ -1434,25 +1139,12 @@ test_cases:
   - id: dirty-buffer-warning-006
     feature: 'Dirty Buffer Warning'
     scenario: 'rangelink.warnOnDirtyBuffer: false disables the dirty buffer warning entirely'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = false (set in VS Code settings)'
-      - 'Terminal bound'
-    steps:
-      - 'Make unsaved change to a file'
-      - 'Select 2-3 lines, press Cmd+R Cmd+L'
     expected_result: 'No dialog appears. RangeLink generated and sent immediately.'
     automated: true
 
   - id: dirty-buffer-warning-007
     feature: 'Dirty Buffer Warning'
     scenario: 'Clean file generates link immediately without showing the dialog'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = true (default)'
-      - 'Terminal bound'
-      - 'File is saved (no unsaved changes)'
-    steps:
-      - 'Save file (Cmd+S) to ensure clean state'
-      - 'Select 2-3 lines, press Cmd+R Cmd+L'
     expected_result: 'No dialog appears. RangeLink generated and sent immediately. Success toast shown.'
     automated: true
 
@@ -1611,12 +1303,6 @@ test_cases:
   - id: dirty-buffer-warning-019
     feature: 'Dirty Buffer Warning — Clean file'
     scenario: 'R-C on clean file generates link without warning'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = true (default)'
-      - 'File is clean (no unsaved changes), text selected'
-    steps:
-      - 'Open a clean file, select text'
-      - 'Press Cmd+R Cmd+C (Copy RangeLink)'
     expected_result: 'No dialog. RangeLink on clipboard with #L reference. File remains clean. No handleDirtyBufferWarning logs emitted (Clean early-return).'
     automated: true
 
@@ -1723,11 +1409,6 @@ test_cases:
       - clipboard
     feature: 'R-V Send Terminal Selection'
     scenario: 'R-V with no text selected in terminal shows error message'
-    preconditions:
-      - 'Terminal focused, nothing highlighted, destination bound'
-    steps:
-      - 'Click in terminal (no selection)'
-      - 'Press Cmd+R Cmd+V'
     expected_result: 'Error notification: No text selected in the terminal. Select text and try again. Nothing sent to destination.'
     automated: true
 
@@ -1765,11 +1446,6 @@ test_cases:
       - clipboard
     feature: 'R-V Send Terminal Selection'
     scenario: 'R-L keybinding pressed while terminal has focus shows guidance message suggesting R-V'
-    preconditions:
-      - 'Terminal has focus'
-    steps:
-      - 'Click in terminal to focus it'
-      - 'Press Cmd+R Cmd+L'
     expected_result: 'Error or info notification guides user: R-L requires editor selection, use R-V for terminal text. Terminal not modified.'
     automated: true
 
@@ -1778,11 +1454,6 @@ test_cases:
       - clipboard
     feature: 'R-V Send Terminal Selection'
     scenario: 'R-C keybinding pressed while terminal has focus shows guidance message suggesting R-V'
-    preconditions:
-      - 'Terminal has focus'
-    steps:
-      - 'Click in terminal to focus it'
-      - 'Press Cmd+R Cmd+C'
     expected_result: 'Notification guides user to use R-V instead. No clipboard write for invalid terminal context.'
     automated: true
 
@@ -1878,10 +1549,6 @@ test_cases:
   - id: go-to-link-001
     feature: 'R-G Go to Link'
     scenario: 'Cmd+R Cmd+G opens the Go to Link input box'
-    preconditions:
-      - 'Any workspace open'
-    steps:
-      - 'Press Cmd+R Cmd+G'
     expected_result: 'An input box appears with placeholder text indicating it expects a RangeLink (e.g., path/to/file.ts#L10).'
     automated: true
 
@@ -1968,11 +1635,6 @@ test_cases:
   - id: unbind-001
     feature: 'R-U Unbind'
     scenario: 'Cmd+R Cmd+U unbinds the current destination when bound'
-    preconditions:
-      - 'A destination is currently bound'
-    steps:
-      - 'Verify binding is active (status bar or prior R-L confirms)'
-      - 'Press Cmd+R Cmd+U'
     expected_result: "Destination is unbound. A toast confirms (e.g., 'Unbound from Terminal'). Subsequent R-L opens picker instead of sending directly."
     automated: true
 
@@ -1993,21 +1655,12 @@ test_cases:
   - id: unbind-003
     feature: 'R-U Unbind'
     scenario: 'R-U with no bound destination is disabled (keybinding gated by rangelink.isBound)'
-    preconditions:
-      - 'No destination is currently bound'
-    steps:
-      - 'Press Cmd+R Cmd+U (Mac) / Ctrl+R Ctrl+U (Win/Linux)'
     expected_result: "Keybinding does not fire (gated by rangelink.isBound when clause). If invoked directly via executeCommand, a status bar message appears ('RangeLink: No destination bound'). No error."
     automated: true
 
   - id: unbind-004
     feature: 'R-U Unbind'
     scenario: 'RangeLink: Unbind Destination available in Command Palette'
-    preconditions:
-      - 'A destination is currently bound'
-    steps:
-      - 'Open Command Palette (Cmd+Shift+P / Ctrl+Shift+P)'
-      - "Type 'Unbind Destination' and select 'RangeLink: Unbind Destination'"
     expected_result: 'Same behavior as R-U keybinding — destination is unbound with confirmation notification.'
     automated: true
 
@@ -2078,13 +1731,6 @@ test_cases:
   - id: editor-binding-validation-004
     feature: 'Editor Binding Validation'
     scenario: 'Binary .png file is excluded from the R-D destination picker even when open'
-    preconditions:
-      - 'A binary .png file is open in column 2 and a plain .txt file is open in column 1'
-    steps:
-      - 'Press Cmd+R Cmd+D to open the destination picker'
-      - 'Confirm the .txt file IS listed (positive control)'
-      - 'Confirm the .png file is NOT listed'
-      - 'Press Escape to dismiss'
     expected_result: 'The .png file does not appear in the picker despite being open. The .txt file does appear. The isBinaryFile filter in the R-D picker is the upstream defense; runtime rejection in PasteDestinationManager.bindTextEditor is a defense-in-depth layer covered by unit tests.'
     automated: true
 
@@ -2107,127 +1753,66 @@ test_cases:
   - id: full-line-navigation-001
     feature: 'Link Navigation — Full-Line Selection'
     scenario: '#L10 navigates and selects the entire line (not just the first character)'
-    preconditions:
-      - 'src/utils/helper.ts exists and is readable'
-    steps:
-      - 'Press Cmd+R Cmd+G'
-      - 'Type: src/utils/helper.ts#L10'
-      - 'Press Enter'
-      - 'Observe the selection in the editor'
     expected_result: 'Line 10 is selected in its entirety (from column 0 to end of line). The cursor is not placed at just the first character.'
     automated: true
 
   - id: full-line-navigation-002
     feature: 'Link Navigation — Full-Line Selection'
     scenario: '#L10-L15 selects from the start of line 10 to the end of line 15'
-    preconditions:
-      - 'src/utils/helper.ts with 15+ lines'
-    steps:
-      - 'Press Cmd+R Cmd+G'
-      - 'Type: src/utils/helper.ts#L10-L15'
-      - 'Press Enter'
     expected_result: 'Lines 10 through 15 are selected. The selection spans all six lines fully.'
     automated: true
 
   - id: char-navigation-001
     feature: 'Link Navigation — Character-Level Precision'
     scenario: '#L10C5 navigates to cursor position at line 10, column 5'
-    preconditions:
-      - 'File with 10+ lines, each 20+ characters'
-    steps:
-      - 'Navigate to a link targeting file.ts#L10C5'
     expected_result: 'Cursor is placed at line 10, column 5 (0-indexed: line 9, char 4). Selection extends 1 character for visibility.'
     automated: true
 
   - id: char-navigation-002
     feature: 'Link Navigation — Character-Level Precision'
     scenario: '#L10C5-L15C10 navigates to character-level range'
-    preconditions:
-      - 'File with 15+ lines, each 20+ characters'
-    steps:
-      - 'Navigate to a link targeting file.ts#L10C5-L15C10'
     expected_result: 'Selection spans from line 10 col 5 to line 15 col 10 (0-indexed: anchor at 9:4, active at 14:9).'
     automated: true
 
   - id: full-line-link-generation-001
     feature: 'Link Generation — Full-Line'
     scenario: 'Selecting a line including its trailing newline generates #L20 (not #L20-L21)'
-    preconditions:
-      - 'File with 20+ lines'
-      - 'Terminal or text editor bound as destination'
-    steps:
-      - 'In src/utils/helper.ts, use Cmd+L (Mac) / Ctrl+L (Win/Linux) to select line 20 including the trailing newline'
-      - 'Verify the selection visually includes the newline (cursor at start of line 21)'
-      - 'Press Cmd+R Cmd+L to generate the link'
     expected_result: 'The generated link is src/utils/helper.ts#L20 (single-line reference). NOT #L20-L21. The trailing newline is excluded.'
     automated: true
 
   - id: wrapped-link-navigation-001
     feature: 'Link Navigation — Wrapped Links'
     scenario: 'Backtick-wrapped RangeLink in terminal is clickable and navigates correctly'
-    preconditions:
-      - 'Terminal open'
-      - 'A valid RangeLink exists for a file in the workspace'
-    steps:
-      - 'In the terminal, type or paste: `src/utils/helper.ts#L5-L10` (surrounded by backticks)'
-      - 'Press Enter (to emit the text)'
-      - 'Hold Cmd (Mac) and click the link in the terminal'
     expected_result: 'VS Code opens src/utils/helper.ts and selects lines 5-10. Backtick wrapping did not prevent link detection.'
     automated: true
 
   - id: wrapped-link-navigation-002
     feature: 'Link Navigation — Wrapped Links'
     scenario: 'Single-quote-wrapped RangeLink in terminal is clickable and navigates correctly'
-    preconditions:
-      - 'Terminal open'
-    steps:
-      - "Type or paste in terminal: 'src/utils/helper.ts#L5' (single quotes)"
-      - 'Cmd-click the link'
     expected_result: 'Navigates to line 5 of the file. Single quotes did not break link detection.'
     automated: true
 
   - id: wrapped-link-navigation-003
     feature: 'Link Navigation — Wrapped Links'
     scenario: 'Double-quote-wrapped RangeLink in terminal is clickable and navigates correctly'
-    preconditions:
-      - 'Terminal open'
-    steps:
-      - 'Type or paste in terminal: "src/utils/helper.ts#L5" (double quotes)'
-      - 'Cmd-click the link'
     expected_result: 'Navigates to line 5. Double quotes did not break link detection.'
     automated: true
 
   - id: wrapped-link-navigation-004
     feature: 'Link Navigation — Wrapped Links'
     scenario: 'Angle-bracket-wrapped RangeLink in terminal is clickable and navigates correctly'
-    preconditions:
-      - 'Terminal open'
-    steps:
-      - 'Type or paste in terminal: <src/utils/helper.ts#L5> (angle brackets)'
-      - 'Cmd-click the link'
     expected_result: 'Navigates to line 5. Angle brackets did not break link detection.'
     automated: true
 
   - id: markdown-link-navigation-001
     feature: 'Link Navigation — Markdown Syntax'
     scenario: 'Markdown link [label](path/to/file.ts#L10) in a document is clickable and navigates correctly'
-    preconditions:
-      - 'A Markdown (.md) file is open in the editor'
-    steps:
-      - 'Add to the Markdown file: [See helper](src/utils/helper.ts#L10)'
-      - 'Hover over the link in the editor'
-      - 'Cmd-click the link'
     expected_result: 'VS Code opens src/utils/helper.ts and navigates to line 10. The [label](path#L10) syntax is recognized as a RangeLink document link.'
     automated: true
 
   - id: url-exclusion-001
     feature: 'Link Navigation — URL Exclusion'
     scenario: 'https://example.com/path/file.ts#L10 in terminal is NOT captured as a RangeLink'
-    preconditions:
-      - 'Terminal open'
-    steps:
-      - 'Type or paste in terminal: https://example.com/path/file.ts#L10'
-      - 'Observe whether RangeLink treats it as a local link'
     expected_result: 'RangeLink does NOT intercept the URL. No navigation to a local file occurs. The https:// prefix is correctly excluded.'
     automated: true
 
@@ -2245,13 +1830,6 @@ test_cases:
   - id: stale-viewcolumn-001
     feature: 'Text Editor Destination — Stale viewColumn'
     scenario: 'Moving bound editor between tab groups — subsequent paste targets the correct new group'
-    preconditions:
-      - 'src/utils/helper.ts is bound as destination and is in tab group 1'
-      - 'Terminal open'
-    steps:
-      - 'Drag the src/utils/helper.ts tab to tab group 2 (or use View → Move Editor to Next Group)'
-      - 'Select text in another file'
-      - 'Press Cmd+R Cmd+L'
     expected_result: 'The RangeLink is inserted into src/utils/helper.ts in tab group 2. Paste did not fail due to stale tab group reference.'
     automated: true
 
@@ -2299,12 +1877,6 @@ test_cases:
   - id: full-line-selection-validation-001
     feature: 'Link Generation — Full-Line Selection Validation'
     scenario: 'Using Ctrl+L (select full line) then R-L generates link without SELECTION_ZERO_WIDTH error'
-    preconditions:
-      - 'Terminal or file destination bound'
-    steps:
-      - 'Place cursor on any line in a TypeScript file'
-      - 'Press Cmd+L (Mac) / Ctrl+L (Win/Linux) to select the full line'
-      - 'Press Cmd+R Cmd+L'
     expected_result: 'A valid RangeLink is generated and sent. No SELECTION_ZERO_WIDTH error notification appears.'
     automated: true
 
@@ -2317,14 +1889,6 @@ test_cases:
       - clipboard
     feature: 'Core Send Commands — R-L'
     scenario: 'R-L (Cmd+R Cmd+L) sends RangeLink to bound terminal destination'
-    preconditions:
-      - 'Workspace open with a TypeScript file containing 10+ lines'
-      - 'Terminal open and bound as destination'
-    steps:
-      - 'Select lines 2-5 in the TypeScript file'
-      - 'Press Cmd+R Cmd+L (Mac) / Ctrl+R Ctrl+L (Win/Linux)'
-      - 'Observe terminal output'
-      - 'Observe VS Code status bar or notification'
     expected_result: 'Terminal receives workspace-relative RangeLink (e.g. src/utils/helper.ts#L2-L5). Success toast appears.'
     automated: true
 
@@ -2333,13 +1897,6 @@ test_cases:
       - clipboard
     feature: 'Core Send Commands — R-L'
     scenario: 'R-L sends RangeLink to bound text editor destination'
-    preconditions:
-      - 'Two files open (file A and file B)'
-      - 'File B bound as text editor destination, cursor positioned in file B'
-    steps:
-      - 'Click in file A and select 3 lines'
-      - 'Press Cmd+R Cmd+L'
-      - 'Observe file B'
     expected_result: 'RangeLink text inserted at cursor in file B. Success toast confirms send.'
     automated: true
 
@@ -2363,13 +1920,6 @@ test_cases:
       - clipboard
     feature: 'Core Send Commands — R-C'
     scenario: 'R-C (Cmd+R Cmd+C) copies RangeLink to clipboard and does NOT send to destination'
-    preconditions:
-      - 'Terminal open and bound (to verify it does NOT receive anything)'
-    steps:
-      - 'Select 3 lines in any file'
-      - 'Press Cmd+R Cmd+C (Mac) / Ctrl+R Ctrl+C (Win/Linux)'
-      - 'Observe terminal — nothing should arrive'
-      - 'Press Cmd+V in any text field'
     expected_result: 'Clipboard contains the RangeLink. Terminal received nothing. No destination picker shown.'
     automated: true
 
@@ -2378,13 +1928,6 @@ test_cases:
       - clipboard
     feature: 'Core Send Commands — R-L'
     scenario: 'RangeLink: Send RangeLink in Command Palette behaves identically to R-L keybinding'
-    preconditions:
-      - 'Terminal bound'
-    steps:
-      - 'Select text in a file'
-      - 'Open Command Palette (Cmd+Shift+P)'
-      - 'Type Send RangeLink and press Enter on RangeLink: Send RangeLink'
-      - 'Observe terminal'
     expected_result: 'Terminal receives the RangeLink. Identical to R-L keybinding.'
     automated: true
 
@@ -2393,14 +1936,6 @@ test_cases:
       - clipboard
     feature: 'Core Send Commands — R-C'
     scenario: 'RangeLink: Copy RangeLink in Command Palette behaves identically to R-C keybinding'
-    preconditions:
-      - 'Terminal bound'
-    steps:
-      - 'Select text in a file'
-      - 'Open Command Palette (Cmd+Shift+P)'
-      - 'Type Copy RangeLink and press Enter on RangeLink: Copy RangeLink'
-      - 'Observe terminal — nothing should arrive'
-      - 'Press Cmd+V in any text field'
     expected_result: 'Terminal received nothing. Clipboard contains the RangeLink.'
     automated: true
 
@@ -2409,13 +1944,6 @@ test_cases:
       - clipboard
     feature: 'Core Send Commands — R-L'
     scenario: 'R-L with no bound destination opens destination picker (not silent clipboard fallback)'
-    preconditions:
-      - 'No destination bound'
-    steps:
-      - 'Confirm no destination is bound'
-      - 'Select text in a file'
-      - 'Press Cmd+R Cmd+L'
-      - 'Observe — destination picker should appear'
     expected_result: 'Destination picker opens. Selecting a destination binds it and sends the RangeLink. Escape dismisses silently with no clipboard write.'
     automated: true
 
@@ -2424,14 +1952,6 @@ test_cases:
       - clipboard
     feature: 'Core Send Commands — R-P'
     scenario: 'R-P (Send Portable Link) with no bound destination opens destination picker'
-    preconditions:
-      - 'No destination bound'
-      - 'Text selected in an editor'
-    steps:
-      - 'Confirm no destination is bound'
-      - 'Open Command Palette'
-      - "Select 'RangeLink: Send Portable Link'"
-      - 'Observe — destination picker should appear'
     expected_result: 'Destination picker opens (not a silent clipboard fallback). Selecting a destination binds it and sends the portable link.'
     automated: true
 
@@ -2440,13 +1960,6 @@ test_cases:
       - clipboard
     feature: 'Core Send Commands — R-V'
     scenario: 'R-V (Send Selected Text, editor) with no bound destination opens destination picker'
-    preconditions:
-      - 'No destination bound'
-      - 'Text selected in editor'
-    steps:
-      - 'Confirm no destination is bound'
-      - 'Select text'
-      - "Open Command Palette, select 'RangeLink: Send Selected Text'"
     expected_result: 'Destination picker opens. Selecting a destination sends the selected text to it.'
     automated: true
 
@@ -2476,107 +1989,72 @@ test_cases:
   - id: clickable-file-paths-001
     feature: 'Clickable File Paths'
     scenario: 'Absolute path (/path/to/file.ts) is detected as a clickable link'
-    steps:
-      - 'Call buildFilePathPattern(DEFAULT_DELIMITERS).exec on text containing /path/to/file.ts'
     expected_result: 'Pattern returns one match; extractFilePath yields /path/to/file.ts'
     automated: true
 
   - id: clickable-file-paths-002
     feature: 'Clickable File Paths'
     scenario: 'Relative path (./file.ts) is detected as a clickable link'
-    steps:
-      - 'Call buildFilePathPattern on text containing ./file.ts'
     expected_result: 'Pattern returns one match; extractFilePath yields ./file.ts'
     automated: true
 
   - id: clickable-file-paths-003
     feature: 'Clickable File Paths'
     scenario: 'Parent-relative path (../dir/file.ts) is detected as a clickable link'
-    steps:
-      - 'Call buildFilePathPattern on text containing ../dir/file.ts'
     expected_result: 'Pattern returns one match; extractFilePath yields ../dir/file.ts'
     automated: true
 
   - id: clickable-file-paths-004
     feature: 'Clickable File Paths'
     scenario: 'Tilde home path (~/projects/app.ts) is detected as a clickable link'
-    steps:
-      - 'Call buildFilePathPattern on text containing ~/projects/app.ts'
     expected_result: 'Pattern returns one match; extractFilePath yields ~/projects/app.ts'
     automated: true
 
   - id: clickable-file-paths-005
     feature: 'Clickable File Paths'
     scenario: 'Double-quoted path with spaces is detected and quotes are stripped'
-    steps:
-      - 'Call buildFilePathPattern on text containing "/path/with spaces/file.ts"'
     expected_result: 'Pattern returns one match; extractFilePath strips quotes and yields /path/with spaces/file.ts'
     automated: true
 
   - id: clickable-file-paths-006
     feature: 'Clickable File Paths'
     scenario: 'Single-quoted path is detected and quotes are stripped'
-    steps:
-      - "Call buildFilePathPattern on text containing '/path/to/file.ts'"
     expected_result: 'Pattern returns one match; extractFilePath strips quotes and yields /path/to/file.ts'
     automated: true
 
   - id: clickable-file-paths-007
     feature: 'Clickable File Paths'
     scenario: 'HTTP URL is NOT detected as a file path (false-positive guard)'
-    steps:
-      - 'Call buildFilePathPattern on text containing https://github.com/foo/bar.ts'
     expected_result: 'Pattern returns zero matches — URL is excluded'
     automated: true
 
   - id: clickable-file-paths-008
     feature: 'Clickable File Paths'
     scenario: 'RangeLink path (src/foo.ts#L5) is NOT detected as a plain file path (coexistence guard)'
-    steps:
-      - 'Call buildFilePathPattern on text containing src/foo.ts#L5'
     expected_result: 'Pattern returns zero matches — the #L suffix blocks the file path match so RangeLinkDocumentProvider handles it without overlap'
     automated: true
 
   - id: clickable-file-paths-009
     feature: 'Clickable File Paths'
     scenario: "ORM-style string ('User') without a path separator is NOT detected"
-    steps:
-      - "Call buildFilePathPattern on text containing 'User'"
     expected_result: 'Pattern returns zero matches — single-quoted string without a path separator is excluded'
     automated: true
 
   - id: clickable-file-paths-010
     feature: 'Clickable File Paths'
     scenario: 'rangelink.handleFilePathClick opens a real workspace file in the active editor'
-    preconditions:
-      - 'A workspace is open'
-    steps:
-      - 'Create a temp .ts file in the workspace root'
-      - 'Open a different anchor file so the temp file is not the active editor'
-      - 'Execute rangelink.handleFilePathClick with { filePath: tempFilePath }'
-      - 'Check vscode.window.activeTextEditor.document.uri.fsPath'
     expected_result: 'Active editor URI matches tempFilePath — the file was opened by the navigation handler'
     automated: true
 
   - id: clickable-file-paths-011
     feature: 'Clickable File Paths'
     scenario: 'rangelink.handleFilePathClick shows a warning for a non-existent file path'
-    preconditions:
-      - 'A workspace is open'
-    steps:
-      - 'Execute rangelink.handleFilePathClick with an absolute path that does not exist on the current OS'
-      - 'Observe VS Code notification area'
     expected_result: 'A warning notification appears (e.g., "Cannot open file: <path>"). No error is thrown; active editor is unchanged.'
     automated: true
 
   - id: clickable-file-paths-012
     feature: 'Clickable File Paths'
     scenario: 'Custom delimiter config respected — file path with custom delimiter suffix defers to RangeLink instead of matching as plain file path'
-    preconditions:
-      - 'Setting rangelink.delimiter.line set to a custom value (e.g., @l)'
-      - 'Terminal or editor contains a path like ./src/file.ts@l10'
-    steps:
-      - 'Hover over ./src/file.ts@l10 in the terminal or editor'
     expected_result: 'The path is detected as a RangeLink (not as a plain file path). Clicking navigates to line 10 via RangeLink, not to the file root via file path provider.'
     automated: true
 
@@ -2589,12 +2067,6 @@ test_cases:
       - clipboard
     feature: 'Smart Padding'
     scenario: 'Whitespace-only text preserved when sent to destination with smart padding enabled'
-    preconditions:
-      - 'A terminal is bound as destination'
-      - 'smartPadding.pasteContent set to "none" (default)'
-    steps:
-      - 'Select whitespace-only text (e.g., spaces or tabs) in an editor'
-      - 'Press R-V to send it to the bound destination'
     expected_result: 'The whitespace-only text is delivered to the destination intact — not trimmed to empty string. Smart padding adds spaces (not newlines) around it without destroying the content.'
     automated: true
 
@@ -2603,12 +2075,6 @@ test_cases:
       - clipboard
     feature: 'Smart Padding'
     scenario: 'Multiline selection sent to destination'
-    preconditions:
-      - 'A text editor is bound as destination'
-      - 'smartPadding.pasteContent set to "none" (default)'
-    steps:
-      - 'Select multiple lines in an editor'
-      - 'Press R-V to send it to the bound destination'
     expected_result: 'All selected lines arrive at the destination intact with no padding (pasteContent=none).'
     automated: true
 
@@ -2617,12 +2083,6 @@ test_cases:
       - clipboard
     feature: 'Smart Padding'
     scenario: 'pasteContent=before adds leading space only'
-    preconditions:
-      - 'A terminal is bound as destination'
-      - 'smartPadding.pasteContent set to "before"'
-    steps:
-      - 'Select text (e.g., "hello") in an editor'
-      - 'Press R-V to send it to the bound destination'
     expected_result: 'The destination receives " hello" — only a leading space is added.'
     automated: true
 
@@ -2631,12 +2091,6 @@ test_cases:
       - clipboard
     feature: 'Smart Padding'
     scenario: 'pasteContent=after adds trailing space only'
-    preconditions:
-      - 'A terminal is bound as destination'
-      - 'smartPadding.pasteContent set to "after"'
-    steps:
-      - 'Select text (e.g., "hello") in an editor'
-      - 'Press R-V to send it to the bound destination'
     expected_result: 'The destination receives "hello " — only a trailing space is added.'
     automated: true
 
@@ -2645,13 +2099,6 @@ test_cases:
       - clipboard
     feature: 'Smart Padding — Single-Write Architecture'
     scenario: 'pasteContent=both: text selection sent to destination has leading and trailing space'
-    preconditions:
-      - 'smartPadding.pasteContent set to "both"'
-      - 'A terminal is bound as destination'
-    steps:
-      - 'Select text "hello world" in the source editor'
-      - 'Press R-V to send it to the bound destination'
-      - 'Verify destination receives " hello world " — both leading and trailing spaces'
     expected_result: 'The destination receives " hello world " — both leading and trailing spaces applied by applySmartPadding upstream.'
     automated: true
 
@@ -2660,13 +2107,6 @@ test_cases:
       - clipboard
     feature: 'Smart Padding — Single-Write Architecture'
     scenario: 'pasteFilePath=both: file path sent to terminal has leading and trailing space'
-    preconditions:
-      - 'smartPadding.pasteFilePath set to "both"'
-      - 'A terminal is bound as destination'
-    steps:
-      - 'Open a file in the editor'
-      - 'Press R-F to send its path to the bound terminal'
-      - 'Verify terminal receives the file path with leading and trailing spaces'
     expected_result: 'The terminal receives the padded file path with leading and trailing spaces.'
     automated: true
 
@@ -2706,13 +2146,6 @@ test_cases:
       - clipboard
     feature: 'Smart Padding — Single-Write Architecture'
     scenario: 'pasteContent=none: no padding applied when setting is off'
-    preconditions:
-      - 'smartPadding.pasteContent set to "none"'
-      - 'A terminal is bound as destination'
-    steps:
-      - 'Select text "hello" in the source editor'
-      - 'Press R-V to send it to the bound destination'
-      - 'Verify destination receives exactly "hello" — no padding applied'
     expected_result: 'The destination receives "hello" without any added spaces — applySmartPadding returns text unchanged when mode is none.'
     automated: true
 
@@ -2723,49 +2156,24 @@ test_cases:
   - id: duplicate-tab-group-001
     feature: 'Text Editor Destination — Multi-Group Guard (Proactive Warning)'
     scenario: 'Proactive warning toast appears when bound file is opened in a second editor group'
-    preconditions:
-      - 'src/utils/helper.ts is bound as a text editor destination (visible in tab group 1)'
-    steps:
-      - 'Drag the src/utils/helper.ts tab to a second tab group (or right-click the tab → Split Right/Down)'
-      - 'Observe the notification area immediately after the split'
     expected_result: 'A warning toast appears: "Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed." No paste was attempted — the warning fires on tab change, not on paste.'
     automated: true
 
   - id: duplicate-tab-group-002
     feature: 'Text Editor Destination — Multi-Group Guard (No Re-warn)'
     scenario: 'Warning is not repeated when the duplicate state is already active'
-    preconditions:
-      - 'src/utils/helper.ts is bound as a text editor destination'
-      - 'The file is already open in two tab groups (duplicate state is active — warning was shown once)'
-    steps:
-      - 'Open src/utils/helper.ts in a third tab group (or trigger another tab change that keeps 2+ instances visible)'
-      - 'Observe the notification area'
     expected_result: 'No second warning toast appears. The warning is shown only once per entry into the duplicate state, not on every subsequent tab change while duplicates exist.'
     automated: true
 
   - id: duplicate-tab-group-003
     feature: 'Text Editor Destination — Multi-Group Guard (Reactive Paste Error)'
     scenario: 'Paste is blocked with a clear error message when bound file is open in multiple tab groups'
-    preconditions:
-      - 'src/utils/helper.ts is bound as a text editor destination'
-      - 'The file is visible in two tab groups simultaneously'
-    steps:
-      - 'Select any text in a different file'
-      - 'Press Cmd+R Cmd+L (or any bound-destination send command: R-V, R-L, Send File Path)'
     expected_result: 'Paste does not occur. An error toast appears: "Bound editor is open in multiple tab groups. Close the duplicate tab and try again." No text is inserted into either instance of src/utils/helper.ts.'
     automated: true
 
   - id: duplicate-tab-group-004
     feature: 'Text Editor Destination — Multi-Group Guard (State Clears on Resolve)'
     scenario: 'Duplicate warning state resets when the conflict is resolved — a new duplicate triggers a fresh warning'
-    preconditions:
-      - 'src/utils/helper.ts is bound as a text editor destination'
-      - 'The file is currently open in two tab groups (proactive warning was already shown once)'
-    steps:
-      - 'Close the duplicate tab (leave only one instance of src/utils/helper.ts open)'
-      - 'Observe the notification area — no toast should appear'
-      - 'Open src/utils/helper.ts again in a second tab group (re-enter the duplicate state)'
-      - 'Observe the notification area again'
     expected_result: 'Step 2: No toast appears when the duplicate is closed. Step 4: A fresh warning toast appears — "Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed." — confirming the flag was reset and re-entry into the duplicate state is correctly detected.'
     automated: true
 
@@ -2776,25 +2184,12 @@ test_cases:
   - id: langswitch-binding-001
     feature: 'Text Editor Destination — Language-Mode Resilience'
     scenario: 'Binding survives manual language-mode change on untitled file'
-    preconditions:
-      - 'An untitled file is open in ViewColumn.Two and bound as a text editor destination'
-    steps:
-      - 'Change the untitled file language mode to Markdown (via status bar or setTextDocumentLanguage)'
-      - 'Switch to the source file in ViewColumn.One, select text'
-      - 'Press R-V to send selected text to the bound destination'
     expected_result: 'The selected text arrives in the untitled file. The binding was preserved across the language-mode change — no re-bind required.'
     automated: true
 
   - id: langswitch-binding-002
     feature: 'Text Editor Destination — Language-Mode Resilience'
     scenario: 'Binding survives language change after content insertion'
-    preconditions:
-      - 'An untitled file (plaintext) is open in ViewColumn.Two and bound as a text editor destination'
-    steps:
-      - 'Insert markdown-style content (e.g., triple backticks with code) into the untitled file'
-      - 'Trigger language detection (manual or via setTextDocumentLanguage to markdown)'
-      - 'Switch to the source file in ViewColumn.One, select text'
-      - 'Press R-V to send selected text to the bound destination'
     expected_result: 'The selected text arrives in the untitled file alongside the markdown content. The binding was preserved despite the language change triggered by content insertion.'
     automated: true
 
@@ -2805,48 +2200,24 @@ test_cases:
   - id: navigation-clamping-001
     feature: 'Navigation Clamping Feedback'
     scenario: 'Navigate to line beyond end of file — cursor lands at last line'
-    preconditions:
-      - 'A file with a known number of lines exists in the workspace (e.g., src/utils/helper.ts with 45 lines)'
-    steps:
-      - 'Press Cmd+R Cmd+G (or Ctrl+R Ctrl+G)'
-      - 'Type: src/utils/helper.ts#L200'
-      - 'Press Enter'
     expected_result: 'The file opens and the cursor lands at the last line of the file (line 45), not line 200. A warning toast is shown indicating that the position was clamped.'
     automated: true
 
   - id: navigation-clamping-002
     feature: 'Navigation Clamping Feedback'
     scenario: 'Navigate to column beyond line length — cursor lands at end of line'
-    preconditions:
-      - 'A file exists in the workspace with lines shorter than 200 characters'
-    steps:
-      - 'Press Cmd+R Cmd+G (or Ctrl+R Ctrl+G)'
-      - 'Type: src/utils/helper.ts#L1C200'
-      - 'Press Enter'
     expected_result: 'The file opens and the cursor lands at the end of line 1 (clamped to line length), not column 200. A warning toast is shown indicating that the column was clamped.'
     automated: true
 
   - id: navigation-clamping-003
     feature: 'Navigation Clamping Feedback'
     scenario: 'Navigate to valid position — cursor lands exactly, info toast shown'
-    preconditions:
-      - 'A file with 10+ lines exists in the workspace'
-    steps:
-      - 'Press Cmd+R Cmd+G (or Ctrl+R Ctrl+G)'
-      - 'Type: src/utils/helper.ts#L5C10'
-      - 'Press Enter'
     expected_result: 'The file opens and the cursor lands at exactly line 5, column 10. An info toast is shown (not a warning).'
     automated: true
 
   - id: navigation-clamping-004
     feature: 'Navigation Clamping Feedback'
     scenario: 'Navigate with both line and column beyond bounds — both axes clamped'
-    preconditions:
-      - 'A file with a known number of lines and short lines exists in the workspace'
-    steps:
-      - 'Press Cmd+R Cmd+G (or Ctrl+R Ctrl+G)'
-      - 'Type: src/utils/helper.ts#L200C500'
-      - 'Press Enter'
     expected_result: 'The file opens and the cursor lands at the last line, last column (both axes clamped). A warning toast is shown indicating both line and column were clamped.'
     automated: true
 
@@ -2857,66 +2228,36 @@ test_cases:
   - id: untitled-navigation-001
     feature: 'Untitled File Navigation'
     scenario: 'Navigate to single line in open untitled file'
-    preconditions:
-      - 'An untitled file is open with at least 10 lines of content'
-    steps:
-      - 'In a terminal or document, create a RangeLink referencing the untitled file: Untitled-1#L5'
-      - 'Click the RangeLink (or use Cmd+R Cmd+G / Ctrl+R Ctrl+G and type Untitled-1#L5)'
     expected_result: 'The untitled file becomes active and line 5 is fully selected (anchor at start, active at end of line).'
     automated: true
 
   - id: untitled-navigation-002
     feature: 'Untitled File Navigation'
     scenario: 'Navigate to line range in open untitled file'
-    preconditions:
-      - 'An untitled file is open with at least 10 lines of content'
-    steps:
-      - 'In a terminal or document, create a RangeLink referencing the untitled file: Untitled-1#L3-L7'
-      - 'Click the RangeLink'
     expected_result: 'The untitled file becomes active with lines 3 through 7 selected (anchor at start of line 3, active at end of line 7).'
     automated: true
 
   - id: untitled-navigation-003
     feature: 'Untitled File Navigation'
     scenario: 'Navigate to untitled file that is not currently open shows file-not-found warning'
-    preconditions:
-      - 'No untitled files are open'
-    steps:
-      - 'Use Cmd+R Cmd+G (or Ctrl+R Ctrl+G) and type Untitled-99#L1'
-      - 'Press Enter'
     expected_result: 'A warning toast is shown: "Cannot find file: Untitled-99". No file opens.'
     automated: true
 
   - id: untitled-navigation-004
     feature: 'Untitled File Navigation'
     scenario: 'Character-precision navigation in open untitled file'
-    preconditions:
-      - 'An untitled file is open with at least 10 lines of content'
-    steps:
-      - 'Create a RangeLink referencing the untitled file with character precision: Untitled-1#L5C10-L5C20'
-      - 'Click the RangeLink'
     expected_result: 'The untitled file becomes active with characters 10-20 on line 5 selected (not full line). An info toast confirms navigation.'
     automated: true
 
   - id: untitled-navigation-005
     feature: 'Untitled File Navigation'
     scenario: 'Line clamping when navigating beyond end of untitled file'
-    preconditions:
-      - 'An untitled file is open with 15 lines of content'
-    steps:
-      - 'Create a RangeLink referencing line 50 of the untitled file: Untitled-1#L50'
-      - 'Click the RangeLink'
     expected_result: 'The cursor is clamped to the last line of the untitled file. A warning toast indicates line exceeded file length.'
     automated: true
 
   - id: untitled-navigation-006
     feature: 'Untitled File Navigation'
     scenario: 'Case-insensitive untitled-name matching'
-    preconditions:
-      - 'An untitled file named "Untitled-1" (or locale equivalent) is open with at least 10 lines'
-    steps:
-      - 'Create a RangeLink using a differently-cased name: untitled-1#L5 (all lowercase)'
-      - 'Click the RangeLink'
     expected_result: 'The untitled file becomes active and line 5 is fully selected. An info toast confirms navigation despite the case mismatch.'
     automated: true
 
@@ -2927,33 +2268,18 @@ test_cases:
   - id: navigation-toast-settings-001
     feature: 'Navigation Toast Settings'
     scenario: 'showNavigatedToast=false suppresses info toast after successful navigation'
-    preconditions:
-      - 'A file with at least 10 lines exists in the workspace'
-    steps:
-      - 'Set rangelink.navigation.showNavigatedToast to false in workspace settings'
-      - 'Click a RangeLink pointing to an exact position (e.g., file.ts#L5)'
     expected_result: 'Navigation succeeds (cursor moves to line 5) but no info toast is shown. The navigation is silent.'
     automated: true
 
   - id: navigation-toast-settings-002
     feature: 'Navigation Toast Settings'
     scenario: 'showClampingWarning=false suppresses clamping warning toast'
-    preconditions:
-      - 'A file with 10 lines exists in the workspace'
-    steps:
-      - 'Set rangelink.navigation.showClampingWarning to false in workspace settings'
-      - 'Click a RangeLink pointing beyond end of file (e.g., file.ts#L50)'
     expected_result: 'Navigation succeeds (cursor clamped to last line) but no clamping warning toast is shown.'
     automated: true
 
   - id: navigation-toast-settings-003
     feature: 'Navigation Toast Settings'
     scenario: 'Default settings show info toast after successful navigation'
-    preconditions:
-      - 'A file with at least 10 lines exists in the workspace'
-      - 'Navigation toast settings are at their defaults (both true)'
-    steps:
-      - 'Click a RangeLink pointing to an exact position (e.g., file.ts#L3)'
     expected_result: 'Navigation succeeds and an info toast is shown: "Navigated to file.ts @ 3".'
     automated: true
 
@@ -2964,40 +2290,24 @@ test_cases:
   - id: filename-fallback-navigation-001
     feature: 'Filename-Only Navigation Fallback'
     scenario: 'Bare filename with unique match navigates to correct file and line'
-    preconditions:
-      - 'A file with a unique name exists somewhere in the workspace (e.g., uniqueTestFile.ts)'
-    steps:
-      - 'Click a RangeLink using only the filename without a directory path (e.g., uniqueTestFile.ts#L5)'
     expected_result: 'Navigation succeeds — the file opens and line 5 is fully selected, same as if the full relative path had been provided.'
     automated: true
 
   - id: filename-fallback-navigation-002
     feature: 'Filename-Only Navigation Fallback'
     scenario: 'Bare filename with multiple matches shows ambiguity warning'
-    preconditions:
-      - 'Two or more files with the same name exist in different directories (e.g., index.ts in src/ and lib/)'
-    steps:
-      - 'Click a RangeLink using only the ambiguous filename (e.g., index.ts#L1)'
     expected_result: 'A warning toast is shown: "Multiple files match: index.ts". No navigation occurs.'
     automated: true
 
   - id: filename-fallback-navigation-003
     feature: 'Filename-Only Navigation Fallback'
     scenario: 'Bare filename with no matches shows file-not-found warning'
-    preconditions:
-      - 'No file named nonexistent-file.ts exists in the workspace'
-    steps:
-      - 'Click a RangeLink using a nonexistent bare filename (e.g., nonexistent-file.ts#L1)'
     expected_result: 'A warning toast is shown: "Cannot find file: nonexistent-file.ts". No navigation occurs.'
     automated: true
 
   - id: filename-fallback-navigation-004
     feature: 'Filename-Only Navigation Fallback'
     scenario: 'Path with directory separators uses standard resolution, not fallback'
-    preconditions:
-      - 'A file exists at a known relative path in the workspace'
-    steps:
-      - 'Click a RangeLink using a relative path with directory separators (e.g., src/utils/resolveWorkspacePath.ts#L10)'
     expected_result: 'Navigation succeeds via standard workspace-relative resolution — the file opens and line 10 is fully selected.'
     automated: true
 
@@ -3008,12 +2318,6 @@ test_cases:
   - id: custom-ai-assistant-001
     feature: 'Custom AI Assistants — Configuration'
     scenario: 'Three-tier config with dummy AI extension is parsed and logged at activation'
-    preconditions:
-      - 'settings.json contains 3 custom AI assistant entries (one per tier) using dummy extension commands'
-      - 'Dummy AI extension loaded via extensionDevelopmentPath'
-    steps:
-      - 'Extension activates with custom AI assistants configured'
-      - 'Check output logs'
     expected_result: 'Log shows "Loaded 3 custom AI assistant(s)" with all three extensionIds'
     automated: true
 
@@ -3022,11 +2326,6 @@ test_cases:
       - clipboard
     feature: 'Custom AI Assistants — Registration'
     scenario: 'All three tier entries registered as destination kinds'
-    preconditions:
-      - 'settings.json contains 3 custom AI assistant entries (one per tier)'
-    steps:
-      - 'Extension activates'
-      - 'Check registration logs'
     expected_result: 'Log shows 3 custom-ai: destination registrations — one for each tier entry'
     automated: true
 
@@ -3036,12 +2335,6 @@ test_cases:
       - requires-extensions
     feature: 'Custom AI Assistants — Destination Picker'
     scenario: 'Custom AI assistant appears in the R-D destination picker with configured display name'
-    preconditions:
-      - 'A real AI extension installed with known focus commands'
-      - 'settings.json configures it as a custom AI assistant'
-    steps:
-      - 'Press Cmd+R Cmd+D to open destination picker'
-      - 'Observe the picker items'
     expected_result: 'The custom AI assistant appears in the picker with its configured extensionName, after the built-in destinations'
     automated: true
 
@@ -3050,10 +2343,6 @@ test_cases:
       - clipboard
     feature: 'Custom AI Assistants — Command Detection'
     scenario: 'Dummy extension insertText command is detectable by the availability system'
-    preconditions:
-      - 'Dummy AI extension loaded with dummyAi.insertText command'
-    steps:
-      - 'Query registered commands'
     expected_result: 'dummyAi.insertText is present in the registered commands list'
     automated: true
 
@@ -3062,12 +2351,6 @@ test_cases:
       - clipboard
     feature: 'Custom AI Assistants — Availability'
     scenario: 'Tier 1 entry availability checked when insertCommand is registered'
-    preconditions:
-      - 'Custom AI assistant configured with insertCommands pointing to dummy extension command'
-      - 'Dummy AI extension loaded and active'
-    steps:
-      - 'Extension checks availability'
-      - 'Check output logs'
     expected_result: 'Availability check log exists for the Tier 1 entry'
     automated: true
 
@@ -3076,10 +2359,6 @@ test_cases:
       - clipboard
     feature: 'Custom AI Assistants — Command Registration'
     scenario: 'All dummy extension commands are registered and detectable'
-    preconditions:
-      - 'Dummy AI extension loaded via extensionDevelopmentPath'
-    steps:
-      - 'Query registered VS Code commands'
     expected_result: 'All 5 dummyAi commands (insertText, focusForPaste, focusPanel, getText, clearAll) are registered'
     automated: true
 
@@ -3088,12 +2367,6 @@ test_cases:
       - clipboard
     feature: 'Custom AI Assistants — Destination Picker'
     scenario: 'Multiple custom AI assistants listed in user-defined order'
-    preconditions:
-      - 'Two or more custom AI assistants configured with different extensionNames'
-      - 'All have available focus commands or extensions'
-    steps:
-      - 'Press Cmd+R Cmd+D to open destination picker'
-      - 'Observe order of custom AI assistants in the picker'
     expected_result: 'Custom AI assistants appear after built-in destinations, in the same order as defined in settings.json'
     automated: true
 
@@ -3102,11 +2375,6 @@ test_cases:
       - clipboard
     feature: 'Custom AI Assistants — Configuration'
     scenario: 'Parser normalizes plain string insertCommands to { command } objects'
-    preconditions:
-      - 'settings.json contains custom AI assistant with insertCommands as plain strings'
-    steps:
-      - 'Extension activates'
-      - 'Check output logs for parsed config'
     expected_result: 'Activation log shows insertCommands were parsed and the assistant was loaded'
     automated: true
 
@@ -3115,12 +2383,6 @@ test_cases:
       - clipboard
     feature: 'Custom AI Assistants — Configuration'
     scenario: 'Template entry with ${content} interpolation in insertCommands is parsed and registered'
-    preconditions:
-      - 'settings.json contains custom AI assistant with insertCommands using { command, args } object with ${content} placeholder'
-      - 'Dummy AI extension loaded with dummyAi.insertWithArgs command'
-    steps:
-      - 'Extension activates'
-      - 'Check registration logs'
     expected_result: 'Destination builder registered for the template entry'
     automated: true
 
@@ -3204,11 +2466,6 @@ test_cases:
       - clipboard
     feature: 'Built-in AI Assistants'
     scenario: 'GitHub Copilot Chat registers as a built-in destination kind'
-    preconditions:
-      - 'No user override for github-copilot-chat in rangelink.customAiAssistants'
-    steps:
-      - 'Extension activates'
-      - 'Check activation logs for registration of github-copilot-chat kind'
     expected_result: 'Exactly one registration for github-copilot-chat kind as a built-in destination'
     automated: true
 
@@ -3217,11 +2474,6 @@ test_cases:
       - clipboard
     feature: 'Built-in AI Assistants'
     scenario: 'GitHub Copilot Chat does not register as custom-ai: prefixed kind'
-    preconditions:
-      - 'No user override for github-copilot-chat in rangelink.customAiAssistants'
-    steps:
-      - 'Extension activates'
-      - 'Check activation logs for absence of custom-ai:github.copilot-chat registration'
     expected_result: 'No custom-ai:github.copilot-chat registration found — registers as built-in kind only'
     automated: true
 
@@ -3249,12 +2501,6 @@ test_cases:
       - requires-extensions
     feature: 'Built-in AI Assistants'
     scenario: 'Claude Code Chat appears in destination picker when extension is active'
-    preconditions:
-      - 'Claude Code extension (anthropic.claude-code) is installed and active'
-      - 'No destination currently bound'
-    steps:
-      - 'Open destination picker via R-D or Command Palette → "Bind to Destination"'
-      - 'Confirm "Claude Code Chat" item appears first in the AI Assistants group'
     expected_result: '"Claude Code Chat" is listed as the first item in the AI Assistants group of the destination picker'
     command_to_run: 'pnpm test:release:with-extensions --grep "claude-code-001"'
     automated: true
@@ -3308,12 +2554,6 @@ test_cases:
   - id: github-copilot-chat-001
     feature: 'Built-in AI Assistants'
     scenario: 'GitHub Copilot Chat appears in destination picker when available'
-    preconditions:
-      - 'VS Code has built-in workbench.action.chat.open command (present in all modern VS Code)'
-      - 'No destination currently bound'
-    steps:
-      - 'Open destination picker via R-D or Command Palette → "Bind to Destination"'
-      - 'Confirm "GitHub Copilot Chat" item appears in the AI Assistants group'
     expected_result: '"GitHub Copilot Chat" is listed in the AI Assistants group of the destination picker'
     automated: true
 
@@ -3375,12 +2615,6 @@ test_cases:
       - cold-start
     feature: 'Built-in AI Assistants'
     scenario: 'Cold-start default settings produce a valid ColdRefocusConfig where totalMs > intervalMs'
-    preconditions:
-      - 'Claude Code extension (anthropic.claude-code) is installed and active'
-      - 'VS Code is running with the standard test:release:with-extensions configuration'
-    steps:
-      - 'Read the rangelink.destinations.claudeCode.coldStartDelayMs and coldRefocusIntervalMs defaults from VS Code configuration'
-      - 'Confirm coldStartDelayMs > coldRefocusIntervalMs'
     expected_result: 'Default settings produce a valid ColdRefocusConfig. coldStartDelayMs is greater than coldRefocusIntervalMs.'
     command_to_run: 'pnpm test:release:with-extensions --grep "claude-code-006"'
     automated: true
@@ -3392,15 +2626,6 @@ test_cases:
       - validation
     feature: 'Built-in AI Assistants'
     scenario: 'Cold-start validation rejects invalid config (totalMs <= intervalMs) and falls back to defaults with a warning'
-    preconditions:
-      - 'Claude Code extension (anthropic.claude-code) is installed and active'
-      - 'VS Code is running with the standard test:release:with-extensions configuration'
-    steps:
-      - 'Set rangelink.destinations.claudeCode.coldStartDelayMs to 100 and coldRefocusIntervalMs to 400 (invalid: delay <= interval)'
-      - 'Bind to Claude Code Chat to trigger getColdRefocus validation'
-      - 'Confirm a warning log is emitted about invalid cold-start config'
-      - 'Confirm the fallback defaults from coldStartDelayMs / coldRefocusIntervalMs are used instead of the invalid values'
-      - 'Restore original configuration values'
     expected_result: 'Invalid config is rejected. Warning is logged. Defaults from coldStartDelayMs / coldRefocusIntervalMs are used as fallback.'
     command_to_run: 'pnpm test:release:with-extensions --grep "claude-code-007"'
     automated: true
@@ -3474,13 +2699,6 @@ test_cases:
       - requires-extensions
     feature: 'Built-in AI Assistants'
     scenario: 'Gemini Code Assist appears in destination picker when extension is active'
-    preconditions:
-      - 'Google Gemini Code Assist extension (google.geminicodeassist) is installed and active'
-      - 'No destination currently bound'
-    steps:
-      - 'Open destination picker via R-D or Command Palette → "Bind to Destination"'
-      - 'Confirm "Gemini Code Assist" item appears in the AI Assistants group'
-      - 'Confirm it appears after "Claude Code Chat" and before "Cursor AI Assistant" in the picker'
     expected_result: '"Gemini Code Assist" is listed in the AI Assistants group of the destination picker'
     command_to_run: 'pnpm test:release:with-extensions --grep "gemini-code-assist-001"'
     automated: true
@@ -3545,12 +2763,6 @@ test_cases:
       - cold-start
     feature: 'Built-in AI Assistants'
     scenario: 'Cold-start default settings produce a valid ColdRefocusConfig where totalMs > intervalMs'
-    preconditions:
-      - 'Google Gemini Code Assist extension (google.geminicodeassist) is installed and active'
-      - 'VS Code is running with the standard test:release:with-extensions configuration'
-    steps:
-      - 'Read the rangelink.destinations.gemini.coldStartDelayMs and coldRefocusIntervalMs defaults from VS Code configuration'
-      - 'Confirm coldStartDelayMs > coldRefocusIntervalMs'
     expected_result: 'Default settings produce a valid ColdRefocusConfig. coldStartDelayMs is greater than coldRefocusIntervalMs.'
     command_to_run: 'pnpm test:release:with-extensions --grep "gemini-code-assist-005"'
     automated: true
@@ -3562,15 +2774,6 @@ test_cases:
       - validation
     feature: 'Built-in AI Assistants'
     scenario: 'Cold-start validation rejects invalid config (totalMs <= intervalMs) and falls back to defaults with a warning'
-    preconditions:
-      - 'Google Gemini Code Assist extension (google.geminicodeassist) is installed and active'
-      - 'VS Code is running with the standard test:release:with-extensions configuration'
-    steps:
-      - 'Set rangelink.destinations.gemini.coldStartDelayMs to 100 and coldRefocusIntervalMs to 400 (invalid: delay <= interval)'
-      - 'Bind to Gemini Code Assist to trigger getColdRefocus validation'
-      - 'Confirm a warning log is emitted about invalid cold-start config'
-      - 'Confirm the fallback defaults from coldStartDelayMs / coldRefocusIntervalMs are used instead of the invalid values'
-      - 'Restore original configuration values'
     expected_result: 'Invalid config is rejected. Warning is logged. Defaults from coldStartDelayMs / coldRefocusIntervalMs are used as fallback.'
     command_to_run: 'pnpm test:release:with-extensions --grep "gemini-code-assist-006"'
     automated: true
@@ -3582,24 +2785,12 @@ test_cases:
   - id: release-notifier-001
     feature: 'Release Notifier'
     scenario: 'First install stores current version silently with no notification'
-    preconditions:
-      - 'Fresh VS Code profile with no prior RangeLink globalState'
-    steps:
-      - 'Open VS Code with the fresh profile'
-      - 'Confirm no "RangeLink updated" notification appears on activation'
-      - 'Open Output → RangeLink and confirm "First install — stored version" log entry'
     expected_result: 'No notification popup; log confirms version stored silently'
     automated: true
 
   - id: release-notifier-002
     feature: 'Release Notifier'
     scenario: 'Same version stored — no notification on subsequent launches'
-    preconditions:
-      - 'Extension already installed and launched once (version stored in globalState)'
-    steps:
-      - 'Close and reopen VS Code'
-      - 'Confirm no "RangeLink updated" notification appears'
-      - 'Open Output → RangeLink and confirm "Same version — skipping" log entry'
     expected_result: 'No notification popup; log confirms same-version skip'
     automated: true
 

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
@@ -33,12 +33,6 @@ test_cases:
   - id: status-bar-menu-001
     feature: 'R-M Status Bar Menu'
     scenario: 'Status bar item visible with correct text and tooltip in unbound state'
-    preconditions:
-      - 'Any workspace is open'
-    steps:
-      - 'Look at the VS Code status bar (bottom bar)'
-      - 'Locate the RangeLink item'
-      - 'Hover over it to see the tooltip'
     expected_result: "Status bar shows $(link) RangeLink. Tooltip reads 'RangeLink Menu'."
     automated: assisted
 
@@ -81,29 +75,18 @@ test_cases:
   - id: status-bar-menu-007
     feature: 'R-M Status Bar Menu'
     scenario: 'R-M menu shows Unbind Destination when a destination is bound'
-    preconditions:
-      - 'A destination is currently bound'
-    steps:
-      - 'Open the R-M menu'
-      - "Select 'Unbind Destination'"
     expected_result: "The destination is unbound. A notification confirms. R-M menu no longer shows 'Jump to Bound Destination' next time."
     automated: assisted
 
   - id: status-bar-menu-008
     feature: 'R-M Status Bar Menu'
     scenario: 'R-M menu Go to Link item opens the R-G input box'
-    steps:
-      - 'Open the R-M menu'
-      - "Select 'Go to Link'"
     expected_result: 'R-G input box opens, ready to accept a RangeLink for navigation.'
     automated: assisted
 
   - id: status-bar-menu-009
     feature: 'R-M Status Bar Menu'
     scenario: 'R-M menu Show Version Info displays version, commit, branch, and build date'
-    steps:
-      - 'Open the R-M menu'
-      - "Select 'Show Version Info'"
     expected_result: 'A notification or info message shows the extension version, short commit SHA, branch name, and build date.'
     automated: assisted
 
@@ -114,24 +97,12 @@ test_cases:
   - id: bind-to-destination-004
     feature: 'R-D Bind to Destination'
     scenario: 'Selecting a terminal destination binds it and shows success toast'
-    preconditions:
-      - 'At least one terminal open'
-      - 'No binding active'
-    steps:
-      - 'Open R-D picker'
-      - 'Select a terminal from the list'
     expected_result: "The terminal is bound. A success toast appears (e.g., 'Bound to Terminal')."
     automated: assisted
 
   - id: bind-to-destination-005
     feature: 'R-D Bind to Destination'
     scenario: 'Selecting a text editor destination binds it and shows success toast'
-    preconditions:
-      - 'At least two editor tabs open'
-      - 'No binding active'
-    steps:
-      - 'Open R-D picker'
-      - 'Select a text file from the list'
     expected_result: 'The selected file becomes the bound destination. Success toast appears.'
     automated: assisted
 
@@ -140,44 +111,24 @@ test_cases:
       - requires-extensions
     feature: 'R-D Bind to Destination'
     scenario: 'Selecting an AI assistant destination binds it and shows success toast'
-    preconditions:
-      - 'A supported AI assistant extension is installed and active (Claude Code, Copilot Chat)'
-    steps:
-      - 'Open R-D picker'
-      - 'Select the AI assistant entry from the list'
     expected_result: 'AI assistant is now the bound destination. Success toast appears.'
     automated: assisted
 
   - id: bind-to-destination-007
     feature: 'R-D Bind to Destination'
     scenario: 'When already bound, destination picker shows smart-bind confirmation dialog'
-    preconditions:
-      - 'A destination is already bound'
-    steps:
-      - 'Open R-D picker'
-      - 'Select a different terminal or file'
     expected_result: "A confirmation dialog appears showing the current binding name and the proposed new binding name, with 'Yes, replace' and 'No, keep current' options."
     automated: assisted
 
   - id: bind-to-destination-008
     feature: 'R-D Bind to Destination'
     scenario: 'Smart-bind confirmation Yes replaces switches the binding to the new destination'
-    preconditions:
-      - 'Destination A already bound'
-      - 'Smart-bind confirmation dialog is showing (run bind-to-destination-007 steps first)'
-    steps:
-      - "Click 'Yes, replace' (or equivalent) in the confirmation dialog"
     expected_result: 'Binding switches to the newly selected destination. Success toast confirms the new binding.'
     automated: assisted
 
   - id: bind-to-destination-009
     feature: 'R-D Bind to Destination'
     scenario: 'Smart-bind confirmation No keep retains the existing binding'
-    preconditions:
-      - 'Destination A already bound'
-      - 'Smart-bind confirmation dialog is showing (run bind-to-destination-007 steps first)'
-    steps:
-      - "Click 'No, keep current' (or equivalent) in the confirmation dialog"
     expected_result: 'Original binding is preserved. No binding change occurs. Neutral info notification (if any).'
     automated: assisted
 
@@ -192,10 +143,6 @@ test_cases:
       - requires-extensions
     feature: 'R-D Bind to Destination'
     scenario: 'Re-binding same AI assistant shows already-bound message instead of confirmation dialog'
-    preconditions:
-      - 'Bound to an AI assistant (e.g., Claude Code)'
-    steps:
-      - 'Run the same bind command again (e.g., Bind to Claude Code)'
     expected_result: 'No confirmation dialog appears. An "already bound" info notification is shown. Binding is unchanged.'
     automated: assisted
 
@@ -204,11 +151,6 @@ test_cases:
       - requires-extensions
     feature: 'R-D Bind to Destination'
     scenario: 'Switching between different AI assistants shows confirmation dialog'
-    preconditions:
-      - 'Bound to an AI assistant (e.g., Claude Code)'
-      - 'At least two AI assistant extensions installed and active'
-    steps:
-      - 'Run a different AI assistant bind command (e.g., Bind to Cursor AI)'
     expected_result: 'A confirmation dialog appears with current and proposed destination names. Selecting Yes switches the binding.'
     automated: assisted
 
@@ -221,23 +163,12 @@ test_cases:
   - id: bind-to-destination-014
     feature: 'R-D Bind to Destination'
     scenario: 'Jump to Bound Destination (R-J) with no destination bound opens the destination picker'
-    preconditions:
-      - 'No destination bound'
-    steps:
-      - 'Open R-M menu or Command Palette'
-      - "Select 'Jump to Bound Destination' (or press Cmd+R Cmd+J)"
     expected_result: 'Destination picker opens so the user can bind a destination first.'
     automated: assisted
 
   - id: bind-to-destination-015
     feature: 'R-D Bind to Destination'
     scenario: 'Binding a text editor in a single tab group (no split) succeeds'
-    preconditions:
-      - 'Only one tab group open (no editor split)'
-      - 'Multiple files open in that one group'
-    steps:
-      - 'Press Cmd+R Cmd+D'
-      - 'Select any open file from the list'
     expected_result: 'The file is bound successfully. Success toast appears. No error about needing a split view or second tab group.'
     automated: assisted
 
@@ -303,20 +234,12 @@ test_cases:
   - id: terminal-picker-009
     feature: 'Terminal Picker'
     scenario: 'Selecting More terminals... opens the secondary full terminal picker'
-    preconditions:
-      - 'Overflow scenario active (more terminals than maxInline)'
-    steps:
-      - "Select 'More terminals...' from the picker"
     expected_result: "A secondary QuickPick opens listing all terminals, including those that were hidden behind 'More terminals...'."
     automated: assisted
 
   - id: terminal-picker-010
     feature: 'Terminal Picker'
     scenario: 'Escaping the secondary terminal picker returns to the parent destination picker'
-    preconditions:
-      - 'Secondary terminal picker is open (from terminal-picker-009)'
-    steps:
-      - 'Press Escape in the secondary terminal picker'
     expected_result: 'The secondary picker closes. The parent destination picker (R-D or R-M) is still visible.'
     automated: assisted
 
@@ -375,32 +298,18 @@ test_cases:
   - id: file-picker-006
     feature: 'File Picker'
     scenario: 'Secondary file picker shows Active Files section'
-    preconditions:
-      - 'Overflow scenario active — select More files... from R-D picker'
-    steps:
-      - "Select 'More files...' from R-D picker"
-      - 'Observe the secondary picker sections'
     expected_result: "A secondary QuickPick opens with an 'Active Files' section header listing all open files."
     automated: assisted
 
   - id: file-picker-007
     feature: 'File Picker'
     scenario: 'Secondary file picker shows Tab Group N sections for each editor group'
-    preconditions:
-      - 'Two or more tab groups open'
-      - 'Secondary file picker is open'
-    steps:
-      - 'Observe the secondary picker sections'
     expected_result: "Files are grouped under 'Tab Group 1', 'Tab Group 2', etc. Each group lists the files in that tab group."
     automated: assisted
 
   - id: file-picker-008
     feature: 'File Picker'
     scenario: 'Escaping the secondary file picker returns to the parent destination picker'
-    preconditions:
-      - 'Secondary file picker is open'
-    steps:
-      - 'Press Escape in the secondary file picker'
     expected_result: 'The secondary picker closes. The parent R-D (or R-M) picker is still visible, not closed.'
     automated: assisted
 
@@ -413,12 +322,6 @@ test_cases:
   - id: file-picker-010
     feature: 'File Picker'
     scenario: 'Secondary picker shows path disambiguation for same-name files'
-    preconditions:
-      - 'More than the inline limit of files are open'
-      - 'Two files share the same base name in different directories'
-    steps:
-      - 'Open R-D destination picker'
-      - 'Click "More files..."'
     expected_result: 'Secondary file picker shows both same-name files with disambiguating path fragments in their descriptions.'
     automated: assisted
 
@@ -467,15 +370,6 @@ test_cases:
       - clipboard
     feature: 'Clipboard Preservation'
     scenario: 'always mode: clipboard content before AI assistant paste is restored after'
-    preconditions:
-      - 'rangelink.clipboard.preserve = "always" (loaded automatically by test)'
-      - 'Dummy AI (Tier 1) destination available'
-    steps:
-      - 'Test writes sentinel to clipboard automatically'
-      - 'Press Cmd+R Cmd+D → bind "Dummy AI (Tier 1)"'
-      - 'Click into the test file (cbp-004-...) and select exactly lines 1-3'
-      - 'Press Cmd+R Cmd+L — link appears in Dummy AI Tier 1 textarea'
-      - 'Press Cancel — test asserts exact link in Dummy AI and clipboard restored to sentinel'
     expected_result: 'Dummy AI tier1 contains the exact link (relPath#L1-L3). Clipboard contains the sentinel value. assertClipboardRestored passes — preserve=always silently restored the clipboard after AI delivery.'
     automated: assisted
 
@@ -524,17 +418,6 @@ test_cases:
       - clipboard
     feature: 'Clipboard Preservation'
     scenario: 'AI assistant auto-paste fails (focus command throws): RangeLink stays in clipboard for manual paste'
-    preconditions:
-      - 'Custom AI assistant "Dummy AI (Focus-Fail)" configured in workspace settings with focusCommands: [dummyAi.focusFail] (registered command that throws intentionally)'
-      - 'Dummy AI extension installed and active'
-      - 'rangelink.clipboard.preserve = "always" (default)'
-      - 'A file is open in the editor'
-    steps:
-      - 'Test writes CLIPBOARD_SENTINEL to clipboard'
-      - 'Human: Cmd+R Cmd+D → select "Dummy AI (Focus-Fail)" from picker'
-      - 'Human: select lines 1-3 in test file and press Cmd+R Cmd+L'
-      - 'The focus command (dummyAi.focusFail) throws — extension logs "Focus failed, cannot paste link"'
-      - 'Test calls assertClipboardChanged — clipboard must contain the RangeLink, NOT the sentinel'
     expected_result: 'Clipboard contains the generated RangeLink (not CLIPBOARD_SENTINEL). isClipboardRestorationApplicable returns false because getUserInstruction(Failure) is defined. The "Paste manually" warning toast was shown.'
     command_to_run: 'pnpm test:release:grep "clipboard-preservation-010"'
     automated: assisted
@@ -596,14 +479,6 @@ test_cases:
       - clipboard
     feature: 'Clipboard Preservation — AI Assistant Lifecycle'
     scenario: 'AI assistant focus/paste command throws: RangeLink stays on clipboard for manual paste'
-    preconditions:
-      - 'Custom AI assistant "Dummy AI (Focus-Fail)" bound via R-D picker'
-      - 'rangelink.clipboard.preserve = "always" (default)'
-    steps:
-      - 'Human binds "Dummy AI (Focus-Fail)" via R-D picker'
-      - 'Sentinel written, selection set, R-L dispatched programmatically'
-      - 'Focus command throws — extension logs paste failure'
-      - 'assertClipboardChanged + #L check verify RangeLink remained on clipboard'
     expected_result: 'RangeLink remains on clipboard (prior content NOT restored). isClipboardRestorationApplicable returns false — user must paste manually.'
     automated: assisted
 
@@ -706,11 +581,6 @@ test_cases:
       - clipboard
     feature: 'Send File Path'
     scenario: 'Unbound: R-F opens destination picker to bind before sending'
-    preconditions:
-      - 'No destination bound'
-    steps:
-      - 'Press Cmd+R Cmd+F'
-      - 'Observe destination picker appearing'
     expected_result: 'Destination picker opens. Selecting a destination binds it and sends the file path.'
     automated: assisted
 
@@ -745,103 +615,54 @@ test_cases:
   - id: context-menus-explorer-001
     feature: 'Context Menus — Explorer'
     scenario: 'Explorer: RangeLink: Send File Path sends absolute path to bound destination'
-    preconditions:
-      - 'A file exists in the Explorer panel'
-      - 'Terminal is bound as destination'
-    steps:
-      - 'In the Explorer panel, right-click any file (e.g., src/utils/helper.ts)'
-      - "Select 'RangeLink: Send File Path'"
-      - 'Observe the terminal'
     expected_result: 'Terminal receives the absolute file path (e.g., /Users/username/project/src/utils/helper.ts). No link format, no line number.'
     automated: assisted
 
   - id: context-menus-explorer-002
     feature: 'Context Menus — Explorer'
     scenario: 'Explorer: RangeLink: Send Relative File Path sends relative path'
-    preconditions:
-      - 'Terminal bound'
-    steps:
-      - 'Right-click a file in Explorer'
-      - "Select 'RangeLink: Send Relative File Path'"
     expected_result: 'Terminal receives the workspace-relative path (e.g., src/utils/helper.ts). No leading slash.'
     automated: assisted
 
   - id: context-menus-explorer-003
     feature: 'Context Menus — Explorer'
     scenario: 'Explorer: RangeLink: Bind Here opens the file and binds it as text editor destination'
-    preconditions:
-      - 'No binding active'
-    steps:
-      - 'Right-click a file in Explorer (e.g., src/utils/helper.ts)'
-      - "Select 'RangeLink: Bind Here'"
     expected_result: 'src/utils/helper.ts opens in the editor and becomes the bound text editor destination. Success toast appears.'
     automated: assisted
 
   - id: context-menus-explorer-004
     feature: 'Context Menus — Explorer'
     scenario: 'Explorer: RangeLink: Unbind is visible when bound and unbinds on click'
-    preconditions:
-      - 'A destination is currently bound'
-    steps:
-      - 'Right-click any file in Explorer'
-      - "Locate and select 'RangeLink: Unbind'"
     expected_result: 'The destination is unbound. Confirmation notification appears.'
     automated: assisted
 
   - id: context-menus-explorer-005
     feature: 'Context Menus — Explorer'
     scenario: 'Explorer: RangeLink: Unbind is hidden when no destination is bound'
-    preconditions:
-      - 'No destination is bound'
-    steps:
-      - 'Right-click any file in Explorer'
-      - 'Observe the context menu'
     expected_result: "'RangeLink: Unbind' is not visible in the menu (or is disabled)."
     automated: assisted
 
   - id: context-menus-editor-tab-001
     feature: 'Context Menus — Editor Tab'
     scenario: 'Editor tab: RangeLink: Send File Path'
-    preconditions:
-      - 'A file is open in a tab'
-      - 'Terminal bound'
-    steps:
-      - 'Right-click the file tab in the tab bar'
-      - "Select 'RangeLink: Send File Path'"
     expected_result: "Terminal receives the absolute file path of the tab's file."
     automated: assisted
 
   - id: context-menus-editor-tab-002
     feature: 'Context Menus — Editor Tab'
     scenario: 'Editor tab: RangeLink: Send Relative File Path'
-    preconditions:
-      - 'A file is open in a tab'
-      - 'Terminal bound'
-    steps:
-      - 'Right-click the file tab'
-      - "Select 'RangeLink: Send Relative File Path'"
     expected_result: 'Terminal receives the workspace-relative path.'
     automated: assisted
 
   - id: context-menus-editor-tab-003
     feature: 'Context Menus — Editor Tab'
     scenario: 'Editor tab: RangeLink: Bind Here binds that editor'
-    preconditions:
-      - 'File is open in a tab'
-    steps:
-      - 'Right-click the file tab'
-      - "Select 'RangeLink: Bind Here'"
     expected_result: "The tab's file is now the bound text editor destination. Success toast appears."
     automated: assisted
 
   - id: context-menus-editor-tab-004
     feature: 'Context Menus — Editor Tab'
     scenario: 'Editor tab: RangeLink: Unbind visible when bound and unbinds on click'
-    preconditions:
-      - 'A destination is bound'
-    steps:
-      - 'Right-click any editor tab'
-      - "Select 'RangeLink: Unbind'"
     expected_result: 'Destination is unbound. Confirmation notification.'
     automated: assisted
 
@@ -850,13 +671,6 @@ test_cases:
       - clipboard
     feature: 'Context Menus — Editor Content'
     scenario: 'Editor content (with selection): RangeLink: Send RangeLink'
-    preconditions:
-      - 'Text selected in an editor'
-      - 'Terminal bound'
-    steps:
-      - 'Select 2-3 lines in a file'
-      - 'Right-click in the editor'
-      - "Select 'RangeLink: Send RangeLink'"
     expected_result: 'Terminal receives the RangeLink (same as R-L keybinding). Success toast.'
     automated: assisted
 
@@ -865,11 +679,6 @@ test_cases:
       - clipboard
     feature: 'Context Menus — Editor Content'
     scenario: 'Editor content (with selection): RangeLink: Send RangeLink (Absolute)'
-    preconditions:
-      - 'Text selected in editor'
-      - 'Terminal bound'
-    steps:
-      - "Select text, right-click, select 'RangeLink: Send RangeLink (Absolute)'"
     expected_result: 'Terminal receives the RangeLink with an absolute file path (e.g., /full/path/to/file.ts#L3-L5).'
     automated: assisted
 
@@ -878,11 +687,6 @@ test_cases:
       - clipboard
     feature: 'Context Menus — Editor Content'
     scenario: 'Editor content (with selection): RangeLink: Send Portable Link'
-    preconditions:
-      - 'Text selected in editor'
-      - 'Terminal bound'
-    steps:
-      - "Select text, right-click, select 'RangeLink: Send Portable Link'"
     expected_result: 'Terminal receives the portable link format (GitHub-style URL with blob path and line anchor).'
     automated: assisted
 
@@ -891,11 +695,6 @@ test_cases:
       - clipboard
     feature: 'Context Menus — Editor Content'
     scenario: 'Editor content (with selection): RangeLink: Send Portable Link (Absolute)'
-    preconditions:
-      - 'Text selected in editor'
-      - 'Terminal bound'
-    steps:
-      - "Select text, right-click, select 'RangeLink: Send Portable Link (Absolute)'"
     expected_result: 'Terminal receives the portable link with an absolute file path variant.'
     automated: assisted
 
@@ -904,11 +703,6 @@ test_cases:
       - clipboard
     feature: 'Context Menus — Editor Content'
     scenario: 'Editor content (with selection): RangeLink: Send Selected Text'
-    preconditions:
-      - 'Text selected in editor'
-      - 'Terminal bound'
-    steps:
-      - "Select 2-3 lines, right-click, select 'RangeLink: Send Selected Text'"
     expected_result: 'Terminal receives the raw selected text (not a link format). Success toast.'
     automated: assisted
 
@@ -917,11 +711,6 @@ test_cases:
       - clipboard
     feature: 'Context Menus — Editor Content'
     scenario: 'Visual separator is visible in editor content context menu'
-    preconditions:
-      - 'Text editor open'
-    steps:
-      - 'Right-click inside the editor (with or without selection)'
-      - 'Observe the context menu structure'
     expected_result: 'A visual separator line is visible between the RangeLink commands and the rest of the VS Code context menu items.'
     automated: assisted
 
@@ -930,12 +719,6 @@ test_cases:
       - clipboard
     feature: 'Context Menus — Editor Content'
     scenario: "Editor content: RangeLink: Send This File's Path (absolute)"
-    preconditions:
-      - 'A file is open in the editor'
-      - 'Terminal bound'
-    steps:
-      - 'Right-click inside the editor (no selection needed)'
-      - "Select 'RangeLink: Send This File's Path'"
     expected_result: 'Terminal receives the absolute path of the current file.'
     automated: assisted
 
@@ -944,12 +727,6 @@ test_cases:
       - clipboard
     feature: 'Context Menus — Editor Content'
     scenario: "Editor content: RangeLink: Send This File's Relative Path"
-    preconditions:
-      - 'A file is open in the editor'
-      - 'Terminal bound'
-    steps:
-      - 'Right-click inside the editor'
-      - "Select 'RangeLink: Send This File's Relative Path'"
     expected_result: 'Terminal receives the workspace-relative path of the current file.'
     automated: assisted
 
@@ -958,11 +735,6 @@ test_cases:
       - clipboard
     feature: 'Context Menus — Editor Content'
     scenario: 'Editor content: RangeLink: Bind Here'
-    preconditions:
-      - 'File open in editor'
-    steps:
-      - 'Right-click inside the editor'
-      - "Select 'RangeLink: Bind Here'"
     expected_result: 'The current file is bound as the text editor destination. Success toast appears.'
     automated: assisted
 
@@ -971,12 +743,6 @@ test_cases:
       - clipboard
     feature: 'Context Menus — Editor Content'
     scenario: 'Editor content: RangeLink: Unbind visible when bound and unbinds on click'
-    preconditions:
-      - 'A destination is bound'
-    steps:
-      - 'Right-click inside any editor'
-      - "Verify 'RangeLink: Unbind' is visible"
-      - "Select 'RangeLink: Unbind'"
     expected_result: "'RangeLink: Unbind' is visible in the editor context menu. Selecting it unbinds the destination and shows the unbind confirmation."
     automated: assisted
 
@@ -985,14 +751,6 @@ test_cases:
       - clipboard
     feature: 'Context Menus — Editor Content'
     scenario: 'Selection-dependent items hidden when no text is selected'
-    preconditions:
-      - 'Editor open'
-      - 'A destination is bound'
-      - 'No text selected (cursor only)'
-    steps:
-      - 'Click in the editor to place cursor (no selection)'
-      - 'Right-click inside the editor'
-      - 'Observe which RangeLink items are present'
     expected_result: "'Send RangeLink', 'Send RangeLink (Absolute)', 'Send Portable Link', 'Send Portable Link (Absolute)', and 'Send Selected Text' are NOT visible. File-path and Bind/Unbind items remain visible."
     automated: assisted
 
@@ -1001,11 +759,6 @@ test_cases:
       - clipboard
     feature: 'Context Menus — Terminal'
     scenario: 'Terminal tab: RangeLink: Bind Here binds that terminal'
-    preconditions:
-      - 'Terminal open'
-    steps:
-      - 'Right-click the terminal tab in the terminal panel tab bar'
-      - "Select 'RangeLink: Bind Here'"
     expected_result: 'That terminal is bound as the destination. Success toast appears.'
     automated: assisted
 
@@ -1014,11 +767,6 @@ test_cases:
       - clipboard
     feature: 'Context Menus — Terminal'
     scenario: 'Terminal content: RangeLink: Bind Here binds the terminal'
-    preconditions:
-      - 'Terminal open'
-    steps:
-      - 'Right-click inside the terminal output area'
-      - "Select 'RangeLink: Bind Here'"
     expected_result: 'Same result as context-menus-terminal-001 — the terminal is bound. Success toast.'
     automated: assisted
 
@@ -1027,11 +775,6 @@ test_cases:
       - clipboard
     feature: 'Context Menus — Terminal'
     scenario: 'Terminal content-area: RangeLink: Unbind is visible when bound and unbinds on click'
-    preconditions:
-      - 'A destination is currently bound'
-    steps:
-      - 'Right-click INSIDE the terminal content area (the tab menu does not render Unbind)'
-      - "Select 'RangeLink: Unbind'"
     expected_result: "'RangeLink: Unbind' is visible in the content-area menu and selecting it unbinds the destination. Confirmation notification."
     automated: assisted
 
@@ -1040,12 +783,6 @@ test_cases:
       - clipboard
     feature: 'Context Menus — Terminal'
     scenario: 'Terminal tab right-click binds THAT specific terminal (multi-terminal disambiguation)'
-    preconditions:
-      - 'Two or more terminals are open with distinct names'
-    steps:
-      - 'Identify a specific TARGET terminal'
-      - "Right-click the TARGET terminal's TAB in the terminal panel's tab bar"
-      - "Select 'RangeLink: Bind Here'"
     expected_result: 'The TARGET terminal is bound (status bar confirms the TARGET name, not the other terminal). No picker is shown.'
     automated: assisted
 
@@ -1054,12 +791,6 @@ test_cases:
       - clipboard
     feature: 'Context Menus — Terminal'
     scenario: 'Terminal content-area right-click binds THAT specific terminal (multi-terminal disambiguation)'
-    preconditions:
-      - 'Two or more terminals are open with distinct names'
-    steps:
-      - 'Focus a specific TARGET terminal'
-      - "Right-click INSIDE the TARGET terminal's content area"
-      - "Select 'RangeLink: Bind Here'"
     expected_result: 'The TARGET terminal is bound (status bar confirms the TARGET name, not the other terminal). No picker is shown.'
     automated: assisted
 
@@ -1070,40 +801,18 @@ test_cases:
   - id: dirty-buffer-warning-001
     feature: 'Dirty Buffer Warning'
     scenario: 'Generating a link from a file with unsaved changes shows the dirty buffer dialog'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = true (default)'
-      - 'Terminal bound'
-    steps:
-      - 'Open a file, make a small edit without saving (add a space)'
-      - 'Select 2-3 lines'
-      - 'Press Cmd+R Cmd+L'
     expected_result: 'A warning dialog appears before the RangeLink is generated. Dialog references unsaved changes.'
     automated: assisted
 
   - id: dirty-buffer-warning-002
     feature: 'Dirty Buffer Warning'
     scenario: 'Dialog shows three options: Save & Generate, Generate Anyway, and dismiss'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = true'
-      - 'Terminal bound'
-      - 'File has unsaved changes'
-    steps:
-      - 'Make unsaved change to a file'
-      - 'Select 2-3 lines, press Cmd+R Cmd+L'
-      - 'Observe the dialog options'
     expected_result: 'Three choices visible: Save & Generate, Generate Anyway, and dismiss/cancel.'
     automated: assisted
 
   - id: dirty-buffer-warning-003
     feature: 'Dirty Buffer Warning'
     scenario: 'Save & Generate: saves the file then generates the link'
-    preconditions:
-      - 'Terminal bound, file has unsaved change'
-    steps:
-      - 'Make unsaved change'
-      - 'Select 2-3 lines, press Cmd+R Cmd+L'
-      - 'Click Save & Generate'
-      - 'Observe file state and terminal'
     expected_result: 'File saved (modified indicator gone). RangeLink generated and sent to terminal. Success toast shown.'
     automated: assisted
 
@@ -1116,12 +825,6 @@ test_cases:
   - id: dirty-buffer-warning-005
     feature: 'Dirty Buffer Warning'
     scenario: 'Dismissing the dialog aborts link generation'
-    preconditions:
-      - 'Terminal bound, file has unsaved change'
-    steps:
-      - 'Make unsaved change'
-      - 'Select 2-3 lines, press Cmd+R Cmd+L'
-      - 'Press Escape or click X to dismiss'
     expected_result: 'No RangeLink generated. Terminal unchanged. File still dirty.'
     automated: assisted
 
@@ -1140,152 +843,66 @@ test_cases:
   - id: dirty-buffer-warning-008
     feature: 'Dirty Buffer Warning — R-F'
     scenario: 'warnOnDirtyBuffer=false — R-F bypasses dialog'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = false'
-      - 'File has unsaved changes'
-      - 'A terminal exists for the destination picker'
-    steps:
-      - 'Set warnOnDirtyBuffer to false'
-      - 'Make unsaved change to a file'
-      - 'Press Cmd+R Cmd+F — confirm dirty buffer dialog does NOT appear'
-      - 'When destination picker appears, select the terminal'
     expected_result: 'No dialog appears. File path copied to clipboard. "Disabled by setting" log emitted. No dialog log.'
     automated: assisted
 
   - id: dirty-buffer-warning-009
     feature: 'Dirty Buffer Warning — R-F'
     scenario: 'R-F on clean file skips warning logic entirely'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = true (default)'
-      - 'File is saved (no unsaved changes)'
-      - 'A terminal exists for the destination picker'
-    steps:
-      - 'Save file to ensure clean state'
-      - 'Press Cmd+R Cmd+F — confirm dirty buffer dialog does NOT appear'
-      - 'When destination picker appears, select the terminal'
     expected_result: 'No dialog appears. File path copied to clipboard. No handleDirtyBufferWarning logs emitted (Clean early-return).'
     automated: assisted
 
   - id: dirty-buffer-warning-010
     feature: 'Dirty Buffer Warning — R-C Dialog'
     scenario: 'R-C Save & Generate saves file and generates link'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = true (default)'
-      - 'File has unsaved changes, text selected'
-    steps:
-      - 'Make unsaved change, select text'
-      - 'Press Cmd+R Cmd+C (Copy RangeLink) — dialog appears'
-      - 'Click Save & Generate'
     expected_result: 'File saved (modified indicator gone). RangeLink on clipboard with #L reference.'
     automated: assisted
 
   - id: dirty-buffer-warning-011
     feature: 'Dirty Buffer Warning — R-C Dialog'
     scenario: 'R-C Generate Anyway sends link without saving'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = true (default)'
-      - 'File has unsaved changes, text selected'
-    steps:
-      - 'Make unsaved change, select text'
-      - 'Press Cmd+R Cmd+C (Copy RangeLink) — dialog appears'
-      - 'Click Generate Anyway'
     expected_result: 'File still dirty. RangeLink on clipboard with #L reference.'
     automated: assisted
 
   - id: dirty-buffer-warning-012
     feature: 'Dirty Buffer Warning — R-C Dialog'
     scenario: 'R-C dismiss aborts link generation'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = true (default)'
-      - 'File has unsaved changes, text selected'
-    steps:
-      - 'Make unsaved change, select text'
-      - 'Press Cmd+R Cmd+C (Copy RangeLink) — dialog appears'
-      - 'Press Escape or click X to dismiss'
     expected_result: 'Clipboard unchanged. File still dirty. No link generated.'
     automated: assisted
 
   - id: dirty-buffer-warning-013
     feature: 'Dirty Buffer Warning — R-F Dialog'
     scenario: 'R-F Save & Send saves file and sends path'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = true (default)'
-      - 'File has unsaved changes'
-    steps:
-      - 'Make unsaved change'
-      - 'Press Cmd+R Cmd+F — dialog appears'
-      - 'Click Save & Send'
-      - 'Destination picker appears — select any terminal'
     expected_result: 'File saved (modified indicator gone). File path on clipboard.'
     automated: assisted
 
   - id: dirty-buffer-warning-014
     feature: 'Dirty Buffer Warning — R-F Dialog'
     scenario: 'R-F Send Anyway sends path without saving'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = true (default)'
-      - 'File has unsaved changes'
-    steps:
-      - 'Make unsaved change'
-      - 'Press Cmd+R Cmd+F — dialog appears'
-      - 'Click Send Anyway'
-      - 'Destination picker appears — select any terminal'
     expected_result: 'File still dirty. File path on clipboard.'
     automated: assisted
 
   - id: dirty-buffer-warning-015
     feature: 'Dirty Buffer Warning — R-F Dialog'
     scenario: 'R-F dismiss aborts file path send'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = true (default)'
-      - 'File has unsaved changes'
-    steps:
-      - 'Make unsaved change'
-      - 'Press Cmd+R Cmd+F — dialog appears'
-      - 'Press Escape or click X to dismiss'
     expected_result: 'Clipboard unchanged. File still dirty. No path sent.'
     automated: assisted
 
   - id: dirty-buffer-warning-016
     feature: 'Dirty Buffer Warning — Clipboard Preservation'
     scenario: 'R-L clipboard preserved after dirty buffer dialog with bound terminal destination'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = true (default)'
-      - 'rangelink.clipboard.preserve = always (default)'
-      - 'A terminal is bound as destination (bound programmatically by the test harness)'
-      - 'File has unsaved changes, text selected'
-    steps:
-      - 'Make unsaved change, write sentinel to clipboard'
-      - 'Press Cmd+R Cmd+L — dialog appears'
-      - 'Click Generate Anyway'
     expected_result: 'Link sent to terminal. Clipboard restored to sentinel (not overwritten by the link).'
     automated: assisted
 
   - id: dirty-buffer-warning-017
     feature: 'Dirty Buffer Warning — Clipboard Preservation'
     scenario: 'R-F clipboard preserved after dirty buffer dialog with bound terminal destination'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = true (default)'
-      - 'rangelink.clipboard.preserve = always (default)'
-      - 'A terminal is bound as destination (bound programmatically by the test harness)'
-      - 'File has unsaved changes'
-    steps:
-      - 'Make unsaved change, write sentinel to clipboard'
-      - 'Press Cmd+R Cmd+F — dialog appears'
-      - 'Click Send Anyway'
     expected_result: 'File path sent to terminal. Clipboard restored to sentinel (not overwritten by the path).'
     automated: assisted
 
   - id: dirty-buffer-warning-018
     feature: 'Dirty Buffer Warning — Setting disabled'
     scenario: 'R-L with warnOnDirtyBuffer=false sends link to bound destination without warning dialog'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = false'
-      - 'A terminal is bound as destination (bound programmatically by the test harness)'
-      - 'File has unsaved changes, text selected'
-    steps:
-      - 'Make unsaved change, select text, write sentinel to clipboard'
-      - 'Press Cmd+R Cmd+L (Send RangeLink) — confirm NO dialog appears'
     expected_result: 'No dialog. Link sent to terminal (Pasted log). Clipboard restored to sentinel. File still dirty (setting disabled should not trigger a save). handleDirtyBufferWarning logs "disabled by setting".'
     automated: assisted
 
@@ -1298,42 +915,18 @@ test_cases:
   - id: dirty-buffer-warning-020
     feature: 'Dirty Buffer Warning — R-L Dialog'
     scenario: 'R-L Save & Generate saves file and sends link to bound destination'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = true (default)'
-      - 'A terminal is bound as destination (bound programmatically by the test harness)'
-      - 'File has unsaved changes, text selected'
-    steps:
-      - 'Make unsaved change, select text, write sentinel to clipboard'
-      - 'Press Cmd+R Cmd+L (Send RangeLink) — dialog appears'
-      - 'Click Save & Generate'
     expected_result: 'File saved (modified indicator gone). Link sent to terminal (Pasted log). Clipboard restored to sentinel. handleDirtyBufferWarning logs "showing warning".'
     automated: assisted
 
   - id: dirty-buffer-warning-021
     feature: 'Dirty Buffer Warning — R-L Dialog'
     scenario: 'R-L Generate Anyway sends link to bound destination without saving'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = true (default)'
-      - 'A terminal is bound as destination (bound programmatically by the test harness)'
-      - 'File has unsaved changes, text selected'
-    steps:
-      - 'Make unsaved change, select text, write sentinel to clipboard'
-      - 'Press Cmd+R Cmd+L (Send RangeLink) — dialog appears'
-      - 'Click Generate Anyway'
     expected_result: 'File still dirty. Link sent to terminal (Pasted log). Clipboard restored to sentinel. handleDirtyBufferWarning logs "showing warning".'
     automated: assisted
 
   - id: dirty-buffer-warning-022
     feature: 'Dirty Buffer Warning — R-L Dialog'
     scenario: 'R-L dismiss aborts link send'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = true (default)'
-      - 'A terminal is bound as destination (bound programmatically by the test harness)'
-      - 'File has unsaved changes, text selected'
-    steps:
-      - 'Make unsaved change, select text, write sentinel to clipboard'
-      - 'Press Cmd+R Cmd+L (Send RangeLink) — dialog appears'
-      - 'Press Escape or click X to dismiss'
     expected_result: 'Clipboard still has sentinel (no send occurred). File still dirty. No Pasted log. handleDirtyBufferWarning logs "showing warning".'
     automated: assisted
 
@@ -1365,14 +958,6 @@ test_cases:
       - clipboard
     feature: 'R-V Send Terminal Selection'
     scenario: 'Cmd+R Cmd+V with terminal focused and text selected sends to bound destination'
-    preconditions:
-      - 'Terminal open with visible output'
-      - 'Another terminal or editor bound as destination'
-    steps:
-      - 'Click in terminal to focus it'
-      - 'Drag to select a line of output'
-      - 'Press Cmd+R Cmd+V'
-      - 'Observe bound destination'
     expected_result: 'Bound destination receives selected terminal text. Success toast appears.'
     automated: assisted
 
@@ -1406,13 +991,6 @@ test_cases:
       - clipboard
     feature: 'R-V Send Terminal Selection'
     scenario: 'R-V with no bound destination (picker or clipboard fallback behavior)'
-    preconditions:
-      - 'No destination bound'
-      - 'Terminal focused, text selected'
-    steps:
-      - 'Unbind any destination'
-      - 'Select text in terminal'
-      - 'Press Cmd+R Cmd+V'
     expected_result: 'Destination picker opens. On selection: text sent to new destination. On Escape: nothing sent.'
     automated: assisted
 
@@ -1421,12 +999,6 @@ test_cases:
       - clipboard
     feature: 'R-V Send Terminal Selection'
     scenario: 'Terminal content-area context menu Send Selection to Destination when text selected and bound'
-    preconditions:
-      - 'Terminal focused, text selected in terminal, destination bound'
-    steps:
-      - 'Select text in terminal'
-      - 'Right-click INSIDE the terminal content area (not the tab)'
-      - 'Click RangeLink: Send Selection to Destination'
     expected_result: 'Selected text sent to bound destination. Same behavior as R-V keybinding.'
     automated: assisted
 
@@ -1451,13 +1023,6 @@ test_cases:
       - clipboard
     feature: 'R-V Send Terminal Selection'
     scenario: 'Cross-terminal: content-area "Send Selection" routes selection from source terminal to bound terminal and shifts focus'
-    preconditions:
-      - 'Two terminals exist (SOURCE and BOUND)'
-      - 'BOUND terminal is bound as destination'
-      - 'Text is selected in SOURCE terminal'
-    steps:
-      - 'Right-click INSIDE the SOURCE terminal content area'
-      - "Select 'RangeLink: Send Selection to Destination'"
     expected_result: 'Selected text is pasted into the BOUND terminal, and focus shifts to BOUND. Status bar confirms "sent to Terminal (BOUND)".'
     automated: assisted
 
@@ -1466,11 +1031,6 @@ test_cases:
       - clipboard
     feature: 'R-V Send Terminal Selection'
     scenario: 'Terminal TAB context menu does NOT include "Send Selection to Destination"'
-    preconditions:
-      - 'Terminal bound, text selected in terminal'
-    steps:
-      - 'Right-click the terminal TAB (not the content area)'
-      - 'Observe the context menu'
     expected_result: '"RangeLink: Send Selection to Destination" is NOT present in the tab menu (the command is only registered for the content-area menu).'
     automated: assisted
 
@@ -1479,12 +1039,6 @@ test_cases:
       - clipboard
     feature: 'R-V Send Terminal Selection'
     scenario: 'Self-paste: bound terminal sends its own selection to itself (no self-paste guard)'
-    preconditions:
-      - 'A terminal is bound as destination'
-      - 'Text is selected in THAT SAME terminal'
-    steps:
-      - 'Right-click INSIDE the bound terminal content area'
-      - "Select 'RangeLink: Send Selection to Destination'"
     expected_result: 'Selected text is pasted back into the same terminal (documents current behavior; a terminal-specific self-paste guard is a potential future improvement).'
     automated: assisted
 
@@ -1493,13 +1047,6 @@ test_cases:
       - clipboard
     feature: 'R-V Send Terminal Selection'
     scenario: 'Unbound: "Send Selection to Destination" is visible; clicking opens destination picker and delivers to picked destination'
-    preconditions:
-      - 'No destination is bound'
-      - 'Two terminals exist — SOURCE (with selected text) and DEST (empty)'
-    steps:
-      - 'Right-click INSIDE the SOURCE terminal content area'
-      - "Select 'RangeLink: Send Selection to Destination'"
-      - 'Pick the DEST terminal from the destination picker that opens'
     expected_result: 'The item is visible (parity with editor family — no isBound gate). The destination picker opens, and after picking DEST, the selection is delivered to DEST and DEST becomes the bound destination.'
     automated: assisted
 
@@ -1508,12 +1055,6 @@ test_cases:
       - clipboard
     feature: 'R-V Send Terminal Selection'
     scenario: '"Send Selection to Destination" is hidden when no terminal text is selected'
-    preconditions:
-      - 'A destination is bound'
-      - 'No text is selected in the terminal'
-    steps:
-      - 'Right-click INSIDE the terminal content area without selecting anything'
-      - 'Observe the context menu'
     expected_result: '"RangeLink: Send Selection to Destination" is NOT present (`when` clause requires `terminalTextSelected`).'
     automated: assisted
 
@@ -1522,12 +1063,6 @@ test_cases:
       - clipboard
     feature: 'R-V Send Terminal Selection'
     scenario: 'Terminal content-area "Send Selection" delivers selected text to a bound AI-assistant destination'
-    preconditions:
-      - 'Dummy AI (Tier 1) is bound as destination (via R-D)'
-      - 'Text is selected in a terminal'
-    steps:
-      - 'Right-click INSIDE the terminal content area'
-      - "Select 'RangeLink: Send Selection to Destination'"
     expected_result: 'The selected text is delivered to the Dummy AI extension via Tier 1 direct insert; the dummy textarea contains the selection.'
     automated: assisted
 
@@ -1548,72 +1083,42 @@ test_cases:
   - id: go-to-link-003
     feature: 'R-G Go to Link'
     scenario: 'Valid RangeLink in input box navigates to the file and selects the range'
-    preconditions:
-      - 'A file with 10+ lines exists in the workspace (e.g., src/utils/helper.ts)'
-    steps:
-      - 'Press Cmd+R Cmd+G'
-      - 'Type or paste: src/utils/helper.ts#L3-L7'
-      - 'Press Enter'
     expected_result: 'VS Code opens src/utils/helper.ts and selects lines 3-7. The selection is visible and highlighted.'
     automated: assisted
 
   - id: go-to-link-004
     feature: 'R-G Go to Link'
     scenario: 'Supports range format: path/to/file.ts#L3C14-L15C9'
-    preconditions:
-      - 'src/utils/helper.ts exists'
-    steps:
-      - 'Press Cmd+R Cmd+G'
-      - 'Type: src/utils/helper.ts#L3C5-L3C20'
-      - 'Press Enter'
     expected_result: 'The file opens and the selection spans from column 5 to column 20 on line 3 (character-level precision).'
     automated: assisted
 
   - id: go-to-link-005
     feature: 'R-G Go to Link'
     scenario: 'Invalid link format shows error message'
-    steps:
-      - 'Press Cmd+R Cmd+G'
-      - 'Type: not-a-valid-link-format'
-      - 'Press Enter'
     expected_result: "An error notification appears (e.g., 'Invalid RangeLink format'). No navigation occurs."
     automated: assisted
 
   - id: go-to-link-006
     feature: 'R-G Go to Link'
     scenario: 'Empty input dismisses with error notification'
-    steps:
-      - 'Press Cmd+R Cmd+G'
-      - 'Clear the input (leave it empty)'
-      - 'Press Enter'
     expected_result: "The input box closes. An error notification appears (e.g., 'Please enter a link to navigate'). No navigation occurs."
     automated: assisted
 
   - id: go-to-link-007
     feature: 'R-G Go to Link'
     scenario: 'File not found shows warning message'
-    steps:
-      - 'Press Cmd+R Cmd+G'
-      - 'Type: src/nonexistent/file.ts#L1'
-      - 'Press Enter'
     expected_result: "A warning notification appears (e.g., 'File not found: src/nonexistent/file.ts'). No navigation occurs."
     automated: assisted
 
   - id: go-to-link-008
     feature: 'R-G Go to Link'
     scenario: 'RangeLink: Go to Link available in Command Palette'
-    steps:
-      - 'Open Command Palette (Cmd+Shift+P / Ctrl+Shift+P)'
-      - "Type 'Go to Link' and select 'RangeLink: Go to Link'"
     expected_result: 'Same input box opens as the R-G keybinding.'
     automated: assisted
 
   - id: go-to-link-009
     feature: 'R-G Go to Link'
     scenario: 'Go to Link item in R-M menu opens the same input box'
-    steps:
-      - 'Open R-M menu'
-      - "Select 'Go to Link'"
     expected_result: 'The R-G input box opens. Behavior is identical to the keybinding.'
     automated: assisted
 
@@ -1656,22 +1161,12 @@ test_cases:
   - id: unbind-005
     feature: 'R-U Unbind'
     scenario: 'RangeLink: Unbind Destination is hidden in the Command Palette when no destination is bound'
-    preconditions:
-      - 'No destination is currently bound'
-    steps:
-      - 'Open Command Palette (Cmd+Shift+P / Ctrl+Shift+P)'
-      - "Type 'RangeLink: Unbind'"
     expected_result: "'RangeLink: Unbind' is NOT visible in the command palette. The when: rangelink.isBound clause hides it when no destination is bound."
     automated: assisted
 
   - id: unbind-006
     feature: 'R-U Unbind'
     scenario: 'RangeLink: Unbind Destination is visible in the Command Palette when a destination is bound'
-    preconditions:
-      - 'A destination is currently bound'
-    steps:
-      - 'Open Command Palette (Cmd+Shift+P / Ctrl+Shift+P)'
-      - "Type 'RangeLink: Unbind'"
     expected_result: "'RangeLink: Unbind' IS visible in the command palette and can be selected. The when: rangelink.isBound clause shows it when a destination is bound."
     automated: assisted
 
@@ -1682,38 +1177,18 @@ test_cases:
   - id: editor-binding-validation-001
     feature: 'Editor Binding Validation'
     scenario: 'Search editor content area hides link-generation and bind commands'
-    preconditions:
-      - 'No destination is bound'
-    steps:
-      - 'Press Cmd+Shift+P → run "Open New Search Editor"'
-      - 'Right-click in the EDITOR CONTENT AREA (not the tab at the top)'
-      - 'Inspect the context menu for RangeLink link and bind items'
     expected_result: '"Send RangeLink", "Send This File''s Path", and "RangeLink: Bind Here" do NOT appear. "Send Selected Text" and "Unbind" are acceptable if present. The when-clauses restrict link-generation commands to resourceScheme == file || resourceScheme == untitled; the bind command carries the same restriction.'
     automated: assisted
 
   - id: editor-binding-validation-002
     feature: 'Editor Binding Validation'
     scenario: 'Output panel hides file path and bind commands in its context menu'
-    preconditions:
-      - 'No destination is bound'
-    steps:
-      - 'Press Cmd+Shift+U (or View → Output) to open the Output panel'
-      - 'Click inside the Output panel to focus it'
-      - 'Right-click anywhere in the Output panel'
-      - 'Inspect the context menu for RangeLink file path and bind items'
     expected_result: 'No "Send This File''s Path" or "RangeLink: Bind Here" appears. "Unbind" is acceptable. The when-clauses restrict editorContent.pasteFilePath and editorContent.bind to resourceScheme == file || resourceScheme == untitled.'
     automated: assisted
 
   - id: editor-binding-validation-003
     feature: 'Editor Binding Validation'
     scenario: 'Settings UI hides file path and bind commands in both content and tab menus'
-    preconditions:
-      - 'No destination is bound'
-    steps:
-      - 'Press Cmd+, to open the Settings UI'
-      - 'Right-click anywhere in the Settings editor content area'
-      - 'Right-click the Settings TAB at the top of the editor area'
-      - 'Press Cmd+R Cmd+D and scan the destination picker; press Escape to dismiss'
     expected_result: 'No "RangeLink: Bind Here" in the content menu. No "Send File Path" or "Send Relative File Path" in the tab menu. Settings UI does not appear as a bindable destination in the R-D picker.'
     automated: assisted
 
@@ -1726,12 +1201,6 @@ test_cases:
   - id: editor-binding-validation-005
     feature: 'Editor Binding Validation'
     scenario: 'Search editor TAB hides file path commands in the tab context menu'
-    preconditions:
-      - 'No destination is bound'
-    steps:
-      - 'Press Cmd+Shift+P → run "Open New Search Editor"'
-      - 'Right-click the search editor TAB at the top of the editor area (not the content)'
-      - 'Inspect the context menu for RangeLink file path items'
     expected_result: 'No "Send File Path" or "Send Relative File Path" appears. "Unbind" is acceptable. The when-clause on editorTab.pasteFilePath and editorTab.pasteRelativeFilePath restricts them to resourceScheme == file || resourceScheme == untitled.'
     automated: assisted
 
@@ -1808,11 +1277,6 @@ test_cases:
   - id: url-exclusion-002
     feature: 'Link Navigation — URL Exclusion'
     scenario: 'https://example.com/path/file.ts#L10 in a document is NOT captured as a RangeLink'
-    preconditions:
-      - 'A Markdown or text file open in the editor'
-    steps:
-      - 'Add the text: https://example.com/path/file.ts#L10'
-      - 'Hover over it to inspect the link tooltip (if any)'
     expected_result: 'RangeLink does not provide a document link for this text. No RangeLink navigation offered.'
     automated: assisted
 
@@ -1827,39 +1291,20 @@ test_cases:
       - clipboard
     feature: 'Text Editor Destination — Hidden Tab Paste'
     scenario: 'Bound editor hidden behind other tabs — R-L paste succeeds and brings the tab to foreground'
-    preconditions:
-      - 'Bound text editor is not the frontmost tab in its group'
-      - 'Source file open in same column with text selected'
-    steps:
-      - 'With bound editor hidden behind source file in same column, press Cmd+R Cmd+L'
-      - 'Observe that the bound editor is brought to the foreground'
-      - 'Confirm RangeLink appears in bound editor at cursor position'
     expected_result: 'Bound editor is surfaced automatically and receives the RangeLink. No error about hidden or inactive tab.'
-    automated: assisted
+    automated: true
 
   - id: hidden-tab-paste-002
     labels:
       - clipboard
     feature: 'Text Editor Destination — Hidden Tab Paste'
     scenario: 'Bound editor hidden behind other tabs — R-V paste succeeds and brings the tab to foreground'
-    preconditions:
-      - 'Bound text editor is not the frontmost tab in its group'
-      - 'Source file open in same column with text selected'
-    steps:
-      - 'With bound editor hidden behind source file in same column, press Cmd+R Cmd+V'
-      - 'Observe that the bound editor is brought to the foreground'
-      - 'Confirm selected text appears in bound editor at cursor position'
     expected_result: 'Bound editor is surfaced automatically and receives the selected text. No error about hidden or inactive tab.'
-    automated: assisted
+    automated: true
 
   - id: document-link-tooltip-001
     feature: 'Clickable Links — Document Link Tooltip'
     scenario: 'Hovering over a clickable document link shows clean tooltip (not raw JSON or command URI)'
-    preconditions:
-      - 'A Markdown file with a RangeLink document link: [See code](src/utils/helper.ts#L5)'
-    steps:
-      - 'Hover over the link in the editor'
-      - 'Observe the tooltip that appears'
     expected_result: 'The tooltip shows clean human-readable text (e.g., file path and line number). It does NOT show raw JSON, a command: URI, or internal command parameters.'
     automated: assisted
 
@@ -1894,13 +1339,6 @@ test_cases:
       - clipboard
     feature: 'Core Send Commands — R-L'
     scenario: 'R-L sends RangeLink to bound AI assistant destination'
-    preconditions:
-      - 'Claude Code or GitHub Copilot Chat extension installed, active, and bound'
-      - 'AI chat panel open'
-    steps:
-      - 'Select 3-5 lines of code in any file'
-      - 'Press Cmd+R Cmd+L'
-      - 'Observe AI chat input area'
     expected_result: 'RangeLink appears in AI chat input. Success toast confirms send.'
     automated: assisted
 
@@ -1961,13 +1399,6 @@ test_cases:
       - clipboard
     feature: 'Text Editor Destination'
     scenario: 'Self-paste: R-L to the same file that is bound as destination copies link to clipboard and shows info message'
-    preconditions:
-      - 'A file is open in the editor'
-      - 'That same file is bound as the text editor destination'
-    steps:
-      - 'With the bound file focused, select 2-3 lines'
-      - 'Press Cmd+R Cmd+L'
-      - 'Observe notifications and file content'
     expected_result: 'Info notification appears: "RangeLink copied to clipboard. Cannot auto-paste to same file. Tip: Use R-C for clipboard-only links." File is not modified. Clipboard contains the RangeLink.'
     automated: assisted
 
@@ -2105,13 +1536,6 @@ test_cases:
       - requires-extensions
     feature: 'Smart Padding — Single-Write Architecture'
     scenario: 'pasteLink=both: RangeLink sent to AI assistant has leading and trailing space'
-    preconditions:
-      - 'smartPadding.pasteLink set to "both"'
-      - 'Claude Code or another AI assistant is bound as destination'
-    steps:
-      - 'Select lines 1-2 in a test file'
-      - 'Press R-L to generate and send a RangeLink to the AI assistant'
-      - 'Click PASS if the chat input shows the link with leading and trailing spaces, FAIL otherwise'
     expected_result: 'The AI assistant chat input contains the RangeLink with leading and trailing spaces applied by applySmartPadding.'
     automated: assisted
 
@@ -2120,13 +1544,6 @@ test_cases:
       - clipboard
     feature: 'Smart Padding — Single-Write Architecture'
     scenario: 'pasteContent=both: terminal selection sent to editor has padding applied'
-    preconditions:
-      - 'smartPadding.pasteContent set to "both"'
-      - 'A text editor is bound as destination'
-    steps:
-      - 'In a terminal, select some text using the mouse and press R-C to copy'
-      - 'Press R-V to send the terminal selection to the bound editor'
-      - 'Click PASS if the editor receives padded content, FAIL otherwise'
     expected_result: 'The editor receives the terminal selection with leading and trailing spaces applied by applySmartPadding.'
     automated: assisted
 
@@ -2380,13 +1797,6 @@ test_cases:
       - clipboard
     feature: 'Custom AI Assistants — Tier 1 Paste Flow'
     scenario: 'Tier 1 direct insert delivers text to dummy extension textarea'
-    preconditions:
-      - 'Dummy AI extension loaded'
-      - 'File open in editor with text selected'
-    steps:
-      - 'Bind to Dummy AI (Tier 1) via R-D picker'
-      - 'Execute R-L (Send RangeLink)'
-      - 'Check dummy extension textarea via dummyAi.getText'
     expected_result: 'tier1 textarea contains the generated link; tier2 textarea is empty'
     automated: assisted
 
@@ -2395,13 +1805,6 @@ test_cases:
       - clipboard
     feature: 'Custom AI Assistants — Tier 1 Clipboard'
     scenario: 'Tier 1 paste preserves clipboard (sentinel restored after R-L)'
-    preconditions:
-      - 'Bound to Dummy AI (Tier 1)'
-      - 'Clipboard sentinel written before R-L'
-    steps:
-      - 'Write clipboard sentinel'
-      - 'Execute R-L'
-      - 'Read clipboard after settle'
     expected_result: 'Clipboard contains the sentinel (outer preserve restores it; DirectInsertFactory never touches clipboard)'
     automated: assisted
 
@@ -2410,13 +1813,6 @@ test_cases:
       - clipboard
     feature: 'Custom AI Assistants — Tier 3 Toast'
     scenario: 'Tier 3 focusCommands shows manual-paste toast after R-L'
-    preconditions:
-      - 'Dummy AI extension loaded'
-      - 'File open in editor with text selected'
-    steps:
-      - 'Bind to Dummy AI (Tier 3) via R-D picker'
-      - 'Execute R-L'
-      - 'Check logs for toast and ManualPasteInsertFactory'
     expected_result: 'Info toast "Paste (Cmd/Ctrl+V) in Dummy AI (Tier 3) to use." logged; ManualPasteInsertFactory success logged'
     automated: assisted
 
@@ -2425,13 +1821,6 @@ test_cases:
       - clipboard
     feature: 'Custom AI Assistants — Tier 2→3 Fallback'
     scenario: 'Tier 2 focusAndPasteCommands not registered — falls through to Tier 3'
-    preconditions:
-      - 'Dummy AI extension loaded'
-      - 'Settings entry with non-existent focusAndPasteCommands + valid focusCommands'
-    steps:
-      - 'Bind to Dummy AI (Fallback) via R-D picker'
-      - 'Execute R-L'
-      - 'Check logs for tier skip and resolution'
     expected_result: 'Tier 2 skip log (nonexistent.paste not registered), Tier 3 resolution log (dummyAi.focusPanel), manual-paste toast shown'
     automated: assisted
 
@@ -2440,13 +1829,6 @@ test_cases:
       - clipboard
     feature: 'Custom AI Assistants — ${content} Template'
     scenario: 'insertCommands with ${content} template interpolation delivers text via insertWithArgs'
-    preconditions:
-      - 'Dummy AI extension loaded with dummyAi.insertWithArgs command'
-      - 'Settings entry uses { command, args } object with ${content} placeholder'
-    steps:
-      - 'Bind to Dummy AI (Template) via R-D picker'
-      - 'Execute R-L'
-      - 'Check dummy extension textarea via dummyAi.getText'
     expected_result: 'tier1 textarea contains the generated link; DirectInsertFactory success log mentions dummyAi.insertWithArgs'
     automated: assisted
 
@@ -2471,13 +1853,6 @@ test_cases:
       - clipboard
     feature: 'Custom AI Assistants — Cold Start'
     scenario: 'Tier 1 direct insert works when the AI extension panel is not yet visible'
-    preconditions:
-      - 'Dummy AI extension loaded but sidebar panel NOT pre-opened'
-      - 'Settings entry with insertCommands pointing to dummyAi.insertText'
-    steps:
-      - 'Bind to Dummy AI (Tier 1) via R-D picker'
-      - 'Execute R-L'
-      - 'Check dummy extension textarea via dummyAi.getText'
     expected_result: 'Panel auto-initializes on first insert; tier1 textarea contains the generated link; tier2 is empty'
     automated: assisted
 
@@ -2500,14 +1875,6 @@ test_cases:
       - requires-extensions
     feature: 'Built-in AI Assistants'
     scenario: 'Binding to Claude Code Chat and sending a link delivers content to chat'
-    preconditions:
-      - 'Claude Code extension (anthropic.claude-code) is installed and active'
-      - 'A file is open in the editor with a selection'
-    steps:
-      - 'Run Command Palette → "RangeLink: Bind to Claude Code" (or select from R-D picker)'
-      - 'Confirm "✓ RangeLink bound to Claude Code Chat" status bar message appears'
-      - 'Select a range of code and press Cmd+R Cmd+L (Mac) / Ctrl+R Ctrl+L (Win/Linux)'
-      - 'Confirm Claude Code chat panel opens and receives the RangeLink payload'
     expected_result: 'Claude Code chat opens and receives the RangeLink payload for the selected range'
     command_to_run: 'pnpm test:release:with-extensions --grep "claude-code-002"'
     automated: assisted
@@ -2568,14 +1935,6 @@ test_cases:
       - requires-extensions
     feature: 'Built-in AI Assistants'
     scenario: 'Cold panel paste verification — content arrives in Claude Code chat input after a single R-L since bind'
-    preconditions:
-      - 'Claude Code extension (anthropic.claude-code) is installed and active'
-      - 'RangeLink is bound to Claude Code Chat'
-      - 'No send has been performed since binding (cold start)'
-    steps:
-      - 'Select a range of code and press Cmd+R Cmd+L (Mac) / Ctrl+R Ctrl+L (Win/Linux)'
-      - 'Confirm the Claude Code chat panel receives the link and selected code'
-      - 'Confirm logs show the single paste command (editor.action.clipboardPasteAction) succeeded'
     expected_result: 'Content arrives in Claude Code chat input. Logs show paste command succeeded with a post-paste delay. Single clipboard write architecture: no double-write.'
     command_to_run: 'pnpm test:release:with-extensions --grep "claude-code-004"'
     automated: assisted
@@ -2586,14 +1945,6 @@ test_cases:
       - requires-extensions
     feature: 'Built-in AI Assistants'
     scenario: 'Warm panel paste verification — content arrives in Claude Code chat input on second R-L without cold-start refocus signals'
-    preconditions:
-      - 'Claude Code extension (anthropic.claude-code) is installed and active'
-      - 'RangeLink is bound to Claude Code Chat'
-      - 'At least one send has been performed since binding (warm path)'
-    steps:
-      - 'Select a different range of code and press Cmd+R Cmd+L (Mac) / Ctrl+R Ctrl+L (Win/Linux)'
-      - 'Confirm the Claude Code chat panel receives the link and selected code'
-      - 'Confirm logs show NO cold-start refocus signals in the warm send'
     expected_result: 'Content arrives in Claude Code chat input. Logs show no cold-start refocus signals. Paste command succeeds with minimal delay.'
     command_to_run: 'pnpm test:release:with-extensions --grep "claude-code-005"'
     automated: assisted
@@ -2698,14 +2049,6 @@ test_cases:
       - requires-extensions
     feature: 'Built-in AI Assistants'
     scenario: 'Binding to Gemini Code Assist and sending a link delivers content to chat'
-    preconditions:
-      - 'Google Gemini Code Assist extension (google.geminicodeassist) is installed and active'
-      - 'A file is open in the editor with a selection'
-    steps:
-      - 'Run Command Palette → "RangeLink: Bind to Gemini Code Assist" (or select from R-D picker)'
-      - 'Confirm "✓ RangeLink bound to Gemini Code Assist" status bar message appears'
-      - 'Select a range of code and press Cmd+R Cmd+L (Mac) / Ctrl+R Ctrl+L (Win/Linux)'
-      - 'Confirm Gemini Code Assist chat panel opens and receives the link + selected text'
     expected_result: 'Gemini Code Assist chat opens and contains the RangeLink and selected code snippet'
     command_to_run: 'pnpm test:release:with-extensions --grep "gemini-code-assist-002"'
     automated: assisted
@@ -2716,14 +2059,6 @@ test_cases:
       - requires-extensions
     feature: 'Built-in AI Assistants'
     scenario: 'Cold panel paste verification — content arrives in Gemini Code Assist chat input after a single R-L since bind'
-    preconditions:
-      - 'Google Gemini Code Assist extension (google.geminicodeassist) is installed and active'
-      - 'RangeLink is bound to Gemini Code Assist'
-      - 'No send has been performed since binding (cold start)'
-    steps:
-      - 'Select a range of code and press Cmd+R Cmd+L (Mac) / Ctrl+R Ctrl+L (Win/Linux)'
-      - 'Confirm the Gemini Code Assist chat panel receives the link and selected code'
-      - 'Confirm logs show paste command succeeded'
     expected_result: 'Content arrives in Gemini Code Assist chat input. Logs show paste command succeeded.'
     command_to_run: 'pnpm test:release:with-extensions --grep "gemini-code-assist-003"'
     automated: assisted
@@ -2734,14 +2069,6 @@ test_cases:
       - requires-extensions
     feature: 'Built-in AI Assistants'
     scenario: 'Warm panel paste verification — content arrives in Gemini Code Assist chat input on second R-L without cold-start refocus signals'
-    preconditions:
-      - 'Google Gemini Code Assist extension (google.geminicodeassist) is installed and active'
-      - 'RangeLink is bound to Gemini Code Assist'
-      - 'At least one send has been performed since binding (warm path)'
-    steps:
-      - 'Select a different range of code and press Cmd+R Cmd+L (Mac) / Ctrl+R Ctrl+L (Win/Linux)'
-      - 'Confirm the Gemini Code Assist chat panel receives the link and selected code'
-      - 'Confirm logs show NO cold-start refocus signals in the warm send'
     expected_result: 'Content arrives in Gemini Code Assist chat input. Logs show no cold-start refocus signals.'
     command_to_run: 'pnpm test:release:with-extensions --grep "gemini-code-assist-004"'
     automated: assisted
@@ -2786,39 +2113,18 @@ test_cases:
   - id: release-notifier-003
     feature: 'Release Notifier'
     scenario: 'Upgrade detected — dismissing (X) is temporary and does not store the version'
-    preconditions:
-      - 'Prior version stored in globalState (simulated via setLastNotifiedVersion in integration test)'
-    steps:
-      - 'Trigger maybeNotify() with a prior version set to 0.0.0'
-      - 'When "RangeLink updated to vX.Y.Z. See what changed!" appears, close it with X'
-      - 'Confirm "Release notification dismissed — will reappear on next activation" log appears'
-      - 'Confirm no "Opened release notes in browser" log'
     expected_result: 'Notification dismissed without storing version; popup will reappear on next activation'
     automated: assisted
 
   - id: release-notifier-004
     feature: 'Release Notifier'
     scenario: "Clicking What's New stores version and opens GitHub releases page in browser"
-    preconditions:
-      - 'Prior version stored in globalState (simulated via setLastNotifiedVersion in integration test)'
-    steps:
-      - 'Trigger maybeNotify() with a prior version set to 0.0.0'
-      - 'When "RangeLink updated" notification appears, click "What''s New"'
-      - 'Confirm browser opens to the GitHub releases page for that version'
-      - 'Confirm "Opened release notes in browser" log appears'
     expected_result: 'Browser navigates to https://github.com/couimet/rangeLink/releases/tag/vscode-extension-vX.Y.Z; version stored — notification will not reappear'
     automated: assisted
 
   - id: release-notifier-005
     feature: 'Release Notifier'
     scenario: 'Clicking Skip for this version stores version without opening browser'
-    preconditions:
-      - 'Prior version stored in globalState (simulated via setLastNotifiedVersion in integration test)'
-    steps:
-      - 'Trigger maybeNotify() with a prior version set to 0.0.0'
-      - 'When "RangeLink updated" notification appears, click "Skip for this version"'
-      - 'Confirm no browser window opens'
-      - 'Confirm "Release notification skipped for this version" log appears'
     expected_result: 'Version stored silently; notification will not reappear; no browser opened'
     automated: assisted
 
@@ -2827,13 +2133,5 @@ test_cases:
       - ubuntu
     feature: 'Platform Keybindings'
     scenario: 'Ctrl+R chord keybindings work on Ubuntu/Linux (R-M menu, R-D picker, R-L send, R-G goto, R-U unbind)'
-    preconditions:
-      - 'Running on Ubuntu/Linux with Ctrl key available'
-    steps:
-      - 'Press Ctrl+R Ctrl+M — verify RangeLink menu opens, then Escape'
-      - 'Press Ctrl+R Ctrl+D — verify destination picker opens, then Escape'
-      - 'Select lines, press Ctrl+R Ctrl+L — verify RangeLink is sent'
-      - 'Press Ctrl+R Ctrl+G — verify Go to Link input box opens, then Escape'
-      - 'Bind a destination, press Ctrl+R Ctrl+U — verify destination unbound'
     expected_result: 'All Ctrl+R chords behave identically to Cmd+R on macOS — menu, picker, send, goto, and unbind work correctly'
     automated: assisted

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
@@ -45,10 +45,6 @@ test_cases:
   - id: status-bar-menu-002
     feature: 'R-M Status Bar Menu'
     scenario: 'Clicking the status bar item opens the R-M menu'
-    preconditions:
-      - 'Any workspace is open'
-    steps:
-      - 'Click the $(link) RangeLink item in the status bar'
     expected_result: "A QuickPick menu opens titled 'RangeLink Menu'. Menu items are visible."
     automated: true
 
@@ -1114,13 +1110,6 @@ test_cases:
   - id: dirty-buffer-warning-004
     feature: 'Dirty Buffer Warning'
     scenario: 'Generate Anyway: generates the link without saving'
-    preconditions:
-      - 'Terminal bound, file has unsaved change'
-    steps:
-      - 'Make unsaved change'
-      - 'Select 2-3 lines, press Cmd+R Cmd+L'
-      - 'Click Generate Anyway'
-      - 'Observe file state and terminal'
     expected_result: 'File still dirty (modified indicator remains). RangeLink generated from current unsaved state and sent.'
     automated: true
 

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-v1.1.0.yaml
@@ -933,16 +933,6 @@ test_cases:
   - id: dirty-buffer-warning-023
     feature: 'Dirty Buffer Warning — R-L Dialog'
     scenario: 'R-L Save & Generate re-reads selections after save mutates the document'
-    preconditions:
-      - 'rangelink.warnOnDirtyBuffer = true (default)'
-      - 'files.trimTrailingWhitespace = true'
-      - 'A terminal is bound as destination'
-      - 'Fixture qa/fixtures/workspace/format-on-save/unformatted.ts opened — each `const` line has 5 trailing spaces before the newline'
-      - 'File made dirty by adding then removing a character'
-    steps:
-      - 'Place a multi-line selection that starts at the beginning of the `const targetLine = ...` line and extends to the END of the trailing whitespace on that same line (column ~36)'
-      - 'Press Cmd+R Cmd+L (Send RangeLink) — dialog appears'
-      - 'Click Save & Generate'
     expected_result: |
       File saved and trailing whitespace trimmed on the selected line (line length shrinks by 5 characters).
       LinkGenerator logs "Re-read selections after Save & Continue to account for possible format-on-save shifts" with both preSaveSelections and postSaveSelections fields. The end character of postSaveSelections is smaller than preSaveSelections by ~5 (the trimmed whitespace).

--- a/packages/rangelink-vscode-extension/scripts/generate-qa-test-plan.sh
+++ b/packages/rangelink-vscode-extension/scripts/generate-qa-test-plan.sh
@@ -73,10 +73,20 @@ HEADER="# RangeLink QA Test Cases — v${PUBLISHED_VERSION} → v${NEXT_VERSION}
 #   id:              Unique test case identifier (<feature-slug>-NNN)
 #   feature:         Feature area / CHANGELOG section
 #   scenario:        One-line description of the specific scenario being tested
-#   preconditions:   List of required setup steps before executing
-#   steps:           Ordered list of test actions
+#   labels:          Optional tags (e.g., cursor, ubuntu, requires-extensions)
+#   preconditions:   Required setup steps — only on \`automated: false\` entries
+#   steps:           Ordered test actions — only on \`automated: false\` entries
 #   expected_result: What a passing run looks like
-#   automated:       false (manual) | true (covered by TypeScript integration tests)"
+#   automated:       Coverage status:
+#                      true     — covered by a non-[assisted] integration test in
+#                                 src/__integration-tests__/suite/ (runs in CI)
+#                      assisted — covered by an [assisted]-tagged integration test
+#                                 that pauses for a human UI action
+#                      false    — fully manual; preconditions and steps are required
+#
+# For \`automated: true\` and \`automated: assisted\` entries the integration test in
+# src/__integration-tests__/suite/ is the canonical source of setup and actions —
+# \`preconditions:\` and \`steps:\` are omitted to prevent duplication and drift."
 
 BODY=$(sed '1,/^test_cases:/{ /^#/d; }' "$PREVIOUS_YAML")
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/terminalPicker.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/terminalPicker.test.ts
@@ -255,43 +255,6 @@ standardSuite('Terminal Picker', (ss) => {
     ss.log('✓ Bound first, active second — all 6 fields');
   });
 
-  test('terminal-picker-006: hidden IDE terminals are absent from the picker', async () => {
-    await ss.createTerminal('rl-tp-006');
-
-    const logCapture = getLogCapture();
-    logCapture.mark('before-tp-006');
-
-    await openAndDismiss(CMD_BIND_TO_DESTINATION);
-
-    const lines = logCapture.getLinesSince('before-tp-006');
-    const items = extractQuickPickItemsLogged(lines);
-    assert.ok(items, 'Expected showQuickPick log entry');
-
-    const termItems = findTerminalItems(items!);
-    assert.deepStrictEqual(
-      termItems.map(({ label, displayName, description, isActive, boundState, itemKind }) => ({
-        label,
-        displayName,
-        description,
-        isActive,
-        boundState,
-        itemKind,
-      })),
-      [
-        {
-          label: 'Terminal ("rl-tp-006")',
-          displayName: 'Terminal ("rl-tp-006")',
-          description: 'active',
-          isActive: true,
-          boundState: 'not-bound',
-          itemKind: 'bindable',
-        },
-      ],
-    );
-
-    ss.log('✓ Only the test terminal appears — full field validation');
-  });
-
   test('terminal-picker-007: all terminals shown inline when within maxInline limit', async () => {
     await ss.createTerminal('rl-tp-007-a');
     await ss.createTerminal('rl-tp-007-b');

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/textEditorDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/textEditorDestination.test.ts
@@ -57,7 +57,7 @@ standardSuite('Text Editor Destination', (ss) => {
     ss.log('✓ Self-paste R-L: info toast shown, file unchanged (log verified)');
   });
 
-  test('[assisted] hidden-tab-paste-001: R-L with bound editor hidden behind another tab — paste still lands in bound editor', async () => {
+  test('hidden-tab-paste-001: R-L with bound editor hidden behind another tab — paste still lands in bound editor', async () => {
     const ANCHOR_START = 'ANCHOR_START';
     const ANCHOR_END = 'ANCHOR_END';
     const SOURCE_CONTENT = 'source-for-rangelink';
@@ -115,7 +115,7 @@ standardSuite('Text Editor Destination', (ss) => {
     ss.log('✓ Bound editor brought to foreground and received RangeLink');
   });
 
-  test('[assisted] hidden-tab-paste-002: R-V with bound editor hidden behind another tab — paste still lands in bound editor', async () => {
+  test('hidden-tab-paste-002: R-V with bound editor hidden behind another tab — paste still lands in bound editor', async () => {
     const ANCHOR_START = 'ANCHOR_START';
     const ANCHOR_END = 'ANCHOR_END';
     const SELECTED_TEXT = 'text-to-paste';


### PR DESCRIPTION
## Summary

Removes duplicated `preconditions:` and `steps:` blocks from every QA YAML test case marked `automated: true` or `automated: assisted` (256 of 269 entries). For those TCs the integration test in `src/__integration-tests__/suite/` is the canonical source of setup and actions; keeping a second copy in YAML invited drift. Manual TCs (`automated: false`) keep both fields intact because the YAML remains their only source of instructions.

## Changes

- `qa/qa-test-cases-v1.1.0.yaml`: stripped `preconditions:` and `steps:` from 143 `automated: true` and 113 `automated: assisted` entries; kept all 13 `automated: false` entries fully detailed. Rewrote the header schema comment to enumerate all three `automated` values, document `labels:`, and explain that preconditions/steps live only on manual TCs.
- `scripts/generate-qa-test-plan.sh`: updated the inline `HEADER=` template (lines 64-79) to match the new schema doc so v1.2.0+ YAML files inherit the corrected wording.
- `TESTING.md`: added a short subsection after the `automated` field table explaining that `preconditions:`/`steps:` are only present on `automated: false` entries and must be deleted when a TC flips from false to true/assisted.
- `.claude/skills/qa-suggest/SKILL.md`: Step 6 now offers two YAML templates (manual form with preconditions/steps, automated/assisted form without); Step 4 ignores `preconditions:`/`steps:` removal as v1.1.0 schema-migration noise so the next /qa-suggest run does not flag all 256 carried-forward TCs as Changed.
- Documentation: CHANGELOG not needed (internal QA tooling change, not user-visible in the shipped extension); README not needed (no commands, settings, or features affected).

## Test Plan

- [x] `pnpm test` — 1925/1925 unit tests pass
- [x] `pnpm fix` + `pnpm lint:fix` — clean
- [x] `node scripts/resolve-qa-labels.js --yaml qa/qa-test-cases-v1.1.0.yaml ...` — TC counts unchanged (143 / 113 / 13)
- [x] Cross-tabulated automated × preconditions × steps presence: every automated/assisted entry has neither field; every manual entry has both
- [ ] `pnpm test:release:automated` — recommend running locally before merge; not run here

## Pre-existing Issue (not in scope)

`pnpm validate:qa-coverage` reports one mismatch on the current `origin/main`: `terminal-picker-006` is `automated: false` in YAML but has an integration test in the suite. Verified pre-existing (confirmed by `git stash` + re-running the validator on the unmodified base). PR #586 (issues/574, squash-merged as `02669f39`) flipped this TC to `false` without removing the corresponding integration test. Worth a separate issue to either re-flip the YAML or remove the test.

## Related

Closes https://github.com/couimet/rangeLink/issues/542


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced testing documentation to clarify YAML test case structure, including how preconditions and steps apply differently across manual, assisted, and fully automated test designations.

* **Chores**
  * Reorganized integration test suite and refined test plan generation infrastructure to improve clarity and reduce documentation drift.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/rangeLink/pull/589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->