### PR TITLE
[side-quest] Document test:release:automated as the default in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -553,9 +553,12 @@
 </integration-test-convention>
 
 <release-test-requirement>
-  <rule>Any change to files in `packages/rangelink-vscode-extension/qa/` or `packages/rangelink-vscode-extension/src/__integration-tests__/` MUST be validated by running `pnpm test:release`</rule>
-  <reason>The QA validator script only checks ID matching — it does not execute the tests. Only `test:release` compiles the extension and runs integration tests in a real VS Code host, which is the only way to verify that log-based assertions and command behavior actually work.</reason>
-  <command>`pnpm test:release` (compiles the extension, launches VS Code host, runs integration tests, then runs QA validator — all in one command)</command>
+  <rule>Any change to files in `packages/rangelink-vscode-extension/qa/` or `packages/rangelink-vscode-extension/src/__integration-tests__/` MUST be validated by running an integration-test command.</rule>
+  <reason>The QA validator script only checks ID matching — it does not execute the tests. Only the integration-test runner compiles the extension and runs tests in a real VS Code host, which is the only way to verify that log-based assertions and command behavior actually work.</reason>
+  <default-command>`pnpm test:release:automated` — runs only `automated: true` TCs. This is the default Claude should use. Skips `[assisted]` tests, so it does not block on human-in-the-loop prompts.</default-command>
+  <targeted-command>`pnpm test:release:grep -- "<TC-ID-or-pattern>"` — runs a focused subset by TC ID or regex. Use this when iterating on a specific feature or test. Pass multiple IDs as a regex alternation, e.g. `"terminal-picker-014|bind-to-destination-013"`.</targeted-command>
+  <full-command>`pnpm test:release` — runs everything including `[assisted]` tests. Only use when the user explicitly asks for the full suite, or when validating a release. Will block waiting for human input on assisted tests.</full-command>
+  <rule>Default to `:automated` for routine validation. When iterating on specific TC IDs, switch to `:grep` with the relevant IDs to keep the feedback loop tight. Do not run the bare `pnpm test:release` unless explicitly asked.</rule>
 </release-test-requirement>
 
 </testing>


### PR DESCRIPTION
## Summary

Rewrite the `<release-test-requirement>` block in `CLAUDE.md` so future Claude sessions default to `pnpm test:release:automated` (or `pnpm test:release:grep -- "<pattern>"` for targeted iteration) instead of bare `pnpm test:release`. The bare command blocks on assisted prompts, so the user kept having to correct it; this codifies the preference at the project level.

## Changes

- `<release-test-requirement>` now distinguishes three commands: `<default-command>` for routine validation (`pnpm test:release:automated`), `<targeted-command>` for focused iteration (`pnpm test:release:grep -- "<TC-ID-or-pattern>"`), and `<full-command>` for the bare `pnpm test:release` (reserved for explicit "full suite" requests).
- Added a closing rule restating the default and forbidding bare `pnpm test:release` unless the user explicitly asks.