### PR TITLE
[tweak_release_cycle_002] Interactive branch conflict prompt in `release:lock`

### DIFF
--- a/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
+++ b/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
@@ -52,17 +52,17 @@ if git -C "$REPO_ROOT" rev-parse --verify "$RELEASE_BRANCH" >/dev/null 2>&1; the
   if [[ "$CURRENT_BRANCH" != "$RELEASE_BRANCH" ]]; then
     echo -e "${YELLOW}Branch $RELEASE_BRANCH already exists (current: $CURRENT_BRANCH).${NC}"
     printf 'Checkout %s and re-run, delete it and start fresh, or abort? [C/d/a] ' "$RELEASE_BRANCH"
-    read -r REPLY
+    read -r REPLY || true
     case "$REPLY" in
       [dD])
         echo -e "${YELLOW}Deleting $RELEASE_BRANCH...${NC}"
         git -C "$REPO_ROOT" branch -D "$RELEASE_BRANCH"
         if [[ "$CURRENT_BRANCH" != "main" ]]; then
           printf 'Checkout main and pull --rebase? [Y/n] '
-          read -r REPLY2
+          read -r REPLY2 || true
           if [[ -z "$REPLY2" || "$REPLY2" =~ ^[Yy]$ ]]; then
             git -C "$REPO_ROOT" checkout main
-            git -C "$REPO_ROOT" pull --rebase
+            git -C "$REPO_ROOT" pull --rebase origin main
           fi
         fi
         git -C "$REPO_ROOT" checkout -b "$RELEASE_BRANCH" main
@@ -78,7 +78,7 @@ if git -C "$REPO_ROOT" rev-parse --verify "$RELEASE_BRANCH" >/dev/null 2>&1; the
         printf 'Pull --rebase from main? [Y/n] '
         read -r REPLY2
         if [[ -z "$REPLY2" || "$REPLY2" =~ ^[Yy]$ ]]; then
-          git -C "$REPO_ROOT" pull --rebase main
+          git -C "$REPO_ROOT" pull --rebase origin main
         fi
         ;;
     esac

--- a/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
+++ b/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
@@ -50,10 +50,41 @@ CURRENT_BRANCH=$(git -C "$REPO_ROOT" branch --show-current)
 
 if git -C "$REPO_ROOT" rev-parse --verify "$RELEASE_BRANCH" >/dev/null 2>&1; then
   if [[ "$CURRENT_BRANCH" != "$RELEASE_BRANCH" ]]; then
-    echo -e "${RED}Error: branch $RELEASE_BRANCH already exists but current branch is $CURRENT_BRANCH.${NC}" >&2
-    exit 1
+    echo -e "${YELLOW}Branch $RELEASE_BRANCH already exists (current: $CURRENT_BRANCH).${NC}"
+    printf 'Checkout %s and re-run, delete it and start fresh, or abort? [C/d/a] ' "$RELEASE_BRANCH"
+    read -r REPLY
+    case "$REPLY" in
+      [dD])
+        echo -e "${YELLOW}Deleting $RELEASE_BRANCH...${NC}"
+        git -C "$REPO_ROOT" branch -D "$RELEASE_BRANCH"
+        if [[ "$CURRENT_BRANCH" != "main" ]]; then
+          printf 'Checkout main and pull --rebase? [Y/n] '
+          read -r REPLY2
+          if [[ -z "$REPLY2" || "$REPLY2" =~ ^[Yy]$ ]]; then
+            git -C "$REPO_ROOT" checkout main
+            git -C "$REPO_ROOT" pull --rebase
+          fi
+        fi
+        git -C "$REPO_ROOT" checkout -b "$RELEASE_BRANCH" main
+        echo -e "${GREEN}Created branch $RELEASE_BRANCH from main${NC}"
+        ;;
+      [aA])
+        echo "Aborted." >&2
+        exit 0
+        ;;
+      *)
+        echo -e "${YELLOW}Checking out $RELEASE_BRANCH...${NC}"
+        git -C "$REPO_ROOT" checkout "$RELEASE_BRANCH"
+        printf 'Pull --rebase from main? [Y/n] '
+        read -r REPLY2
+        if [[ -z "$REPLY2" || "$REPLY2" =~ ^[Yy]$ ]]; then
+          git -C "$REPO_ROOT" pull --rebase main
+        fi
+        ;;
+    esac
+  else
+    echo -e "${YELLOW}Re-running on existing branch $RELEASE_BRANCH.${NC}"
   fi
