### PR TITLE
Fix "Send RangeLink" ctx menu item missing in devcontainers // fixes #679

### DIFF
--- a/packages/rangelink-vscode-extension/CHANGELOG.md
+++ b/packages/rangelink-vscode-extension/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Auto-unbind when a bound file is deleted from disk**, matching the existing terminal-close behavior. Deleting a bound file now triggers an auto-unbind with a status bar message and warning toast. Previously the binding survived and subsequent paste attempts would target a non-existent file. (#611)
 - **R-F (paste current file path) now works for any active tab that maps to a file** — image previews, notebooks, and diff views — not just text editors. (#643)
+- **RangeLink context menu items now appear in devcontainers and other remote workspaces.** (#679)
 
 ## [2.0.0]
 

--- a/packages/rangelink-vscode-extension/package.json
+++ b/packages/rangelink-vscode-extension/package.json
@@ -834,22 +834,22 @@
       ],
       "editor/context": [
         {
-          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled)",
+          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)",
           "command": "rangelink.editorContext.copyLink",
           "group": "8_rangelink@0"
         },
         {
-          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled)",
+          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)",
           "command": "rangelink.editorContext.copyLinkAbsolute",
           "group": "8_rangelink@1"
         },
         {
-          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled)",
+          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)",
           "command": "rangelink.editorContext.copyPortableLink",
           "group": "8_rangelink@2"
         },
         {
-          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled)",
+          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)",
           "command": "rangelink.editorContext.copyPortableLinkAbsolute",
           "group": "8_rangelink@3"
         },
