### PR TITLE
[tweak_release_cycle_005] Always regenerate release testing instructions

### DIFF
--- a/packages/rangelink-vscode-extension/scripts/generate-release-testing-instructions.sh
+++ b/packages/rangelink-vscode-extension/scripts/generate-release-testing-instructions.sh
@@ -45,11 +45,6 @@ echo -e "${GREEN}Generating release testing instructions for ${NEXT_LABEL}${NC}"
 
 OUTPUT_FILE="$QA_DIR/${BASE_NAME}.md"
 
-if [[ -f "$OUTPUT_FILE" ]]; then
-  echo "$OUTPUT_FILE already exists — nothing to generate"
-  exit 0
-fi
-
 GENERATED_TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 cat > "$OUTPUT_FILE" <<EOF

--- a/packages/rangelink-vscode-extension/scripts/lock-version.sh
+++ b/packages/rangelink-vscode-extension/scripts/lock-version.sh
@@ -70,19 +70,15 @@ fi
 
 # --- Step 2: Regenerate versioned release testing instructions ---
 
-if [[ -f "$VERSIONED_INSTRUCTIONS" ]]; then
-  echo -e "${YELLOW}Step 2: ${VERSIONED_INSTRUCTIONS} already exists — skipped.${NC}"
-else
-  "$SCRIPT_DIR/generate-release-testing-instructions.sh" --version "$VERSION"
+"$SCRIPT_DIR/generate-release-testing-instructions.sh" --version "$VERSION"
 
-  # PUBLISHED_VERSION is the pre-bump version (read before step 1), so the
-  # scope line captures the correct range (e.g. "Changes from v1.0.0 → v2.0.0").
-  sed -i.bak \
-    -e "s|Changes from v[0-9.]* → .*|Changes from v${PUBLISHED_VERSION} → v${VERSION}|" \
-    "$VERSIONED_INSTRUCTIONS" && rm -f "${VERSIONED_INSTRUCTIONS}.bak"
+# PUBLISHED_VERSION is the pre-bump version (read before step 1), so the
+# scope line captures the correct range (e.g. "Changes from v1.0.0 → v2.0.0").
+sed -i.bak \
+  -e "s|Changes from v[0-9.]* → .*|Changes from v${PUBLISHED_VERSION} → v${VERSION}|" \
+  "$VERSIONED_INSTRUCTIONS" && rm -f "${VERSIONED_INSTRUCTIONS}.bak"
 
-  echo -e "${GREEN}Step 2: Generated release-testing-instructions-v${VERSION}.md${NC}"
-fi
+echo -e "${GREEN}Step 2: Generated release-testing-instructions-v${VERSION}.md${NC}"
 
 echo ""
 echo -e "${GREEN}Locked at v${VERSION}. QA can now begin against a concrete version.${NC}"

--- a/tests/shell/generate-release-testing-instructions.bats
+++ b/tests/shell/generate-release-testing-instructions.bats
@@ -134,9 +134,9 @@ EOF
   [[ -f "$FIXTURE_ROOT/qa/release-testing-instructions-unreleased.md" ]]
 }
 
-# ── Early-exit (kept for this script per A006 scope) ───────────────────────────
+# ── Overwrite ─────────────────────────────────────────────────────────────────────
 
-@test "file-exists early-exit still applies (no clobber)" {
+@test "overwrites existing file instead of early-exit" {
   setup_fixture
   write_package_json <<'EOF'
 {
@@ -147,9 +147,9 @@ EOF
 
   run "$SCRIPT"
   [[ "$status" -eq 0 ]]
-  [[ "$output" =~ "already exists" ]]
-  # File unchanged.
+  # File overwritten with generated content, not the preexisting text.
   local content
   content=$(cat "$FIXTURE_ROOT/qa/release-testing-instructions-unreleased.md")
-  [[ "$content" == "preexisting content" ]]
+  [[ "$content" =~ "Release Testing" ]]
+  ! [[ "$content" =~ "preexisting content" ]]
 }

--- a/tests/shell/lock-version.bats
+++ b/tests/shell/lock-version.bats
@@ -184,7 +184,7 @@ EOF
   [[ "$output" =~ "Already locked at v2.0.0" ]]
 }
 
-@test "re-run after partial completion picks up remaining steps" {
+@test "re-run overwrites stale instructions instead of skipping" {
   setup_fixture
   write_package_json <<'EOF'
 {
@@ -192,17 +192,23 @@ EOF
 }
 EOF
 
-  # Simulate partial state: versioned instructions exist but .version not bumped.
+  # Write a stale instructions file to simulate a prior run.
   mkdir -p "$FIXTURE_ROOT/qa"
-  touch "$FIXTURE_ROOT/qa/release-testing-instructions-v2.0.0.md"
+  echo "stale content" > "$FIXTURE_ROOT/qa/release-testing-instructions-v2.0.0.md"
 
   run "$SCRIPT" 2.0.0
   [[ "$status" -eq 0 ]]
 
-  # Should bump version (the missing step).
+  # Version bumped.
   local ver
   ver=$(jq -r '.version' "$FIXTURE_ROOT/package.json")
   [[ "$ver" == "2.0.0" ]]
+
+  # Instructions were regenerated, not left stale.
+  local content
+  content=$(cat "$FIXTURE_ROOT/qa/release-testing-instructions-v2.0.0.md")
+  [[ "$content" =~ "Release Testing" ]]
+  ! [[ "$content" =~ "stale content" ]]
 }
 
 # ── Error paths ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The generator and lock-version scripts had early-exit guards that preserved stale instructions files from prior runs. When the "delete and start fresh" path re-created the release branch, the old instructions file carried over from the working tree was silently reused — wrong timestamp, stale body text. Remove both guards so the instructions are always regenerated fresh.

## Changes

- `generate-release-testing-instructions.sh`: drop the `[[ -f "$OUTPUT_FILE" ]]` early-exit. Always overwrite.
- `lock-version.sh`: drop the Step 2 `[[ -f "$VERSIONED_INSTRUCTIONS" ]]` skip. Always regenerate. The top-level idempotency check (version bumped + file exists) stays.
- `tests/shell/generate-release-testing-instructions.bats`: replace the "file-exists early-exit" test with an "overwrites existing file" test.
- `tests/shell/lock-version.bats`: replace the "partial completion" test with an "overwrites stale instructions" test that asserts version bumps AND file content is regenerated.

## Test Plan

- [x] All 194 bats tests pass
- [x] All 2060 unit tests pass