### PR TITLE
[tweak_release_cycle_004] Tolerate release artifact in dirty-tree check

### DIFF
--- a/packages/rangelink-vscode-extension/scripts/check-dirty-tree.sh
+++ b/packages/rangelink-vscode-extension/scripts/check-dirty-tree.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Shared helper sourced by the release scripts. Exit 1 if the working tree has
+# uncommitted changes, except for the release instructions artifact
+# (release-testing-instructions-vX.Y.Z.md) which the supersession logic
+# needs to read on re-run.
+#
+# Usage:
+#   source "$SCRIPT_DIR/check-dirty-tree.sh"
+#   check_dirty_tree "$REPO_ROOT"
+
+check_dirty_tree() {
+  local repo_root="$1"
+  local artifact_glob='packages/rangelink-vscode-extension/qa/release-testing-instructions-v*.md'
+  local dirty
+  dirty=$(git -C "$repo_root" status --porcelain -- ":(exclude)$artifact_glob")
+  if [[ -n "$dirty" ]]; then
+    echo -e "${RED:-}Error: working tree is dirty. Commit or stash changes first.${NC:-}" >&2
+    echo "$dirty" >&2
+    exit 1
+  fi
+  # Surface the relaxation so it is visible in the log.
+  if [[ -n "$(git -C "$repo_root" status --porcelain -- "$artifact_glob")" ]]; then
+    echo -e "${YELLOW:-}Note: tolerating uncommitted release-testing-instructions-v*.md (release artifact).${NC:-}"
+  fi
+}

--- a/packages/rangelink-vscode-extension/scripts/lock-version.sh
+++ b/packages/rangelink-vscode-extension/scripts/lock-version.sh
@@ -41,10 +41,8 @@ VERSIONED_INSTRUCTIONS="$QA_DIR/release-testing-instructions-v${VERSION}.md"
 
 # --- Validation ---
 
-if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
-  echo -e "${RED}Error: working tree is dirty. Commit or stash changes first.${NC}" >&2
-  exit 1
-fi
+source "$SCRIPT_DIR/check-dirty-tree.sh"
+check_dirty_tree "$REPO_ROOT"
 
 PUBLISHED_VERSION=$(jq -r '.version // empty' "$PACKAGE_JSON")
 if [[ -z "$PUBLISHED_VERSION" ]]; then

--- a/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
+++ b/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
@@ -13,6 +13,10 @@ set -euo pipefail
 # Idempotent: safe to re-run after adding bug-fix TCs. On re-run,
 # detects the prior QA issue from the instructions frontmatter, closes it
 # with a "Superseded by #NEW" comment, and creates a fresh issue.
+#
+# Tolerates uncommitted release-testing-instructions-vX.Y.Z.md so the
+# supersession logic can read its frontmatter on re-run. Any other dirty
+# file still blocks.
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -36,12 +40,10 @@ PACKAGE_DIR="$(dirname "$SCRIPT_DIR")"
 REPO_ROOT="$(git -C "$PACKAGE_DIR" rev-parse --show-toplevel)"
 INSTRUCTIONS_FILE="$PACKAGE_DIR/qa/release-testing-instructions-v${VERSION}.md"
 
-# --- Working tree must be clean ---
+# --- Working tree must be clean (except for the release instructions artifact) ---
 
-if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
-  echo -e "${RED}Error: working tree is dirty. Commit or stash changes first.${NC}" >&2
-  exit 1
-fi
+source "$SCRIPT_DIR/check-dirty-tree.sh"
+check_dirty_tree "$REPO_ROOT"
 
 # --- Create or re-enter release branch ---
 

