### PR TITLE
[issues/660] Add test dynamism using `@couimet/dynamic-testing`

### DIFF
--- a/packages/rangelink-core-ts/package.json
+++ b/packages/rangelink-core-ts/package.json
@@ -34,6 +34,7 @@
     "@couimet/logger-contract": "^1.0.0"
   },
   "devDependencies": {
+    "@couimet/dynamic-testing": "^0.1.0",
     "@couimet/logger-contract-testing": "^1.0.0",
     "@types/jest": "^29.5.0",
     "@types/node": "^18.0.0",

--- a/packages/rangelink-core-ts/src/__tests__/detection/findLinksInText.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/detection/findLinksInText.test.ts
@@ -2,8 +2,11 @@ import type { Logger } from '@couimet/logger-contract';
 import { createMockLogger } from '@couimet/logger-contract-testing';
 
 import { DEFAULT_DELIMITERS } from '../../constants';
+import { detectQuotedLinks } from '../../detection/detectQuotedLinks';
 import { findLinksInText } from '../../detection/findLinksInText';
+import type { OccupiedRange } from '../../detection/types';
 import { RangeLinkError, RangeLinkErrorCodes } from '../../errors';
+import type { DetectedLink } from '../../types';
 import { parseLink } from '../../parsing/parseLink';
 import { Result } from '../../types/Result';
 
@@ -398,6 +401,30 @@ describe('findLinksInText', () => {
         },
         'Link detection complete',
       );
+    });
+  });
+
+  describe('detectQuotedLinks overlap handling', () => {
+    it('should skip quoted link when it partially overlaps an unquoted match', () => {
+      // "prefix'src/file.ts#L10'"
+      //  ^0    ^6              ^23
+      // Quoted segment spans [6, 24). Occupied range [0, 18) starts before the
+      // quoted segment and ends inside it — not fully encompassed, so partial.
+      const text = "prefix'src/file.ts#L10'";
+      const links: DetectedLink[] = [];
+      const occupiedRanges: OccupiedRange[] = [{ start: 0, end: 18 }];
+
+      const result = detectQuotedLinks(
+        text,
+        links,
+        occupiedRanges,
+        DEFAULT_DELIMITERS,
+        logger,
+      );
+
+      expect(result.quotedCandidates).toBe(1);
+      expect(result.quotedReplacements).toBe(0);
+      expect(links).toHaveLength(0);
     });
   });
 });

--- a/packages/rangelink-core-ts/src/__tests__/detection/findLinksInText.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/detection/findLinksInText.test.ts
@@ -6,8 +6,8 @@ import { detectQuotedLinks } from '../../detection/detectQuotedLinks';
 import { findLinksInText } from '../../detection/findLinksInText';
 import type { OccupiedRange } from '../../detection/types';
 import { RangeLinkError, RangeLinkErrorCodes } from '../../errors';
-import type { DetectedLink } from '../../types';
 import { parseLink } from '../../parsing/parseLink';
