### PR TITLE
[issues/652] Add 2.0.0 release article to README Featured In section

### DIFF
--- a/packages/rangelink-vscode-extension/README.md
+++ b/packages/rangelink-vscode-extension/README.md
@@ -566,6 +566,7 @@ When filing a bug report, please include:
 
 The most recent posts are at the top.
 
+- [RangeLink 2.0.0: Bind first. Every R-\* follows](https://dev.to/couimet/rangelink-200-bind-first-every-r-follows-11nd) - DEV Community
 - [RangeLink v1.0.0: Perfected AI Workflows + The R-Keybinding Family](https://dev.to/couimet/rangelink-v100-perfected-ai-workflows-the-r-keybinding-family-104b) - DEV Community
 - [RangeLink v0.3.0: One Keybinding to Rule Them All](https://dev.to/couimet/rangelink-v030-one-keybinding-to-rule-them-all-2h01) - DEV Community
 - [I Built a VS Code Extension to Stop the Copy-Paste Madness](https://dev.to/couimet/i-built-a-vs-code-extension-to-stop-the-copy-paste-madness-3d7l) - DEV Community


### PR DESCRIPTION
The 2.0.0 release announcement article was published on dev.to but not linked from the README's "Featured In" section. This adds it at the top of the list (most recent first).

- Added "RangeLink 2.0.0: Bind first. Every R-* follows" article link to README Featured In

- Closes https://github.com/couimet/rangeLink/issues/652

@coderabbitai ignore