### PR TITLE
[issues/603] Fix terminal R-V context menu, add self-bind gate, cleanup assisted tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,6 +278,61 @@
   </bad-example>
 </rule>
 
+<rule id="T017" priority="critical">
+  <title>waitForHuman instructions are self-contained; waitForHumanVerdict defines PASS</title>
+  <scope>Integration tests under `src/__integration-tests__/` only</scope>
+
+<do>Make the 2nd param of `waitForHuman(label, instruction, steps)` self-contained — every action the tester must perform is stated in `instruction`. The `steps` array adds background context and step-by-step breakdown but the tester can complete the test from `instruction` alone.</do>
+<never>Hide a required action only in `steps`. If the tester must select a picker item, press a keybinding, or dismiss a dialog, that belongs in `instruction`.</never>
+
+<do>In `waitForHumanVerdict(label, question, steps)`, phrase `question` as a yes/no question where YES = PASS. State exactly what the tester must verify before pressing PASS.</do>
+<never>Explain the FAIL path in `steps`. The default action is FAIL — no explanation needed. Do not write "FAIL if …" or "press FAIL when …".</never>
+
+<never>Tell the tester to click Cancel or press Escape to dismiss. They know how to dismiss menus and pickers.</never>
+
+  <good-example>
+    ```typescript
+    // BAD: required action hidden in steps[3]
+    await waitForHuman(
+      'context-menus-terminal-001',
+      `Right-click terminal TAB "${name}" → "RangeLink: Send Selection"`,
+      [
+        `The terminal "${name}" has selected text.`,
+        '1. Right-click the terminal TAB',
+        '2. Verify the entry is present',
+        '3. Select it to open the destination picker and pick any destination',
+      ],
+    );
+
+    // GOOD: instruction is self-contained
+    await waitForHuman(
+      'context-menus-terminal-001',
+      `Right-click terminal TAB "${name}" → "RangeLink: Send Selection" → pick any destination from the picker that opens`,
+      [
+        `The terminal "${name}" has selected text. No destination is bound.`,
+        '1. Right-click the terminal TAB (not the content area)',
+        '2. Verify "RangeLink: Send Selection to Destination" is present',
+        '3. Select it — a destination picker opens',
+        '4. Pick any destination and press Enter',
+      ],
+    );
+
+    // VERDICT — GOOD: question states what to verify for PASS, no FAIL explanation
+    const verdict = await waitForHumanVerdict(
+      'context-menus-terminal-012',
+      `Is "RangeLink: Send Selection" ABSENT from both the tab menu AND the content-area menu?`,
+      [
+        `The terminal "${name}" IS the bound destination.`,
+        '1. Right-click the terminal TAB — check the entry is absent',
+        '2. Right-click the terminal CONTENT AREA — check the entry is absent',
+        '3. Press PASS if absent from both',
+      ],
+    );
+    ```
+
+  </good-example>
+</rule>
+
 <rule id="E001" priority="critical">
   <title>Shell environment setup</title>
   <when>Before the first pnpm, npm, or node command in a session</when>
@@ -589,6 +644,7 @@
   <mark>New rows in command/setting tables</mark>
   <mark>A `> [!IMPORTANT]` banner at the top of the README if one doesn't exist yet</mark>
   <skip>Cosmetic renames or rewording of existing features — only mark genuinely new functionality</skip>