-  echo -e "${YELLOW}Re-running on existing branch $RELEASE_BRANCH.${NC}"
 else
   if [[ "$CURRENT_BRANCH" != "main" ]]; then
     echo -e "${YELLOW}Not on main (current: $CURRENT_BRANCH). Creating $RELEASE_BRANCH from main.${NC}"

--- a/tests/shell/orchestrate-release-lock.bats
+++ b/tests/shell/orchestrate-release-lock.bats
@@ -20,6 +20,7 @@ setup_fixture() {
 
   stub_dir
   make_stub "git" <<'ENDOFSTUB'
+echo "git $*" >> "$GIT_CALL_LOG"
 case "$*" in
   *--show-toplevel*) echo "$FIXTURE_ROOT_FOR_GIT" ;;
   *"status"*) [[ "$GIT_STATUS_DIRTY" -eq 1 ]] && echo "?? dirty" ; exit 0 ;;
@@ -33,6 +34,8 @@ case "$*" in
 esac
 ENDOFSTUB
   export FIXTURE_ROOT_FOR_GIT="$FIXTURE_ROOT"
+  export GIT_CALL_LOG="$FIXTURE_ROOT/git-calls.log"
+  : > "$GIT_CALL_LOG"
 
   # gh stub that logs each call so tests can assert on the workflow comment body.
   cat > "$STUB_DIR/gh" <<'GHSTUB'
@@ -180,10 +183,12 @@ INSTEOF
   export GIT_BRANCH_EXISTS=0
   export GIT_CURRENT_BRANCH="some-other-branch"
 
-  # Pipe 'c' (checkout) + 'n' (no pull) to skip interactive prompts.
+  # Pipe 'c' (checkout) + 'n' (no pull).
   run bash -c 'echo -e "c\nn" | '"$SCRIPT"' 1.0.0'
   [[ "$status" -eq 0 ]]
   [[ "$output" =~ "Branch release/v1.0.0 already exists" ]]
+  grep -q 'checkout release/v1.0.0' "$GIT_CALL_LOG"
+  ! grep -q 'pull --rebase' "$GIT_CALL_LOG"
 }
 
 @test "re-run: prompts when branch exists — delete and start fresh" {
@@ -191,10 +196,12 @@ INSTEOF
   export GIT_BRANCH_EXISTS=0
   export GIT_CURRENT_BRANCH="some-other-branch"
 
-  # Pipe 'd' (delete) + 'n' (no checkout main) to skip prompts.
+  # Pipe 'd' (delete) + 'n' (no checkout main).
   run bash -c 'echo -e "d\nn" | '"$SCRIPT"' 1.0.0'
   [[ "$status" -eq 0 ]]
   [[ "$output" =~ "Deleting release/v1.0.0" ]]
+  grep -q 'branch -D release/v1.0.0' "$GIT_CALL_LOG"
+  grep -q 'checkout -b release/v1.0.0 main' "$GIT_CALL_LOG"
 }
 
 @test "re-run: prompts when branch exists — abort" {
@@ -217,6 +224,8 @@ INSTEOF
   run bash -c 'echo -e "\n" | '"$SCRIPT"' 1.0.0'
   [[ "$status" -eq 0 ]]
   [[ "$output" =~ "Checking out release/v1.0.0" ]]
+  grep -q 'checkout release/v1.0.0' "$GIT_CALL_LOG"
+  grep -q 'pull --rebase origin main' "$GIT_CALL_LOG"
 }
 
 @test "re-run: delete path — default yes to checkout main and pull" {
@@ -229,6 +238,9 @@ INSTEOF
   [[ "$status" -eq 0 ]]
   [[ "$output" =~ "Deleting release/v1.0.0" ]]
   [[ "$output" =~ "Created branch release/v1.0.0 from main" ]]
+  grep -q 'checkout main' "$GIT_CALL_LOG"
+  grep -q 'pull --rebase origin main' "$GIT_CALL_LOG"
+  grep -q 'checkout -b release/v1.0.0 main' "$GIT_CALL_LOG"
 }
 
 # ── Commit message numbering ──────────────────────────────────────────────────────

