### PR TITLE
[issues/565] Pin GitHub Actions to Node.js 24-compatible SHA versions

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -22,7 +22,7 @@ runs:
 
     - name: Cache pnpm store
       id: pnpm-cache
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.pnpm-config.outputs.store-dir }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -60,7 +60,7 @@ runs:
         sudo apt-get install -y --no-install-recommends xvfb libgtk-3-0 libxss1 libnss3 "$ALSA_PKG"
 
     - name: Cache VS Code test binary
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           ~/.vscode-test
@@ -70,7 +70,7 @@ runs:
 
     - name: Cache VS Code marketplace extensions
       if: env.CACHE_EXTENSIONS == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.vscode-test/extensions
         key: vscode-extensions-${{ runner.os }}-${{ hashFiles('packages/rangelink-vscode-extension/.vscode-test.with-extensions.mjs') }}
@@ -93,7 +93,7 @@ runs:
 
     - name: Upload test report artifact
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ env.ARTIFACT_NAME }}
         path: ${{ env.REPORT_FILE }}

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Setup Node.js from .nvmrc
       id: setup-node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: '.nvmrc'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Fetch more history for TODO comparison in PRs
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -73,7 +74,9 @@ jobs:
         run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
 
       - name: Checkout code
-        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           # Fetch more history for TODO comparison in PRs
           fetch-depth: 0
@@ -73,7 +73,7 @@ jobs:
         run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm

--- a/.github/workflows/qa-gap-check.yml
+++ b/.github/workflows/qa-gap-check.yml
@@ -19,9 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Get PR diff
         id: diff

--- a/.github/workflows/qa-gap-check.yml
+++ b/.github/workflows/qa-gap-check.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test-shell-scripts.yml
+++ b/.github/workflows/test-shell-scripts.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: bats-core/bats-action@4.0.0
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: bats-core/bats-action@5b1e60c2ee94cb1b44a616ea4b1f466f9d6e38ef # 4.0.0
         with:
           support-install: false
           assert-install: false

--- a/.github/workflows/test-shell-scripts.yml
+++ b/.github/workflows/test-shell-scripts.yml
@@ -13,8 +13,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
-      - uses: bats-core/bats-action@5b1e60c2ee94cb1b44a616ea4b1f466f9d6e38ef # 4.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
           support-install: false
           assert-install: false


### PR DESCRIPTION
## Summary

GitHub Actions deprecates Node.js 20 runtime on June 2, 2026. CI runs flagged `actions/checkout@v4`, `actions/setup-node@v4`, `actions/cache@v4`, and `actions/upload-artifact@v4` as running on Node.js 20. This bumps all third-party actions to their latest major versions (which ship with Node.js 24 support) and pins each to its exact commit SHA.

## Changes

- `actions/checkout`: v4 → v6.0.3 (SHA `9f69817`) across all three workflow files
- `actions/setup-node`: v4 → v6.4.0 (SHA `48b55a0`) in setup-node-pnpm composite action
- `actions/cache`: v4 → v5.0.5 (SHA `27d5ce7`) in install-deps and run-integration-tests composite actions
- `actions/upload-artifact`: v4 → v7.0.1 (SHA `043fb46`) in run-integration-tests composite action
- `bats-core/bats-action@4.0.0`: pinned to exact SHA (`5b1e60c`) for consistency with other pinned actions

## Test Plan

- [ ] CI passes on this PR with no Node.js 20 deprecation annotations in the Actions run log
- [ ] All 3 integration test matrix modes (automated, with extensions, with overrides) complete successfully

## Related

Closes https://github.com/couimet/rangeLink/issues/565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions across CI workflows to use pinned action revisions for checkout, caching, node setup, and artifact uploads to improve build reproducibility.
  * Standardized checkout steps to include persist-credentials: false where applicable.
  * No behavioral changes to tests, workflows, or public inputs/outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->