+  <never>Add `<sup>Unreleased</sup>` markers in CHANGELOG. The `## [Unreleased]` section header already conveys that everything within it is unreleased. Markers are for README only, where released and unreleased content is interleaved.</never>
   <see>docs/RELEASE-STRATEGY.md § Trunk-Based Documentation</see>
 </unreleased-markers>
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/couimet.rangelink-vscode-extension?label=VS%20Code%20Marketplace&color=blue)](https://marketplace.visualstudio.com/items?itemName=couimet.rangelink-vscode-extension)
 [![Open VSX Version](https://img.shields.io/open-vsx/v/couimet/rangelink-vscode-extension?label=Open%20VSX&color=blue)](https://open-vsx.org/extension/couimet/rangelink-vscode-extension)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
-![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/couimet/rangeLink?utm_source=oss&utm_medium=github&utm_campaign=couimet%2FrangeLink&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/couimet/rangeLink?label=CodeRabbit+Reviews)
 
 **"Claude Code today. Cursor AI tomorrow. Different shortcuts, different muscle memory."** <br />
 **RangeLink ends it.** One keybinding. Any AI, any tool. Character-level precision. `recipes/baking/chickenpie.ts#L3C14-L314C16`

--- a/packages/rangelink-vscode-extension/CHANGELOG.md
+++ b/packages/rangelink-vscode-extension/CHANGELOG.md
@@ -36,17 +36,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - When more open files exist beyond the inline list, extras collapse into "More files..." which opens a secondary picker
   - Secondary picker organizes all open files into "Active Files" section + per-"Tab Group N" sections
   - Escaping the secondary picker returns to the destination picker
-- **Gemini Code Assist Integration** - Paste destination for Google's Gemini Code Assist (#529) <sup>Unreleased</sup>
+- **Gemini Code Assist Integration** - Paste destination for Google's Gemini Code Assist (#529)
   - Automatically inserts links and selected text directly into Gemini Code Assist
   - Requires [Gemini Code Assist](https://marketplace.visualstudio.com/items?itemName=Google.geminicodeassist) extension (`Google.geminicodeassist`)
   - Configurable cold-start timing: `rangelink.destinations.gemini.coldStartDelayMs` (default: `2500`) and `rangelink.destinations.gemini.coldRefocusIntervalMs` (default: `300`) — tune for your machine's speed; increase the delay on slower hardware if the initial paste after binding silently fails to reach the Gemini panel
-- **Custom AI Assistants** - Connect RangeLink to any AI tool with a VS Code extension (#500) <sup>Unreleased</sup>
+- **Custom AI Assistants** - Connect RangeLink to any AI tool with a VS Code extension (#500)
   - New setting `rangelink.customAiAssistants`: three-tier command schema — `insertCommands` (direct text delivery), `focusAndPasteCommands` (focus + auto-paste), `focusCommands` (focus + manual paste toast)
   - Custom assistants appear in the destination picker (R-D) alongside built-in destinations
   - Lazy tier resolution: RangeLink checks which commands are registered on first use and caches the winning tier — no per-operation overhead
   - Override built-in assistants (Cursor, Claude Code, Copilot) via config with automatic fallback to hardcoded commands
   - `${content}` template interpolation for insert commands with non-standard argument formats
-- **Claude Code Cold-Start Timing** - Configurable cold-start settings for the Claude Code Extension destination <sup>Unreleased</sup>
+- **Claude Code Cold-Start Timing** - Configurable cold-start settings for the Claude Code Extension destination
   - `rangelink.destinations.claudeCode.coldStartDelayMs` (default: `2500`) and `rangelink.destinations.claudeCode.coldRefocusIntervalMs` (default: `300`) — tune for your machine's speed; increase the delay on slower hardware if the initial paste after binding silently fails to reach the Claude Code panel
 - **Release Notifier** - Once-per-upgrade notification so new versions don't go unnoticed (#525)
   - On upgrade, shows "RangeLink updated to vX.Y.Z. See what changed!" with "What's New" and "Skip for this version" buttons
@@ -88,10 +88,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - "RangeLink: Send This File's Relative Path" - Send relative path to bound destination
     - "RangeLink: Bind Here" - Bind this editor as destination (file/untitled only)
     - "RangeLink: Unbind" - Unbind current destination (when bound)
-  - **Terminal** (right-click on terminal tabs or inside terminal):
-    - "RangeLink: Send Selection to Destination" - Send the selected terminal text to the bound destination (content-area menu only; opens the destination picker if nothing is bound)
+  - **Terminal Tab** (right-click on tabs):
     - "RangeLink: Bind Here" - Bind this terminal as destination
-    - "RangeLink: Unbind" - Unbind current destination (content-area menu only when bound)
+    - "RangeLink: Unbind" - Unbind current destination (when bound)
+  - **Terminal Content** (right-click inside terminal):
+    - "RangeLink: Send Selected Text" - Send the selected terminal text to the bound destination (hidden when the terminal IS the bound destination; opens the destination picker if nothing is bound)
+    - "RangeLink: Bind Here" - Bind this terminal as destination
+    - "RangeLink: Unbind" - Unbind current destination (when bound)
 - **Navigation clamping feedback** - Navigation now warns when a link points beyond file boundaries instead of silently landing at the nearest valid position
 - **Navigation toast settings** - Control which toasts appear after clicking a RangeLink (#54)
   - `rangelink.navigation.showNavigatedToast` (default: `true`) — suppress the "Navigated to …" info toast for a quieter workflow

--- a/packages/rangelink-vscode-extension/README.md
+++ b/packages/rangelink-vscode-extension/README.md
@@ -353,13 +353,20 @@ Positioned after VSCode's "Copy Path" / "Copy Relative Path":
 | RangeLink: Save Selection as Bookmark      | Has selection    | Save selection for quick access later   |
 -->
 
-#### Terminal (right-click on tab or inside terminal)
+#### Terminal Tab (right-click on tabs)
 
-| Menu Item                                | Visibility                   | Action                                                                    |
-| ---------------------------------------- | ---------------------------- | ------------------------------------------------------------------------- |
-| RangeLink: Send Selection to Destination | Text selected (content-area) | Copy terminal selection and send to destination (opens picker if unbound) |
-| RangeLink: Bind Here                     | Always                       | Bind this terminal as destination                                         |
-| RangeLink: Unbind                        | When bound (content-area)    | Unbind current destination                                                |
+| Menu Item            | Visibility | Action                            |
+| -------------------- | ---------- | --------------------------------- |
+| RangeLink: Bind Here | Always     | Bind this terminal as destination |
+| RangeLink: Unbind    | When bound | Unbind current destination        |
+
+#### Terminal Content (right-click inside terminal)
+
+| Menu Item                     | Visibility                                           | Action                                                                    |
+| ----------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------- |
+| RangeLink: Send Selected Text | Text selected, terminal is not the bound destination | Copy terminal selection and send to destination (opens picker if unbound) |
+| RangeLink: Bind Here          | Always                                               | Bind this terminal as destination                                         |
+| RangeLink: Unbind             | When bound                                           | Unbind current destination                                                |
 
 ## Configuration
 

--- a/packages/rangelink-vscode-extension/package.json
+++ b/packages/rangelink-vscode-extension/package.json
@@ -338,7 +338,7 @@
       },
       {
         "command": "rangelink.terminal.pasteSelectedTextToDestination",
-        "title": "RangeLink: Send Selection to Destination",
+        "title": "RangeLink: Send Selected Text",
         "icon": "$(symbol-snippet)"
       },
       {
@@ -941,19 +941,19 @@
       ],
       "terminal/context": [
         {
-          "when": "terminalTextSelected",
+          "when": "terminalTextSelected && !rangelink.isActiveTerminalPasteDestination",
           "command": "rangelink.terminal.pasteSelectedTextToDestination",
-          "group": "2_edit@10"
+          "group": "rangelink@1"
         },
         {
           "when": "rangelink.isActiveTerminalBindable",
           "command": "rangelink.terminal.bind",
-          "group": "rangelink@1"
+          "group": "rangelink@2"
         },
         {
           "when": "rangelink.isBound",
           "command": "rangelink.terminal.unbind",
-          "group": "rangelink@2"
+          "group": "rangelink@3"
         }
       ]
     }

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-unreleased.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-unreleased.yaml
@@ -987,7 +987,7 @@ test_cases:
       - terminal
     feature: 'context-menus'
     scenario: 'Terminal content-area "Send Selected Text" appears when terminal has selection and is not the bound destination'
-    expected_result: 'With a terminal that has selected text and no destination bound, right-clicking the terminal CONTENT AREA shows "RangeLink: Send Selection to Destination". Selecting it opens the destination picker.'
+    expected_result: 'With a terminal that has selected text and no destination bound, right-clicking the terminal CONTENT AREA shows "RangeLink: Send Selected Text". Selecting it opens the destination picker.'
     automated: assisted
 
   - id: context-menus-terminal-011
@@ -1003,7 +1003,7 @@ test_cases:
       - terminal
     feature: 'context-menus'
     scenario: 'Terminal content-area "Send Selected Text" is absent when no text is selected'
-    expected_result: 'With a terminal that has NO text selected, right-clicking the terminal CONTENT AREA does not show "RangeLink: Send Selection to Destination". The `terminalTextSelected` clause hides it.'
+    expected_result: 'With a terminal that has NO text selected, right-clicking the terminal CONTENT AREA does not show "RangeLink: Send Selected Text". The `terminalTextSelected` clause hides it.'
     automated: assisted
 
   # ---------------------------------------------------------------------------
@@ -1270,7 +1270,7 @@ test_cases:
       - clipboard
     feature: 'send-terminal-selection'
     scenario: 'Terminal TAB context menu does NOT include "Send Selected Text"'
-    expected_result: '"RangeLink: Send Selection to Destination" is NOT present in the tab menu (the command is only registered for the content-area menu).'
+    expected_result: '"RangeLink: Send Selected Text" is NOT present in the tab menu (the command is only registered for the content-area menu).'
     automated: assisted
 
   - id: send-terminal-selection-010
@@ -1294,7 +1294,7 @@ test_cases:
       - clipboard
     feature: 'send-terminal-selection'
     scenario: '"Send Selected Text" is hidden when no terminal text is selected'
-    expected_result: '"RangeLink: Send Selection to Destination" is NOT present (`when` clause requires `terminalTextSelected`).'
+    expected_result: '"RangeLink: Send Selected Text" is NOT present (`when` clause requires `terminalTextSelected`).'
     automated: assisted
 
   - id: send-terminal-selection-013

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases-unreleased.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases-unreleased.yaml
@@ -982,6 +982,30 @@ test_cases:
     expected_result: 'With a different terminal already bound, the pty terminal content-area menu shows "RangeLink: Unbind" but does NOT show "RangeLink: Bind Here". Proves Unbind rides on `rangelink.isBound` (not bindability).'
     automated: assisted
 
+  - id: context-menus-terminal-010
+    labels:
+      - terminal
+    feature: 'context-menus'
+    scenario: 'Terminal content-area "Send Selected Text" appears when terminal has selection and is not the bound destination'
+    expected_result: 'With a terminal that has selected text and no destination bound, right-clicking the terminal CONTENT AREA shows "RangeLink: Send Selection to Destination". Selecting it opens the destination picker.'
+    automated: assisted
+
+  - id: context-menus-terminal-011
+    labels:
+      - terminal
+    feature: 'context-menus'
+    scenario: '"Send Selected Text" is hidden from the terminal content-area menu when the terminal IS the bound destination'
+    expected_result: 'When a terminal is the bound destination and has selected text, "RangeLink: Send Selected Text" is absent from the content-area context menu. The `!rangelink.isActiveTerminalPasteDestination` gate prevents circular self-paste.'
+    automated: assisted
+
+  - id: context-menus-terminal-012
+    labels:
+      - terminal
+    feature: 'context-menus'
+    scenario: 'Terminal content-area "Send Selected Text" is absent when no text is selected'
+    expected_result: 'With a terminal that has NO text selected, right-clicking the terminal CONTENT AREA does not show "RangeLink: Send Selection to Destination". The `terminalTextSelected` clause hides it.'
+    automated: assisted
+
   # ---------------------------------------------------------------------------
   # Section 8 — Dirty Buffer Warning
   # ---------------------------------------------------------------------------
@@ -1245,7 +1269,7 @@ test_cases:
     labels:
       - clipboard
     feature: 'send-terminal-selection'
-    scenario: 'Terminal TAB context menu does NOT include "Send Selection to Destination"'
+    scenario: 'Terminal TAB context menu does NOT include "Send Selected Text"'
     expected_result: '"RangeLink: Send Selection to Destination" is NOT present in the tab menu (the command is only registered for the content-area menu).'
     automated: assisted
 
@@ -1261,7 +1285,7 @@ test_cases:
     labels:
       - clipboard
     feature: 'send-terminal-selection'
-    scenario: 'Unbound: "Send Selection to Destination" is visible; clicking opens destination picker and delivers to picked destination'
+    scenario: 'Unbound: "Send Selected Text" is visible; clicking opens destination picker and delivers to picked destination'
     expected_result: 'The item is visible (parity with editor family — no isBound gate). The destination picker opens, and after picking DEST, the selection is delivered to DEST and DEST becomes the bound destination.'
     automated: assisted
 
@@ -1269,7 +1293,7 @@ test_cases:
     labels:
       - clipboard
     feature: 'send-terminal-selection'
-    scenario: '"Send Selection to Destination" is hidden when no terminal text is selected'
+    scenario: '"Send Selected Text" is hidden when no terminal text is selected'
     expected_result: '"RangeLink: Send Selection to Destination" is NOT present (`when` clause requires `terminalTextSelected`).'
     automated: assisted
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/assistedTestHelper.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/assistedTestHelper.ts
@@ -115,7 +115,7 @@ export const waitForHumanVerdict = async (
   if (consoleSteps !== undefined) {
     consoleSteps.forEach((line) => nodeConsole.log(`  ${line}`));
   }
-  nodeConsole.log('PASS / FAIL buttons in the status bar (bottom-left).');
+  nodeConsole.log('Verdict — status bar (bottom-left)');
   nodeConsole.log(SECTION_LINE);
 
   // Dispose any stale UI from a previous invocation that never settled
@@ -142,7 +142,7 @@ export const waitForHumanVerdict = async (
       cancellable: false,
     },
     (progress) => {
-      progress.report({ message: 'Click PASS or FAIL in the bottom-left status bar' });
+      progress.report({ message: 'Verdict — status bar (bottom-left)' });
 
       return new Promise<HumanVerdict>((resolve, reject) => {
         activeVerdictReject = reject;

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/assistedTestHelper.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/assistedTestHelper.ts
@@ -30,7 +30,6 @@ export const waitForHuman = async (
   if (consoleSteps !== undefined) {
     consoleSteps.forEach((line) => nodeConsole.log(`  ${line}`));
   }
-  nodeConsole.log('Click Cancel on the notification when done.');
   nodeConsole.log(SECTION_LINE);
 
   await vscode.window.withProgress(
@@ -116,7 +115,7 @@ export const waitForHumanVerdict = async (
   if (consoleSteps !== undefined) {
     consoleSteps.forEach((line) => nodeConsole.log(`  ${line}`));
   }
-  nodeConsole.log('Click the PASS or FAIL button in the status bar (bottom-left) when done.');
+  nodeConsole.log('PASS / FAIL buttons in the status bar (bottom-left).');
   nodeConsole.log(SECTION_LINE);
 
   // Dispose any stale UI from a previous invocation that never settled

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
@@ -226,8 +226,7 @@ standardSuite('R-D Bind to Destination', (ss) => {
         '1. Press Cmd+R Cmd+D',
         '2. Select Terminal ("rl-btd-009-b") from the list',
         '3. When the confirmation dialog appears, click "No, keep current binding"',
-        '4. Click Pass if the original binding to "rl-btd-009-a" was kept (no rebind, no status-bar change).',
-        '   Click Fail if "rl-btd-009-b" ended up bound or you saw a rebind toast.',
+        'Verdict:',
       ],
     );
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/builtInAiAssistants.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/builtInAiAssistants.test.ts
@@ -72,11 +72,7 @@ standardSuite('Built-in AI Assistants', (ss) => {
     const verdict = await waitForHumanVerdict(
       'claude-code-002',
       'Did the RangeLink + selected code appear in Claude Code chat?',
-      [
-        '1. The RangeLink send was fired automatically',
-        '2. Click PASS if the link + selected code appeared in Claude Code chat input',
-        '3. Click FAIL otherwise',
-      ],
+      ['1. The RangeLink send was fired automatically', 'Verdict:'],
     );
     assert.strictEqual(
       verdict,
@@ -119,8 +115,7 @@ standardSuite('Built-in AI Assistants', (ss) => {
       [
         '1. Lines 1-2 of cc-004 are already selected',
         '2. The send was fired automatically (no keypress needed)',
-        '3. Click PASS if the RangeLink appeared in Claude Code chat input',
-        '4. Click FAIL otherwise',
+        'Verdict:',
       ],
     );
     assert.strictEqual(
@@ -156,11 +151,7 @@ standardSuite('Built-in AI Assistants', (ss) => {
     const coldVerdict = await waitForHumanVerdict(
       'claude-code-005-cold',
       'Cold send: did the RangeLink appear in Claude Code chat?',
-      [
-        '1. Lines 1-2 of cc-005 are selected; cold send was fired automatically',
-        '2. Click PASS if the RangeLink appeared in Claude Code chat input',
-        '3. Click FAIL otherwise',
-      ],
+      ['1. Lines 1-2 of cc-005 are selected; cold send was fired automatically', 'Verdict:'],
     );
     assert.strictEqual(
       coldVerdict,
@@ -188,11 +179,7 @@ standardSuite('Built-in AI Assistants', (ss) => {
     const warmVerdict = await waitForHumanVerdict(
       'claude-code-005-warm',
       'Warm send: did the lines 3-4 RangeLink appear in Claude Code chat without refocus flicker?',
-      [
-        '1. Lines 3-4 of cc-005 are selected; warm send was fired automatically',
-        '2. Click PASS if the new RangeLink appeared AND the panel did not flicker/refocus',
-        '3. Click FAIL otherwise (no content, or visible flicker indicating cold-start path)',
-      ],
+      ['1. Lines 3-4 of cc-005 are selected; warm send was fired automatically', 'Verdict:'],
     );
     assert.strictEqual(
       warmVerdict,
@@ -239,11 +226,7 @@ standardSuite('Built-in AI Assistants', (ss) => {
     const verdict = await waitForHumanVerdict(
       'gemini-code-assist-002',
       'Did the RangeLink + selected code appear in Gemini Code Assist chat?',
-      [
-        '1. The RangeLink send was fired automatically',
-        '2. Click PASS if the link + selected code appeared in Gemini Code Assist chat input',
-        '3. Click FAIL otherwise',
-      ],
+      ['1. The RangeLink send was fired automatically', 'Verdict:'],
     );
     assert.strictEqual(
       verdict,
@@ -288,8 +271,7 @@ standardSuite('Built-in AI Assistants', (ss) => {
       [
         '1. Lines 1-2 of gc-003 are already selected',
         '2. The send was fired automatically (no keypress needed)',
-        '3. Click PASS if the RangeLink appeared in Gemini Code Assist chat input',
-        '4. Click FAIL otherwise',
+        'Verdict:',
       ],
     );
     assert.strictEqual(
@@ -327,11 +309,7 @@ standardSuite('Built-in AI Assistants', (ss) => {
     const coldVerdict = await waitForHumanVerdict(
       'gemini-code-assist-004-cold',
       'Cold send: did the RangeLink appear in Gemini Code Assist chat?',
-      [
-        '1. Lines 1-2 of gc-004 are selected; cold send was fired automatically',
-        '2. Click PASS if the RangeLink appeared in Gemini Code Assist chat input',
-        '3. Click FAIL otherwise',
-      ],
+      ['1. Lines 1-2 of gc-004 are selected; cold send was fired automatically', 'Verdict:'],
     );
     assert.strictEqual(
       coldVerdict,
@@ -357,11 +335,7 @@ standardSuite('Built-in AI Assistants', (ss) => {
     const warmVerdict = await waitForHumanVerdict(
       'gemini-code-assist-004-warm',
       'Warm send: did the lines 3-4 RangeLink appear in Gemini Code Assist chat without refocus flicker?',
-      [
-        '1. Lines 3-4 of gc-004 are selected; warm send was fired automatically',
-        '2. Click PASS if the new RangeLink appeared AND the panel did not flicker/refocus',
-        '3. Click FAIL otherwise (no content, or visible flicker indicating cold-start path)',
-      ],
+      ['1. Lines 3-4 of gc-004 are selected; warm send was fired automatically', 'Verdict:'],
     );
     assert.strictEqual(
       warmVerdict,
@@ -406,11 +380,7 @@ standardSuite('Built-in AI Assistants', (ss) => {
     const verdict = await waitForHumanVerdict(
       'github-copilot-chat-002',
       'Did the RangeLink + selected code appear in GitHub Copilot Chat?',
-      [
-        '1. The RangeLink send was fired automatically',
-        '2. Click PASS if the link + selected code appeared in GitHub Copilot Chat input',
-        '3. Click FAIL otherwise',
-      ],
+      ['1. The RangeLink send was fired automatically', 'Verdict:'],
     );
     assert.strictEqual(
       verdict,
@@ -453,8 +423,7 @@ standardSuite('Built-in AI Assistants', (ss) => {
       [
         '1. Lines 1-2 of ghc-003 are already selected',
         '2. The send was fired automatically (no keypress needed)',
-        '3. Click PASS if the RangeLink appeared in GitHub Copilot Chat input',
-        '4. Click FAIL otherwise',
+        'Verdict:',
       ],
     );
     assert.strictEqual(
@@ -490,11 +459,7 @@ standardSuite('Built-in AI Assistants', (ss) => {
     const coldVerdict = await waitForHumanVerdict(
       'github-copilot-chat-004-cold',
       'Cold send: did the RangeLink appear in GitHub Copilot Chat?',
-      [
-        '1. Lines 1-2 of ghc-004 are selected; cold send was fired automatically',
-        '2. Click PASS if the RangeLink appeared in GitHub Copilot Chat input',
-        '3. Click FAIL otherwise',
-      ],
+      ['1. Lines 1-2 of ghc-004 are selected; cold send was fired automatically', 'Verdict:'],
     );
     assert.strictEqual(
       coldVerdict,
@@ -520,11 +485,7 @@ standardSuite('Built-in AI Assistants', (ss) => {
     const warmVerdict = await waitForHumanVerdict(
       'github-copilot-chat-004-warm',
       'Warm send: did the lines 3-4 RangeLink appear in GitHub Copilot Chat without refocus flicker?',
-      [
-        '1. Lines 3-4 of ghc-004 are selected; warm send was fired automatically',
-        '2. Click PASS if the new RangeLink appeared AND the panel did not flicker/refocus',
-        '3. Click FAIL otherwise (no content, or visible flicker indicating cold-start path)',
-      ],
+      ['1. Lines 3-4 of ghc-004 are selected; warm send was fired automatically', 'Verdict:'],
     );
     assert.strictEqual(
       warmVerdict,
@@ -791,8 +752,7 @@ standardSuite('Built-in AI Assistants', (ss) => {
       [
         '1. Two rapid sends were fired automatically',
         '2. Check Claude Code chat for BOTH RangeLinks (lines 1-2 and lines 3-4)',
-        '3. Click PASS if both links were delivered',
-        '4. Click FAIL otherwise (missing link or wrong content)',
+        'Verdict:',
       ],
     );
     assert.strictEqual(

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
@@ -277,8 +277,7 @@ standardSuite('Context Menus — Editor Content', (ss) => {
       [
         '1. Right-click anywhere inside the editor',
         '2. Look at the RangeLink commands as a group (grouped together in the menu)',
-        '3. Click Pass if a visual separator line sits between the RangeLink block and the adjacent VS Code menu items.',
-        '   Click Fail if there is no separator (the RangeLink commands blend into the rest of the menu).',
+        'Verdict:',
       ],
     );
 
@@ -471,9 +470,8 @@ standardSuite('Context Menus — Editor Content', (ss) => {
         `A Terminal "${terminalName}" is bound so Unbind should remain visible.`,
         '1. Do NOT click-drag or double-click to create a text selection — cursor only',
         '2. Right-click anywhere inside the editor',
-        '3. Click Pass if ALL FIVE of these items are NOT visible: "Send RangeLink", "Send RangeLink (Absolute)", "Send Portable Link", "Send Portable Link (Absolute)", "Send Selected Text"',
+        'Verdict:',
         '   (File-path items and Bind/Unbind should remain visible — that is correct.)',
-        '   Click Fail if any of the five selection-dependent items appear despite no selection.',
       ],
     );
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
@@ -435,7 +435,6 @@ standardSuite('Context Menus — Editor Content', (ss) => {
         `A Terminal "${terminalName}" is bound as the current destination.`,
         '1. Right-click anywhere inside the editor',
         '2. Select "RangeLink: Unbind" from the context menu',
-        '3. Click Cancel on the notification',
       ],
     );
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuExplorer.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuExplorer.test.ts
@@ -177,12 +177,7 @@ standardSuite('Context Menus — Explorer', (ss) => {
     const verdict = await waitForHumanVerdict(
       'context-menus-explorer-005',
       `Right-click "${fn}" in Explorer — is "RangeLink: Unbind" ABSENT from the menu?`,
-      [
-        `1. Locate "${fn}" in the Explorer panel`,
-        '2. Right-click it',
-        '3. Click Pass if "RangeLink: Unbind" is NOT in the menu (the `when: rangelink.isBound` clause should hide it).',
-        '   Click Fail if it IS present (that would be a bug).',
-      ],
+      [`1. Locate "${fn}" in the Explorer panel`, '2. Right-click it', 'Verdict:'],
     );
 
     assert.strictEqual(

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
@@ -352,86 +352,87 @@ standardSuite('Context Menus — Terminal', (ss) => {
     ss.log(
       '✓ Terminal content-area "Send Selected Text" visible when terminal has selection and is not bound',
     );
-
-    // TC context-menus-terminal-011: R-V HIDDEN from both terminal menus when
-    // the terminal IS the bound destination (self-paste gate)
-    // ---------------------------------------------------------------------------
-
-    test('[assisted] context-menus-terminal-011: "Send Selected Text" is hidden from the terminal content-area menu when the terminal IS the bound destination', async () => {
-      const terminalName = 'rl-ctxmenu-term-011';
-      const terminal = await ss.createTerminal(terminalName);
-
-      await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL, terminal);
-      await ss.settle();
-
-      const markerText = 'CTXMENU_011_SELF_BIND_MARKER';
-      echoToTerminal(terminal, markerText);
-      await ss.settle(TERMINAL_READY_MS);
-
-      ss.expectStatusBarMessages([`✓ RangeLink: Bound to Terminal ("${terminalName}")`]);
-      ss.expectContextKeys({
-        'rangelink.isActiveTerminalBindable': true,
-        'rangelink.isActiveTerminalPasteDestination': true,
-        'rangelink.isBound': true,
-      });
-
-      const logCapture = getLogCapture();
-      logCapture.mark('before-ctxmenu-term-011');
-
-      const verdict = await waitForHumanVerdict(
-        'context-menus-terminal-011',
-        `Select "${markerText}" in "${terminalName}". Is "RangeLink: Send Selected Text" ABSENT from the content-area right-click menu?`,
-        [
-          `The terminal "${terminalName}" IS the bound destination (self-paste would be circular).`,
-          `1. Select "${markerText}" in the terminal content area`,
-          '2. Right-click the terminal CONTENT AREA — verify "RangeLink: Send Selected Text" is ABSENT',
-          'Verdict:',
-        ],
-      );
-      assert.strictEqual(
-        verdict,
-        'pass',
-        'Expected "Send Selected Text" to be hidden from the terminal content-area menu when the terminal IS the bound destination',
-      );
-
-      ss.log(
-        '✓ Self-paste gate: R-V hidden from terminal content-area menu when terminal IS the bound destination',
-      );
-    });
-
-    // ---------------------------------------------------------------------------
-
-    test('[assisted] context-menus-terminal-012: Terminal content-area "Send Selected Text" is absent when no terminal text is selected', async () => {
-      const terminalName = 'rl-ctxmenu-term-012';
-      const terminal = await ss.createTerminal(terminalName);
-      echoToTerminal(terminal, 'CTXMENU_012_NO_SELECTION');
-      await ss.settle(TERMINAL_READY_MS);
-
-      ss.expectContextKeys({
-        'rangelink.isActiveTerminalBindable': true,
-        'rangelink.isActiveTerminalPasteDestination': false,
-        'rangelink.isBound': false,
-      });
-
-      const verdict = await waitForHumanVerdict(
-        'context-menus-terminal-012',
-        `Right-click INSIDE "${terminalName}" content area WITHOUT selecting text. Is "RangeLink: Send Selected Text" ABSENT from the content-area menu?`,
-        [
-          `The terminal "${terminalName}" has output text but nothing is selected.`,
-          '1. Do NOT select any text in the terminal',
-          '2. Right-click INSIDE the terminal content area (not the tab)',
-          'Verdict:',
-        ],
-      );
-      assert.strictEqual(
-        verdict,
-        'pass',
-        'Expected "Send Selected Text" to be absent from terminal content-area menu when no text is selected',
-      );
-
-      ss.log('✓ No-selection negative: R-V absent from terminal content-area menu');
-    });
   });
+
+  // TC context-menus-terminal-011: R-V HIDDEN from both terminal menus when
+  // the terminal IS the bound destination (self-paste gate)
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-terminal-011: "Send Selected Text" is hidden from the terminal content-area menu when the terminal IS the bound destination', async () => {
+    const terminalName = 'rl-ctxmenu-term-011';
+    const terminal = await ss.createTerminal(terminalName);
+
+    await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL, terminal);
+    await ss.settle();
+
+    const markerText = 'CTXMENU_011_SELF_BIND_MARKER';
+    echoToTerminal(terminal, markerText);
+    await ss.settle(TERMINAL_READY_MS);
+
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Terminal ("${terminalName}")`]);
+    ss.expectContextKeys({
+      'rangelink.isActiveTerminalBindable': true,
+      'rangelink.isActiveTerminalPasteDestination': true,
+      'rangelink.isBound': true,
+    });
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-ctxmenu-term-011');
+
+    const verdict = await waitForHumanVerdict(
+      'context-menus-terminal-011',
+      `Select "${markerText}" in "${terminalName}". Is "RangeLink: Send Selected Text" ABSENT from the content-area right-click menu?`,
+      [
+        `The terminal "${terminalName}" IS the bound destination (self-paste would be circular).`,
+        `1. Select "${markerText}" in the terminal content area`,
+        '2. Right-click the terminal CONTENT AREA — verify "RangeLink: Send Selected Text" is ABSENT',
+        'Verdict:',
+      ],
+    );
+    assert.strictEqual(
+      verdict,
+      'pass',
+      'Expected "Send Selected Text" to be hidden from the terminal content-area menu when the terminal IS the bound destination',
+    );
+
+    ss.log(
+      '✓ Self-paste gate: R-V hidden from terminal content-area menu when terminal IS the bound destination',
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-terminal-012: Terminal content-area "Send Selected Text" is absent when no terminal text is selected', async () => {
+    const terminalName = 'rl-ctxmenu-term-012';
+    const terminal = await ss.createTerminal(terminalName);
+    echoToTerminal(terminal, 'CTXMENU_012_NO_SELECTION');
+    await ss.settle(TERMINAL_READY_MS);
+
+    ss.expectContextKeys({
+      'rangelink.isActiveTerminalBindable': true,
+      'rangelink.isActiveTerminalPasteDestination': false,
+      'rangelink.isBound': false,
+    });
+
+    const verdict = await waitForHumanVerdict(
+      'context-menus-terminal-012',
+      `Right-click INSIDE "${terminalName}" content area WITHOUT selecting text. Is "RangeLink: Send Selected Text" ABSENT from the content-area menu?`,
+      [
+        `The terminal "${terminalName}" has output text but nothing is selected.`,
+        '1. Do NOT select any text in the terminal',
+        '2. Right-click INSIDE the terminal content area (not the tab)',
+        'Verdict:',
+      ],
+    );
+    assert.strictEqual(
+      verdict,
+      'pass',
+      'Expected "Send Selected Text" to be absent from terminal content-area menu when no text is selected',
+    );
+
+    ss.log('✓ No-selection negative: R-V absent from terminal content-area menu');
+  });
+
   // ---------------------------------------------------------------------------
   // TC send-terminal-selection-005 (lives here because the scenario is
   // specifically the terminal-context-menu path into R-V; the test file's slug

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
@@ -191,8 +191,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
       [
         `1. Locate the "${terminalName}" tab in the terminal panel's tab bar`,
         '2. Right-click the tab (NOT the content area)',
-        '3. PASS if "RangeLink: Bind Here" is NOT in the menu',
-        '4. FAIL if "RangeLink: Bind Here" appears in the menu',
+        'Verdict:',
       ],
     );
     assert.strictEqual(
@@ -222,8 +221,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
       [
         `1. Focus the "${terminalName}" pty terminal`,
         '2. Right-click INSIDE the terminal output area (NOT the tab)',
-        '3. PASS if "RangeLink: Bind Here" is NOT in the menu',
-        '4. FAIL if "RangeLink: Bind Here" appears in the menu',
+        'Verdict:',
       ],
     );
     assert.strictEqual(
@@ -300,11 +298,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
     const verdict = await waitForHumanVerdict(
       'context-menus-terminal-009',
       `Right-click inside the "${ptyName}" pty terminal content area. Is "RangeLink: Unbind" PRESENT and "RangeLink: Bind Here" ABSENT?`,
-      [
-        '1. Right-click INSIDE the pty terminal content area',
-        '2. PASS if "RangeLink: Unbind" IS in the menu AND "RangeLink: Bind Here" is NOT',
-        '3. FAIL if either condition is violated',
-      ],
+      ['1. Right-click INSIDE the pty terminal content area', 'Verdict:'],
     );
     assert.strictEqual(
       verdict,
@@ -315,6 +309,129 @@ standardSuite('Context Menus — Terminal', (ss) => {
     ss.log('✓ Pty content menu: Unbind present, Bind Here absent (when bound to shell)');
   });
 
+  // TC context-menus-terminal-010: R-V in terminal CONTENT-AREA context menu
+  // when terminal has selection and is NOT the bound destination
+  // ---------------------------------------------------------------------------
+
+  test('[assisted] context-menus-terminal-010: Terminal content-area "Send Selected Text" appears when terminal has selection and is not the bound destination', async () => {
+    const terminalName = 'rl-ctxmenu-term-010';
+    const destName = 'rl-ctxmenu-term-010-DEST';
+    const terminal = await ss.createTerminal(terminalName);
+    await ss.createTerminal(destName);
+
+    const markerText = 'CTXMENU_010_RV_CONTENT_MARKER';
+    echoToTerminal(terminal, markerText);
+    terminal.show(true);
+    await ss.settle(TERMINAL_READY_MS);
+
+    ss.expectStatusBarMessages([
+      `✓ RangeLink: Bound to Terminal ("${destName}")`,
+      `✓ RangeLink: Selected text sent to Terminal ("${destName}")`,
+    ]);
+    ss.expectContextKeys({
+      'rangelink.isActiveTerminalBindable': true,
+      'rangelink.isActiveTerminalPasteDestination': true,
+      'rangelink.isBound': true,
+    });
+
+    const logCapture = getLogCapture();
+    logCapture.mark('before-ctxmenu-term-010');
+
+    await waitForHuman(
+      'context-menus-terminal-010',
+      `Select "${markerText}" in "${terminalName}" → right-click CONTENT AREA → "RangeLink: Send Selected Text" → pick "${destName}" from the destination picker`,
+      [
+        `The terminal "${terminalName}" has "${markerText}" in its output. No destination is bound.`,
+        '1. Select the marker text in the terminal content area',
+        '2. Right-click INSIDE the terminal content area (not the tab)',
+        '3. Verify "RangeLink: Send Selected Text" is present in the content-area context menu',
+        '4. Select it — a destination picker opens — pick Terminal ("' + destName + '")',
+      ],
+    );
+
+    ss.log(
+      '✓ Terminal content-area "Send Selected Text" visible when terminal has selection and is not bound',
+    );
+
+    // TC context-menus-terminal-011: R-V HIDDEN from both terminal menus when
+    // the terminal IS the bound destination (self-paste gate)
+    // ---------------------------------------------------------------------------
+
+    test('[assisted] context-menus-terminal-011: "Send Selected Text" is hidden from the terminal content-area menu when the terminal IS the bound destination', async () => {
+      const terminalName = 'rl-ctxmenu-term-011';
+      const terminal = await ss.createTerminal(terminalName);
+
+      await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL, terminal);
+      await ss.settle();
+
+      const markerText = 'CTXMENU_011_SELF_BIND_MARKER';
+      echoToTerminal(terminal, markerText);
+      await ss.settle(TERMINAL_READY_MS);
+
+      ss.expectStatusBarMessages([`✓ RangeLink: Bound to Terminal ("${terminalName}")`]);
+      ss.expectContextKeys({
+        'rangelink.isActiveTerminalBindable': true,
+        'rangelink.isActiveTerminalPasteDestination': true,
+        'rangelink.isBound': true,
+      });
+
+      const logCapture = getLogCapture();
+      logCapture.mark('before-ctxmenu-term-011');
+
+      const verdict = await waitForHumanVerdict(
+        'context-menus-terminal-011',
+        `Select "${markerText}" in "${terminalName}". Is "RangeLink: Send Selected Text" ABSENT from the content-area right-click menu?`,
+        [
+          `The terminal "${terminalName}" IS the bound destination (self-paste would be circular).`,
+          `1. Select "${markerText}" in the terminal content area`,
+          '2. Right-click the terminal CONTENT AREA — verify "RangeLink: Send Selected Text" is ABSENT',
+          'Verdict:',
+        ],
+      );
+      assert.strictEqual(
+        verdict,
+        'pass',
+        'Expected "Send Selected Text" to be hidden from the terminal content-area menu when the terminal IS the bound destination',
+      );
+
+      ss.log(
+        '✓ Self-paste gate: R-V hidden from terminal content-area menu when terminal IS the bound destination',
+      );
+    });
+
+    // ---------------------------------------------------------------------------
+
+    test('[assisted] context-menus-terminal-012: Terminal content-area "Send Selected Text" is absent when no terminal text is selected', async () => {
+      const terminalName = 'rl-ctxmenu-term-012';
+      const terminal = await ss.createTerminal(terminalName);
+      echoToTerminal(terminal, 'CTXMENU_012_NO_SELECTION');
+      await ss.settle(TERMINAL_READY_MS);
+
+      ss.expectContextKeys({
+        'rangelink.isActiveTerminalBindable': true,
+        'rangelink.isActiveTerminalPasteDestination': false,
+        'rangelink.isBound': false,
+      });
+
+      const verdict = await waitForHumanVerdict(
+        'context-menus-terminal-012',
+        `Right-click INSIDE "${terminalName}" content area WITHOUT selecting text. Is "RangeLink: Send Selected Text" ABSENT from the content-area menu?`,
+        [
+          `The terminal "${terminalName}" has output text but nothing is selected.`,
+          '1. Do NOT select any text in the terminal',
+          '2. Right-click INSIDE the terminal content area (not the tab)',
+          'Verdict:',
+        ],
+      );
+      assert.strictEqual(
+        verdict,
+        'pass',
+        'Expected "Send Selected Text" to be absent from terminal content-area menu when no text is selected',
+      );
+
+      ss.log('✓ No-selection negative: R-V absent from terminal content-area menu');
+    });
+  });
   // ---------------------------------------------------------------------------
   // TC send-terminal-selection-005 (lives here because the scenario is
   // specifically the terminal-context-menu path into R-V; the test file's slug
@@ -322,7 +439,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
   // QA journal.)
   // ---------------------------------------------------------------------------
 
-  test('[assisted] send-terminal-selection-005: Terminal content-area "Send Selection to Destination" sends selected text to bound editor', async () => {
+  test('[assisted] send-terminal-selection-005: Terminal content-area "Send Selected Text" sends selected text to bound editor', async () => {
     const editorUri = await ss.createAndOpenFile(
       'ctxmenu-term-sts-005',
       'destination file — terminal selection arrives here\n',
@@ -353,14 +470,14 @@ standardSuite('Context Menus — Terminal', (ss) => {
 
     await waitForHuman(
       'send-terminal-selection-005',
-      `Select "${markerText}" in terminal "${terminalName}" → right-click → "RangeLink: Send Selection to Destination"`,
+      `Select "${markerText}" in terminal "${terminalName}" → right-click → "RangeLink: Send Selected Text"`,
       [
         `A Text Editor "${editorFn}" is currently bound as the destination.`,
         `The terminal "${terminalName}" has "${markerText}" in its output.`,
         `1. Select the "${markerText}" text in the terminal content area`,
         '2. Right-click INSIDE the terminal content area (not the tab)',
-        '3. Verify "RangeLink: Send Selection to Destination" is present',
-        '4. Select "RangeLink: Send Selection to Destination"',
+        '3. Verify "RangeLink: Send Selected Text" is present',
+        '4. Select "RangeLink: Send Selected Text"',
         `The selected text should appear in the "${editorFn}" editor.`,
       ],
     );
@@ -372,9 +489,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
       `Expected editor to contain "${markerText}" but got: ${editorText}`,
     );
 
-    ss.log(
-      '✓ Terminal context-menu "Send Selection to Destination" routed selection to bound editor',
-    );
+    ss.log('✓ Terminal context-menu "Send Selected Text" routed selection to bound editor');
   });
 
   // ---------------------------------------------------------------------------
@@ -409,14 +524,14 @@ standardSuite('Context Menus — Terminal', (ss) => {
 
     await waitForHuman(
       'send-terminal-selection-008',
-      `Select "${markerText}" in SOURCE terminal "${sourceName}" → right-click → "Send Selection to Destination"`,
+      `Select "${markerText}" in SOURCE terminal "${sourceName}" → right-click → "Send Selected Text"`,
       [
         `Destination: Terminal "${boundName}" is bound (pty-captured — the test reads its buffer to verify content).`,
         `Source: Terminal "${sourceName}" contains "${markerText}".`,
         `1. Click the "${sourceName}" terminal to focus it`,
         `2. Select the "${markerText}" text in its output`,
         '3. Right-click INSIDE the source terminal content area (not the tab)',
-        '4. Select "RangeLink: Send Selection to Destination"',
+        '4. Select "RangeLink: Send Selected Text"',
         `The selection should paste into "${boundName}" and focus should shift there.`,
       ],
     );
@@ -435,7 +550,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
     );
   });
 
-  test('[assisted] send-terminal-selection-009: "Send Selection to Destination" is NOT in the terminal TAB menu', async () => {
+  test('[assisted] send-terminal-selection-009: "Send Selected Text" is NOT in the terminal TAB menu', async () => {
     const terminalName = 'rl-sts-009';
     const terminal = await ss.createTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
@@ -455,20 +570,19 @@ standardSuite('Context Menus — Terminal', (ss) => {
 
     const verdict = await waitForHumanVerdict(
       'send-terminal-selection-009',
-      `Select text in "${terminalName}" → right-click the TAB → is "Send Selection to Destination" ABSENT from the menu?`,
+      `Select text in "${terminalName}" → right-click the TAB → is "Send Selected Text" ABSENT from the menu?`,
       [
         `The terminal "${terminalName}" is bound to itself (self-bind for this contract test).`,
         `1. Click the "${terminalName}" terminal and select "STS_009_MARKER_TEXT" in its output`,
         '2. Right-click the terminal TAB (not the content area)',
-        '3. Click Pass if "RangeLink: Send Selection to Destination" is NOT in the menu.',
-        '   Click Fail if it IS present (that would be a bug).',
+        'Verdict:',
       ],
     );
 
     assert.strictEqual(
       verdict,
       'pass',
-      'Human reported "Send Selection to Destination" WAS visible in the tab menu — this is a bug',
+      'Human reported "Send Selected Text" WAS visible in the tab menu — this is a bug',
     );
 
     ss.log('✓ Tab menu did NOT offer "Send Selection" (human verdict)');
@@ -503,12 +617,12 @@ standardSuite('Context Menus — Terminal', (ss) => {
 
     await waitForHuman(
       'send-terminal-selection-010',
-      `Select "${markerText}" in "${terminalName}" → right-click content area → "Send Selection to Destination"`,
+      `Select "${markerText}" in "${terminalName}" → right-click content area → "Send Selected Text"`,
       [
         `Destination: Terminal "${terminalName}" is bound (the SAME terminal we'll select from).`,
         `1. Select "${markerText}" in "${terminalName}" (the marker text is visible in the buffer)`,
         '2. Right-click INSIDE the content area',
-        '3. Select "RangeLink: Send Selection to Destination"',
+        '3. Select "RangeLink: Send Selected Text"',
         'The selection will be pasted BACK into the same terminal (this documents current behavior; a self-paste guard for terminals is worth filing as a follow-up).',
       ],
     );
@@ -553,12 +667,12 @@ standardSuite('Context Menus — Terminal', (ss) => {
 
     await waitForHuman(
       'send-terminal-selection-011',
-      `Select "${markerText}" in "${sourceName}" → right-click content area → "Send Selection to Destination" → pick Terminal ("${destName}")`,
+      `Select "${markerText}" in "${sourceName}" → right-click content area → "Send Selected Text" → pick Terminal ("${destName}")`,
       [
         `No destination is currently bound. Two terminals exist: "${sourceName}" (with marker text) and "${destName}" (empty destination).`,
         `1. Click the "${sourceName}" terminal and select "${markerText}"`,
         '2. Right-click INSIDE the content area (NOT the tab)',
-        '3. Select "RangeLink: Send Selection to Destination"',
+        '3. Select "RangeLink: Send Selected Text"',
         `4. In the destination picker that opens, pick Terminal ("${destName}")`,
         `The selection should be delivered to "${destName}" and "${destName}" should become the bound destination.`,
       ],
@@ -604,13 +718,12 @@ standardSuite('Context Menus — Terminal', (ss) => {
 
     const verdict = await waitForHumanVerdict(
       'send-terminal-selection-012',
-      `Right-click inside "${terminalName}" WITHOUT selecting → is "Send Selection to Destination" ABSENT from the menu?`,
+      `Right-click inside "${terminalName}" WITHOUT selecting → is "Send Selected Text" ABSENT from the menu?`,
       [
         `The terminal "${terminalName}" is bound to itself.`,
         '1. Do NOT click-drag or double-click to create a text selection',
         `2. Right-click INSIDE the "${terminalName}" content area on an empty region`,
-        '3. Click Pass if "RangeLink: Send Selection to Destination" is NOT in the menu (the `when: terminalTextSelected` clause should hide it).',
-        '   Click Fail if it IS present (that would be a bug).',
+        'Verdict:',
       ],
     );
 
@@ -659,14 +772,14 @@ standardSuite('Context Menus — Terminal', (ss) => {
 
     await waitForHuman(
       'send-terminal-selection-013',
-      `Select "${markerText}" in "${terminalName}" → right-click content area → "Send Selection to Destination"`,
+      `Select "${markerText}" in "${terminalName}" → right-click content area → "Send Selected Text"`,
       [
         'Destination: Dummy AI (Tier 1) is bound.',
         `Source: "${terminalName}" has "${markerText}" in its output.`,
         `1. Click the "${terminalName}" terminal to focus it`,
         `2. Select "${markerText}" in its output`,
         '3. Right-click INSIDE the terminal content area (not the tab)',
-        '4. Select "RangeLink: Send Selection to Destination"',
+        '4. Select "RangeLink: Send Selected Text"',
         'The selection should be delivered to the Dummy AI extension via direct insert.',
       ],
     );

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
@@ -303,7 +303,7 @@ standardSuite('Core Send Commands', (ss) => {
       [
         `1. Click into "csc-sts-004-src", drag-select "${MARKER}"`,
         '2. Press Cmd+R Cmd+V — the RangeLink destination picker opens',
-        '3. Press Escape to dismiss the picker, then click Cancel',
+        '3. Press Escape to dismiss the picker',
       ],
     );
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/editorBindingValidation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/editorBindingValidation.test.ts
@@ -25,7 +25,7 @@ standardSuite('Editor Binding Validation', (ss) => {
         '2. Right-click anywhere in the EDITOR CONTENT AREA (not the tab at the top)',
         '3. Confirm these do NOT appear: "Send RangeLink", "Send This File\'s Path", "RangeLink: Bind Here"',
         '4. "Send Selected Text" and "Unbind" are acceptable if present',
-        '   Click Pass if link/bind commands are absent, Fail if any appear',
+        'Verdict:',
       ],
     );
 
@@ -47,7 +47,7 @@ standardSuite('Editor Binding Validation', (ss) => {
         '3. Right-click anywhere in the Output panel',
         '4. Confirm no "Send This File\'s Path" or "RangeLink: Bind Here" appears',
         '5. "Unbind" is acceptable if present',
-        '   Click Pass if those commands are absent, Fail if any appear',
+        'Verdict:',
       ],
     );
 
@@ -71,7 +71,7 @@ standardSuite('Editor Binding Validation', (ss) => {
         '5. Confirm no "Send File Path" or "Send Relative File Path" appears',
         '6. Press Cmd+R Cmd+D — confirm Settings UI is not listed as a bindable destination',
         '7. Press Escape to dismiss the picker',
-        '   Click Pass if all commands are absent, Fail if any appear',
+        'Verdict:',
       ],
     );
 
@@ -136,7 +136,7 @@ standardSuite('Editor Binding Validation', (ss) => {
         '2. Right-click the search editor TAB at the top of the editor area (not the content)',
         '3. Confirm no "Send File Path" or "Send Relative File Path" appears in the context menu',
         '4. "Unbind" is acceptable if present',
-        '   Click Pass if file path commands are absent, Fail if any appear',
+        'Verdict:',
       ],
     );
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/linkGeneration.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/linkGeneration.test.ts
@@ -165,8 +165,7 @@ standardSuite('Link Generation — Clickable Links (Assisted)', (ss) => {
       [
         '1. Hover your cursor over https://example.com/path/file.ts#L10 in the editor',
         '2. The URL will show a regular VS Code browser-style link hover — that is expected and fine',
-        '3. PASS if: RangeLink does NOT add its own clickable underline or tooltip',
-        '4. FAIL if: RangeLink adds a clickable underline or tooltip on the URL',
+        'Verdict:',
       ],
     );
 
@@ -191,8 +190,7 @@ standardSuite('Link Generation — Clickable Links (Assisted)', (ss) => {
       [
         '1. Look at the line: See code at src/utils/helper.ts#L5 for details',
         '2. Hover your cursor over the RangeLink (it should be underlined/clickable)',
-        '3. PASS if: the RangeLink tooltip shows clean text (file path and line number)',
-        '4. FAIL if: the tooltip shows raw JSON, a command: URI, or internal parameters',
+        'Verdict:',
       ],
     );
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/linkGeneration.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/linkGeneration.test.ts
@@ -161,7 +161,7 @@ standardSuite('Link Generation — Clickable Links (Assisted)', (ss) => {
 
     const verdict = await waitForHumanVerdict(
       'url-exclusion-002',
-      'Verify RangeLink does NOT add its own hover/tooltip on a regular https:// URL',
+      "Is RangeLink's hover/tooltip ABSENT from the https:// URL?",
       [
         '1. Hover your cursor over https://example.com/path/file.ts#L10 in the editor',
         '2. The URL will show a regular VS Code browser-style link hover — that is expected and fine',
@@ -186,7 +186,7 @@ standardSuite('Link Generation — Clickable Links (Assisted)', (ss) => {
 
     const verdict = await waitForHumanVerdict(
       'document-link-tooltip-001',
-      'Hover over the RangeLink — expect a clean human-readable tooltip (file path + line number)',
+      'Is the RangeLink tooltip clean and human-readable (showing file path + line number)?',
       [
         '1. Look at the line: See code at src/utils/helper.ts#L5 for details',
         '2. Hover your cursor over the RangeLink (it should be underlined/clickable)',

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/statusBarMenu.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/statusBarMenu.test.ts
@@ -197,12 +197,11 @@ standardSuite('R-M Status Bar Menu', (ss) => {
 
     await waitForHuman(
       'status-bar-menu-008',
-      'Open the R-M menu (Cmd+R Cmd+M), select "$(link-external) Go to Link", dismiss the R-G input box (Escape), then click Cancel.',
+      'Open the R-M menu (Cmd+R Cmd+M), select "$(link-external) Go to Link", then dismiss the R-G input box (Escape).',
       [
         '1. Press Cmd+R Cmd+M to open the R-M menu',
         '2. Select "$(link-external) Go to Link"',
         '3. The R-G input box opens — press Escape to dismiss it',
-        '4. Click Cancel on this notification',
       ],
     );
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/statusBarMenu.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/statusBarMenu.test.ts
@@ -130,8 +130,7 @@ standardSuite('R-M Status Bar Menu', (ss) => {
       [
         '1. Locate the RangeLink item in the bottom-right status bar',
         '2. Hover over it to reveal the tooltip',
-        '3. Click PASS if it shows "$(link) RangeLink" with tooltip "RangeLink — no destination bound"',
-        '   Click FAIL if the text or tooltip is wrong, or the item is missing',
+        'Verdict:',
       ],
     );
     assert.strictEqual(verdict, 'pass', 'Human reported status bar text or tooltip was incorrect');
@@ -336,8 +335,7 @@ standardSuite('R-M Status Bar Menu', (ss) => {
         '1. Locate the RangeLink item in the bottom-right status bar',
         '2. Hover over it to reveal the tooltip',
         '3. Verify the icon does NOT have a prominent/bright color (it should look default/neutral)',
-        '4. Click PASS if tooltip is "RangeLink — no destination bound" and color is default',
-        '   Click FAIL if the tooltip or color is wrong',
+        'Verdict:',
       ],
     );
     assert.strictEqual(
@@ -356,8 +354,7 @@ standardSuite('R-M Status Bar Menu', (ss) => {
         '1. Hover over the RangeLink status bar item again',
         `2. Verify the tooltip shows "RangeLink — Terminal (\\"${terminalName}\\")"`,
         '3. Verify the icon now has a prominent/bright color (different from the default)',
-        '4. Click PASS if both tooltip and color changed correctly',
-        '   Click FAIL if the tooltip or color is wrong',
+        'Verdict:',
       ],
     );
     assert.strictEqual(verdictBound, 'pass', 'Human reported bound tooltip or color was incorrect');
@@ -372,8 +369,7 @@ standardSuite('R-M Status Bar Menu', (ss) => {
         '1. Hover over the RangeLink status bar item again',
         '2. Verify the tooltip is back to "RangeLink — no destination bound"',
         '3. Verify the icon color is back to default (no prominent color)',
-        '4. Click PASS if both tooltip and color reverted correctly',
-        '   Click FAIL if the tooltip or color is wrong',
+        'Verdict:',
       ],
     );
     assert.strictEqual(

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/unbind.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/unbind.test.ts
@@ -106,7 +106,6 @@ standardSuite('Unbind Destination', (ss) => {
         '1. Open the Command Palette (Cmd+Shift+P / Ctrl+Shift+P)',
         '2. Type "RangeLink: Unbind"',
         '3. Execute "RangeLink: Unbind" to unbind the destination',
-        '4. Click Cancel on the notification',
       ],
     );
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/unbind.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/unbind.test.ts
@@ -74,8 +74,7 @@ standardSuite('Unbind Destination', (ss) => {
       [
         '1. Open the Command Palette (Cmd+Shift+P / Ctrl+Shift+P)',
         '2. Type "RangeLink: Unbind"',
-        '3. Click Pass if "RangeLink: Unbind" is NOT visible (the `when: rangelink.isBound` clause should hide it).',
-        '   Click Fail if it IS present (that would be a bug).',
+        'Verdict:',
       ],
     );
 

--- a/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
@@ -491,7 +491,7 @@ describe('package.json contributions', () => {
       it('rangelink.terminal.pasteSelectedTextToDestination', () => {
         expect(findCommand('rangelink.terminal.pasteSelectedTextToDestination')).toStrictEqual({
           command: 'rangelink.terminal.pasteSelectedTextToDestination',
-          title: 'RangeLink: Send Selection to Destination',
+          title: 'RangeLink: Send Selected Text',
           icon: '$(symbol-snippet)',
         });
       });
@@ -1454,11 +1454,11 @@ describe('package.json contributions', () => {
         expect(terminalContextMenu).toHaveLength(3);
       });
 
-      it('pasteSelectedTextToDestination in edit group when text selected (matches editor family — no isBound gate)', () => {
+      it('pasteSelectedTextToDestination leads terminal context menu when text selected and terminal is not the bound destination', () => {
         expect(terminalContextMenu[0]).toStrictEqual({
-          when: 'terminalTextSelected',
+          when: 'terminalTextSelected && !rangelink.isActiveTerminalPasteDestination',
           command: 'rangelink.terminal.pasteSelectedTextToDestination',
-          group: '2_edit@10',
+          group: 'rangelink@1',
         });
       });
 
@@ -1466,7 +1466,7 @@ describe('package.json contributions', () => {
         expect(terminalContextMenu[1]).toStrictEqual({
           when: 'rangelink.isActiveTerminalBindable',
           command: 'rangelink.terminal.bind',
-          group: 'rangelink@1',
+          group: 'rangelink@2',
         });
       });
 
@@ -1474,7 +1474,7 @@ describe('package.json contributions', () => {
         expect(terminalContextMenu[2]).toStrictEqual({
           when: 'rangelink.isBound',
           command: 'rangelink.terminal.unbind',
-          group: 'rangelink@2',
+          group: 'rangelink@3',
         });
       });
     });


### PR DESCRIPTION
## Summary

Fixes "RangeLink: Send Selected Text" (R-V) in the terminal content-area context menu — the entry was assigned to an unrecognized menu group (`2_edit@10`) that VS Code silently drops. Moves it to the `rangelink@` group so it actually renders. Adds a self-bind gate (`!rangelink.isActiveTerminalPasteDestination`) so the entry is hidden when the terminal IS the bound destination. Harmonizes the terminal command title to "Send Selected Text" matching the editor variant. Adds 3 new assisted integration tests with negative coverage. Splits the Terminal section in CHANGELOG and README into Tab/Content subsections for clarity. Cleans up all `waitForHumanVerdict` call sites across 11 integration test files: replaces verbose PASS/FAIL instructions with a single "Verdict:" step, removes "Click Cancel" from `waitForHuman` helper output.

## Changes

- package.json: `terminal/context` R-V group `2_edit@10` → `rangelink@1`, when clause `terminalTextSelected` → `terminalTextSelected && !rangelink.isActiveTerminalPasteDestination`; command title harmonized to "Send Selected Text"
- packageJsonContracts.test.ts: updated terminal/context assertions for new group and when clause; updated command title assertion
- contextMenuTerminal.test.ts: 3 new [assisted] tests (010=content-area R-V appears, 011=self-bind gate, 012=no-selection absent); Verdict: cleanup; import ordering
- qa-test-cases-unreleased.yaml: matching TCs for new tests
- CHANGELOG.md: Terminal section split into Tab/Content; self-bind gate; command title harmonization
- README.md: Terminal section split into Tab/Content; CodeRabbit badge fix
- CLAUDE.md: T017 rule (waitForHuman/waitForHumanVerdict conventions); unreleased-markers <never> for CHANGELOG
- assistedTestHelper.ts: removed "Click Cancel on the notification when done" from waitForHuman; shortened "PASS or FAIL" message
- 10 integration test files: "Verdict:" replaces verbose PASS/FAIL instructions in all waitForHumanVerdict call sites
- EditorBindingValidation test: "Verdict:" replaces PASS/FAIL in waitForHumanVerdict

## Test Plan

- [ ] All unit tests pass: `pnpm test`
- [ ] Contract tests pass: `pnpm jest --testPathPattern=packageJsonContracts`
- [ ] QA coverage validates: `pnpm validate:qa-coverage`
- [ ] Automated integration tests pass: `pnpm test:release:automated`
- [ ] New assisted TCs: `pnpm test:release:grep "context-menus-terminal-010|context-menus-terminal-011|context-menus-terminal-012" --assisted`

## Related

- Closes https://github.com/couimet/rangeLink/issues/603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified terminal context menu documentation, separating Terminal Tab and Terminal Content sections
  * Renamed terminal command to "RangeLink: Send Selected Text" for clarity
  * Updated README badge references
  * Refined changelog formatting standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->