+import type { DetectedLink } from '../../types';
 import { Result } from '../../types/Result';
 
 jest.mock('../../parsing/parseLink', () => ({
@@ -414,13 +414,7 @@ describe('findLinksInText', () => {
       const links: DetectedLink[] = [];
       const occupiedRanges: OccupiedRange[] = [{ start: 0, end: 18 }];
 
-      const result = detectQuotedLinks(
-        text,
-        links,
-        occupiedRanges,
-        DEFAULT_DELIMITERS,
-        logger,
-      );
+      const result = detectQuotedLinks(text, links, occupiedRanges, DEFAULT_DELIMITERS, logger);
 
       expect(result.quotedCandidates).toBe(1);
       expect(result.quotedReplacements).toBe(0);

--- a/packages/rangelink-core-ts/src/__tests__/formatting/buildAnchor.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/formatting/buildAnchor.test.ts
@@ -1,36 +1,63 @@
+import { getUniqueInt } from '@couimet/dynamic-testing';
+
 import { buildAnchor } from '../../formatting/buildAnchor';
 import { DelimiterConfig } from '../../types/DelimiterConfig';
 import { RangeFormat } from '../../types/RangeFormat';
 
+const DEFAULT_DELIMITERS = {
+  line: 'L',
+  position: 'C',
+  hash: '#',
+  range: '-',
+} as const;
+
 describe('buildAnchor', () => {
-  const defaultDelimiters: DelimiterConfig = {
-    line: 'L',
-    position: 'C',
-    hash: '#',
-    range: '-',
-  };
+  let startLine: number;
+  let endLine: number;
+  let startPosition: number;
+  let endPosition: number;
+
+  beforeEach(() => {
+    startLine = getUniqueInt();
+    endLine = getUniqueInt();
+    startPosition = getUniqueInt();
+    endPosition = getUniqueInt();
+  });
 
   describe('with positions', () => {
     it('should build anchor with positions', () => {
-      const result = buildAnchor(11, 21, 6, 16, defaultDelimiters, RangeFormat.WithPositions);
-      expect(result).toBe('L11C6-L21C16');
+      const result = buildAnchor(
+        startLine,
+        endLine,
+        startPosition,
+        endPosition,
+        DEFAULT_DELIMITERS,
+        RangeFormat.WithPositions,
+      );
+      expect(result).toBe(`L${startLine}C${startPosition}-L${endLine}C${endPosition}`);
     });
 
     it('should default to WithPositions format when not specified', () => {
-      const result = buildAnchor(11, 21, 6, 16, defaultDelimiters);
-      expect(result).toBe('L11C6-L21C16');
+      const result = buildAnchor(
+        startLine,
+        endLine,
+        startPosition,
+        endPosition,
+        DEFAULT_DELIMITERS,
+      );
+      expect(result).toBe(`L${startLine}C${startPosition}-L${endLine}C${endPosition}`);
     });
 
     it('should default to position 1 when positions are undefined', () => {
       const result = buildAnchor(
-        11,
-        21,
+        startLine,
+        endLine,
         undefined,
         undefined,
-        defaultDelimiters,
+        DEFAULT_DELIMITERS,
         RangeFormat.WithPositions,
       );
-      expect(result).toBe('L11C1-L21C1');
+      expect(result).toBe(`L${startLine}C1-L${endLine}C1`);
     });
 
     it('should work with custom delimiters', () => {
@@ -40,27 +67,41 @@ describe('buildAnchor', () => {
         hash: '#',
         range: 'TO',
       };
-      const result = buildAnchor(10, 20, 5, 15, customDelimiters, RangeFormat.WithPositions);
-      expect(result).toBe('LINE10COL5TOLINE20COL15');
+      const result = buildAnchor(
+        startLine,
+        endLine,
+        startPosition,
+        endPosition,
+        customDelimiters,
+        RangeFormat.WithPositions,
+      );
+      expect(result).toBe(`LINE${startLine}COL${startPosition}TOLINE${endLine}COL${endPosition}`);
     });
   });
 
   describe('line only', () => {
     it('should build anchor without positions', () => {
-      const result = buildAnchor(11, 21, 6, 16, defaultDelimiters, RangeFormat.LineOnly);
-      expect(result).toBe('L11-L21');
+      const result = buildAnchor(
+        startLine,
+        endLine,
+        startPosition,
+        endPosition,
+        DEFAULT_DELIMITERS,
+        RangeFormat.LineOnly,
+      );
+      expect(result).toBe(`L${startLine}-L${endLine}`);
     });
 
     it('should ignore position values when format is LineOnly', () => {
       const result = buildAnchor(
-        11,
-        21,
+        startLine,
+        endLine,
         undefined,
         undefined,
-        defaultDelimiters,
+        DEFAULT_DELIMITERS,
         RangeFormat.LineOnly,
       );
-      expect(result).toBe('L11-L21');
+      expect(result).toBe(`L${startLine}-L${endLine}`);
     });
 
     it('should work with custom delimiters for line-only format', () => {
@@ -71,33 +112,40 @@ describe('buildAnchor', () => {
         range: 'thru',
       };
       const result = buildAnchor(
-        10,
-        20,
+        startLine,
+        endLine,
         undefined,
         undefined,
         customDelimiters,
         RangeFormat.LineOnly,
       );
-      expect(result).toBe('LINE10thruLINE20');
+      expect(result).toBe(`LINE${startLine}thruLINE${endLine}`);
     });
   });
 
   describe('single line', () => {
     it('should handle single-line selection with positions', () => {
-      const result = buildAnchor(11, 11, 6, 16, defaultDelimiters, RangeFormat.WithPositions);
-      expect(result).toBe('L11C6-L11C16');
+      const result = buildAnchor(
+        startLine,
+        startLine,
+        startPosition,
+        endPosition,
+        DEFAULT_DELIMITERS,
+        RangeFormat.WithPositions,
+      );
+      expect(result).toBe(`L${startLine}C${startPosition}-L${startLine}C${endPosition}`);
     });
 
     it('should handle single-line selection without positions', () => {
       const result = buildAnchor(
-        11,
-        11,
+        startLine,
+        startLine,
         undefined,
         undefined,
-        defaultDelimiters,
+        DEFAULT_DELIMITERS,
         RangeFormat.LineOnly,
       );
-      expect(result).toBe('L11-L11');
+      expect(result).toBe(`L${startLine}-L${startLine}`);
     });
   });
 });

--- a/packages/rangelink-core-ts/src/__tests__/formatting/formatLink.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/formatting/formatLink.test.ts
@@ -1,3 +1,4 @@
+import { getUniqueInt } from '@couimet/dynamic-testing';
 import { getLogger } from '@couimet/logger-contract';
 
 import { formatLink } from '../../formatting/formatLink';
@@ -9,41 +10,62 @@ import { RangeNotation } from '../../types/RangeNotation';
 import { SelectionCoverage } from '../../types/SelectionCoverage';
 import { SelectionType } from '../../types/SelectionType';
 
+const DEFAULT_DELIMITERS = {
+  line: 'L',
+  position: 'C',
+  hash: '#',
+  range: '-',
+} as const;
+
+const byodSuffix = (d: DelimiterConfig, withPositions: boolean): string => {
+  const base = `~${d.hash}~${d.line}~${d.range}~`;
+  return withPositions ? `${base}${d.position}~` : base;
+};
+
 describe('formatLink', () => {
-  const defaultDelimiters: DelimiterConfig = {
-    line: 'L',
-    position: 'C',
-    hash: '#',
-    range: '-',
-  };
+  let startLine: number;
+  let endLine: number;
+  let startPosition: number;
+  let endPosition: number;
+
+  beforeEach(() => {
+    startLine = getUniqueInt();
+    endLine = getUniqueInt();
+    startPosition = getUniqueInt();
+    endPosition = getUniqueInt();
+  });
 
   it('should format a simple multi-line selection', () => {
+    const expectedStartLine = startLine + 1;
+    const expectedEndLine = endLine + 1;
+    const expectedStartPosition = startPosition + 1;
+    const expectedEndPosition = endPosition + 1;
+
     const inputSelection: InputSelection = {
       selections: [
         {
-          start: { line: 10, character: 5 },
-
-          end: { line: 20, character: 15 },
+          start: { line: startLine, character: startPosition },
+          end: { line: endLine, character: endPosition },
           coverage: SelectionCoverage.PartialLine,
         },
       ],
       selectionType: SelectionType.Normal,
     };
-    const result = formatLink('src/file.ts', inputSelection, defaultDelimiters);
+    const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS);
 
     expect(result).toBeOkWith((value: FormattedLink) => {
       expect(value).toStrictEqual({
-        link: 'src/file.ts#L11C6-L21C16',
-        rawLink: 'src/file.ts#L11C6-L21C16',
+        link: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}`,
+        rawLink: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}`,
         linkType: 'regular',
         rangeFormat: 'WithPositions',
         selectionType: 'Normal',
-        delimiters: defaultDelimiters,
+        delimiters: DEFAULT_DELIMITERS,
         computedSelection: {
-          startLine: 11,
-          endLine: 21,
-          startPosition: 6,
-          endPosition: 16,
+          startLine: expectedStartLine,
+          endLine: expectedEndLine,
+          startPosition: expectedStartPosition,
+          endPosition: expectedEndPosition,
           rangeFormat: 'WithPositions',
         },
       });
@@ -51,32 +73,35 @@ describe('formatLink', () => {
   });
 
   it('should format a single-line selection', () => {
+    const expectedStartLine = startLine + 1;
+    const expectedStartPosition = startPosition + 1;
+    const expectedEndPosition = endPosition + 1;
+
     const inputSelection: InputSelection = {
       selections: [
         {
-          start: { line: 10, character: 5 },
-
-          end: { line: 10, character: 15 },
+          start: { line: startLine, character: startPosition },
+          end: { line: startLine, character: endPosition },
           coverage: SelectionCoverage.PartialLine,
         },
       ],
       selectionType: SelectionType.Normal,
     };
-    const result = formatLink('src/file.ts', inputSelection, defaultDelimiters);
+    const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS);
 
     expect(result).toBeOkWith((value: FormattedLink) => {
       expect(value).toStrictEqual({
-        link: 'src/file.ts#L11C6-L11C16',
-        rawLink: 'src/file.ts#L11C6-L11C16',
+        link: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine}C${expectedEndPosition}`,
+        rawLink: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine}C${expectedEndPosition}`,
         linkType: 'regular',
         rangeFormat: 'WithPositions',
         selectionType: 'Normal',
-        delimiters: defaultDelimiters,
+        delimiters: DEFAULT_DELIMITERS,
         computedSelection: {
-          startLine: 11,
-          endLine: 11,
-          startPosition: 6,
-          endPosition: 16,
+          startLine: expectedStartLine,
+          endLine: expectedStartLine,
+          startPosition: expectedStartPosition,
+          endPosition: expectedEndPosition,
           rangeFormat: 'WithPositions',
         },
       });
@@ -84,30 +109,32 @@ describe('formatLink', () => {
   });
 
   it('should use line-only format for full-block selection with FullLine coverage', () => {
+    const expectedStartLine = startLine + 1;
+    const expectedEndLine = endLine + 1;
+
     const inputSelection: InputSelection = {
       selections: [
         {
-          start: { line: 10, character: 0 },
-
-          end: { line: 20, character: 0 },
+          start: { line: startLine, character: 0 },
+          end: { line: endLine, character: 0 },
           coverage: SelectionCoverage.FullLine,
         },
       ],
       selectionType: SelectionType.Normal,
     };
-    const result = formatLink('src/file.ts', inputSelection, defaultDelimiters);
+    const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS);
 
     expect(result).toBeOkWith((value: FormattedLink) => {
       expect(value).toStrictEqual({
-        link: 'src/file.ts#L11-L21',
-        rawLink: 'src/file.ts#L11-L21',
+        link: `src/file.ts#L${expectedStartLine}-L${expectedEndLine}`,
+        rawLink: `src/file.ts#L${expectedStartLine}-L${expectedEndLine}`,
         linkType: 'regular',
         rangeFormat: 'LineOnly',
         selectionType: 'Normal',
-        delimiters: defaultDelimiters,
+        delimiters: DEFAULT_DELIMITERS,
         computedSelection: {
-          startLine: 11,
-          endLine: 21,
+          startLine: expectedStartLine,
+          endLine: expectedEndLine,
           rangeFormat: 'LineOnly',
         },
       });
@@ -115,30 +142,31 @@ describe('formatLink', () => {
   });
 
   it('should use simple line reference format for single line with FullLine coverage', () => {
+    const expectedStartLine = startLine + 1;
+
     const inputSelection: InputSelection = {
       selections: [
         {
-          start: { line: 41, character: 0 },
-
-          end: { line: 41, character: 50 },
+          start: { line: startLine, character: 0 },
+          end: { line: startLine, character: endPosition },
           coverage: SelectionCoverage.FullLine,
         },
       ],
       selectionType: SelectionType.Normal,
     };
-    const result = formatLink('src/file.ts', inputSelection, defaultDelimiters);
+    const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS);
 
     expect(result).toBeOkWith((value: FormattedLink) => {
       expect(value).toStrictEqual({
-        link: 'src/file.ts#L42',
-        rawLink: 'src/file.ts#L42',
+        link: `src/file.ts#L${expectedStartLine}`,
+        rawLink: `src/file.ts#L${expectedStartLine}`,
         linkType: 'regular',
         rangeFormat: 'LineOnly',
         selectionType: 'Normal',
-        delimiters: defaultDelimiters,
+        delimiters: DEFAULT_DELIMITERS,
         computedSelection: {
-          startLine: 42,
-          endLine: 42,
+          startLine: expectedStartLine,
+          endLine: expectedStartLine,
           rangeFormat: 'LineOnly',
         },
       });
@@ -146,32 +174,33 @@ describe('formatLink', () => {
   });
 
   it('should use line-only format with EnforceFullLine notation even for PartialLine', () => {
+    const expectedStartLine = startLine + 1;
+
     const inputSelection: InputSelection = {
       selections: [
         {
-          start: { line: 10, character: 5 },
-
-          end: { line: 10, character: 15 },
+          start: { line: startLine, character: startPosition },
+          end: { line: startLine, character: endPosition },
           coverage: SelectionCoverage.PartialLine,
         },
       ],
       selectionType: SelectionType.Normal,
     };
-    const result = formatLink('src/file.ts', inputSelection, defaultDelimiters, {
+    const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
       notation: RangeNotation.EnforceFullLine,
     });
 
     expect(result).toBeOkWith((value: FormattedLink) => {
       expect(value).toStrictEqual({
-        link: 'src/file.ts#L11',
-        rawLink: 'src/file.ts#L11',
+        link: `src/file.ts#L${expectedStartLine}`,
+        rawLink: `src/file.ts#L${expectedStartLine}`,
         linkType: 'regular',
         rangeFormat: 'LineOnly',
         selectionType: 'Normal',
-        delimiters: defaultDelimiters,
+        delimiters: DEFAULT_DELIMITERS,
         computedSelection: {
-          startLine: 11,
-          endLine: 11,
+          startLine: expectedStartLine,
+          endLine: expectedStartLine,
           rangeFormat: 'LineOnly',
         },
       });
@@ -184,7 +213,7 @@ describe('formatLink', () => {
       selectionType: SelectionType.Normal,
     };
 
-    const result = formatLink('src/file.ts', inputSelection, defaultDelimiters);
+    const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS);
     expect(result).toBeRangeLinkErrorErr('SELECTION_EMPTY', {
       message: 'Selections array must not be empty',
       functionName: 'validateInputSelection',
@@ -193,6 +222,11 @@ describe('formatLink', () => {
   });
 
   it('should work with custom delimiters', () => {
+    const expectedStartLine = startLine + 1;
+    const expectedEndLine = endLine + 1;
+    const expectedStartPosition = startPosition + 1;
+    const expectedEndPosition = endPosition + 1;
+
     const customDelimiters: DelimiterConfig = {
       line: 'LINE',
       position: 'COL',
@@ -202,9 +236,8 @@ describe('formatLink', () => {
     const inputSelection: InputSelection = {
       selections: [
         {
-          start: { line: 9, character: 4 },
-
-          end: { line: 19, character: 14 },
+          start: { line: startLine, character: startPosition },
+          end: { line: endLine, character: endPosition },
           coverage: SelectionCoverage.PartialLine,
         },
       ],
@@ -214,17 +247,17 @@ describe('formatLink', () => {
 
     expect(result).toBeOkWith((value: FormattedLink) => {
       expect(value).toStrictEqual({
-        link: 'path/to/file.ts>>LINE10COL5thruLINE20COL15',
-        rawLink: 'path/to/file.ts>>LINE10COL5thruLINE20COL15',
+        link: `path/to/file.ts>>LINE${expectedStartLine}COL${expectedStartPosition}thruLINE${expectedEndLine}COL${expectedEndPosition}`,
+        rawLink: `path/to/file.ts>>LINE${expectedStartLine}COL${expectedStartPosition}thruLINE${expectedEndLine}COL${expectedEndPosition}`,
         linkType: 'regular',
         rangeFormat: 'WithPositions',
         selectionType: 'Normal',
         delimiters: customDelimiters,
         computedSelection: {
-          startLine: 10,
-          endLine: 20,
-          startPosition: 5,
-          endPosition: 15,
+          startLine: expectedStartLine,
+          endLine: expectedEndLine,
+          startPosition: expectedStartPosition,
+          endPosition: expectedEndPosition,
           rangeFormat: 'WithPositions',
         },
       });
@@ -232,44 +265,45 @@ describe('formatLink', () => {
   });
 
   it('should format rectangular selection with double hash', () => {
+    const expectedStartLine = startLine + 1;
+    const expectedStartPosition = startPosition + 1;
+    const expectedEndPosition = endPosition + 1;
+
     const inputSelection: InputSelection = {
       selections: [
         {
-          start: { line: 5, character: 10 },
-
-          end: { line: 5, character: 20 },
+          start: { line: startLine, character: startPosition },
+          end: { line: startLine, character: endPosition },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 6, character: 10 },
-
-          end: { line: 6, character: 20 },
+          start: { line: startLine + 1, character: startPosition },
+          end: { line: startLine + 1, character: endPosition },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 7, character: 10 },
-
-          end: { line: 7, character: 20 },
+          start: { line: startLine + 2, character: startPosition },
+          end: { line: startLine + 2, character: endPosition },
           coverage: SelectionCoverage.PartialLine,
         },
       ],
       selectionType: SelectionType.Rectangular,
     };
-    const result = formatLink('src/file.ts', inputSelection, defaultDelimiters);
+    const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS);
 
     expect(result).toBeOkWith((value: FormattedLink) => {
       expect(value).toStrictEqual({
-        link: 'src/file.ts##L6C11-L8C21',
-        rawLink: 'src/file.ts##L6C11-L8C21',
+        link: `src/file.ts##L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine + 2}C${expectedEndPosition}`,
+        rawLink: `src/file.ts##L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine + 2}C${expectedEndPosition}`,
         linkType: 'regular',
         rangeFormat: 'WithPositions',
         selectionType: 'Rectangular',
-        delimiters: defaultDelimiters,
+        delimiters: DEFAULT_DELIMITERS,
         computedSelection: {
-          startLine: 6,
-          endLine: 8,
-          startPosition: 11,
-          endPosition: 21,
+          startLine: expectedStartLine,
+          endLine: expectedStartLine + 2,
+          startPosition: expectedStartPosition,
+          endPosition: expectedEndPosition,
           rangeFormat: 'WithPositions',
         },
       });
@@ -277,6 +311,10 @@ describe('formatLink', () => {
   });
 
   it('should format rectangular selection with custom single-char delimiters', () => {
+    const expectedStartLine = startLine + 1;
+    const expectedStartPosition = startPosition + 1;
+    const expectedEndPosition = endPosition + 1;
+
     const customDelimiters: DelimiterConfig = {
       line: 'X',
       position: 'Y',
@@ -286,18 +324,18 @@ describe('formatLink', () => {
     const inputSelection: InputSelection = {
       selections: [
         {
-          start: { line: 5, character: 3 },
-          end: { line: 5, character: 8 },
+          start: { line: startLine, character: startPosition },
+          end: { line: startLine, character: endPosition },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 6, character: 3 },
-          end: { line: 6, character: 8 },
+          start: { line: startLine + 1, character: startPosition },
+          end: { line: startLine + 1, character: endPosition },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 7, character: 3 },
-          end: { line: 7, character: 8 },
+          start: { line: startLine + 2, character: startPosition },
+          end: { line: startLine + 2, character: endPosition },
           coverage: SelectionCoverage.PartialLine,
         },
       ],
@@ -307,17 +345,17 @@ describe('formatLink', () => {
 
     expect(result).toBeOkWith((value: FormattedLink) => {
       expect(value).toStrictEqual({
-        link: 'src/file.ts@@X6Y4..X8Y9',
-        rawLink: 'src/file.ts@@X6Y4..X8Y9',
+        link: `src/file.ts@@X${expectedStartLine}Y${expectedStartPosition}..X${expectedStartLine + 2}Y${expectedEndPosition}`,
+        rawLink: `src/file.ts@@X${expectedStartLine}Y${expectedStartPosition}..X${expectedStartLine + 2}Y${expectedEndPosition}`,
         linkType: 'regular',
         rangeFormat: 'WithPositions',
         selectionType: 'Rectangular',
         delimiters: customDelimiters,
         computedSelection: {
-          startLine: 6,
-          endLine: 8,
-          startPosition: 4,
-          endPosition: 9,
+          startLine: expectedStartLine,
+          endLine: expectedStartLine + 2,
+          startPosition: expectedStartPosition,
+          endPosition: expectedEndPosition,
           rangeFormat: 'WithPositions',
         },
       });
@@ -325,6 +363,10 @@ describe('formatLink', () => {
   });
 
   it('should format rectangular selection with custom multi-char delimiters (hash doubling)', () => {
+    const expectedStartLine = startLine + 1;
+    const expectedStartPosition = startPosition + 1;
+    const expectedEndPosition = endPosition + 1;
+
     const customDelimiters: DelimiterConfig = {
       line: 'LINE',
       position: 'COL',
@@ -334,18 +376,18 @@ describe('formatLink', () => {
     const inputSelection: InputSelection = {
       selections: [
         {
-          start: { line: 20, character: 10 },
-          end: { line: 20, character: 15 },
+          start: { line: startLine, character: startPosition },
+          end: { line: startLine, character: endPosition },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 21, character: 10 },
-          end: { line: 21, character: 15 },
+          start: { line: startLine + 1, character: startPosition },
+          end: { line: startLine + 1, character: endPosition },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 22, character: 10 },
-          end: { line: 22, character: 15 },
+          start: { line: startLine + 2, character: startPosition },
+          end: { line: startLine + 2, character: endPosition },
           coverage: SelectionCoverage.PartialLine,
         },
       ],
@@ -355,17 +397,17 @@ describe('formatLink', () => {
 
     expect(result).toBeOkWith((value: FormattedLink) => {
       expect(value).toStrictEqual({
-        link: 'src/file.ts####LINE21COL11TOLINE23COL16',
-        rawLink: 'src/file.ts####LINE21COL11TOLINE23COL16',
+        link: `src/file.ts####LINE${expectedStartLine}COL${expectedStartPosition}TOLINE${expectedStartLine + 2}COL${expectedEndPosition}`,
+        rawLink: `src/file.ts####LINE${expectedStartLine}COL${expectedStartPosition}TOLINE${expectedStartLine + 2}COL${expectedEndPosition}`,
         linkType: 'regular',
         rangeFormat: 'WithPositions',
         selectionType: 'Rectangular',
         delimiters: customDelimiters,
         computedSelection: {
-          startLine: 21,
-          endLine: 23,
-          startPosition: 11,
-          endPosition: 16,
+          startLine: expectedStartLine,
+          endLine: expectedStartLine + 2,
+          startPosition: expectedStartPosition,
+          endPosition: expectedEndPosition,
           rangeFormat: 'WithPositions',
         },
       });
@@ -373,32 +415,34 @@ describe('formatLink', () => {
   });
 
   it('should use WithPositions format with EnforcePositions notation even for FullLine', () => {
+    const expectedStartLine = startLine + 1;
+    const expectedEndLine = endLine + 1;
+
     const inputSelection: InputSelection = {
       selections: [
         {
-          start: { line: 10, character: 0 },
-
-          end: { line: 20, character: 0 },
+          start: { line: startLine, character: 0 },
+          end: { line: endLine, character: 0 },
           coverage: SelectionCoverage.FullLine,
         },
       ],
       selectionType: SelectionType.Normal,
     };
-    const result = formatLink('src/file.ts', inputSelection, defaultDelimiters, {
+    const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
       notation: RangeNotation.EnforcePositions,
     });
 
     expect(result).toBeOkWith((value: FormattedLink) => {
       expect(value).toStrictEqual({
-        link: 'src/file.ts#L11C1-L21C1',
-        rawLink: 'src/file.ts#L11C1-L21C1',
+        link: `src/file.ts#L${expectedStartLine}C1-L${expectedEndLine}C1`,
+        rawLink: `src/file.ts#L${expectedStartLine}C1-L${expectedEndLine}C1`,
         linkType: 'regular',
         rangeFormat: 'WithPositions',
         selectionType: 'Normal',
-        delimiters: defaultDelimiters,
+        delimiters: DEFAULT_DELIMITERS,
         computedSelection: {
-          startLine: 11,
-          endLine: 21,
+          startLine: expectedStartLine,
+          endLine: expectedEndLine,
           startPosition: 1,
           endPosition: 1,
           rangeFormat: 'WithPositions',
@@ -409,31 +453,33 @@ describe('formatLink', () => {
 
   describe('portable links', () => {
     it('should append BYOD metadata for single-line FullLine selection', () => {
+      const expectedStartLine = startLine + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 41, character: 0 },
-            end: { line: 41, character: 50 },
+            start: { line: startLine, character: 0 },
+            end: { line: startLine, character: endPosition },
             coverage: SelectionCoverage.FullLine,
           },
         ],
         selectionType: SelectionType.Normal,
       };
-      const result = formatLink('src/file.ts', inputSelection, defaultDelimiters, {
+      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
         linkType: LinkType.Portable,
       });
 
       expect(result).toBeOkWith((value: FormattedLink) => {
         expect(value).toStrictEqual({
-          link: 'src/file.ts#L42~#~L~-~',
-          rawLink: 'src/file.ts#L42~#~L~-~',
+          link: `src/file.ts#L${expectedStartLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`,
+          rawLink: `src/file.ts#L${expectedStartLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`,
           linkType: 'portable',
           rangeFormat: 'LineOnly',
           selectionType: 'Normal',
-          delimiters: defaultDelimiters,
+          delimiters: DEFAULT_DELIMITERS,
           computedSelection: {
-            startLine: 42,
-            endLine: 42,
+            startLine: expectedStartLine,
+            endLine: expectedStartLine,
             rangeFormat: 'LineOnly',
           },
         });
@@ -441,31 +487,34 @@ describe('formatLink', () => {
     });
 
     it('should append BYOD metadata for multi-line FullLine selection', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedEndLine = endLine + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 0 },
-            end: { line: 20, character: 0 },
+            start: { line: startLine, character: 0 },
+            end: { line: endLine, character: 0 },
             coverage: SelectionCoverage.FullLine,
           },
         ],
         selectionType: SelectionType.Normal,
       };
-      const result = formatLink('src/file.ts', inputSelection, defaultDelimiters, {
+      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
         linkType: LinkType.Portable,
       });
 
       expect(result).toBeOkWith((value: FormattedLink) => {
         expect(value).toStrictEqual({
-          link: 'src/file.ts#L11-L21~#~L~-~',
-          rawLink: 'src/file.ts#L11-L21~#~L~-~',
+          link: `src/file.ts#L${expectedStartLine}-L${expectedEndLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`,
+          rawLink: `src/file.ts#L${expectedStartLine}-L${expectedEndLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`,
           linkType: 'portable',
           rangeFormat: 'LineOnly',
           selectionType: 'Normal',
-          delimiters: defaultDelimiters,
+          delimiters: DEFAULT_DELIMITERS,
           computedSelection: {
-            startLine: 11,
-            endLine: 21,
+            startLine: expectedStartLine,
+            endLine: expectedEndLine,
             rangeFormat: 'LineOnly',
           },
         });
@@ -473,33 +522,38 @@ describe('formatLink', () => {
     });
 
     it('should append BYOD metadata with positions for PartialLine selection', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedEndLine = endLine + 1;
+      const expectedStartPosition = startPosition + 1;
+      const expectedEndPosition = endPosition + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 5 },
-            end: { line: 20, character: 15 },
+            start: { line: startLine, character: startPosition },
+            end: { line: endLine, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
         selectionType: SelectionType.Normal,
       };
-      const result = formatLink('src/file.ts', inputSelection, defaultDelimiters, {
+      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
         linkType: LinkType.Portable,
       });
 
       expect(result).toBeOkWith((value: FormattedLink) => {
         expect(value).toStrictEqual({
-          link: 'src/file.ts#L11C6-L21C16~#~L~-~C~',
-          rawLink: 'src/file.ts#L11C6-L21C16~#~L~-~C~',
+          link: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}${byodSuffix(DEFAULT_DELIMITERS, true)}`,
+          rawLink: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}${byodSuffix(DEFAULT_DELIMITERS, true)}`,
           linkType: 'portable',
           rangeFormat: 'WithPositions',
           selectionType: 'Normal',
-          delimiters: defaultDelimiters,
+          delimiters: DEFAULT_DELIMITERS,
           computedSelection: {
-            startLine: 11,
-            endLine: 21,
-            startPosition: 6,
-            endPosition: 16,
+            startLine: expectedStartLine,
+            endLine: expectedEndLine,
+            startPosition: expectedStartPosition,
+            endPosition: expectedEndPosition,
             rangeFormat: 'WithPositions',
           },
         });
@@ -507,43 +561,47 @@ describe('formatLink', () => {
     });
 
     it('should append BYOD metadata for rectangular selection', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedStartPosition = startPosition + 1;
+      const expectedEndPosition = endPosition + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 5, character: 10 },
-            end: { line: 5, character: 20 },
+            start: { line: startLine, character: startPosition },
+            end: { line: startLine, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
           {
-            start: { line: 6, character: 10 },
-            end: { line: 6, character: 20 },
+            start: { line: startLine + 1, character: startPosition },
+            end: { line: startLine + 1, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
           {
-            start: { line: 7, character: 10 },
-            end: { line: 7, character: 20 },
+            start: { line: startLine + 2, character: startPosition },
+            end: { line: startLine + 2, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
         selectionType: SelectionType.Rectangular,
       };
-      const result = formatLink('src/file.ts', inputSelection, defaultDelimiters, {
+      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
         linkType: LinkType.Portable,
       });
 
       expect(result).toBeOkWith((value: FormattedLink) => {
         expect(value).toStrictEqual({
-          link: 'src/file.ts##L6C11-L8C21~#~L~-~C~',
-          rawLink: 'src/file.ts##L6C11-L8C21~#~L~-~C~',
+          link: `src/file.ts##L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine + 2}C${expectedEndPosition}${byodSuffix(DEFAULT_DELIMITERS, true)}`,
+          rawLink: `src/file.ts##L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine + 2}C${expectedEndPosition}${byodSuffix(DEFAULT_DELIMITERS, true)}`,
           linkType: 'portable',
           rangeFormat: 'WithPositions',
           selectionType: 'Rectangular',
-          delimiters: defaultDelimiters,
+          delimiters: DEFAULT_DELIMITERS,
           computedSelection: {
-            startLine: 6,
-            endLine: 8,
-            startPosition: 11,
-            endPosition: 21,
+            startLine: expectedStartLine,
+            endLine: expectedStartLine + 2,
+            startPosition: expectedStartPosition,
+            endPosition: expectedEndPosition,
             rangeFormat: 'WithPositions',
           },
         });
@@ -551,6 +609,10 @@ describe('formatLink', () => {
     });
 
     it('should append BYOD metadata for rectangular selection with custom delimiters', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedStartPosition = startPosition + 1;
+      const expectedEndPosition = endPosition + 1;
+
       const customDelimiters: DelimiterConfig = {
         line: 'LINE',
         position: 'COL',
@@ -560,18 +622,18 @@ describe('formatLink', () => {
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 9, character: 4 },
-            end: { line: 9, character: 9 },
+            start: { line: startLine, character: startPosition },
+            end: { line: startLine, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
           {
-            start: { line: 10, character: 4 },
-            end: { line: 10, character: 9 },
+            start: { line: startLine + 1, character: startPosition },
+            end: { line: startLine + 1, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
           {
-            start: { line: 11, character: 4 },
-            end: { line: 11, character: 9 },
+            start: { line: startLine + 2, character: startPosition },
+            end: { line: startLine + 2, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
@@ -583,17 +645,17 @@ describe('formatLink', () => {
 
       expect(result).toBeOkWith((value: FormattedLink) => {
         expect(value).toStrictEqual({
-          link: 'src/file.ts##LINE10COL5TOLINE12COL10~#~LINE~TO~COL~',
-          rawLink: 'src/file.ts##LINE10COL5TOLINE12COL10~#~LINE~TO~COL~',
+          link: `src/file.ts##LINE${expectedStartLine}COL${expectedStartPosition}TOLINE${expectedStartLine + 2}COL${expectedEndPosition}${byodSuffix(customDelimiters, true)}`,
+          rawLink: `src/file.ts##LINE${expectedStartLine}COL${expectedStartPosition}TOLINE${expectedStartLine + 2}COL${expectedEndPosition}${byodSuffix(customDelimiters, true)}`,
           linkType: 'portable',
           rangeFormat: 'WithPositions',
           selectionType: 'Rectangular',
           delimiters: customDelimiters,
           computedSelection: {
-            startLine: 10,
-            endLine: 12,
-            startPosition: 5,
-            endPosition: 10,
+            startLine: expectedStartLine,
+            endLine: expectedStartLine + 2,
+            startPosition: expectedStartPosition,
+            endPosition: expectedEndPosition,
             rangeFormat: 'WithPositions',
           },
         });
@@ -601,6 +663,9 @@ describe('formatLink', () => {
     });
 
     it('should append BYOD metadata with custom delimiters (line-only)', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedEndLine = endLine + 1;
+
       const customDelimiters: DelimiterConfig = {
         line: 'LINE',
         position: 'COL',
@@ -610,8 +675,8 @@ describe('formatLink', () => {
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 9, character: 0 },
-            end: { line: 19, character: 0 },
+            start: { line: startLine, character: 0 },
+            end: { line: endLine, character: 0 },
             coverage: SelectionCoverage.FullLine,
           },
         ],
@@ -623,15 +688,15 @@ describe('formatLink', () => {
 
       expect(result).toBeOkWith((value: FormattedLink) => {
         expect(value).toStrictEqual({
-          link: 'path/to/file.ts>>LINE10thruLINE20~>>~LINE~thru~',
-          rawLink: 'path/to/file.ts>>LINE10thruLINE20~>>~LINE~thru~',
+          link: `path/to/file.ts>>LINE${expectedStartLine}thruLINE${expectedEndLine}${byodSuffix(customDelimiters, false)}`,
+          rawLink: `path/to/file.ts>>LINE${expectedStartLine}thruLINE${expectedEndLine}${byodSuffix(customDelimiters, false)}`,
           linkType: 'portable',
           rangeFormat: 'LineOnly',
           selectionType: 'Normal',
           delimiters: customDelimiters,
           computedSelection: {
-            startLine: 10,
-            endLine: 20,
+            startLine: expectedStartLine,
+            endLine: expectedEndLine,
             rangeFormat: 'LineOnly',
           },
         });
@@ -639,6 +704,11 @@ describe('formatLink', () => {
     });
 
     it('should append BYOD metadata with custom delimiters (with positions)', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedEndLine = endLine + 1;
+      const expectedStartPosition = startPosition + 1;
+      const expectedEndPosition = endPosition + 1;
+
       const customDelimiters: DelimiterConfig = {
         line: 'LINE',
         position: 'COL',
@@ -648,8 +718,8 @@ describe('formatLink', () => {
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 9, character: 4 },
-            end: { line: 19, character: 14 },
+            start: { line: startLine, character: startPosition },
+            end: { line: endLine, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
@@ -661,17 +731,17 @@ describe('formatLink', () => {
 
       expect(result).toBeOkWith((value: FormattedLink) => {
         expect(value).toStrictEqual({
-          link: 'path/to/file.ts>>LINE10COL5thruLINE20COL15~>>~LINE~thru~COL~',
-          rawLink: 'path/to/file.ts>>LINE10COL5thruLINE20COL15~>>~LINE~thru~COL~',
+          link: `path/to/file.ts>>LINE${expectedStartLine}COL${expectedStartPosition}thruLINE${expectedEndLine}COL${expectedEndPosition}${byodSuffix(customDelimiters, true)}`,
+          rawLink: `path/to/file.ts>>LINE${expectedStartLine}COL${expectedStartPosition}thruLINE${expectedEndLine}COL${expectedEndPosition}${byodSuffix(customDelimiters, true)}`,
           linkType: 'portable',
           rangeFormat: 'WithPositions',
           selectionType: 'Normal',
           delimiters: customDelimiters,
           computedSelection: {
-            startLine: 10,
-            endLine: 20,
-            startPosition: 5,
-            endPosition: 15,
+            startLine: expectedStartLine,
+            endLine: expectedEndLine,
+            startPosition: expectedStartPosition,
+            endPosition: expectedEndPosition,
             rangeFormat: 'WithPositions',
           },
         });
@@ -679,32 +749,34 @@ describe('formatLink', () => {
     });
 
     it('should append BYOD metadata for EnforceFullLine notation', () => {
+      const expectedStartLine = startLine + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 5 },
-            end: { line: 10, character: 15 },
+            start: { line: startLine, character: startPosition },
+            end: { line: startLine, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
         selectionType: SelectionType.Normal,
       };
-      const result = formatLink('src/file.ts', inputSelection, defaultDelimiters, {
+      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
         notation: RangeNotation.EnforceFullLine,
         linkType: LinkType.Portable,
       });
 
       expect(result).toBeOkWith((value: FormattedLink) => {
         expect(value).toStrictEqual({
-          link: 'src/file.ts#L11~#~L~-~',
-          rawLink: 'src/file.ts#L11~#~L~-~',
+          link: `src/file.ts#L${expectedStartLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`,
+          rawLink: `src/file.ts#L${expectedStartLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`,
           linkType: 'portable',
           rangeFormat: 'LineOnly',
           selectionType: 'Normal',
-          delimiters: defaultDelimiters,
+          delimiters: DEFAULT_DELIMITERS,
           computedSelection: {
-            startLine: 11,
-            endLine: 11,
+            startLine: expectedStartLine,
+            endLine: expectedStartLine,
             rangeFormat: 'LineOnly',
           },
         });
@@ -712,32 +784,35 @@ describe('formatLink', () => {
     });
 
     it('should append BYOD metadata for EnforcePositions notation', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedEndLine = endLine + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 0 },
-            end: { line: 20, character: 0 },
+            start: { line: startLine, character: 0 },
+            end: { line: endLine, character: 0 },
             coverage: SelectionCoverage.FullLine,
           },
         ],
         selectionType: SelectionType.Normal,
       };
-      const result = formatLink('src/file.ts', inputSelection, defaultDelimiters, {
+      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
         notation: RangeNotation.EnforcePositions,
         linkType: LinkType.Portable,
       });
 
       expect(result).toBeOkWith((value: FormattedLink) => {
         expect(value).toStrictEqual({
-          link: 'src/file.ts#L11C1-L21C1~#~L~-~C~',
-          rawLink: 'src/file.ts#L11C1-L21C1~#~L~-~C~',
+          link: `src/file.ts#L${expectedStartLine}C1-L${expectedEndLine}C1${byodSuffix(DEFAULT_DELIMITERS, true)}`,
+          rawLink: `src/file.ts#L${expectedStartLine}C1-L${expectedEndLine}C1${byodSuffix(DEFAULT_DELIMITERS, true)}`,
           linkType: 'portable',
           rangeFormat: 'WithPositions',
           selectionType: 'Normal',
-          delimiters: defaultDelimiters,
+          delimiters: DEFAULT_DELIMITERS,
           computedSelection: {
-            startLine: 11,
-            endLine: 21,
+            startLine: expectedStartLine,
+            endLine: expectedEndLine,
             startPosition: 1,
             endPosition: 1,
             rangeFormat: 'WithPositions',
@@ -750,38 +825,43 @@ describe('formatLink', () => {
   describe('integration', () => {
     it.each([
       { linkType: LinkType.Regular, suffix: '' },
-      { linkType: LinkType.Portable, suffix: '~#~L~-~C~' },
+      { linkType: LinkType.Portable, suffix: byodSuffix(DEFAULT_DELIMITERS, true) },
     ])(
       'should handle end-to-end link generation with linkType=$linkType',
       ({ linkType, suffix }) => {
+        const expectedStartLine = startLine + 1;
+        const expectedEndLine = endLine + 1;
+        const expectedStartPosition = startPosition + 1;
+        const expectedEndPosition = endPosition + 1;
+
         const inputSelection: InputSelection = {
           selections: [
             {
-              start: { line: 10, character: 5 },
-              end: { line: 20, character: 15 },
+              start: { line: startLine, character: startPosition },
+              end: { line: endLine, character: endPosition },
               coverage: SelectionCoverage.PartialLine,
             },
           ],
           selectionType: SelectionType.Normal,
         };
 
-        const result = formatLink('src/file.ts', inputSelection, defaultDelimiters, {
+        const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
           linkType,
         });
 
         expect(result).toBeOkWith((value: FormattedLink) => {
           expect(value).toStrictEqual({
-            link: `src/file.ts#L11C6-L21C16${suffix}`,
-            rawLink: `src/file.ts#L11C6-L21C16${suffix}`,
+            link: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}${suffix}`,
+            rawLink: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}${suffix}`,
             linkType: linkType === LinkType.Regular ? 'regular' : 'portable',
             rangeFormat: 'WithPositions',
             selectionType: 'Normal',
-            delimiters: defaultDelimiters,
+            delimiters: DEFAULT_DELIMITERS,
             computedSelection: {
-              startLine: 11,
-              endLine: 21,
-              startPosition: 6,
-              endPosition: 16,
+              startLine: expectedStartLine,
+              endLine: expectedEndLine,
+              startPosition: expectedStartPosition,
+              endPosition: expectedEndPosition,
               rangeFormat: 'WithPositions',
             },
           });
@@ -791,41 +871,45 @@ describe('formatLink', () => {
 
     it.each([
       { linkType: LinkType.Regular, suffix: '' },
-      { linkType: LinkType.Portable, suffix: '~#~L~-~C~' },
+      { linkType: LinkType.Portable, suffix: byodSuffix(DEFAULT_DELIMITERS, true) },
     ])('should handle rectangular selection with linkType=$linkType', ({ linkType, suffix }) => {
+      const expectedStartLine = startLine + 1;
+      const expectedStartPosition = startPosition + 1;
+      const expectedEndPosition = endPosition + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 5, character: 10 },
-            end: { line: 5, character: 20 },
+            start: { line: startLine, character: startPosition },
+            end: { line: startLine, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
           {
-            start: { line: 6, character: 10 },
-            end: { line: 6, character: 20 },
+            start: { line: startLine + 1, character: startPosition },
+            end: { line: startLine + 1, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
         selectionType: SelectionType.Rectangular,
       };
 
-      const result = formatLink('src/file.ts', inputSelection, defaultDelimiters, {
+      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
         linkType,
       });
 
       expect(result).toBeOkWith((value: FormattedLink) => {
         expect(value).toStrictEqual({
-          link: `src/file.ts##L6C11-L7C21${suffix}`,
-          rawLink: `src/file.ts##L6C11-L7C21${suffix}`,
+          link: `src/file.ts##L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine + 1}C${expectedEndPosition}${suffix}`,
+          rawLink: `src/file.ts##L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine + 1}C${expectedEndPosition}${suffix}`,
           linkType: linkType === LinkType.Regular ? 'regular' : 'portable',
           rangeFormat: 'WithPositions',
           selectionType: 'Rectangular',
-          delimiters: defaultDelimiters,
+          delimiters: DEFAULT_DELIMITERS,
           computedSelection: {
-            startLine: 6,
-            endLine: 7,
-            startPosition: 11,
-            endPosition: 21,
+            startLine: expectedStartLine,
+            endLine: expectedStartLine + 1,
+            startPosition: expectedStartPosition,
+            endPosition: expectedEndPosition,
             rangeFormat: 'WithPositions',
           },
         });
@@ -840,7 +924,7 @@ describe('formatLink', () => {
           selectionType: SelectionType.Normal,
         };
 
-        const result = formatLink('src/file.ts', inputSelection, defaultDelimiters, {
+        const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
           linkType,
         });
 
@@ -855,30 +939,32 @@ describe('formatLink', () => {
 
   describe('quoting', () => {
     it('should quote link when path contains spaces', () => {
+      const expectedStartLine = startLine + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 9, character: 0 },
-            end: { line: 9, character: 50 },
+            start: { line: startLine, character: 0 },
+            end: { line: startLine, character: endPosition },
             coverage: SelectionCoverage.FullLine,
           },
         ],
         selectionType: SelectionType.Normal,
       };
 
-      const result = formatLink('My Folder/file.ts', inputSelection, defaultDelimiters);
+      const result = formatLink('My Folder/file.ts', inputSelection, DEFAULT_DELIMITERS);
 
       expect(result).toBeOkWith((value: FormattedLink) => {
         expect(value).toStrictEqual({
-          link: "'My Folder/file.ts#L10'",
-          rawLink: 'My Folder/file.ts#L10',
+          link: `'My Folder/file.ts#L${expectedStartLine}'`,
+          rawLink: `My Folder/file.ts#L${expectedStartLine}`,
           linkType: 'regular',
           rangeFormat: 'LineOnly',
           selectionType: 'Normal',
-          delimiters: defaultDelimiters,
+          delimiters: DEFAULT_DELIMITERS,
           computedSelection: {
-            startLine: 10,
-            endLine: 10,
+            startLine: expectedStartLine,
+            endLine: expectedStartLine,
             rangeFormat: 'LineOnly',
           },
         });
@@ -886,32 +972,37 @@ describe('formatLink', () => {
     });
 
     it('should quote link when path contains parentheses', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedEndLine = endLine + 1;
+      const expectedStartPosition = startPosition + 1;
+      const expectedEndPosition = endPosition + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 4, character: 3 },
-            end: { line: 14, character: 10 },
+            start: { line: startLine, character: startPosition },
+            end: { line: endLine, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
         selectionType: SelectionType.Normal,
       };
 
-      const result = formatLink('src/(group)/file.ts', inputSelection, defaultDelimiters);
+      const result = formatLink('src/(group)/file.ts', inputSelection, DEFAULT_DELIMITERS);
 
       expect(result).toBeOkWith((value: FormattedLink) => {
         expect(value).toStrictEqual({
-          link: "'src/(group)/file.ts#L5C4-L15C11'",
-          rawLink: 'src/(group)/file.ts#L5C4-L15C11',
+          link: `'src/(group)/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}'`,
+          rawLink: `src/(group)/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}`,
           linkType: 'regular',
           rangeFormat: 'WithPositions',
           selectionType: 'Normal',
-          delimiters: defaultDelimiters,
+          delimiters: DEFAULT_DELIMITERS,
           computedSelection: {
-            startLine: 5,
-            endLine: 15,
-            startPosition: 4,
-            endPosition: 11,
+            startLine: expectedStartLine,
+            endLine: expectedEndLine,
+            startPosition: expectedStartPosition,
+            endPosition: expectedEndPosition,
             rangeFormat: 'WithPositions',
           },
         });
@@ -919,61 +1010,65 @@ describe('formatLink', () => {
     });
 
     it('should not quote link when path is safe', () => {
+      const expectedStartLine = startLine + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 9, character: 0 },
-            end: { line: 9, character: 50 },
+            start: { line: startLine, character: 0 },
+            end: { line: startLine, character: endPosition },
             coverage: SelectionCoverage.FullLine,
           },
         ],
         selectionType: SelectionType.Normal,
       };
 
-      const result = formatLink('src/file.ts', inputSelection, defaultDelimiters);
+      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS);
 
       expect(result).toBeOkWith((value: FormattedLink) => {
-        expect(value.link).toBe('src/file.ts#L10');
-        expect(value.rawLink).toBe('src/file.ts#L10');
+        expect(value.link).toBe(`src/file.ts#L${expectedStartLine}`);
+        expect(value.rawLink).toBe(`src/file.ts#L${expectedStartLine}`);
       });
     });
   });
 
   describe('logging integration', () => {
     it('should log with correct attributes through standard anchor path', () => {
-      // Integration test: Verifies formatLink → finalizeLinkGeneration → logger flow
-      // Tests standard anchor path (multi-line PartialLine selection)
-
       const mockDebug = jest.fn();
       jest.spyOn(getLogger(), 'debug').mockImplementation(mockDebug);
+
+      const expectedStartLine = startLine + 1;
+      const expectedEndLine = endLine + 1;
+      const expectedStartPosition = startPosition + 1;
+      const expectedEndPosition = endPosition + 1;
 
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 5 },
-            end: { line: 20, character: 15 },
+            start: { line: startLine, character: startPosition },
+            end: { line: endLine, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
         selectionType: SelectionType.Normal,
       };
 
-      // Call formatLink (internally generates logContext that would collide)
-      const result = formatLink('src/file.ts', inputSelection, defaultDelimiters);
+      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS);
 
+      const expectedLink = `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}`;
       expect(result).toBeOkWith((value: FormattedLink) => {
         expect(value).toStrictEqual({
-          link: 'src/file.ts#L11C6-L21C16',
-          rawLink: 'src/file.ts#L11C6-L21C16',
+          link: expectedLink,
+          rawLink: expectedLink,
           linkType: 'regular',
           rangeFormat: 'WithPositions',
           selectionType: 'Normal',
-          delimiters: defaultDelimiters,
+          delimiters: DEFAULT_DELIMITERS,
           computedSelection: {
-            startLine: 11,
-            endLine: 21,
-            startPosition: 6,
-            endPosition: 16,
+            startLine: expectedStartLine,
+            endLine: expectedEndLine,
+            startPosition: expectedStartPosition,
+            endPosition: expectedEndPosition,
             rangeFormat: 'WithPositions',
           },
         });
@@ -982,9 +1077,9 @@ describe('formatLink', () => {
       expect(mockDebug).toHaveBeenCalledWith(
         {
           fn: 'formatLink',
-          link: 'src/file.ts#L11C6-L21C16',
-          rawLink: 'src/file.ts#L11C6-L21C16',
-          linkLength: 24,
+          link: expectedLink,
+          rawLink: expectedLink,
+          linkLength: expectedLink.length,
           selectionType: 'Normal',
           rangeFormat: 'WithPositions',
         },
@@ -995,37 +1090,38 @@ describe('formatLink', () => {
     });
 
     it('should log with correct attributes through simple line reference path', () => {
-      // Integration test: Verifies portable link generation through simple line reference path
-      // Tests single-line FullLine selection (uses formatSimpleLineReference)
       const mockDebug = jest.fn();
       jest.spyOn(getLogger(), 'debug').mockImplementation(mockDebug);
+
+      const expectedStartLine = startLine + 1;
 
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 41, character: 0 },
-            end: { line: 41, character: 50 },
+            start: { line: startLine, character: 0 },
+            end: { line: startLine, character: endPosition },
             coverage: SelectionCoverage.FullLine,
           },
         ],
         selectionType: SelectionType.Normal,
       };
 
-      const result = formatLink('src/file.ts', inputSelection, defaultDelimiters, {
+      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
         linkType: LinkType.Portable,
       });
 
+      const expectedLink = `src/file.ts#L${expectedStartLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`;
       expect(result).toBeOkWith((value: FormattedLink) => {
         expect(value).toStrictEqual({
-          link: 'src/file.ts#L42~#~L~-~',
-          rawLink: 'src/file.ts#L42~#~L~-~',
+          link: expectedLink,
+          rawLink: expectedLink,
           linkType: 'portable',
           rangeFormat: 'LineOnly',
           selectionType: 'Normal',
-          delimiters: defaultDelimiters,
+          delimiters: DEFAULT_DELIMITERS,
           computedSelection: {
-            startLine: 42,
-            endLine: 42,
+            startLine: expectedStartLine,
+            endLine: expectedStartLine,
             rangeFormat: 'LineOnly',
           },
         });
@@ -1034,9 +1130,9 @@ describe('formatLink', () => {
       expect(mockDebug).toHaveBeenCalledWith(
         {
           fn: 'formatLink',
-          link: 'src/file.ts#L42~#~L~-~',
-          rawLink: 'src/file.ts#L42~#~L~-~',
-          linkLength: 22,
+          link: expectedLink,
+          rawLink: expectedLink,
+          linkLength: expectedLink.length,
           format: 'simple',
         },
         'Generated link',

--- a/packages/rangelink-core-ts/src/__tests__/selection/computeRangeSpec.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/selection/computeRangeSpec.test.ts
@@ -1,3 +1,5 @@
+import { getUniqueInt } from '@couimet/dynamic-testing';
+
 import { computeRangeSpec } from '../../selection/computeRangeSpec';
 import * as validateInputSelectionModule from '../../selection/validateInputSelection';
 import { InputSelection } from '../../types/InputSelection';
@@ -7,14 +9,29 @@ import { SelectionCoverage } from '../../types/SelectionCoverage';
 import { SelectionType } from '../../types/SelectionType';
 
 describe('computeRangeSpec', () => {
+  let startLine: number;
+  let endLine: number;
+  let startPosition: number;
+  let endPosition: number;
+
+  beforeEach(() => {
+    startLine = getUniqueInt();
+    endLine = getUniqueInt();
+    startPosition = getUniqueInt();
+    endPosition = getUniqueInt();
+  });
+
   describe('Default behavior (no options)', () => {
     it('should default to Auto notation for PartialLine coverage', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedStartPosition = startPosition + 1;
+      const expectedEndPosition = endPosition + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 5 },
-
-            end: { line: 10, character: 15 },
+            start: { line: startLine, character: startPosition },
+            end: { line: startLine, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
@@ -24,22 +41,23 @@ describe('computeRangeSpec', () => {
 
       expect(result).toBeOkWith((value) => {
         expect(value).toStrictEqual({
-          startLine: 11,
-          endLine: 11,
-          startPosition: 6,
-          endPosition: 16,
+          startLine: expectedStartLine,
+          endLine: expectedStartLine,
+          startPosition: expectedStartPosition,
+          endPosition: expectedEndPosition,
           rangeFormat: RangeFormat.WithPositions,
         });
       });
     });
 
     it('should default to Auto notation for FullLine coverage', () => {
+      const expectedStartLine = startLine + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 0 },
-
-            end: { line: 10, character: 50 },
+            start: { line: startLine, character: 0 },
+            end: { line: startLine, character: endPosition },
             coverage: SelectionCoverage.FullLine,
           },
         ],
@@ -49,8 +67,8 @@ describe('computeRangeSpec', () => {
 
       expect(result).toBeOkWith((value) => {
         expect(value).toStrictEqual({
-          startLine: 11,
-          endLine: 11,
+          startLine: expectedStartLine,
+          endLine: expectedStartLine,
           rangeFormat: RangeFormat.LineOnly,
         });
       });
@@ -59,12 +77,15 @@ describe('computeRangeSpec', () => {
 
   describe('Auto notation - Normal selections', () => {
     it('should use WithPositions format for partial line coverage', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedStartPosition = startPosition + 1;
+      const expectedEndPosition = endPosition + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 5 },
-
-            end: { line: 10, character: 15 },
+            start: { line: startLine, character: startPosition },
+            end: { line: startLine, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
@@ -74,22 +95,26 @@ describe('computeRangeSpec', () => {
 
       expect(result).toBeOkWith((value) => {
         expect(value).toStrictEqual({
-          startLine: 11, // 1-based
-          endLine: 11,
-          startPosition: 6, // 1-based
-          endPosition: 16,
+          startLine: expectedStartLine,
+          endLine: expectedStartLine,
+          startPosition: expectedStartPosition,
+          endPosition: expectedEndPosition,
           rangeFormat: RangeFormat.WithPositions,
         });
       });
     });
 
     it('should use WithPositions format for multi-line partial selection', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedEndLine = endLine + 1;
+      const expectedStartPosition = startPosition + 1;
+      const expectedEndPosition = endPosition + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 5 },
-
-            end: { line: 20, character: 15 },
+            start: { line: startLine, character: startPosition },
+            end: { line: endLine, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
@@ -99,22 +124,24 @@ describe('computeRangeSpec', () => {
 
       expect(result).toBeOkWith((value) => {
         expect(value).toStrictEqual({
-          startLine: 11,
-          endLine: 21,
-          startPosition: 6,
-          endPosition: 16,
+          startLine: expectedStartLine,
+          endLine: expectedEndLine,
+          startPosition: expectedStartPosition,
+          endPosition: expectedEndPosition,
           rangeFormat: RangeFormat.WithPositions,
         });
       });
     });
 
     it('should use LineOnly format when all selections have FullLine coverage', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedEndLine = endLine + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 0 },
-
-            end: { line: 15, character: 0 },
+            start: { line: startLine, character: 0 },
+            end: { line: endLine, character: 0 },
             coverage: SelectionCoverage.FullLine,
           },
         ],
@@ -124,20 +151,21 @@ describe('computeRangeSpec', () => {
 
       expect(result).toBeOkWith((value) => {
         expect(value).toStrictEqual({
-          startLine: 11,
-          endLine: 16,
+          startLine: expectedStartLine,
+          endLine: expectedEndLine,
           rangeFormat: RangeFormat.LineOnly,
         });
       });
     });
 
     it('should use LineOnly format for single line with FullLine coverage', () => {
+      const expectedStartLine = startLine + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 0 },
-
-            end: { line: 10, character: 50 },
+            start: { line: startLine, character: 0 },
+            end: { line: startLine, character: endPosition },
             coverage: SelectionCoverage.FullLine,
           },
         ],
@@ -147,8 +175,8 @@ describe('computeRangeSpec', () => {
 
       expect(result).toBeOkWith((value) => {
         expect(value).toStrictEqual({
-          startLine: 11,
-          endLine: 11,
+          startLine: expectedStartLine,
+          endLine: expectedStartLine,
           rangeFormat: RangeFormat.LineOnly,
         });
       });
@@ -157,24 +185,25 @@ describe('computeRangeSpec', () => {
 
   describe('Auto notation - Rectangular selections', () => {
     it('should always use WithPositions and double-hash for rectangular mode', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedStartPosition = startPosition + 1;
+      const expectedEndPosition = endPosition + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 5 },
-
-            end: { line: 10, character: 15 },
+            start: { line: startLine, character: startPosition },
+            end: { line: startLine, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
           {
-            start: { line: 11, character: 5 },
-
-            end: { line: 11, character: 15 },
+            start: { line: startLine + 1, character: startPosition },
+            end: { line: startLine + 1, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
           {
-            start: { line: 12, character: 5 },
-
-            end: { line: 12, character: 15 },
+            start: { line: startLine + 2, character: startPosition },
+            end: { line: startLine + 2, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
@@ -184,34 +213,35 @@ describe('computeRangeSpec', () => {
 
       expect(result).toBeOkWith((value) => {
         expect(value).toStrictEqual({
-          startLine: 11,
-          endLine: 13, // Last selection line
-          startPosition: 6,
-          endPosition: 16,
+          startLine: expectedStartLine,
+          endLine: expectedStartLine + 2,
+          startPosition: expectedStartPosition,
+          endPosition: expectedEndPosition,
           rangeFormat: RangeFormat.WithPositions,
         });
       });
     });
 
     it('should use first and last selection lines for rectangular mode', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedStartPosition = startPosition + 1;
+      const expectedEndPosition = endPosition + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 9, character: 10 },
-
-            end: { line: 9, character: 20 },
+            start: { line: startLine, character: startPosition },
+            end: { line: startLine, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
           {
-            start: { line: 10, character: 10 },
-
-            end: { line: 10, character: 20 },
+            start: { line: startLine + 1, character: startPosition },
+            end: { line: startLine + 1, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
           {
-            start: { line: 11, character: 10 },
-
-            end: { line: 11, character: 20 },
+            start: { line: startLine + 2, character: startPosition },
+            end: { line: startLine + 2, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
@@ -221,10 +251,10 @@ describe('computeRangeSpec', () => {
 
       expect(result).toBeOkWith((value) => {
         expect(value).toStrictEqual({
-          startLine: 10, // First selection + 1
-          endLine: 12, // Last selection + 1
-          startPosition: 11,
-          endPosition: 21,
+          startLine: expectedStartLine,
+          endLine: expectedStartLine + 2,
+          startPosition: expectedStartPosition,
+          endPosition: expectedEndPosition,
           rangeFormat: RangeFormat.WithPositions,
         });
       });
@@ -233,12 +263,13 @@ describe('computeRangeSpec', () => {
 
   describe('EnforceFullLine notation', () => {
     it('should use LineOnly format even for PartialLine coverage', () => {
+      const expectedStartLine = startLine + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 5 },
-
-            end: { line: 10, character: 15 },
+            start: { line: startLine, character: startPosition },
+            end: { line: startLine, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
@@ -248,20 +279,22 @@ describe('computeRangeSpec', () => {
 
       expect(result).toBeOkWith((value) => {
         expect(value).toStrictEqual({
-          startLine: 11,
-          endLine: 11,
+          startLine: expectedStartLine,
+          endLine: expectedStartLine,
           rangeFormat: RangeFormat.LineOnly,
         });
       });
     });
 
     it('should discard position information for multi-line partial selection', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedEndLine = endLine + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 5 },
-
-            end: { line: 20, character: 15 },
+            start: { line: startLine, character: startPosition },
+            end: { line: endLine, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
@@ -271,20 +304,22 @@ describe('computeRangeSpec', () => {
 
       expect(result).toBeOkWith((value) => {
         expect(value).toStrictEqual({
-          startLine: 11,
-          endLine: 21,
+          startLine: expectedStartLine,
+          endLine: expectedEndLine,
           rangeFormat: RangeFormat.LineOnly,
         });
       });
     });
 
     it('should use LineOnly format for FullLine coverage (consistent with Auto)', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedEndLine = endLine + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 0 },
-
-            end: { line: 15, character: 0 },
+            start: { line: startLine, character: 0 },
+            end: { line: endLine, character: 0 },
             coverage: SelectionCoverage.FullLine,
           },
         ],
@@ -294,8 +329,8 @@ describe('computeRangeSpec', () => {
 
       expect(result).toBeOkWith((value) => {
         expect(value).toStrictEqual({
-          startLine: 11,
-          endLine: 16,
+          startLine: expectedStartLine,
+          endLine: expectedEndLine,
           rangeFormat: RangeFormat.LineOnly,
         });
       });
@@ -304,12 +339,14 @@ describe('computeRangeSpec', () => {
 
   describe('EnforcePositions notation', () => {
     it('should use WithPositions format even for FullLine coverage', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedEndPosition = endPosition + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 0 },
-
-            end: { line: 10, character: 50 },
+            start: { line: startLine, character: 0 },
+            end: { line: startLine, character: endPosition },
             coverage: SelectionCoverage.FullLine,
           },
         ],
@@ -319,22 +356,24 @@ describe('computeRangeSpec', () => {
 
       expect(result).toBeOkWith((value) => {
         expect(value).toStrictEqual({
-          startLine: 11,
-          endLine: 11,
+          startLine: expectedStartLine,
+          endLine: expectedStartLine,
           startPosition: 1,
-          endPosition: 51,
+          endPosition: expectedEndPosition,
           rangeFormat: RangeFormat.WithPositions,
         });
       });
     });
 
     it('should include positions for multi-line FullLine coverage', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedEndLine = endLine + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 0 },
-
-            end: { line: 15, character: 0 },
+            start: { line: startLine, character: 0 },
+            end: { line: endLine, character: 0 },
             coverage: SelectionCoverage.FullLine,
           },
         ],
@@ -344,8 +383,8 @@ describe('computeRangeSpec', () => {
 
       expect(result).toBeOkWith((value) => {
         expect(value).toStrictEqual({
-          startLine: 11,
-          endLine: 16,
+          startLine: expectedStartLine,
+          endLine: expectedEndLine,
           startPosition: 1,
           endPosition: 1,
           rangeFormat: RangeFormat.WithPositions,
@@ -354,12 +393,15 @@ describe('computeRangeSpec', () => {
     });
 
     it('should use WithPositions format for PartialLine coverage (consistent with Auto)', () => {
+      const expectedStartLine = startLine + 1;
+      const expectedStartPosition = startPosition + 1;
+      const expectedEndPosition = endPosition + 1;
+
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 5 },
-
-            end: { line: 10, character: 15 },
+            start: { line: startLine, character: startPosition },
+            end: { line: startLine, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
@@ -369,10 +411,10 @@ describe('computeRangeSpec', () => {
 
       expect(result).toBeOkWith((value) => {
         expect(value).toStrictEqual({
-          startLine: 11,
-          endLine: 11,
-          startPosition: 6,
-          endPosition: 16,
+          startLine: expectedStartLine,
+          endLine: expectedStartLine,
+          startPosition: expectedStartPosition,
+          endPosition: expectedEndPosition,
           rangeFormat: RangeFormat.WithPositions,
         });
       });
@@ -381,9 +423,8 @@ describe('computeRangeSpec', () => {
 
   describe('Error handling', () => {
     it('should return Err Result when validateInputSelection throws RangeLinkError', () => {
-      // Create invalid input that will cause validateInputSelection to throw RangeLinkError
       const inputSelection: InputSelection = {
-        selections: [], // Empty selections array is invalid
+        selections: [],
         selectionType: SelectionType.Normal,
       };
 
@@ -397,13 +438,10 @@ describe('computeRangeSpec', () => {
     });
 
     it('should re-throw unexpected errors from validateInputSelection', () => {
-      // Input doesn't matter - mock will intercept before validation
       const inputSelection = {} as InputSelection;
 
-      // Define expected error as test-scoped constant
       const expectedError = new TypeError('Unexpected validation error');
 
-      // Mock validateInputSelection to throw unexpected error
       const spy = jest
         .spyOn(validateInputSelectionModule, 'validateInputSelection')
         .mockImplementationOnce(() => {
@@ -412,7 +450,6 @@ describe('computeRangeSpec', () => {
 
       expect(() => computeRangeSpec(inputSelection)).toThrow(expectedError);
 
-      // Verify spy was called with the input (validates integration point)
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith(inputSelection);
     });

--- a/packages/rangelink-core-ts/src/__tests__/selection/validateInputSelection.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/selection/validateInputSelection.test.ts
@@ -1,3 +1,5 @@
+import { getUniqueInt } from '@couimet/dynamic-testing';
+
 import { RangeLinkError } from '../../errors/RangeLinkError';
 import { RangeLinkErrorCodes } from '../../errors/RangeLinkErrorCodes';
 import { validateInputSelection } from '../../selection/validateInputSelection';
@@ -7,7 +9,6 @@ import { InputSelection } from '../../types/InputSelection';
 import { SelectionCoverage } from '../../types/SelectionCoverage';
 import { SelectionType } from '../../types/SelectionType';
 
-// Mock the mode-specific validators to test only validateInputSelection's logic
 jest.mock('../../selection/validateNormalMode');
 jest.mock('../../selection/validateRectangularMode');
 
@@ -37,11 +38,14 @@ describe('validateInputSelection', () => {
 
   describe('Backward line selection', () => {
     it('should throw error when startLine > endLine', () => {
+      const base = getUniqueInt();
+      const startLine = base + 10;
+      const endLine = base;
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 20, character: 0 },
-            end: { line: 10, character: 10 }, // Backward
+            start: { line: startLine, character: getUniqueInt() },
+            end: { line: endLine, character: getUniqueInt() },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
@@ -51,12 +55,12 @@ describe('validateInputSelection', () => {
       expect(() => validateInputSelection(inputSelection)).toThrowRangeLinkError(
         'SELECTION_BACKWARD_LINE',
         {
-          message: 'Backward selection not allowed (startLine=20 > endLine=10)',
+          message: `Backward selection not allowed (startLine=${startLine} > endLine=${endLine})`,
           functionName: 'validateInputSelection',
           details: {
             selectionIndex: 0,
-            startLine: 20,
-            endLine: 10,
+            startLine,
+            endLine,
           },
         },
       );
@@ -65,12 +69,15 @@ describe('validateInputSelection', () => {
 
   describe('Backward character selection', () => {
     it('should throw error when startCharacter > endCharacter on same line', () => {
+      const base = getUniqueInt();
+      const line = getUniqueInt();
+      const startPosition = base + 15;
+      const endPosition = base;
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 20 },
-
-            end: { line: 10, character: 5 }, // Backward on same line
+            start: { line, character: startPosition },
+            end: { line, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
@@ -80,26 +87,29 @@ describe('validateInputSelection', () => {
       expect(() => validateInputSelection(inputSelection)).toThrowRangeLinkError(
         'SELECTION_BACKWARD_CHARACTER',
         {
-          message:
-            'Backward character selection not allowed (startCharacter=20 > endCharacter=5 on line 10)',
+          message: `Backward character selection not allowed (startCharacter=${startPosition} > endCharacter=${endPosition} on line ${line})`,
           functionName: 'validateInputSelection',
           details: {
             selectionIndex: 0,
-            line: 10,
-            startCharacter: 20,
-            endCharacter: 5,
+            line,
+            startCharacter: startPosition,
+            endCharacter: endPosition,
           },
         },
       );
     });
 
     it('should allow startCharacter > endCharacter when on different lines', () => {
+      const base = getUniqueInt();
+      const startLine = getUniqueInt();
+      const endLine = startLine + 5;
+      const startPosition = base + 15;
+      const endPosition = base;
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 20 },
-
-            end: { line: 15, character: 5 }, // Different line, OK
+            start: { line: startLine, character: startPosition },
+            end: { line: endLine, character: endPosition },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
@@ -243,7 +253,7 @@ describe('validateInputSelection', () => {
             coverage: SelectionCoverage.PartialLine,
           },
         ],
-        selectionType: 'InvalidType' as any, // Force invalid type
+        selectionType: 'InvalidType' as any,
       };
 
       expect(() => validateInputSelection(inputSelection)).toThrowRangeLinkError(
@@ -259,12 +269,13 @@ describe('validateInputSelection', () => {
 
   describe('ERR_3011: Zero-width selection', () => {
     it('should throw error for zero-width selection (cursor position)', () => {
+      const line = getUniqueInt();
+      const position = getUniqueInt();
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 5 },
-
-            end: { line: 10, character: 5 }, // Same position = zero-width
+            start: { line, character: position },
+            end: { line, character: position },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
@@ -274,12 +285,12 @@ describe('validateInputSelection', () => {
       expect(() => validateInputSelection(inputSelection)).toThrowRangeLinkError(
         'SELECTION_ZERO_WIDTH',
         {
-          message: 'Zero-width selection not allowed (cursor position at line 10, character 5)',
+          message: `Zero-width selection not allowed (cursor position at line ${line}, character ${position})`,
           functionName: 'validateInputSelection',
           details: {
             selectionIndex: 0,
-            line: 10,
-            character: 5,
+            line,
+            character: position,
           },
         },
       );
@@ -316,15 +327,13 @@ describe('validateInputSelection', () => {
   describe('Mode-specific validation delegation', () => {
     describe('Normal mode', () => {
       it('should call validateNormalMode with selections array', () => {
-        mockValidateNormalMode.mockImplementation(() => {
-          // Mock successful validation
-        });
+        mockValidateNormalMode.mockImplementation(() => {});
 
         const inputSelection: InputSelection = {
           selections: [
             {
-              start: { line: 10, character: 5 },
-              end: { line: 20, character: 15 },
+              start: { line: getUniqueInt(), character: getUniqueInt() },
+              end: { line: getUniqueInt(), character: getUniqueInt() },
               coverage: SelectionCoverage.PartialLine,
             },
           ],
@@ -351,13 +360,13 @@ describe('validateInputSelection', () => {
         const inputSelection: InputSelection = {
           selections: [
             {
-              start: { line: 10, character: 5 },
-              end: { line: 10, character: 15 },
+              start: { line: getUniqueInt(), character: getUniqueInt() },
+              end: { line: getUniqueInt(), character: getUniqueInt() },
               coverage: SelectionCoverage.PartialLine,
             },
             {
-              start: { line: 15, character: 0 },
-              end: { line: 15, character: 10 },
+              start: { line: getUniqueInt(), character: getUniqueInt() },
+              end: { line: getUniqueInt(), character: getUniqueInt() },
               coverage: SelectionCoverage.PartialLine,
             },
           ],
@@ -368,15 +377,13 @@ describe('validateInputSelection', () => {
       });
 
       it('should not call validateRectangularMode for Normal mode', () => {
-        mockValidateNormalMode.mockImplementation(() => {
-          // Mock successful validation
-        });
+        mockValidateNormalMode.mockImplementation(() => {});
 
         const inputSelection: InputSelection = {
           selections: [
             {
-              start: { line: 10, character: 5 },
-              end: { line: 20, character: 15 },
+              start: { line: getUniqueInt(), character: getUniqueInt() },
+              end: { line: getUniqueInt(), character: getUniqueInt() },
               coverage: SelectionCoverage.PartialLine,
             },
           ],
@@ -391,20 +398,18 @@ describe('validateInputSelection', () => {
 
     describe('Rectangular mode', () => {
       it('should call validateRectangularMode with selections array', () => {
-        mockValidateRectangularMode.mockImplementation(() => {
-          // Mock successful validation
-        });
+        mockValidateRectangularMode.mockImplementation(() => {});
 
         const inputSelection: InputSelection = {
           selections: [
             {
-              start: { line: 10, character: 5 },
-              end: { line: 10, character: 15 },
+              start: { line: getUniqueInt(), character: getUniqueInt() },
+              end: { line: getUniqueInt(), character: getUniqueInt() },
               coverage: SelectionCoverage.PartialLine,
             },
             {
-              start: { line: 11, character: 5 },
-              end: { line: 11, character: 15 },
+              start: { line: getUniqueInt(), character: getUniqueInt() },
+              end: { line: getUniqueInt(), character: getUniqueInt() },
               coverage: SelectionCoverage.PartialLine,
             },
           ],
@@ -431,13 +436,13 @@ describe('validateInputSelection', () => {
         const inputSelection: InputSelection = {
           selections: [
             {
-              start: { line: 10, character: 5 },
-              end: { line: 10, character: 15 },
+              start: { line: getUniqueInt(), character: getUniqueInt() },
+              end: { line: getUniqueInt(), character: getUniqueInt() },
               coverage: SelectionCoverage.PartialLine,
             },
             {
-              start: { line: 8, character: 5 },
-              end: { line: 8, character: 15 },
+              start: { line: getUniqueInt(), character: getUniqueInt() },
+              end: { line: getUniqueInt(), character: getUniqueInt() },
               coverage: SelectionCoverage.PartialLine,
             },
           ],
@@ -448,20 +453,18 @@ describe('validateInputSelection', () => {
       });
 
       it('should not call validateNormalMode for Rectangular mode', () => {
-        mockValidateRectangularMode.mockImplementation(() => {
-          // Mock successful validation
-        });
+        mockValidateRectangularMode.mockImplementation(() => {});
 
         const inputSelection: InputSelection = {
           selections: [
             {
-              start: { line: 10, character: 5 },
-              end: { line: 10, character: 15 },
+              start: { line: getUniqueInt(), character: getUniqueInt() },
+              end: { line: getUniqueInt(), character: getUniqueInt() },
               coverage: SelectionCoverage.PartialLine,
             },
             {
-              start: { line: 11, character: 5 },
-              end: { line: 11, character: 15 },
+              start: { line: getUniqueInt(), character: getUniqueInt() },
+              end: { line: getUniqueInt(), character: getUniqueInt() },
               coverage: SelectionCoverage.PartialLine,
             },
           ],
@@ -477,16 +480,13 @@ describe('validateInputSelection', () => {
 
   describe('Integration: Valid selections', () => {
     it('should not throw for valid Normal selection', () => {
-      mockValidateNormalMode.mockImplementation(() => {
-        // Mock successful validation
-      });
+      mockValidateNormalMode.mockImplementation(() => {});
 
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 5 },
-
-            end: { line: 20, character: 15 },
+            start: { line: getUniqueInt(), character: getUniqueInt() },
+            end: { line: getUniqueInt(), character: getUniqueInt() },
             coverage: SelectionCoverage.PartialLine,
           },
         ],
@@ -498,28 +498,23 @@ describe('validateInputSelection', () => {
     });
 
     it('should not throw for valid Rectangular selections', () => {
-      mockValidateRectangularMode.mockImplementation(() => {
-        // Mock successful validation
-      });
+      mockValidateRectangularMode.mockImplementation(() => {});
 
       const inputSelection: InputSelection = {
         selections: [
           {
-            start: { line: 10, character: 5 },
-
-            end: { line: 10, character: 15 },
+            start: { line: getUniqueInt(), character: getUniqueInt() },
+            end: { line: getUniqueInt(), character: getUniqueInt() },
             coverage: SelectionCoverage.PartialLine,
           },
           {
-            start: { line: 11, character: 5 },
-
-            end: { line: 11, character: 15 },
+            start: { line: getUniqueInt(), character: getUniqueInt() },
+            end: { line: getUniqueInt(), character: getUniqueInt() },
             coverage: SelectionCoverage.PartialLine,
           },
           {
-            start: { line: 12, character: 5 },
-
-            end: { line: 12, character: 15 },
+            start: { line: getUniqueInt(), character: getUniqueInt() },
+            end: { line: getUniqueInt(), character: getUniqueInt() },
             coverage: SelectionCoverage.PartialLine,
           },
         ],

--- a/packages/rangelink-vscode-extension/package.json
+++ b/packages/rangelink-vscode-extension/package.json
@@ -966,6 +966,7 @@
     "rangelink-core-ts": "workspace:*"
   },
   "devDependencies": {
+    "@couimet/dynamic-testing": "^0.1.0",
     "@couimet/logger-contract-testing": "^1.0.0",
     "@types/jest": "^29.5.0",
     "@types/mocha": "^10.0.10",

--- a/packages/rangelink-vscode-extension/src/__tests__/navigation/FilePathNavigationHandler.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/navigation/FilePathNavigationHandler.test.ts
@@ -220,5 +220,23 @@ describe('FilePathNavigationHandler', () => {
         'Navigation failed',
       );
     });
+
+    it('should convert non-Error throwables to string for error message', async () => {
+      const fileUri = createMockUri('/path/file.ts');
+      jest
+        .spyOn(mockAdapter, 'resolveWorkspacePath')
+        .mockResolvedValue({ uri: fileUri, resolvedVia: PathFormat.WorkspaceRelative });
+      const nonErrorThrowable = 'Disk I/O failure';
+      jest.spyOn(mockAdapter, 'showTextDocument').mockRejectedValue(nonErrorThrowable);
+      const showErrorMessageSpy = jest
+        .spyOn(mockAdapter, 'showErrorMessage')
+        .mockResolvedValue(undefined);
+
+      await expect(handler.navigateToFile('/path/file.ts')).rejects.toBe(nonErrorThrowable);
+
+      expect(showErrorMessageSpy).toHaveBeenCalledWith(
+        'Failed to open file /path/file.ts: Disk I/O failure',
+      );
+    });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/toInputSelection.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/toInputSelection.test.ts
@@ -1,6 +1,6 @@
+import { getUniqueInt } from '@couimet/dynamic-testing';
 import type { Logger } from '@couimet/logger-contract';
 import { createMockLogger } from '@couimet/logger-contract-testing';
-import { getUniqueInt } from '@couimet/dynamic-testing';
 import { InputSelection } from 'rangelink-core-ts';
 import * as vscode from 'vscode';
 

--- a/packages/rangelink-vscode-extension/src/__tests__/toInputSelection.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/toInputSelection.test.ts
@@ -1,5 +1,6 @@
 import type { Logger } from '@couimet/logger-contract';
 import { createMockLogger } from '@couimet/logger-contract-testing';
+import { getUniqueInt } from '@couimet/dynamic-testing';
 import { InputSelection } from 'rangelink-core-ts';
 import * as vscode from 'vscode';
 
@@ -16,17 +17,17 @@ let mockLogger: Logger;
  */
 const createSelection = (
   startLine: number,
-  startCharacter: number,
+  startPosition: number,
   endLine: number,
-  endCharacter: number,
+  endPosition: number,
 ): vscode.Selection => {
   return {
-    start: { line: startLine, character: startCharacter },
-    end: { line: endLine, character: endCharacter },
-    anchor: { line: startLine, character: startCharacter },
-    active: { line: endLine, character: endCharacter },
+    start: { line: startLine, character: startPosition },
+    end: { line: endLine, character: endPosition },
+    anchor: { line: startLine, character: startPosition },
+    active: { line: endLine, character: endPosition },
     isReversed: false,
-    isEmpty: startLine === endLine && startCharacter === endCharacter,
+    isEmpty: startLine === endLine && startPosition === endPosition,
   } as vscode.Selection;
 };
 
@@ -150,7 +151,11 @@ describe('toInputSelection', () => {
     describe('PartialLine coverage', () => {
       it('should detect PartialLine when selection does not start at column 0', () => {
         const lineText = 'const x = 5;';
-        const editor = createMockEditor([createSelection(0, 5, 0, lineText.length)], [lineText]);
+        const startPosition = getUniqueInt();
+        const editor = createMockEditor(
+          [createSelection(0, startPosition, 0, lineText.length)],
+          [lineText],
+        );
 
         (isRectangularSelection as jest.Mock).mockReturnValue(false);
 
@@ -158,13 +163,14 @@ describe('toInputSelection', () => {
 
         expect(result).toBeOkWith((value: InputSelection) => {
           expect(value.selections[0].coverage).toBe('PartialLine');
-          expect(value.selections[0].start).toStrictEqual({ line: 0, character: 5 });
+          expect(value.selections[0].start).toStrictEqual({ line: 0, character: startPosition });
         });
       });
 
       it('should detect PartialLine when selection does not reach end of line', () => {
         const lineText = 'const x = 5; more text';
-        const editor = createMockEditor([createSelection(0, 0, 0, 10)], [lineText]);
+        const endPosition = getUniqueInt();
+        const editor = createMockEditor([createSelection(0, 0, 0, endPosition)], [lineText]);
 
         (isRectangularSelection as jest.Mock).mockReturnValue(false);
 
@@ -172,13 +178,18 @@ describe('toInputSelection', () => {
 
         expect(result).toBeOkWith((value: InputSelection) => {
           expect(value.selections[0].coverage).toBe('PartialLine');
-          expect(value.selections[0].end).toStrictEqual({ line: 0, character: 10 });
+          expect(value.selections[0].end).toStrictEqual({ line: 0, character: endPosition });
         });
       });
 
       it('should detect PartialLine when selection starts mid-line and ends mid-line', () => {
         const lineText = 'const x = 5; more text';
-        const editor = createMockEditor([createSelection(0, 6, 0, 11)], [lineText]);
+        const startPosition = getUniqueInt();
+        const endPosition = startPosition + 5;
+        const editor = createMockEditor(
+          [createSelection(0, startPosition, 0, endPosition)],
+          [lineText],
+        );
 
         (isRectangularSelection as jest.Mock).mockReturnValue(false);
 
@@ -204,8 +215,9 @@ describe('toInputSelection', () => {
 
       it('should normalize end line for partial selection ending at next line char 0', () => {
         // User selects from L0 C5 to L1 C0 (partial start, includes newline)
+        const startPosition = getUniqueInt();
         const lineTexts = ['line zero content', 'line one'];
-        const editor = createMockEditor([createSelection(0, 5, 1, 0)], lineTexts);
+        const editor = createMockEditor([createSelection(0, startPosition, 1, 0)], lineTexts);
 
         (isRectangularSelection as jest.Mock).mockReturnValue(false);
 
@@ -213,8 +225,11 @@ describe('toInputSelection', () => {
 
         expect(result).toBeOkWith((value: InputSelection) => {
           expect(value.selections[0].coverage).toBe('PartialLine'); // NOT FullLine (start != 0)
-          expect(value.selections[0].start).toStrictEqual({ line: 0, character: 5 });
-          expect(value.selections[0].end).toStrictEqual({ line: 0, character: 17 });
+          expect(value.selections[0].start).toStrictEqual({ line: 0, character: startPosition });
+          expect(value.selections[0].end).toStrictEqual({
+            line: 0,
+            character: lineTexts[0].length,
+          });
         });
       });
     });
@@ -222,12 +237,19 @@ describe('toInputSelection', () => {
 
   describe('Rectangular selection delegation', () => {
     it('should call isRectangularSelection with provided selections', () => {
+      const startLine = getUniqueInt();
+      const startPosition = getUniqueInt();
+      const endPosition = startPosition + 5;
       const selections = [
-        createSelection(0, 5, 0, 10),
-        createSelection(1, 5, 1, 10),
-        createSelection(2, 5, 2, 10),
+        createSelection(startLine, startPosition, startLine, endPosition),
+        createSelection(startLine + 1, startPosition, startLine + 1, endPosition),
+        createSelection(startLine + 2, startPosition, startLine + 2, endPosition),
       ];
-      const editor = createMockEditor(selections, ['line one', 'line two', 'line three']);
+      const lineTexts: string[] = [];
+      lineTexts[startLine] = 'line one';
+      lineTexts[startLine + 1] = 'line two';
+      lineTexts[startLine + 2] = 'line three';
+      const editor = createMockEditor(selections, lineTexts);
 
       (isRectangularSelection as jest.Mock).mockReturnValue(true);
 
@@ -238,8 +260,17 @@ describe('toInputSelection', () => {
     });
 
     it('should return SelectionType.Rectangular when isRectangularSelection returns true', () => {
-      const selections = [createSelection(0, 5, 0, 10), createSelection(1, 5, 1, 10)];
-      const editor = createMockEditor(selections, ['line one', 'line two']);
+      const startLine = getUniqueInt();
+      const startPosition = getUniqueInt();
+      const endPosition = startPosition + 5;
+      const selections = [
+        createSelection(startLine, startPosition, startLine, endPosition),
+        createSelection(startLine + 1, startPosition, startLine + 1, endPosition),
+      ];
+      const lineTexts: string[] = [];
+      lineTexts[startLine] = 'line one';
+      lineTexts[startLine + 1] = 'line two';
+      const editor = createMockEditor(selections, lineTexts);
 
       (isRectangularSelection as jest.Mock).mockReturnValue(true);
 
@@ -252,11 +283,18 @@ describe('toInputSelection', () => {
     });
 
     it('should return SelectionType.Normal when isRectangularSelection returns false', () => {
+      const startLine = getUniqueInt();
+      const startPosition = getUniqueInt();
+      const endPosition = startPosition + 5;
       const selections = [
-        createSelection(0, 5, 0, 10),
-        createSelection(2, 3, 2, 8), // Non-rectangular
+        createSelection(startLine, startPosition, startLine, endPosition),
+        createSelection(startLine + 2, startPosition + 1, startLine + 2, endPosition + 1), // Non-rectangular
       ];
-      const editor = createMockEditor(selections, ['line one', 'line two', 'line three']);
+      const lineTexts: string[] = [];
+      lineTexts[startLine] = 'line one';
+      lineTexts[startLine + 1] = 'line two';
+      lineTexts[startLine + 2] = 'line three';
+      const editor = createMockEditor(selections, lineTexts);
 
       (isRectangularSelection as jest.Mock).mockReturnValue(false);
 
@@ -269,12 +307,19 @@ describe('toInputSelection', () => {
     });
 
     it('should convert all selections when rectangular', () => {
+      const startLine = getUniqueInt();
+      const startPosition = getUniqueInt();
+      const endPosition = startPosition + 5;
       const selections = [
-        createSelection(0, 5, 0, 10),
-        createSelection(1, 5, 1, 10),
-        createSelection(2, 5, 2, 10),
+        createSelection(startLine, startPosition, startLine, endPosition),
+        createSelection(startLine + 1, startPosition, startLine + 1, endPosition),
+        createSelection(startLine + 2, startPosition, startLine + 2, endPosition),
       ];
-      const editor = createMockEditor(selections, ['aaaaa12345', 'bbbbb12345', 'ccccc12345']);
+      const lineTexts: string[] = [];
+      lineTexts[startLine] = 'aaaaa12345';
+      lineTexts[startLine + 1] = 'bbbbb12345';
+      lineTexts[startLine + 2] = 'ccccc12345';
+      const editor = createMockEditor(selections, lineTexts);
 
       (isRectangularSelection as jest.Mock).mockReturnValue(true);
 
@@ -283,36 +328,39 @@ describe('toInputSelection', () => {
       expect(result).toBeOkWith((value: InputSelection) => {
         expect(value.selections).toHaveLength(3);
         expect(value.selections[0]).toStrictEqual({
-          start: { line: 0, character: 5 },
-          end: { line: 0, character: 10 },
+          start: { line: startLine, character: startPosition },
+          end: { line: startLine, character: endPosition },
           coverage: 'PartialLine',
         });
         expect(value.selections[1]).toStrictEqual({
-          start: { line: 1, character: 5 },
-          end: { line: 1, character: 10 },
+          start: { line: startLine + 1, character: startPosition },
+          end: { line: startLine + 1, character: endPosition },
           coverage: 'PartialLine',
         });
         expect(value.selections[2]).toStrictEqual({
-          start: { line: 2, character: 5 },
-          end: { line: 2, character: 10 },
+          start: { line: startLine + 2, character: startPosition },
+          end: { line: startLine + 2, character: endPosition },
           coverage: 'PartialLine',
         });
       });
     });
 
     it('should only convert first selection when not rectangular', () => {
+      const startLine = getUniqueInt();
+      const startPosition = getUniqueInt();
+      const endPosition = startPosition + 5;
       const selections = [
-        createSelection(0, 5, 0, 10),
-        createSelection(5, 3, 5, 8), // Different line - not rectangular
+        createSelection(startLine, startPosition, startLine, endPosition),
+        createSelection(startLine + 5, startPosition + 1, startLine + 5, endPosition + 1), // Different line - not rectangular
       ];
-      const editor = createMockEditor(selections, [
-        'aaaaa12345',
-        'line2',
-        'line3',
-        'line4',
-        'line5',
-        'bbb12345',
-      ]);
+      const lineTexts: string[] = [];
+      lineTexts[startLine] = 'aaaaa12345';
+      lineTexts[startLine + 1] = 'line2';
+      lineTexts[startLine + 2] = 'line3';
+      lineTexts[startLine + 3] = 'line4';
+      lineTexts[startLine + 4] = 'line5';
+      lineTexts[startLine + 5] = 'bbb12345';
+      const editor = createMockEditor(selections, lineTexts);
 
       (isRectangularSelection as jest.Mock).mockReturnValue(false);
 
@@ -320,7 +368,10 @@ describe('toInputSelection', () => {
 
       expect(result).toBeOkWith((value: InputSelection) => {
         expect(value.selections).toHaveLength(1);
-        expect(value.selections[0].start).toStrictEqual({ line: 0, character: 5 });
+        expect(value.selections[0].start).toStrictEqual({
+          line: startLine,
+          character: startPosition,
+        });
       });
     });
   });

--- a/packages/rangelink-vscode-extension/src/__tests__/toInputSelection.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/toInputSelection.test.ts
@@ -1,4 +1,4 @@
-import { getUniqueInt } from '@couimet/dynamic-testing';
+import { getRandomInt, getUniqueInt } from '@couimet/dynamic-testing';
 import type { Logger } from '@couimet/logger-contract';
 import { createMockLogger } from '@couimet/logger-contract-testing';
 import { InputSelection } from 'rangelink-core-ts';
@@ -169,7 +169,7 @@ describe('toInputSelection', () => {
 
       it('should detect PartialLine when selection does not reach end of line', () => {
         const lineText = 'const x = 5; more text';
-        const endPosition = getUniqueInt();
+        const endPosition = getRandomInt(1, lineText.length - 1);
         const editor = createMockEditor([createSelection(0, 0, 0, endPosition)], [lineText]);
 
         (isRectangularSelection as jest.Mock).mockReturnValue(false);
@@ -466,6 +466,98 @@ describe('toInputSelection', () => {
           'Cannot generate link: document was modified and selection is no longer valid. Please reselect and try again.',
         functionName: 'toInputSelection',
       });
+    });
+
+    it('should retrieve start line content when end line is out of bounds', () => {
+      const LINE_COUNT = 5;
+      const VALID_START_LINE = 2;
+      const VALID_LINE_CONTENT = 'valid line content';
+      const INVALID_END_LINE = 10;
+      const lineAtError = new Error('Line out of bounds');
+
+      const mockDocument = {
+        lineAt: jest.fn((line: number) => {
+          if (line === INVALID_END_LINE) {
+            throw lineAtError;
+          }
+          return {
+            text: VALID_LINE_CONTENT,
+            range: { start: { character: 0 }, end: { character: VALID_LINE_CONTENT.length } },
+          };
+        }),
+        lineCount: LINE_COUNT,
+        version: 42,
+      } as unknown as vscode.TextDocument;
+
+      const selections = [createSelection(VALID_START_LINE, 0, INVALID_END_LINE, 10)];
+
+      (isRectangularSelection as jest.Mock).mockReturnValue(false);
+
+      const result = toInputSelection(mockDocument, selections, mockLogger);
+
+      expect(result).toBeRangeLinkExtensionErrorErr('SELECTION_CONVERSION_FAILED', {
+        message:
+          'Cannot generate link: document was modified and selection is no longer valid. Please reselect and try again.',
+        functionName: 'toInputSelection',
+      });
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        {
+          fn: 'toInputSelection',
+          error: lineAtError,
+          selection: {
+            start: { line: VALID_START_LINE, char: 0 },
+            end: { line: INVALID_END_LINE, char: 10 },
+            isEmpty: false,
+          },
+          documentVersion: 42,
+          documentLineCount: LINE_COUNT,
+          startLineContent: VALID_LINE_CONTENT,
+          endLineContent: undefined,
+        },
+        'Document modified during link generation - selection out of bounds',
+      );
+    });
+
+    it('should return undefined for all lines when lineAt throws for in-bounds lines', () => {
+      const LINE_COUNT = 5;
+      const VALID_LINE = 2;
+      const lineAtError = new Error('Document corrupt');
+
+      const mockDocument = {
+        lineAt: jest.fn(() => {
+          throw lineAtError;
+        }),
+        lineCount: LINE_COUNT,
+        version: 3,
+      } as unknown as vscode.TextDocument;
+
+      const selections = [createSelection(VALID_LINE, 0, VALID_LINE, 10)];
+
+      (isRectangularSelection as jest.Mock).mockReturnValue(false);
+
+      const result = toInputSelection(mockDocument, selections, mockLogger);
+
+      expect(result).toBeRangeLinkExtensionErrorErr('SELECTION_CONVERSION_FAILED', {
+        message:
+          'Cannot generate link: document was modified and selection is no longer valid. Please reselect and try again.',
+        functionName: 'toInputSelection',
+      });
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        {
+          fn: 'toInputSelection',
+          error: lineAtError,
+          selection: {
+            start: { line: VALID_LINE, char: 0 },
+            end: { line: VALID_LINE, char: 10 },
+            isEmpty: false,
+          },
+          documentVersion: 3,
+          documentLineCount: LINE_COUNT,
+          startLineContent: undefined,
+          endLineContent: undefined,
+        },
+        'Document modified during link generation - selection out of bounds',
+      );
     });
   });
 

--- a/packages/rangelink-vscode-extension/src/utils/__tests__/formatMessage.test.ts
+++ b/packages/rangelink-vscode-extension/src/utils/__tests__/formatMessage.test.ts
@@ -2,7 +2,13 @@ import { getLogger } from '@couimet/logger-contract';
 
 import { formatMessage } from '..';
 import { RangeLinkExtensionError, RangeLinkExtensionErrorCodes } from '../../errors';
-import { getCurrentLocale, messagesEn, setLocale, supportedLocales, type LocaleCode } from '../../i18n';
+import {
+  getCurrentLocale,
+  messagesEn,
+  setLocale,
+  supportedLocales,
+  type LocaleCode,
+} from '../../i18n';
 import { MessageCode } from '../../types';
 
 /**
@@ -407,7 +413,6 @@ describe('formatMessage', () => {
     });
 
     it('should fallback to English when code is missing from non-English locale', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (supportedLocales as any)['fr'] = {};
       const enResult = formatMessage(MessageCode.STATUS_BAR_DESTINATION_NOT_BOUND);
 

--- a/packages/rangelink-vscode-extension/src/utils/__tests__/formatMessage.test.ts
+++ b/packages/rangelink-vscode-extension/src/utils/__tests__/formatMessage.test.ts
@@ -2,7 +2,7 @@ import { getLogger } from '@couimet/logger-contract';
 
 import { formatMessage } from '..';
 import { RangeLinkExtensionError, RangeLinkExtensionErrorCodes } from '../../errors';
-import { getCurrentLocale, messagesEn, setLocale, supportedLocales } from '../../i18n';
+import { getCurrentLocale, messagesEn, setLocale, supportedLocales, type LocaleCode } from '../../i18n';
 import { MessageCode } from '../../types';
 
 /**
@@ -397,6 +397,35 @@ describe('formatMessage', () => {
       });
 
       expect(result).toStrictEqual('Unbound Terminal, now bound to Cursor AI Assistant');
+    });
+  });
+
+  describe('Missing translation fallback', () => {
+    beforeEach(() => {
+      supportedLocales.en = messagesEn;
+      setLocale('en');
+    });
+
+    it('should fallback to English when code is missing from non-English locale', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (supportedLocales as any)['fr'] = {};
+      const enResult = formatMessage(MessageCode.STATUS_BAR_DESTINATION_NOT_BOUND);
+
+      const result = formatMessage(
+        MessageCode.STATUS_BAR_DESTINATION_NOT_BOUND,
+        undefined,
+        'fr' as LocaleCode,
+      );
+
+      expect(result).toBe(enResult);
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        {
+          fn: 'formatMessage',
+          code: MessageCode.STATUS_BAR_DESTINATION_NOT_BOUND,
+          locale: 'fr',
+        },
+        "Missing translation for message code 'STATUS_BAR_DESTINATION_NOT_BOUND' in locale 'fr', using English fallback",
+      );
     });
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
     devDependencies:
+      '@couimet/dynamic-testing':
+        specifier: ^0.1.0
+        version: 0.1.1
       '@couimet/logger-contract-testing':
         specifier: ^1.0.0
         version: 1.0.0(@couimet/logger-contract@1.0.0)(jest@29.7.0(@types/node@18.19.130))
@@ -85,6 +88,9 @@ importers:
         specifier: workspace:*
         version: link:../rangelink-core-ts
     devDependencies:
+      '@couimet/dynamic-testing':
+        specifier: ^0.1.0
+        version: 0.1.1
       '@couimet/logger-contract-testing':
         specifier: ^1.0.0
         version: 1.0.0(@couimet/logger-contract@1.0.0)(jest@29.7.0(@types/node@20.19.24))
@@ -342,6 +348,14 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@couimet/dynamic-testing@0.1.1':
+    resolution: {integrity: sha512-7rf2k8GYRRxk2X5lhOV+HDZuG3dPdgfyzj6qaNz4Ms4JBGebqmsrtNZbOgwNmteaJawwaqbDwE9fJf1ro2oDjg==}
+    peerDependencies:
+      decimal.js: '>=10.0.0'
+    peerDependenciesMeta:
+      decimal.js:
+        optional: true
 
   '@couimet/logger-contract-testing@1.0.0':
     resolution: {integrity: sha512-Ug2SKE1RS/MPNKh0yoEtBftNFMWgfigiVbynytokf0XFnXwVMywHjAnfvU3amnNiQkV2HQYorl44wUWxvdZGqg==}
@@ -3918,6 +3932,8 @@ snapshots:
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@couimet/dynamic-testing@0.1.1': {}
 
   '@couimet/logger-contract-testing@1.0.0(@couimet/logger-contract@1.0.0)(jest@29.7.0(@types/node@18.19.130))':
     dependencies:


### PR DESCRIPTION
## Summary

Adds `@couimet/dynamic-testing` as a devDependency to both packages and applies its counter-based `getUnique*()` functions to 5 test files. Hardcoded synthetic values (line numbers, character positions) are replaced with dynamic inputs from a shared counter. Expected output strings are computed from the same inputs, so each test proves the function works for arbitrary values, not just the one example the author picked.

## Changes

- Added `@couimet/dynamic-testing@^0.1.0` devDependency to `rangelink-core-ts` and `rangelink-vscode-extension`
- `buildAnchor.test.ts`: shared `let` variables with `beforeEach` initialization, `DEFAULT_DELIMITERS` moved to file scope with `as const`
- `formatLink.test.ts`: same `beforeEach` pattern; `expectedStartLine`/`expectedEndLine`/`expectedStartPosition`/`expectedEndPosition` local consts capture `+ 1` conversions once per test, eliminating noise from assertion blocks
- `computeRangeSpec.test.ts`: same `beforeEach` pattern with `expected` prefix for 1-based outputs
- `validateInputSelection.test.ts`: per-test `getUniqueInt()` calls for backward line/character constraints using `base + N` arithmetic
- `toInputSelection.test.ts`: dynamic line/position values in `createSelection` calls; rectangular delegation tests use `startLine + 1`, `startLine + 2` for consecutive lines
- Consistent variable naming (`startLine`/`endLine`/`startPosition`/`endPosition`) across all 5 files

## Test Plan

- [x] All existing tests pass: 586 tests (`rangelink-core-ts`), 2111 tests (`rangelink-vscode-extension`)
- [x] 165 automated release integration tests pass
- [x] Coverage thresholds maintained (core-ts: 99%+, extension: 98%+)
- [x] `DYNAMIC_TESTING_COUNTER_START` left at package default (1) — test runs are deterministic by default

## Related

- Part of https://github.com/couimet/rangeLink/issues/660
- Parent: https://github.com/couimet/ts-npm-packages/issues/22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded and stabilized selection/link formatting coverage with more data-driven scenarios.
  * Improved checks for line, position, rectangular selection, and custom delimiter behavior.
  * Made link-generation assertions more reliable across regular and portable link outputs.
* **Chores**
  * Added a new development testing dependency to support the updated test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->