### PR TITLE
[issues/688] Add `Dependabot` config for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'America/Toronto'
+    versioning-strategy: increase
+    groups:
+      deps:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'America/Toronto'
+    groups:
+      actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to automate weekly dependency updates for the pnpm workspace and GitHub Actions. Both ecosystems use grouped PRs to batch all bumps into a single PR per week. Part of an account-wide Dependabot rollout.

## Changes

- Dependabot enabled for npm (pnpm workspace) with a weekly Monday schedule, `versioning-strategy: increase`, and one grouped PR matching all dependencies
- Dependabot enabled for GitHub Actions with the same schedule and one grouped PR for all action version bumps
- `@couimet/*` packages (`@couimet/logger-contract`, `@couimet/logger-contract-testing`) batch with the general deps group since this repo consumes them from npm, unlike the publisher repo which excludes them as workspace deps

## Key Discoveries

- The issue body stated no `@couimet/*` dependencies existed, but `@couimet/logger-contract` and `@couimet/logger-contract-testing` are consumed by two packages. No `exclude-patterns` for `@couimet/*` was added — they batch with the general group, matching the parent issue's goal of tracking first-party package releases.

## Test Plan

- [ ] All existing tests pass (pre-existing `@couimet/detailed-error-testing` module resolution failure is unrelated — confirmed identical with and without this change)
- [ ] New tests added for: none (config file only)
- [ ] Manual testing: Dependabot validates the config on merge; YAML syntax confirmed valid via `python3 -c "import yaml; yaml.safe_load(...)"`

## Related

- Closes https://github.com/couimet/rangeLink/issues/688
- Parent: https://github.com/couimet/idea-garden/issues/11

Generated by /finish-issue v2026.07.14.3@8469237 • [my-claude-skills](https://github.com/couimet/my-claude-skills)

@coderabbitai ignore