### PR TITLE
[tweak_release_cycle_003] Bullet prompt, delete-path supersession, fenced code blocks

### DIFF
--- a/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
+++ b/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
@@ -51,11 +51,20 @@ CURRENT_BRANCH=$(git -C "$REPO_ROOT" branch --show-current)
 if git -C "$REPO_ROOT" rev-parse --verify "$RELEASE_BRANCH" >/dev/null 2>&1; then
   if [[ "$CURRENT_BRANCH" != "$RELEASE_BRANCH" ]]; then
     echo -e "${YELLOW}Branch $RELEASE_BRANCH already exists (current: $CURRENT_BRANCH).${NC}"
-    printf 'Checkout %s and re-run, delete it and start fresh, or abort? [C/d/a] ' "$RELEASE_BRANCH"
+    echo ""
+    echo "  [C] Checkout the branch and re-run (idempotent)"
+    echo "  [D] Delete it and start fresh"
+    echo "  [A] Abort"
+    echo ""
+    printf 'Choice: '
     read -r REPLY || true
     case "$REPLY" in
       [dD])
         echo -e "${YELLOW}Deleting $RELEASE_BRANCH...${NC}"
+        # Snapshot the prior QA issue before the instructions file is destroyed.
+        if [[ -f "$INSTRUCTIONS_FILE" ]]; then
+          PRIOR_ISSUE_URL=$(sed -n '/^---$/,/^---$/p' "$INSTRUCTIONS_FILE" | grep 'qa_issue_url:' | sed 's/qa_issue_url: *"*//;s/"$//')
+        fi
         git -C "$REPO_ROOT" branch -D "$RELEASE_BRANCH"
         if [[ "$CURRENT_BRANCH" != "main" ]]; then
           printf 'Checkout main and pull --rebase? [Y/n] '
@@ -100,8 +109,9 @@ echo ""
 
 # --- Step 2: Detect prior QA issue (idempotency re-run) ---
 
-PRIOR_ISSUE_URL=""
-if [[ -f "$INSTRUCTIONS_FILE" ]]; then
+# Only discover from the current instructions file if the "d"elete path
+# didn't already snapshot it before destroying the old branch.
+if [[ -z "${PRIOR_ISSUE_URL:-}" ]] && [[ -f "$INSTRUCTIONS_FILE" ]]; then
   PRIOR_ISSUE_URL=$(sed -n '/^---$/,/^---$/p' "$INSTRUCTIONS_FILE" | grep 'qa_issue_url:' | sed 's/qa_issue_url: *"*//;s/"$//')
 fi
 
@@ -169,9 +179,18 @@ echo -e "${GREEN}Commit message: $(basename "$COMMIT_MSG_FILE")${NC}"
 COMMIT_MSG_REL="${COMMIT_MSG_FILE#"$REPO_ROOT"/}"
 gh issue comment "$QA_ISSUE_URL" --body "## Workflow
 
-- [ ] Commit: \`git add -u && git commit -F $COMMIT_MSG_REL\`
-- [ ] Push: \`git push -u origin $RELEASE_BRANCH\`
-- [ ] Create PR: \`gh pr create --title \"[release] Lock version v${VERSION}\" --body-file $COMMIT_MSG_REL\`
+- [ ] Commit:
+  \`\`\`
+  git add -u && git commit -F $COMMIT_MSG_REL
+  \`\`\`
+- [ ] Push:
+  \`\`\`
+  git push -u origin $RELEASE_BRANCH
+  \`\`\`
+- [ ] Create PR:
+  \`\`\`
+  gh pr create --title \"[release] Lock version v${VERSION}\" --body-file $COMMIT_MSG_REL
+  \`\`\`
 - [ ] \`pnpm test\` — unit tests + coverage gate
 - [ ] Work through the checkboxes above — each row has the exact pnpm command
 - [ ] \`pnpm validate:qa-coverage:vscode-extension\`

--- a/tests/shell/orchestrate-release-lock.bats
+++ b/tests/shell/orchestrate-release-lock.bats
@@ -204,6 +204,34 @@ INSTEOF
   grep -q 'checkout -b release/v1.0.0 main' "$GIT_CALL_LOG"
 }
 
+@test "re-run: delete path — supersedes prior issue when old instructions had a URL" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=0
+  export GIT_CURRENT_BRANCH="some-other-branch"
+
+  # Write instructions with a prior qa_issue_url (simulating previous run).
+  local ins="$FIXTURE_ROOT/qa/release-testing-instructions-v1.0.0.md"
+  mkdir -p "$(dirname "$ins")"
+  cat > "$ins" <<'INSTEOF'
+---
+version: 1.0.0
+qa_issue_url: "https://github.com/couimet/rangeLink/issues/888"
+generated: 2026-01-01T00:00:00Z
+---
+
+# Release Testing: Placeholder
+
+**Scope:** Changes from v1.0.0 → v1.0.0
+**QA tracker:** https://github.com/couimet/rangeLink/issues/888
+INSTEOF
+
+  # 'd' (delete) + 'n' (no checkout main).
+  run bash -c 'echo -e "d\nn" | '"$SCRIPT"' 1.0.0'
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "Prior QA issue found" ]]
+  [[ "$output" =~ "Closed prior issue" ]]
+}
+
 @test "re-run: prompts when branch exists — abort" {
   setup_fixture
   export GIT_BRANCH_EXISTS=0
@@ -281,6 +309,8 @@ INSTEOF
   local body
   body=$(grep -A 20 '## Workflow' "$GH_CALL_LOG")
 
+  # Fenced code blocks (triple backticks) for GitHub copy buttons.
+  [[ "$body" =~ '```' ]]
   # Commit step with pre-generated file path.
   [[ "$body" =~ "git add -u && git commit -F .commit-msgs/0001-lock-version-v1.0.0.txt" ]]
   # Push step with branch name.


### PR DESCRIPTION
## Summary

Three refinements to the `release:lock` interactive prompt: a scannable bullet-list design with explicit letter-to-action mapping, supersession detection on the delete-and-restart path (the old branch's QA issue was being orphaned), and fenced code blocks in the workflow comment for GitHub copy buttons.

## Changes

- `orchestrate-release-lock.sh`: replace the one-liner prompt with a bullet list mapping `[C]`, `[D]`, `[A]` to their actions. Snapshot the prior QA issue URL before deleting the old branch so supersession fires on the delete path, not just the checkout-and-re-run path. Wrap commit/push/PR commands in indented fenced code blocks for GitHub copy buttons.
- `tests/shell/orchestrate-release-lock.bats`: add a test for delete-path supersession. Add assertion for fenced code blocks in the workflow comment body. Add `GIT_CALL_LOG` to the git stub and assert exact git argv in interactive-path tests.

## Test Plan

- [x] All 185 bats tests pass
- [x] All 2060 unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow to support safer re-runs when release branches already exist, with explicit menu options.
  * Enhanced QA issue tracking to preserve prior issue references during workflow re-execution.
  * Reformatted release workflow instructions for improved clarity and usability.

* **Tests**
  * Added test coverage for release branch deletion and re-run scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->