--- a/tests/shell/orchestrate-release-lock.bats
+++ b/tests/shell/orchestrate-release-lock.bats
@@ -24,6 +24,9 @@ case "$*" in
   *--show-toplevel*) echo "$FIXTURE_ROOT_FOR_GIT" ;;
   *"status"*) [[ "$GIT_STATUS_DIRTY" -eq 1 ]] && echo "?? dirty" ; exit 0 ;;
   *"checkout -b"*) exit 0 ;;
+  *"branch -D"*) exit 0 ;;
+  *"checkout"*) echo "Switched to branch" ;;
+  *"pull --rebase"*) exit 0 ;;
   *"rev-parse --verify"*) exit "$GIT_BRANCH_EXISTS" ;;
   *"branch --show-current"*) echo "$GIT_CURRENT_BRANCH" ;;
   *) exit 0 ;;
@@ -172,14 +175,60 @@ INSTEOF
 
 # ── Error: branch exists on different checkout ─────────────────────────────────────
 
-@test "re-run: exits 1 when branch exists but we are on different branch" {
+@test "re-run: prompts when branch exists on different checkout — checkout option" {
   setup_fixture
   export GIT_BRANCH_EXISTS=0
   export GIT_CURRENT_BRANCH="some-other-branch"
 
-  run "$SCRIPT" "1.0.0"
-  [[ "$status" -eq 1 ]]
-  [[ "$output" =~ "already exists but current branch is" ]]
+  # Pipe 'c' (checkout) + 'n' (no pull) to skip interactive prompts.
+  run bash -c 'echo -e "c\nn" | '"$SCRIPT"' 1.0.0'
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "Branch release/v1.0.0 already exists" ]]
+}
+
+@test "re-run: prompts when branch exists — delete and start fresh" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=0
+  export GIT_CURRENT_BRANCH="some-other-branch"
+
+  # Pipe 'd' (delete) + 'n' (no checkout main) to skip prompts.
+  run bash -c 'echo -e "d\nn" | '"$SCRIPT"' 1.0.0'
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "Deleting release/v1.0.0" ]]
+}
+
+@test "re-run: prompts when branch exists — abort" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=0
+  export GIT_CURRENT_BRANCH="some-other-branch"
+
+  # Pipe 'a' to abort.
+  run bash -c 'echo a | '"$SCRIPT"' 1.0.0'
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "Aborted" ]]
+}
+
+@test "re-run: checkout path — default yes to pull" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=0
+  export GIT_CURRENT_BRANCH="some-other-branch"
+
+  # Default 'c' (checkout) then empty (yes) to pull.
+  run bash -c 'echo -e "\n" | '"$SCRIPT"' 1.0.0'
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "Checking out release/v1.0.0" ]]
+}
+
+@test "re-run: delete path — default yes to checkout main and pull" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=0
+  export GIT_CURRENT_BRANCH="some-other-branch"
+
+  # 'd' (delete) then empty (yes) to checkout main + pull.
+  run bash -c 'echo -e "d\n" | '"$SCRIPT"' 1.0.0'
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "Deleting release/v1.0.0" ]]
+  [[ "$output" =~ "Created branch release/v1.0.0 from main" ]]
 }
 
 # ── Commit message numbering ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Running `pnpm release:lock:vscode-extension` from a non-release branch when `release/vX.Y.Z` already existed produced a hard error with no way forward other than manual git cleanup. Replace the hard error with an interactive prompt offering three paths: checkout the existing branch and re-run (idempotent path), delete it and start fresh, or abort.

## Changes

- `orchestrate-release-lock.sh`: replace the exit-1 branch-exists guard with a `[C/d/a]` prompt. Checkout option offers to pull --rebase from main. Delete option offers to checkout main and pull before recreating. Default (enter) is checkout-and-re-run.
- `tests/shell/orchestrate-release-lock.bats`: replace the single exit-1 test with five tests covering each prompt path (checkout+no-pull, checkout+yes-pull, delete+no-checkout-main, delete+yes-checkout-main, abort). Add `branch -D`, `checkout`, and `pull --rebase` cases to the git stub.

## Test Plan

- [x] All 184 bats tests pass
- [x] All 2060 unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release branch creation now offers interactive options when an existing release branch is detected, enabling users to delete and recreate, abort, or checkout the branch instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->