### PR TITLE
[issues/579] CI Summary Comment Improvements

### DIFF
--- a/.github/actions/post-pr-ci-summary/action.yml
+++ b/.github/actions/post-pr-ci-summary/action.yml
@@ -62,23 +62,17 @@ runs:
 
         # Determine pass/fail
         PASS=true
+        MISSING_INT_REPORT=false
         if [ -n "${{ inputs.unit-total }}" ] && [ "${{ inputs.unit-passed }}" != "${{ inputs.unit-total }}" ]; then
           PASS=false
         fi
         if [ -n "${{ inputs.int-failed }}" ] && [ "${{ inputs.int-failed }}" != "0" ]; then
           PASS=false
         fi
-
-        if [ "$PASS" = "true" ]; then
-          ICON="✅"
-        else
-          ICON="❌"
-        fi
         JOB_KEY=$(echo "${{ inputs.title }}" | sed 's/ — run summary$//')
 
-        # Build table
-        TABLE="### ${ICON} ${{ inputs.title }}"
-        TABLE="${TABLE}"$'\n'"| | |"
+        # Build table body (title with icon is prepended after pass/fail is finalized)
+        TABLE="| | |"
         TABLE="${TABLE}"$'\n'"|---|---|"
         TABLE="${TABLE}"$'\n'"| Duration | ${DURATION_STR} |"
 
@@ -101,12 +95,24 @@ runs:
         INT_PASSING="${{ inputs.int-passing }}"
         INT_FAILED="${{ inputs.int-failed }}"
         if { [ -z "$INT_PASSING" ] || [ "$INT_PASSING" = "0" ]; } && { [ -z "$INT_FAILED" ] || [ "$INT_FAILED" = "0" ]; }; then
-          if [ -n "${{ inputs.report-file }}" ] && [ -f "${{ inputs.report-file }}" ]; then
-            if ! grep -qE '[0-9]+ (passing|failing)' "${{ inputs.report-file }}" 2>/dev/null; then
-              TABLE="${TABLE}"$'\n'"| ⚠️ Integration test report missing | Runner may have crashed |"
-            fi
+          if [ -n "${{ inputs.report-file }}" ] && { [ ! -f "${{ inputs.report-file }}" ] || ! grep -qE '[0-9]+ (passing|failing)' "${{ inputs.report-file }}" 2>/dev/null; }; then
+            MISSING_INT_REPORT=true
+            TABLE="${TABLE}"$'\n'"| ⚠️ Integration test report missing | Runner may have crashed |"
           fi
         fi
+
+        # Finalize pass/fail and icon after report check
+        if [ "$MISSING_INT_REPORT" = "true" ]; then
+          PASS=false
+        fi
+        if [ "$PASS" = "true" ]; then
+          ICON="✅"
+        else
+          ICON="❌"
+        fi
+
+        # Prepend title with icon
+        TABLE="### ${ICON} ${{ inputs.title }}"$'\n'"${TABLE}"
 
         TABLE="${TABLE}"$'\n'"| QA TC IDs exercised | ${TC_IDS} |"
         TABLE="${TABLE}"$'\n'"| Report | [View run & artifacts](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) |"
@@ -134,7 +140,7 @@ runs:
 
         # Minimize previous successful comments from this job
         if [ "$PASS" = "true" ] && [ -n "$NEW_COMMENT_ID" ] && [ "$NEW_COMMENT_ID" != "null" ]; then
-          PREV_NODES=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+          PREV_NODES=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
             --jq ".[] | select(.id != ${NEW_COMMENT_ID}) | select(.body | startswith(\"### ✅ ${JOB_KEY}\")) | .node_id" 2>/dev/null || true)
           for NID in $PREV_NODES; do
             gh api graphql -f query='mutation($id:ID!){minimizeComment(input:{subjectId:$id,classifier:OUTDATED}){clientMutationId}}' \

--- a/.github/actions/post-pr-ci-summary/action.yml
+++ b/.github/actions/post-pr-ci-summary/action.yml
@@ -60,8 +60,24 @@ runs:
         fi
         TC_IDS=$(node packages/rangelink-vscode-extension/scripts/resolve-qa-labels.js "${RESOLVE_ARGS[@]}")
 
+        # Determine pass/fail
+        PASS=true
+        if [ -n "${{ inputs.unit-total }}" ] && [ "${{ inputs.unit-passed }}" != "${{ inputs.unit-total }}" ]; then
+          PASS=false
+        fi
+        if [ -n "${{ inputs.int-failed }}" ] && [ "${{ inputs.int-failed }}" != "0" ]; then
+          PASS=false
+        fi
+
+        if [ "$PASS" = "true" ]; then
+          ICON="✅"
+        else
+          ICON="❌"
+        fi
+        JOB_KEY=$(echo "${{ inputs.title }}" | sed 's/ — run summary$//')
+
         # Build table
-        TABLE="### ${{ inputs.title }}"
+        TABLE="### ${ICON} ${{ inputs.title }}"
         TABLE="${TABLE}"$'\n'"| | |"
         TABLE="${TABLE}"$'\n'"|---|---|"
         TABLE="${TABLE}"$'\n'"| Duration | ${DURATION_STR} |"
@@ -69,11 +85,27 @@ runs:
         if [ -n "${{ inputs.unit-total }}" ]; then
           TABLE="${TABLE}"$'\n'"| Unit tests passed | ${{ inputs.unit-passed }} / ${{ inputs.unit-total }} |"
         fi