--- a/tests/shell/check-dirty-tree.bats
+++ b/tests/shell/check-dirty-tree.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+REAL_SCRIPT="$PROJECT_ROOT/packages/rangelink-vscode-extension/scripts/check-dirty-tree.sh"
+
+# ── Fixture scaffolding ────────────────────────────────────────────────────────
+# The helper calls exit 1 directly. Test it via a bash -c subshell so the
+# bats test harness is not killed. The helper and stubs are at known paths.
+
+setup_fixture() {
+  FIXTURE_ROOT="$TEST_TEMP_DIR"
+
+  stub_dir
+
+  make_stub "git" <<'ENDOFSTUB'
+case "$*" in
+  *"status"*)
+    case "${GIT_DIRTY_LEVEL:-0}" in
+      0) ;;  # clean
+      1) echo "?? dirty.txt" ;;
+      2)
+        if [[ "$*" == *"(exclude)"*"release-testing-instructions-v"* ]]; then
+          :  # excluded — no output
+        else
+          echo "?? packages/rangelink-vscode-extension/qa/release-testing-instructions-v2.0.0.md"
+        fi
+        ;;
+    esac
+    exit 0 ;;
+esac
+ENDOFSTUB
+
+  cp "$REAL_SCRIPT" "$FIXTURE_ROOT/check-dirty-tree.sh"
+}
+
+# ── Clean tree ─────────────────────────────────────────────────────────────────
+
+@test "clean tree exits 0 with no stdout output" {
+  setup_fixture
+  export GIT_DIRTY_LEVEL=0
+  run bash -c "source '${FIXTURE_ROOT}/check-dirty-tree.sh'; check_dirty_tree '${FIXTURE_ROOT}'"
+  [[ "$status" -eq 0 ]]
+  [[ -z "$output" ]]
+}
+
+# ── Artifact-only dirty ────────────────────────────────────────────────────────
+
+@test "artifact-only dirty exits 0 with tolerating notice" {
+  setup_fixture
+  export GIT_DIRTY_LEVEL=2
+  run bash -c "source '${FIXTURE_ROOT}/check-dirty-tree.sh'; check_dirty_tree '${FIXTURE_ROOT}'"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "tolerating uncommitted" ]]
+}
+
+# ── Other file dirty ───────────────────────────────────────────────────────────
+
+@test "other file dirty exits 1 with error and dirty paths" {
+  setup_fixture
+  export GIT_DIRTY_LEVEL=1
+  run bash -c "source '${FIXTURE_ROOT}/check-dirty-tree.sh'; check_dirty_tree '${FIXTURE_ROOT}'"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "working tree is dirty" ]]
+  [[ "$output" =~ "dirty.txt" ]]
+}
+
+# ── No color variables defined (tests ${RED:-} fallback) ───────────────────────
+
+@test "works without RED/YELLOW/NC color variables" {
+  setup_fixture
+  export GIT_DIRTY_LEVEL=2
+  run bash -c "source '${FIXTURE_ROOT}/check-dirty-tree.sh'; check_dirty_tree '${FIXTURE_ROOT}'"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "tolerating uncommitted" ]]
+}

--- a/tests/shell/lock-version.bats
+++ b/tests/shell/lock-version.bats
@@ -10,13 +10,27 @@ setup_fixture() {
   mkdir -p "$FIXTURE_ROOT/qa"
 
   cp "$REAL_SCRIPT" "$FIXTURE_ROOT/scripts/lock-version.sh"
+  cp "$PROJECT_ROOT/packages/rangelink-vscode-extension/scripts/check-dirty-tree.sh" \
+     "$FIXTURE_ROOT/scripts/check-dirty-tree.sh"
   SCRIPT="$FIXTURE_ROOT/scripts/lock-version.sh"
 
   stub_dir
   make_stub "git" <<'ENDOFSTUB'
 case "$*" in
   *--show-toplevel*) echo "${FIXTURE_ROOT_FOR_GIT:-$TEST_TEMP_DIR}" ;;
-  *status*) exit 0 ;;
+  *status*)
+    # GIT_STATUS_DIRTY: 0=clean, 1=arbitrary dirty file, 2=only release artifact dirty.
+    case "${GIT_STATUS_DIRTY:-0}" in
+      1) echo "?? dirty.txt" ;;
+      2)
+        if [[ "$*" == *"(exclude)"*"release-testing-instructions-v"* ]]; then
+          :  # excluded — no output
+        else
+          echo "?? packages/rangelink-vscode-extension/qa/release-testing-instructions-v2.0.0.md"
+        fi
+        ;;
+    esac
+    exit 0 ;;
   *) exit 0 ;;
 esac
 ENDOFSTUB
@@ -231,6 +245,36 @@ EOF
   run "$SCRIPT" 2.0.0
   [[ "$status" -eq 1 ]]
   [[ "$output" =~ "version not set" ]]
+}
+
+# ── Dirty-tree tolerance for release artifact ─────────────────────────────────────
+
+@test "dirty-tree: artifact-only is tolerated" {
+  setup_fixture
+  write_package_json <<'EOF'
+{
+  "version": "1.0.0"
+}
+EOF
+  export GIT_STATUS_DIRTY=2
+
+  run "$SCRIPT" 2.0.0
+  [[ "$status" -eq 0 ]]
+  ! [[ "$output" =~ "working tree is dirty" ]]
+}
+
+@test "dirty-tree: other dirty file still blocks" {
+  setup_fixture
+  write_package_json <<'EOF'
+{
+  "version": "1.0.0"
+}
+EOF
+  export GIT_STATUS_DIRTY=1
+
+  run "$SCRIPT" 2.0.0
+  [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "working tree is dirty" ]]
 }
 
 # ── YAML content preservation ──────────────────────────────────────────────────

