### PR TITLE
[tweak_release_cycle_006] Use single quotes for empty `qa_issue_url` to pass prettier

### DIFF
--- a/packages/rangelink-vscode-extension/scripts/generate-release-testing-instructions.sh
+++ b/packages/rangelink-vscode-extension/scripts/generate-release-testing-instructions.sh
@@ -50,7 +50,7 @@ GENERATED_TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 cat > "$OUTPUT_FILE" <<EOF
 ---
 version: ${VERSION_ARG:-$PUBLISHED_VERSION}
-qa_issue_url: ""
+qa_issue_url: ''
 generated: ${GENERATED_TS}
 ---
 

--- a/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
+++ b/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
@@ -65,7 +65,7 @@ if git -C "$REPO_ROOT" rev-parse --verify "$RELEASE_BRANCH" >/dev/null 2>&1; the
         echo -e "${YELLOW}Deleting $RELEASE_BRANCH...${NC}"
         # Snapshot the prior QA issue before the instructions file is destroyed.
         if [[ -f "$INSTRUCTIONS_FILE" ]]; then
-          PRIOR_ISSUE_URL=$(sed -n '/^---$/,/^---$/p' "$INSTRUCTIONS_FILE" | grep 'qa_issue_url:' | sed 's/qa_issue_url: *"*//;s/"$//')
+          PRIOR_ISSUE_URL=$(sed -n '/^---$/,/^---$/p' "$INSTRUCTIONS_FILE" | grep 'qa_issue_url:' | sed "s/qa_issue_url: *['\"]*//;s/['\"]$//")
         fi
         git -C "$REPO_ROOT" branch -D "$RELEASE_BRANCH"
         if [[ "$CURRENT_BRANCH" != "main" ]]; then
@@ -114,7 +114,7 @@ echo ""
 # Only discover from the current instructions file if the "d"elete path
 # didn't already snapshot it before destroying the old branch.
 if [[ -z "${PRIOR_ISSUE_URL:-}" ]] && [[ -f "$INSTRUCTIONS_FILE" ]]; then
-  PRIOR_ISSUE_URL=$(sed -n '/^---$/,/^---$/p' "$INSTRUCTIONS_FILE" | grep 'qa_issue_url:' | sed 's/qa_issue_url: *"*//;s/"$//')
+  PRIOR_ISSUE_URL=$(sed -n '/^---$/,/^---$/p' "$INSTRUCTIONS_FILE" | grep 'qa_issue_url:' | sed "s/qa_issue_url: *['\"]*//;s/['\"]$//")
 fi
 
 # --- Step 3: Generate QA issue ---
@@ -146,7 +146,7 @@ fi
 
 # Inject the QA issue URL into the instructions file.
 sed -i.bak \
-  -e "s|qa_issue_url: \".*\"|qa_issue_url: \"$QA_ISSUE_URL\"|" \
+  -e "s|qa_issue_url: ['\"].*['\"]|qa_issue_url: \"$QA_ISSUE_URL\"|" \
   -e "s|\*\*QA tracker:\*\* .*|\*\*QA tracker:\*\* $QA_ISSUE_URL|" \
   "$INSTRUCTIONS_FILE" && rm -f "${INSTRUCTIONS_FILE}.bak"
 

--- a/tests/shell/lock-version.bats
+++ b/tests/shell/lock-version.bats
@@ -62,7 +62,7 @@ if [[ -n "$VERSION_ARG" ]]; then
   cat > "$QA_DIR/release-testing-instructions-v${VERSION_ARG}.md" <<EOF
 ---
 version: ${VERSION_ARG}
-qa_issue_url: ""
+qa_issue_url: ''
 generated: 2026-06-11T00:00:00Z
 ---
 
@@ -82,7 +82,7 @@ else
   cat > "$QA_DIR/release-testing-instructions-unreleased.md" <<EOF
 ---
 version: 1.0.0
-qa_issue_url: ""
+qa_issue_url: ''
 generated: 2026-06-11T00:00:00Z
 ---
 

--- a/tests/shell/orchestrate-release-lock.bats
+++ b/tests/shell/orchestrate-release-lock.bats
@@ -71,7 +71,7 @@ if [[ ! -f "$INSTRUCTIONS_FILE" ]]; then
   cat > "$INSTRUCTIONS_FILE" <<'INSTEOF'
 ---
 version: PLACEHOLDER
-qa_issue_url: ""
+qa_issue_url: ''
 generated: 2026-01-01T00:00:00Z
 ---
 


### PR DESCRIPTION
## Summary

Prettier formats empty YAML strings with single quotes ('' not ""). The generator template used double quotes, so CI's prettier --check failed. Switch to single quotes and update the sed patterns in orchestrate-release-lock.sh that read and write qa_issue_url to handle both quote styles.

## Changes

- generate-release-testing-instructions.sh: qa_issue_url: "" → qa_issue_url: ''
- orchestrate-release-lock.sh: update the PRIOR_ISSUE_URL extraction sed and the QA_ISSUE_URL injection sed to match either single or double quotes
- tests/shell/*.bats: update all fixtures to use single quotes for the empty-string case

## Test Plan

- [x] Generated file passes prettier --check
- [x] All 194 bats tests pass
- [x] All 2060 unit tests pass