+
+        if [ "$LABEL_FILTER" = "requires-extensions" ]; then
+          TABLE="${TABLE}"$'\n'"| Unit tests | Ran in Test &amp; Validate job |"
+        fi
+
         if [ -n "${{ inputs.int-passing }}" ]; then
           TABLE="${TABLE}"$'\n'"| Integration tests passing | ${{ inputs.int-passing }} |"
         fi
         if [ -n "${{ inputs.int-failed }}" ] && [ "${{ inputs.int-failed }}" != "0" ]; then
           TABLE="${TABLE}"$'\n'"| Integration tests failed | ${{ inputs.int-failed }} |"
+        fi
+
+        # Detect missing test report (runner crash before producing stats)
+        INT_PASSING="${{ inputs.int-passing }}"
+        INT_FAILED="${{ inputs.int-failed }}"
+        if { [ -z "$INT_PASSING" ] || [ "$INT_PASSING" = "0" ]; } && { [ -z "$INT_FAILED" ] || [ "$INT_FAILED" = "0" ]; }; then
+          if [ -n "${{ inputs.report-file }}" ] && [ -f "${{ inputs.report-file }}" ]; then
+            if ! grep -qE '[0-9]+ (passing|failing)' "${{ inputs.report-file }}" 2>/dev/null; then
+              TABLE="${TABLE}"$'\n'"| ⚠️ Integration test report missing | Runner may have crashed |"
+            fi
+          fi
         fi
 
         TABLE="${TABLE}"$'\n'"| QA TC IDs exercised | ${TC_IDS} |"
@@ -84,9 +116,28 @@ runs:
         if [ -n "${{ inputs.report-file }}" ] && [ -f "${{ inputs.report-file }}" ]; then
           RE_RUN=$(sed -n '/^Re-run failed tests:/,$p' "${{ inputs.report-file }}" | tail -n +2 | sed 's/^  //')
           if [ -n "$RE_RUN" ]; then
-            BODY="${BODY}"$'\n\n'"To re-run failed tests:"$'\n'"\`\`\`"$'\n'"${RE_RUN}"$'\n'"\`\`\`"
+            # Suppress re-run block when failures dominate passing
+            INT_FAILED_NUM="${INT_FAILED:-0}"
+            INT_PASSING_NUM="${INT_PASSING:-0}"
+            if [ "$INT_FAILED_NUM" -gt "$INT_PASSING_NUM" ] 2>/dev/null; then
+              BODY="${BODY}"$'\n\n'"${INT_FAILED_NUM} tests failed — re-run the full suite with \`pnpm test:release:automated\`"
+            else
+              BODY="${BODY}"$'\n\n'"To re-run failed tests:"$'\n'"\`\`\`"$'\n'"${RE_RUN}"$'\n'"\`\`\`"
+            fi
           fi
         fi
 
-        gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-          -f body="$BODY"
+        # Post the comment
+        RESPONSE=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+          -f body="$BODY")
+        NEW_COMMENT_ID=$(echo "$RESPONSE" | jq -r '.id')
+
+        # Minimize previous successful comments from this job
+        if [ "$PASS" = "true" ] && [ -n "$NEW_COMMENT_ID" ] && [ "$NEW_COMMENT_ID" != "null" ]; then
+          PREV_NODES=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.id != ${NEW_COMMENT_ID}) | select(.body | startswith(\"### ✅ ${JOB_KEY}\")) | .node_id" 2>/dev/null || true)
+          for NID in $PREV_NODES; do
+            gh api graphql -f query='mutation($id:ID!){minimizeComment(input:{subjectId:$id,classifier:OUTDATED}){clientMutationId}}' \
+              -f id="$NID" 2>/dev/null || true
+          done
+        fi


### PR DESCRIPTION
## Summary

Fixes six bugs in the PR CI summary action introduced in #570. Comments now show pass/fail at a glance, previous successful comments are minimized instead of piling up, missing test reports are surfaced explicitly, the extensions job explains its scope, and re-run blocks are suppressed when most tests fail.

## Changes

- Pass/fail icon (S1): ✅ or ❌ prefix on the comment title, inferred from unit test pass rate and integration test failure count
- Stale comment cleanup (S1): after a successful run posts, previous successful comments from the same job are minimized via GraphQL. Failed comments stay visible, preserving error history
- Missing report detection (S2): when both integration test stats are 0/empty, the report file is checked for mocha output. If absent, a warning row is added
- Extension job scope (S3): when label-filter is requires-extensions, a row explains that unit tests ran in the Test & Validate job
- Re-run suppression (S4): when int-failed exceeds int-passing, the full re-run command block is replaced with a one-liner pointing to the suite command
- Documentation: CHANGELOG not needed (CI infrastructure); README not needed (no user-facing changes)

## Test Plan

- [ ] All existing tests pass
- [ ] Manual testing: CI run on this PR will exercise all changes (comment posting, minimizing, icon, missing-report detection, scope note, re-run suppression)

Closes https://github.com/couimet/rangeLink/issues/579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI summary now shows an overall pass/fail status with matching visual icon and title.
  * Summary table conditionally displays unit/integration rows and adds a "Unit tests" row in specific label-filter cases.
  * Adds a warning row when a report appears to contain no recognizable test stats.
  * Re-run guidance omits per-test re-run instructions when integration failures exceed passes, prompting a full-suite re-run.
  * Previous successful PR comments are minimized only when the current run is successful and a new comment was created.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/rangeLink/pull/591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->