--- a/tests/shell/orchestrate-release-lock.bats
+++ b/tests/shell/orchestrate-release-lock.bats
@@ -11,19 +11,33 @@ setup_fixture() {
   mkdir -p "$FIXTURE_ROOT/.commit-msgs"
 
   cp "$REAL_SCRIPT" "$FIXTURE_ROOT/scripts/orchestrate-release-lock.sh"
+  cp "$PROJECT_ROOT/packages/rangelink-vscode-extension/scripts/check-dirty-tree.sh" \
+     "$FIXTURE_ROOT/scripts/check-dirty-tree.sh"
   SCRIPT="$FIXTURE_ROOT/scripts/orchestrate-release-lock.sh"
 
   # Default: branch does not exist, we are on main, working tree clean.
   export GIT_BRANCH_EXISTS=1    # 0 = exists, 1 = does not exist
   export GIT_CURRENT_BRANCH="main"
-  export GIT_STATUS_DIRTY=0     # 0 = clean, 1 = dirty
+  export GIT_STATUS_DIRTY=0     # 0=clean, 1=arbitrary dirty, 2=artifact-only
 
   stub_dir
   make_stub "git" <<'ENDOFSTUB'
 echo "git $*" >> "$GIT_CALL_LOG"
 case "$*" in
   *--show-toplevel*) echo "$FIXTURE_ROOT_FOR_GIT" ;;
-  *"status"*) [[ "$GIT_STATUS_DIRTY" -eq 1 ]] && echo "?? dirty" ; exit 0 ;;
+  *"status"*)
+    # GIT_STATUS_DIRTY: 0=clean, 1=arbitrary dirty file, 2=only release artifact dirty.
+    case "${GIT_STATUS_DIRTY:-0}" in
+      1) echo "?? dirty.txt" ;;
+      2)
+        if [[ "$*" == *"(exclude)"*"release-testing-instructions-v"* ]]; then
+          :  # excluded — no output
+        else
+          echo "?? packages/rangelink-vscode-extension/qa/release-testing-instructions-v2.0.0.md"
+        fi
+        ;;
+    esac
+    exit 0 ;;
   *"checkout -b"*) exit 0 ;;
   *"branch -D"*) exit 0 ;;
   *"checkout"*) echo "Switched to branch" ;;
@@ -269,6 +283,39 @@ INSTEOF
   grep -q 'checkout main' "$GIT_CALL_LOG"
   grep -q 'pull --rebase origin main' "$GIT_CALL_LOG"
   grep -q 'checkout -b release/v1.0.0 main' "$GIT_CALL_LOG"
+}
+
+# ── Dirty-tree tolerance for release artifact ─────────────────────────────────────
+
+@test "dirty-tree: clean tree passes" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=1
+  export GIT_STATUS_DIRTY=0
+
+  run "$SCRIPT" "1.0.0"
+  [[ "$status" -eq 0 ]]
+  ! [[ "$output" =~ "working tree is dirty" ]]
+  ! [[ "$output" =~ "tolerating" ]]
+}
+
+@test "dirty-tree: only release artifact dirty passes with notice" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=1
+  export GIT_STATUS_DIRTY=2
+
+  run "$SCRIPT" "1.0.0"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "tolerating uncommitted release-testing-instructions" ]]
+}
+
+@test "dirty-tree: other dirty file blocks with exit 1" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=1
+  export GIT_STATUS_DIRTY=1
+
+  run "$SCRIPT" "1.0.0"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "working tree is dirty" ]]
 }
 
 # ── Commit message numbering ──────────────────────────────────────────────────────


### PR DESCRIPTION
The dirty-tree guard in release:lock blocked the script when `release-testing-instructions-vX.Y.Z.md` was present from a prior run — but that file is exactly what the supersession logic needs to read on re-run. Relax the check to ignore the release artifact while still blocking on any other dirty file.

- Extract a shared `check-dirty-tree.sh` helper so both `orchestrate-release-lock.sh` and `lock-version.sh` use the same pathspec-excluded dirty-tree check. Previously `lock-version.sh` was missed by the original fix in https://github.com/couimet/rangeLink/pull/631, causing the orchestrator to pass the check but lock-version to block on re-run.
- `tests/shell/orchestrate-release-lock.bats` + `tests/shell/lock-version.bats`: extend each git stub to honour the `(exclude)` pathspec via a tri-state `GIT_STATUS_DIRTY`. Three new tests in orchestrate and two new in lock-version.

- [x] All 187 bats tests pass
- [x] All 2060 unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow validation to intelligently handle build artifacts and testing documentation during version locking

* **Tests**
  * Expanded test coverage for release process validation and dirty-tree detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->