@@ -864,19 +864,19 @@
           "group": "8_rangelink@5"
         },
         {
-          "when": "resourceScheme == file || resourceScheme == untitled",
+          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote",
           "command": "rangelink.editorContent.pasteFilePath",
           "group": "8_rangelink_files@0"
         },
         {
-          "when": "resourceScheme == file || resourceScheme == untitled",
+          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote",
           "command": "rangelink.editorContent.pasteRelativeFilePath",
           "group": "8_rangelink_files@1"
         },
         {
           "command": "rangelink.editorContent.bind",
           "group": "8_rangelink_files@2",
-          "when": "resourceScheme == file || resourceScheme == untitled"
+          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote"
         },
         {
           "when": "rangelink.isBound",
@@ -886,19 +886,19 @@
       ],
       "editor/title/context": [
         {
-          "when": "resourceScheme == file || resourceScheme == untitled",
+          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote",
           "command": "rangelink.editorTab.pasteFilePath",
           "group": "3_rangelink@1"
         },
         {
-          "when": "resourceScheme == file || resourceScheme == untitled",
+          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote",
           "command": "rangelink.editorTab.pasteRelativeFilePath",
           "group": "3_rangelink@2"
         },
         {
           "command": "rangelink.editorContent.bind",
           "group": "3_rangelink@3",
-          "when": "resourceScheme == file || resourceScheme == untitled"
+          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote"
         },
         {
           "when": "rangelink.isBound",

--- a/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
@@ -1044,7 +1044,7 @@ describe('package.json contributions', () => {
 
       it('editorContext.copyLink at top of RangeLink group', () => {
         expect(editorContextMenu[0]).toStrictEqual({
-          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled)',
+          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)',
           command: 'rangelink.editorContext.copyLink',
           group: '8_rangelink@0',
         });
@@ -1052,7 +1052,7 @@ describe('package.json contributions', () => {
 
       it('editorContext.copyLinkAbsolute in context menu', () => {
         expect(editorContextMenu[1]).toStrictEqual({
-          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled)',
+          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)',
           command: 'rangelink.editorContext.copyLinkAbsolute',
           group: '8_rangelink@1',
         });
@@ -1060,7 +1060,7 @@ describe('package.json contributions', () => {
 
       it('editorContext.copyPortableLink in context menu', () => {
         expect(editorContextMenu[2]).toStrictEqual({
-          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled)',
+          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)',
           command: 'rangelink.editorContext.copyPortableLink',
           group: '8_rangelink@2',
         });
@@ -1068,7 +1068,7 @@ describe('package.json contributions', () => {
 
       it('editorContext.copyPortableLinkAbsolute in context menu', () => {
         expect(editorContextMenu[3]).toStrictEqual({
-          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled)',
+          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)',
           command: 'rangelink.editorContext.copyPortableLinkAbsolute',
           group: '8_rangelink@3',
         });
@@ -1092,7 +1092,7 @@ describe('package.json contributions', () => {
 
       it('editorContent.pasteFilePath in context menu', () => {
         expect(editorContextMenu[6]).toStrictEqual({
-          when: 'resourceScheme == file || resourceScheme == untitled',
+          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote',
           command: 'rangelink.editorContent.pasteFilePath',
           group: '8_rangelink_files@0',
         });
@@ -1100,7 +1100,7 @@ describe('package.json contributions', () => {
 
       it('editorContent.pasteRelativeFilePath in context menu', () => {
         expect(editorContextMenu[7]).toStrictEqual({
-          when: 'resourceScheme == file || resourceScheme == untitled',
+          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote',
           command: 'rangelink.editorContent.pasteRelativeFilePath',
           group: '8_rangelink_files@1',
         });
@@ -1110,7 +1110,7 @@ describe('package.json contributions', () => {
         expect(editorContextMenu[8]).toStrictEqual({
           command: 'rangelink.editorContent.bind',
           group: '8_rangelink_files@2',
-          when: 'resourceScheme == file || resourceScheme == untitled',
+          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote',
         });
       });
 
@@ -1134,7 +1134,7 @@ describe('package.json contributions', () => {
 
       it('editorTab.pasteFilePath in editor title context menu', () => {
         expect(editorTitleContextMenu[0]).toStrictEqual({
-          when: 'resourceScheme == file || resourceScheme == untitled',
+          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote',
           command: 'rangelink.editorTab.pasteFilePath',
           group: '3_rangelink@1',
         });
@@ -1142,7 +1142,7 @@ describe('package.json contributions', () => {
 
       it('editorTab.pasteRelativeFilePath in editor title context menu', () => {
         expect(editorTitleContextMenu[1]).toStrictEqual({
-          when: 'resourceScheme == file || resourceScheme == untitled',
+          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote',
           command: 'rangelink.editorTab.pasteRelativeFilePath',
           group: '3_rangelink@2',
         });
@@ -1152,7 +1152,7 @@ describe('package.json contributions', () => {
         expect(editorTitleContextMenu[2]).toStrictEqual({
           command: 'rangelink.editorContent.bind',
           group: '3_rangelink@3',
-          when: 'resourceScheme == file || resourceScheme == untitled',
+          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote',
         });
       });
 

--- a/packages/rangelink-vscode-extension/src/utils/__tests__/isWritableScheme.test.ts
+++ b/packages/rangelink-vscode-extension/src/utils/__tests__/isWritableScheme.test.ts
@@ -9,6 +9,10 @@ describe('isWritableScheme', () => {
     it('returns true for untitled scheme', () => {
       expect(isWritableScheme('untitled')).toBe(true);
     });
+
+    it('returns true for vscode-remote scheme', () => {
+      expect(isWritableScheme('vscode-remote')).toBe(true);
+    });
   });
 
   describe('read-only schemes', () => {
@@ -26,10 +30,6 @@ describe('isWritableScheme', () => {
 
     it('returns false for debug scheme', () => {
       expect(isWritableScheme('debug')).toBe(false);
-    });
-
-    it('returns false for vscode-remote scheme', () => {
-      expect(isWritableScheme('vscode-remote')).toBe(false);
     });
 
     it('returns false for walkThrough scheme', () => {

--- a/packages/rangelink-vscode-extension/src/utils/isWritableScheme.ts
+++ b/packages/rangelink-vscode-extension/src/utils/isWritableScheme.ts
@@ -3,10 +3,11 @@
  *
  * - `file` - Regular file system files
  * - `untitled` - New unsaved files
+ * - `vscode-remote` - Files opened via a remote connection (e.g. devcontainers, SSH)
  *
  * All other schemes (git, output, vscode-settings, etc.) are read-only.
  */
-const WRITABLE_SCHEMES = ['file', 'untitled'];
+const WRITABLE_SCHEMES = ['file', 'untitled', 'vscode-remote'];
 
 /**
  * Check if a URI scheme supports text editing.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RangeLink context-menu commands are now available for files opened in devcontainers and other remote workspaces.
  * Remote workspace files support copying links, pasting paths, and binding paths as expected.

* **Documentation**
  * Updated the extension changelog to document remote workspace support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->