### PR TITLE
Post workflow checklist as QA issue comment after release lock

### DIFF
--- a/packages/rangelink-vscode-extension/scripts/generate-release-testing-instructions.sh
+++ b/packages/rangelink-vscode-extension/scripts/generate-release-testing-instructions.sh
@@ -66,10 +66,7 @@ generated: ${GENERATED_TS}
 
 ## Next steps
 
-1. \`pnpm test\` — unit tests + coverage gate
-2. Work through the QA tracker checkboxes — each row has the exact pnpm command to run
-3. \`pnpm validate:qa-coverage:vscode-extension\`
-4. When all checkboxes pass: \`pnpm release:prepare:vscode-extension\`
+Work through the QA tracker issue — the first comment has the workflow checklist and each checkbox row has the exact pnpm command to run.
 EOF
 
 RELATIVE_PATH="${OUTPUT_FILE#"$MONOREPO_ROOT"/}"

--- a/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
+++ b/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
@@ -76,7 +76,7 @@ fi
 
 # --- Step 3: Generate QA issue ---
 
-echo -e "${GREEN}Step 4: Generating QA issue tracker...${NC}"
+echo -e "${GREEN}Step 3: Generating QA issue tracker...${NC}"
 
 QA_OUTPUT=$("$SCRIPT_DIR/generate-qa-issue.sh") || {
   echo -e "${RED}Error: generate-qa-issue.sh failed${NC}" >&2
@@ -130,6 +130,21 @@ Soft-lock the deferred "Unreleased" version for QA.
 EOF
 
 echo -e "${GREEN}Commit message: $(basename "$COMMIT_MSG_FILE")${NC}"
+
+# Post the workflow instructions as a comment on the QA issue so they are
+# visible alongside the checkboxes — no need to switch between the issue
+# and the instructions file. The commit message path is now known, so the
+# comment includes the exact copy-paste commands.
+COMMIT_MSG_REL="${COMMIT_MSG_FILE#"$REPO_ROOT"/}"
+gh issue comment "$QA_ISSUE_URL" --body "## Workflow
+
+- [ ] Commit: \`git add -u && git commit -F $COMMIT_MSG_REL\`
+- [ ] Push: \`git push -u origin $RELEASE_BRANCH\`
+- [ ] Create PR: \`gh pr create --title \"[release] Lock version v${VERSION}\" --body-file $COMMIT_MSG_REL\`
+- [ ] \`pnpm test\` — unit tests + coverage gate
+- [ ] Work through the checkboxes above — each row has the exact pnpm command
+- [ ] \`pnpm validate:qa-coverage:vscode-extension\`
+- [ ] When all checkboxes pass: \`pnpm release:prepare:vscode-extension\`"
 
 # --- Summary ---
 

--- a/tests/shell/orchestrate-release-lock.bats
+++ b/tests/shell/orchestrate-release-lock.bats
@@ -31,7 +31,15 @@ esac
 ENDOFSTUB
   export FIXTURE_ROOT_FOR_GIT="$FIXTURE_ROOT"
 
-  make_passive_stub "gh"
+  # gh stub that logs each call so tests can assert on the workflow comment body.
+  cat > "$STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+echo "gh $*" >> "$GH_CALL_LOG"
+exit 0
+GHSTUB
+  chmod +x "$STUB_DIR/gh"
+  export GH_CALL_LOG="$FIXTURE_ROOT/gh-calls.log"
+  : > "$GH_CALL_LOG"
 
   # Stub lock-version.sh (idempotent: does not clobber existing instructions).
   cat > "$FIXTURE_ROOT/scripts/lock-version.sh" <<'STUBEOF'
@@ -186,4 +194,40 @@ INSTEOF
   run "$SCRIPT" "2.0.0"
   [[ "$status" -eq 0 ]]
   [[ -f "$FIXTURE_ROOT/.commit-msgs/0011-lock-version-v2.0.0.txt" ]]
+}
+
+# ── Workflow comment on QA issue ──────────────────────────────────────────────────
+
+@test "posts workflow comment on QA issue after commit message" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=1
+
+  run "$SCRIPT" "1.0.0"
+  [[ "$status" -eq 0 ]]
+
+  # Verify gh was called with the workflow comment body.
+  grep -q '## Workflow' "$GH_CALL_LOG"
+}
+
+@test "workflow comment includes commit, push, PR, test, and release steps" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=1
+
+  run "$SCRIPT" "1.0.0"
+  [[ "$status" -eq 0 ]]
+
+  # The workflow body contains embedded newlines; grep -A captures the full block.
+  local body
+  body=$(grep -A 20 '## Workflow' "$GH_CALL_LOG")
+
+  # Commit step with pre-generated file path.
+  [[ "$body" =~ "git add -u && git commit -F .commit-msgs/0001-lock-version-v1.0.0.txt" ]]
+  # Push step with branch name.
+  [[ "$body" =~ "git push -u origin release/v1.0.0" ]]
+  # PR creation step.
+  [[ "$body" =~ "gh pr create" ]]
+  # Unit test, validate, and release steps.
+  [[ "$body" =~ "pnpm test" ]]
+  [[ "$body" =~ "pnpm validate:qa-coverage:vscode-extension" ]]
+  [[ "$body" =~ "pnpm release:prepare:vscode-extension" ]]
 }


### PR DESCRIPTION
The release testing instructions file lived in the git worktree, making it invisible when working from other worktrees. Post the same checklist as a comment on the QA issue so the commit/push/PR/test/validate/prepare steps are always one click away alongside the checkboxes.

Benefits:
- Workflow steps live on the QA issue for visibility across worktrees
- Commit and PR creation commands are copy-paste ready with the pre-generated commit message path
- Instructions file "Next steps" section simplified to a one-liner pointing at the issue comment