### PR TITLE
[issues/699] Adopt `printWidth` 160 from `@couimet/eslint-config`

### DIFF
--- a/.claude/agents/tc-implement.md
+++ b/.claude/agents/tc-implement.md
@@ -270,16 +270,12 @@ Do not tell the tester to click Cancel or press Escape to dismiss menus and pick
 
 ```typescript
 // BAD: required action hidden in steps[3]
-await waitForHuman(
-  'context-menus-terminal-001',
-  `Right-click terminal TAB "${name}" → "RangeLink: Send Selection"`,
-  [
-    `The terminal "${name}" has selected text.`,
-    '1. Right-click the terminal TAB',
-    '2. Verify the entry is present',
-    '3. Select it to open the destination picker and pick any destination',
-  ],
-);
+await waitForHuman('context-menus-terminal-001', `Right-click terminal TAB "${name}" → "RangeLink: Send Selection"`, [
+  `The terminal "${name}" has selected text.`,
+  '1. Right-click the terminal TAB',
+  '2. Verify the entry is present',
+  '3. Select it to open the destination picker and pick any destination',
+]);
 
 // GOOD: instruction is self-contained
 await waitForHuman(

--- a/.claude/agents/test-scope-fixer.md
+++ b/.claude/agents/test-scope-fixer.md
@@ -265,10 +265,7 @@ When refactoring tests for classes that use facade patterns:
    ```typescript
    // ✅ Import constants directly (facades don't wrap these)
    import * as vscode from 'vscode';
-   expect(mockEditor.revealRange).toHaveBeenCalledWith(
-     range,
-     vscode.TextEditorRevealType.InCenterIfOutsideViewport,
-   );
+   expect(mockEditor.revealRange).toHaveBeenCalledWith(range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
    ```
 
 3. **Test enum values appropriately**:

--- a/.claude/skills/affected-tests/SKILL.md
+++ b/.claude/skills/affected-tests/SKILL.md
@@ -89,10 +89,7 @@ const compressSet = (numSet) => {
     let i = 0;
     while (i < ones.length) {
       let j = i;
-      while (
-        j + 1 < ones.length &&
-        ones[j + 1] === String.fromCharCode(ones[j].charCodeAt(0) + 1)
-      ) {
+      while (j + 1 < ones.length && ones[j + 1] === String.fromCharCode(ones[j].charCodeAt(0) + 1)) {
         j++;
       }
       if (j > i) {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,14 +5,8 @@
       "name": "Debug RangeLink Extension",
       "type": "extensionHost",
       "request": "launch",
-      "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}/packages/rangelink-vscode-extension",
-        "--profile-temp"
-      ],
-      "outFiles": [
-        "${workspaceFolder}/packages/rangelink-vscode-extension/out/**/*.js",
-        "${workspaceFolder}/packages/rangelink-core-ts/out/**/*.js"
-      ]
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}/packages/rangelink-vscode-extension", "--profile-temp"],
+      "outFiles": ["${workspaceFolder}/packages/rangelink-vscode-extension/out/**/*.js", "${workspaceFolder}/packages/rangelink-core-ts/out/**/*.js"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -192,9 +192,7 @@ function activate(context) {
     const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
 
     // Get relative path from workspace root
-    const relativePath = workspaceFolder
-      ? document.uri.path.substring(workspaceFolder.uri.path.length + 1)
-      : vscode.workspace.asRelativeUri(document.uri).path;
+    const relativePath = workspaceFolder ? document.uri.path.substring(workspaceFolder.uri.path.length + 1) : vscode.workspace.asRelativeUri(document.uri).path;
 
     const startLine = selection.start.line + 1;
     const startChar = selection.start.character + 1;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -612,11 +612,7 @@ describe('Contract: Rectangular Mode', () => {
 
   contract.testCases.forEach((testCase) => {
     it(testCase.name, () => {
-      const result = formatLink(
-        testCase.input.path,
-        testCase.input.selections,
-        testCase.input.config,
-      );
+      const result = formatLink(testCase.input.path, testCase.input.selections, testCase.input.config);
 
       expect(result).toBe(testCase.expected.link);
     });

--- a/docs/ERROR-HANDLING.md
+++ b/docs/ERROR-HANDLING.md
@@ -164,9 +164,7 @@ function validateInputSelection(input: InputSelection): void {
 }
 
 // Public API - catches and converts to Result
-export function computeRangeSpec(
-  inputSelection: InputSelection,
-): Result<ComputedSelection, RangeLinkError> {
+export function computeRangeSpec(inputSelection: InputSelection): Result<ComputedSelection, RangeLinkError> {
   try {
     validateInputSelection(inputSelection);
     // ... compute logic

--- a/docs/I18N.md
+++ b/docs/I18N.md
@@ -110,11 +110,7 @@ import { messagesEn } from './messages.en';
  * // Returns: "Configuration loaded: line=L, column=C, hash=#, range=-"
  * ```
  */
-export function getMessage(
-  code: RangeLinkMessageCode,
-  params?: Record<string, string | number>,
-  locale?: string,
-): string {
+export function getMessage(code: RangeLinkMessageCode, params?: Record<string, string | number>, locale?: string): string {
   // Get message map for locale (default: 'en')
   const messages = getMessagesForLocale(locale || getCurrentLocale());
 

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -234,16 +234,10 @@ interface Logger {
 import { RangeLinkMessageCode } from './types/RangeLinkMessageCode';
 
 // Configuration loaded
-logger.info(
-  RangeLinkMessageCode.CONFIG_LOADED,
-  `Configuration loaded: line="${config.delimiterLine}", column="${config.delimiterPosition}"`,
-);
+logger.info(RangeLinkMessageCode.CONFIG_LOADED, `Configuration loaded: line="${config.delimiterLine}", column="${config.delimiterPosition}"`);
 
 // Validation error
-logger.error(
-  RangeLinkMessageCode.CONFIG_ERR_DELIMITER_EMPTY,
-  `Invalid delimiterLine value "" (empty string not allowed)`,
-);
+logger.error(RangeLinkMessageCode.CONFIG_ERR_DELIMITER_EMPTY, `Invalid delimiterLine value "" (empty string not allowed)`);
 
 // BYOD warning
 logger.warn(
@@ -371,10 +365,7 @@ The structured logging approach with message codes enables future internationali
 **Current approach:**
 
 ```typescript
-logger.error(
-  RangeLinkMessageCode.CONFIG_ERR_DELIMITER_EMPTY,
-  `Invalid delimiterLine value "" (empty string not allowed)`,
-);
+logger.error(RangeLinkMessageCode.CONFIG_ERR_DELIMITER_EMPTY, `Invalid delimiterLine value "" (empty string not allowed)`);
 ```
 
 **Future approach (with i18n):**

--- a/docs/PLAN-UNIVERSAL-PASTE.md
+++ b/docs/PLAN-UNIVERSAL-PASTE.md
@@ -234,8 +234,7 @@ class DestinationFactory {
 **New file:** `packages/rangelink-vscode-extension/src/destinations/PasteDestination.ts`
 
 ```typescript
-export type DestinationType =
-  'terminal' | 'text-editor' | 'cursor-ai' | 'github-copilot' | 'claude-code';
+export type DestinationType = 'terminal' | 'text-editor' | 'cursor-ai' | 'github-copilot' | 'claude-code';
 
 export interface PasteDestination {
   /** Unique identifier for this destination type */
@@ -295,10 +294,7 @@ export class TerminalDestination implements PasteDestination {
     this.boundTerminal.sendText(paddedText, false);
     this.boundTerminal.show(false);
 
-    this.logger.info(
-      { fn: 'TerminalDestination.paste', terminalName: this.boundTerminal.name },
-      `Pasted to terminal: ${this.boundTerminal.name}`,
-    );
+    this.logger.info({ fn: 'TerminalDestination.paste', terminalName: this.boundTerminal.name }, `Pasted to terminal: ${this.boundTerminal.name}`);
 
     return true;
   }
@@ -457,10 +453,7 @@ export class TextEditorDestination implements PasteDestination {
     const editor = vscode.window.activeTextEditor;
 
     if (!editor) {
-      this.logger.warn(
-        { fn: 'TextEditorDestination.paste' },
-        'Cannot paste: No active text editor',
-      );
+      this.logger.warn({ fn: 'TextEditorDestination.paste' }, 'Cannot paste: No active text editor');
       return false;
     }
 
@@ -472,17 +465,11 @@ export class TextEditorDestination implements PasteDestination {
         editBuilder.insert(position, paddedText);
       });
 
-      this.logger.info(
-        { fn: 'TextEditorDestination.paste', textLength: text.length },
-        'Successfully pasted to text editor at cursor',
-      );
+      this.logger.info({ fn: 'TextEditorDestination.paste', textLength: text.length }, 'Successfully pasted to text editor at cursor');
 
       return true;
     } catch (error) {
-      this.logger.error(
-        { fn: 'TextEditorDestination.paste', error },
-        'Failed to paste to text editor',
-      );
+      this.logger.error({ fn: 'TextEditorDestination.paste', error }, 'Failed to paste to text editor');
       return false;
     }
   }
@@ -514,20 +501,14 @@ export class CursorAIDestination implements PasteDestination {
     // Runtime check: try to detect Cursor environment
     const isCursor = this.detectCursorEnvironment();
 
-    this.logger.debug(
-      { fn: 'CursorAIDestination.isAvailable', isCursor },
-      isCursor ? 'Running in Cursor' : 'Not running in Cursor',
-    );
+    this.logger.debug({ fn: 'CursorAIDestination.isAvailable', isCursor }, isCursor ? 'Running in Cursor' : 'Not running in Cursor');
 
     return isCursor;
   }
 
   async paste(text: string): Promise<boolean> {
     if (!(await this.isAvailable())) {
-      this.logger.warn(
-        { fn: 'CursorAIDestination.paste' },
-        'Cannot paste: Not running in Cursor IDE',
-      );
+      this.logger.warn({ fn: 'CursorAIDestination.paste' }, 'Cannot paste: Not running in Cursor IDE');
       return false;
     }
 
@@ -603,18 +584,12 @@ export class GitHubCopilotDestination implements PasteDestination {
     const extension = vscode.extensions.getExtension(COPILOT_EXTENSION_ID);
 
     if (!extension) {
-      this.logger.debug(
-        { fn: 'GitHubCopilotDestination.isAvailable' },
-        'GitHub Copilot extension not installed',
-      );
+      this.logger.debug({ fn: 'GitHubCopilotDestination.isAvailable' }, 'GitHub Copilot extension not installed');
       return false;
     }
 
     if (!extension.isActive) {
-      this.logger.debug(
-        { fn: 'GitHubCopilotDestination.isAvailable' },
-        'GitHub Copilot extension not active',
-      );
+      this.logger.debug({ fn: 'GitHubCopilotDestination.isAvailable' }, 'GitHub Copilot extension not active');
       return false;
     }
 
@@ -623,10 +598,7 @@ export class GitHubCopilotDestination implements PasteDestination {
 
   async paste(text: string): Promise<boolean> {
     if (!(await this.isAvailable())) {
-      this.logger.warn(
-        { fn: 'GitHubCopilotDestination.paste' },
-        'Cannot paste: GitHub Copilot not available',
-      );
+      this.logger.warn({ fn: 'GitHubCopilotDestination.paste' }, 'Cannot paste: GitHub Copilot not available');
       return false;
     }
 
@@ -638,17 +610,11 @@ export class GitHubCopilotDestination implements PasteDestination {
         query: paddedText,
       });
 
-      this.logger.info(
-        { fn: 'GitHubCopilotDestination.paste', textLength: text.length },
-        'Successfully pasted to GitHub Copilot Chat',
-      );
+      this.logger.info({ fn: 'GitHubCopilotDestination.paste', textLength: text.length }, 'Successfully pasted to GitHub Copilot Chat');
 
       return true;
     } catch (error) {
-      this.logger.error(
-        { fn: 'GitHubCopilotDestination.paste', error },
-        'Failed to paste to GitHub Copilot Chat',
-      );
+      this.logger.error({ fn: 'GitHubCopilotDestination.paste', error }, 'Failed to paste to GitHub Copilot Chat');
       return false;
     }
   }
@@ -680,10 +646,7 @@ export class ClaudeCodeDestination implements PasteDestination {
     const extension = vscode.extensions.getExtension(CLAUDE_CODE_EXTENSION_ID);
 
     if (!extension || !extension.isActive) {
-      this.logger.debug(
-        { fn: 'ClaudeCodeDestination.isAvailable' },
-        'Claude Code extension not available',
-      );
+      this.logger.debug({ fn: 'ClaudeCodeDestination.isAvailable' }, 'Claude Code extension not available');
       return false;
     }
 
@@ -692,10 +655,7 @@ export class ClaudeCodeDestination implements PasteDestination {
 
   async paste(text: string): Promise<boolean> {
     if (!(await this.isAvailable())) {
-      this.logger.warn(
-        { fn: 'ClaudeCodeDestination.paste' },
-        'Cannot paste: Claude Code not available',
-      );
+      this.logger.warn({ fn: 'ClaudeCodeDestination.paste' }, 'Cannot paste: Claude Code not available');
       return false;
     }
 
@@ -709,30 +669,18 @@ export class ClaudeCodeDestination implements PasteDestination {
       // 2. Try programmatic paste
       try {
         await vscode.commands.executeCommand('editor.action.clipboardPasteAction');
-        this.logger.info(
-          { fn: 'ClaudeCodeDestination.paste' },
-          'Successfully pasted to Claude Code (automatic)',
-        );
+        this.logger.info({ fn: 'ClaudeCodeDestination.paste' }, 'Successfully pasted to Claude Code (automatic)');
         return true;
       } catch (pasteError) {
         // 3. Fallback: Show notification for manual paste
-        this.logger.warn(
-          { fn: 'ClaudeCodeDestination.paste', error: pasteError },
-          'Automatic paste failed, prompting user for manual paste',
-        );
+        this.logger.warn({ fn: 'ClaudeCodeDestination.paste', error: pasteError }, 'Automatic paste failed, prompting user for manual paste');
 
-        vscode.window.showInformationMessage(
-          'RangeLink focused in Claude Code - press Cmd+V (Mac) or Ctrl+V (Win/Linux) to paste',
-          { modal: false },
-        );
+        vscode.window.showInformationMessage('RangeLink focused in Claude Code - press Cmd+V (Mac) or Ctrl+V (Win/Linux) to paste', { modal: false });
 
         return true; // Still count as success (focused)
       }
     } catch (error) {
-      this.logger.error(
-        { fn: 'ClaudeCodeDestination.paste', error },
-        'Failed to paste to Claude Code',
-      );
+      this.logger.error({ fn: 'ClaudeCodeDestination.paste', error }, 'Failed to paste to Claude Code');
       return false;
     }
   }
@@ -816,10 +764,7 @@ export class PasteDestinationManager implements vscode.Disposable {
     // Listen for terminal closure (backward compatibility)
     const terminalCloseListener = vscode.window.onDidCloseTerminal((closedTerminal) => {
       if (this.boundTerminal === closedTerminal) {
-        this.logger.info(
-          { fn: 'PasteDestinationManager.onDidCloseTerminal' },
-          'Bound terminal closed - auto-unbinding',
-        );
+        this.logger.info({ fn: 'PasteDestinationManager.onDidCloseTerminal' }, 'Bound terminal closed - auto-unbinding');
         this.unbind();
         vscode.window.setStatusBarMessage('Destination binding removed (terminal closed)', 3000);
       }
@@ -837,13 +782,8 @@ export class PasteDestinationManager implements vscode.Disposable {
     // Check if already bound
     if (this.boundDestination) {
       const currentType = this.boundDestination.id;
-      this.logger.warn(
-        { fn: 'bind', currentType, requestedType: type },
-        'Already bound to a destination',
-      );
-      vscode.window.showErrorMessage(
-        `RangeLink: Already bound to ${this.boundDestination.displayName}. Unbind first.`,
-      );
+      this.logger.warn({ fn: 'bind', currentType, requestedType: type }, 'Already bound to a destination');
+      vscode.window.showErrorMessage(`RangeLink: Already bound to ${this.boundDestination.displayName}. Unbind first.`);
       return false;
     }
 
@@ -856,14 +796,8 @@ export class PasteDestinationManager implements vscode.Disposable {
     const destination = this.factory.create(type);
 
     if (!(await destination.isAvailable())) {
-      this.logger.warn(
-        { fn: 'bind', type },
-        `Cannot bind: ${destination.displayName} not available`,
-      );
-      vscode.window.showErrorMessage(
-        `RangeLink: ${destination.displayName} is not available. ` +
-          `Make sure the extension is installed and active.`,
-      );
+      this.logger.warn({ fn: 'bind', type }, `Cannot bind: ${destination.displayName} not available`);
+      vscode.window.showErrorMessage(`RangeLink: ${destination.displayName} is not available. ` + `Make sure the extension is installed and active.`);
       return false;
     }
 
@@ -885,9 +819,7 @@ export class PasteDestinationManager implements vscode.Disposable {
 
     if (!activeTerminal) {
       this.logger.warn({ fn: 'bindTerminal' }, 'No active terminal');
-      vscode.window.showErrorMessage(
-        'RangeLink: No active terminal. Open a terminal and try again.',
-      );
+      vscode.window.showErrorMessage('RangeLink: No active terminal. Open a terminal and try again.');
       return false;
     }
 
@@ -897,15 +829,9 @@ export class PasteDestinationManager implements vscode.Disposable {
     this.boundDestination = destination;
     this.boundTerminal = activeTerminal; // Track for closure events
 
-    this.logger.info(
-      { fn: 'bindTerminal', terminalName: activeTerminal.name },
-      `Successfully bound to terminal: ${activeTerminal.name}`,
-    );
+    this.logger.info({ fn: 'bindTerminal', terminalName: activeTerminal.name }, `Successfully bound to terminal: ${activeTerminal.name}`);
 
-    vscode.window.setStatusBarMessage(
-      `✓ RangeLink bound to terminal: ${activeTerminal.name}`,
-      3000,
-    );
+    vscode.window.setStatusBarMessage(`✓ RangeLink bound to terminal: ${activeTerminal.name}`, 3000);
 
     return true;
   }
@@ -956,10 +882,7 @@ export class PasteDestinationManager implements vscode.Disposable {
     const result = await this.boundDestination.paste(text);
 
     if (!result) {
-      this.logger.error(
-        { fn: 'sendToDestination', destinationType: this.boundDestination.id },
-        'Paste failed',
-      );
+      this.logger.error({ fn: 'sendToDestination', destinationType: this.boundDestination.id }, 'Paste failed');
       // Don't show error toast (paste() already logged, user sees no action)
     }
 
@@ -1207,10 +1130,7 @@ context.subscriptions.push(
 ```typescript
 const MIGRATION_KEY = 'rangelink.settingsMigrated.v2';
 
-export const migrateSettingsIfNeeded = async (
-  context: vscode.ExtensionContext,
-  logger: Logger,
-): Promise<void> => {
+export const migrateSettingsIfNeeded = async (context: vscode.ExtensionContext, logger: Logger): Promise<void> => {
   const migrated = context.globalState.get<boolean>(MIGRATION_KEY, false);
 
   if (migrated) {
@@ -1222,10 +1142,7 @@ export const migrateSettingsIfNeeded = async (
   const boundTerminal = config.get<string | null>('autoPaste.boundTerminal');
 
   if (boundTerminal) {
-    logger.info(
-      { fn: 'migrateSettingsIfNeeded', boundTerminal },
-      'Migrating legacy terminal binding setting',
-    );
+    logger.info({ fn: 'migrateSettingsIfNeeded', boundTerminal }, 'Migrating legacy terminal binding setting');
 
     // Migrate: boundTerminal set → destinationType = 'terminal'
     await config.update('autoPaste.destinationType', 'terminal', vscode.ConfigurationTarget.Global);
@@ -1234,8 +1151,7 @@ export const migrateSettingsIfNeeded = async (
     // User might want to rebind to same terminal later
 
     vscode.window.showInformationMessage(
-      'RangeLink: Your terminal binding has been migrated to the new system. ' +
-        'Use "RangeLink: Bind terminal" to re-bind.',
+      'RangeLink: Your terminal binding has been migrated to the new system. ' + 'Use "RangeLink: Bind terminal" to re-bind.',
     );
   } else {
     logger.debug({ fn: 'migrateSettingsIfNeeded' }, 'No legacy settings to migrate');

--- a/docs/RESEARCH-CLAUDE-CODE-INTEGRATION-UPDATE.md
+++ b/docs/RESEARCH-CLAUDE-CODE-INTEGRATION-UPDATE.md
@@ -196,10 +196,7 @@ export class ClaudeCodeDestination implements PasteDestination {
       } catch (pasteError) {
         // 5. Fallback: Show notification for manual paste
         this.logger.warn('Automatic paste failed, prompting user');
-        vscode.window.showInformationMessage(
-          'RangeLink focused in Claude Code - press Cmd+V to paste',
-          { modal: false },
-        );
+        vscode.window.showInformationMessage('RangeLink focused in Claude Code - press Cmd+V to paste', { modal: false });
         return true; // Still count as success (focused)
       }
     } catch (error) {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,29 +1,15 @@
 import baseConfig from '@couimet/eslint-config/eslint';
-import prettierOptions from '@couimet/eslint-config/prettier';
 import globals from 'globals';
 
 export default [
   ...baseConfig,
-  // TODO [2026-12-31]: https://github.com/couimet/rangeLink/issues/699 — remove printWidth override and adopt upstream 160
   {
     rules: {
-      'prettier/prettier': ['error', { ...prettierOptions, printWidth: 100, endOfLine: 'auto' }],
       'barrel-boundary/enforce-barrel-files': 'off',
     },
   },
   {
-    ignores: [
-      '**/out/**',
-      '**/coverage2/**',
-      '**/.vscode-test/**',
-      '**/.claude-work/**',
-      '**/*.vsix',
-      '**/*.config.js',
-      '**/*.config.mjs',
-      '**/*.config.cjs',
-      '**/scripts/**',
-      '**/test-fixtures/**',
-    ],
+    ignores: ['**/out/**', '**/coverage2/**', '**/.vscode-test/**', '**/.claude-work/**', '**/*.vsix', '**/scripts/**', '**/test-fixtures/**'],
   },
   {
     files: ['**/*.test.ts', '**/__tests__/**/*.ts'],

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "verify:qa-scripts:vscode-extension": "pnpm --filter rangelink-vscode-extension verify:qa-scripts",
     "watch": "pnpm -r --parallel watch"
   },
+  "prettier": "@couimet/eslint-config/prettier",
   "devDependencies": {
     "@couimet/eslint-config": "^1.1.0",
     "baseline-browser-mapping": "^2.10.10",

--- a/packages/rangelink-core-ts/PUBLISHING.md
+++ b/packages/rangelink-core-ts/PUBLISHING.md
@@ -30,11 +30,7 @@ const link = formatLink('/path/to/file.ts', {
 // => "/path/to/file.ts#L10C5-L20C15"
 
 // Generate a portable link with metadata
-const portableLink = formatPortableLink(
-  '/path/to/file.ts',
-  { start: { line: 10 }, end: { line: 20 } },
-  'Selected code snippet',
-);
+const portableLink = formatPortableLink('/path/to/file.ts', { start: { line: 10 }, end: { line: 20 } }, 'Selected code snippet');
 // => "/path/to/file.ts#L10-L20|Selected code snippet"
 ```
 

--- a/packages/rangelink-core-ts/README.md
+++ b/packages/rangelink-core-ts/README.md
@@ -69,12 +69,7 @@ const delimiters: DelimiterConfig = {
   range: '-',
 };
 
-const result = formatLink(
-  'recipes/baking/chickenpie.ts',
-  selection,
-  delimiters,
-  PathFormat.WorkspaceRelative,
-);
+const result = formatLink('recipes/baking/chickenpie.ts', selection, delimiters, PathFormat.WorkspaceRelative);
 
 if (result.success) {
   console.log(result.value); // "recipes/baking/chickenpie.ts#L3C14-L15C9"

--- a/packages/rangelink-core-ts/src/__tests__/detection/findLinksInText.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/detection/findLinksInText.test.ts
@@ -14,8 +14,7 @@ jest.mock('../../parsing/parseLink', () => ({
   ...jest.requireActual('../../parsing/parseLink'),
   parseLink: jest.fn(),
 }));
-const realParseLink =
-  jest.requireActual<typeof import('../../parsing/parseLink')>('../../parsing/parseLink').parseLink;
+const realParseLink = jest.requireActual<typeof import('../../parsing/parseLink')>('../../parsing/parseLink').parseLink;
 const mockParseLink = parseLink as jest.MockedFunction<typeof parseLink>;
 
 describe('findLinksInText', () => {
@@ -28,11 +27,7 @@ describe('findLinksInText', () => {
 
   describe('unquoted links', () => {
     it('should detect a single unquoted link', () => {
-      const results = findLinksInText(
-        'Check src/auth.ts#L10 for details',
-        DEFAULT_DELIMITERS,
-        logger,
-      );
+      const results = findLinksInText('Check src/auth.ts#L10 for details', DEFAULT_DELIMITERS, logger);
 
       expect(results).toHaveLength(1);
       expect(results[0].linkText).toBe('src/auth.ts#L10');
@@ -43,11 +38,7 @@ describe('findLinksInText', () => {
     });
 
     it('should detect multiple unquoted links', () => {
-      const results = findLinksInText(
-        'See src/a.ts#L1 and src/b.ts#L2-L5',
-        DEFAULT_DELIMITERS,
-        logger,
-      );
+      const results = findLinksInText('See src/a.ts#L1 and src/b.ts#L2-L5', DEFAULT_DELIMITERS, logger);
 
       expect(results).toHaveLength(2);
       expect(results[0].linkText).toBe('src/a.ts#L1');
@@ -169,11 +160,7 @@ describe('findLinksInText', () => {
       });
 
       it('should detect the path from a simple markdown link embedded in prose', () => {
-        const results = findLinksInText(
-          'See [text](src/auth.ts#L10) for details',
-          DEFAULT_DELIMITERS,
-          logger,
-        );
+        const results = findLinksInText('See [text](src/auth.ts#L10) for details', DEFAULT_DELIMITERS, logger);
 
         expect(results).toHaveLength(1);
         expect(results[0].linkText).toBe('src/auth.ts#L10');
@@ -189,12 +176,8 @@ describe('findLinksInText', () => {
         );
 
         expect(results).toHaveLength(1);
-        expect(results[0].linkText).toBe(
-          'packages/rangelink-vscode-extension/src/RangeLinkService.ts#L876',
-        );
-        expect(results[0].parsed.path).toBe(
-          'packages/rangelink-vscode-extension/src/RangeLinkService.ts',
-        );
+        expect(results[0].linkText).toBe('packages/rangelink-vscode-extension/src/RangeLinkService.ts#L876');
+        expect(results[0].parsed.path).toBe('packages/rangelink-vscode-extension/src/RangeLinkService.ts');
         expect(results[0].parsed.start.line).toBe(876);
       });
 
@@ -204,12 +187,8 @@ describe('findLinksInText', () => {
         const results = findLinksInText(line, DEFAULT_DELIMITERS, logger);
 
         expect(results).toHaveLength(1);
-        expect(results[0].linkText).toBe(
-          'packages/rangelink-vscode-extension/src/RangeLinkService.ts#L876',
-        );
-        expect(results[0].parsed.path).toBe(
-          'packages/rangelink-vscode-extension/src/RangeLinkService.ts',
-        );
+        expect(results[0].linkText).toBe('packages/rangelink-vscode-extension/src/RangeLinkService.ts#L876');
+        expect(results[0].parsed.path).toBe('packages/rangelink-vscode-extension/src/RangeLinkService.ts');
         expect(results[0].parsed.start.line).toBe(876);
       });
 
@@ -224,11 +203,7 @@ describe('findLinksInText', () => {
       });
 
       it('should detect a range link inside a markdown link embedded in prose', () => {
-        const results = findLinksInText(
-          'Check [text](src/auth.ts#L10-L20) above',
-          DEFAULT_DELIMITERS,
-          logger,
-        );
+        const results = findLinksInText('Check [text](src/auth.ts#L10-L20) above', DEFAULT_DELIMITERS, logger);
 
         expect(results).toHaveLength(1);
         expect(results[0].linkText).toBe('src/auth.ts#L10-L20');
@@ -238,11 +213,7 @@ describe('findLinksInText', () => {
       });
 
       it('should detect both links when multiple markdown links appear in one line', () => {
-        const results = findLinksInText(
-          'Compare [a](src/a.ts#L1) with [b](src/b.ts#L2)',
-          DEFAULT_DELIMITERS,
-          logger,
-        );
+        const results = findLinksInText('Compare [a](src/a.ts#L1) with [b](src/b.ts#L2)', DEFAULT_DELIMITERS, logger);
 
         expect(results).toHaveLength(2);
         expect(results[0].linkText).toBe('src/a.ts#L1');
@@ -255,11 +226,7 @@ describe('findLinksInText', () => {
 
   describe('quoted links', () => {
     it('should detect single-quoted links with spaces in paths', () => {
-      const results = findLinksInText(
-        "Open 'My Folder/file.ts#L10' to see",
-        DEFAULT_DELIMITERS,
-        logger,
-      );
+      const results = findLinksInText("Open 'My Folder/file.ts#L10' to see", DEFAULT_DELIMITERS, logger);
 
       expect(results).toHaveLength(1);
       expect(results[0].linkText).toBe('My Folder/file.ts#L10');
@@ -278,11 +245,7 @@ describe('findLinksInText', () => {
     });
 
     it('should detect quoted links with column positions', () => {
-      const results = findLinksInText(
-        "'Meslo Slashed/LICENSE.txt#L10C24-L11C24'",
-        DEFAULT_DELIMITERS,
-        logger,
-      );
+      const results = findLinksInText("'Meslo Slashed/LICENSE.txt#L10C24-L11C24'", DEFAULT_DELIMITERS, logger);
 
       expect(results).toHaveLength(1);
       expect(results[0].linkText).toBe('Meslo Slashed/LICENSE.txt#L10C24-L11C24');
@@ -303,11 +266,7 @@ describe('findLinksInText', () => {
     });
 
     it('should skip quoted segments that are not valid links', () => {
-      const results = findLinksInText(
-        "Some 'random text' and 'not a link' here",
-        DEFAULT_DELIMITERS,
-        logger,
-      );
+      const results = findLinksInText("Some 'random text' and 'not a link' here", DEFAULT_DELIMITERS, logger);
 
       expect(results).toHaveLength(0);
     });
@@ -315,11 +274,7 @@ describe('findLinksInText', () => {
 
   describe('mixed unquoted and quoted links', () => {
     it('should detect both unquoted and quoted links in same text', () => {
-      const results = findLinksInText(
-        "See src/a.ts#L1 and 'My Dir/b.ts#L5-L10'",
-        DEFAULT_DELIMITERS,
-        logger,
-      );
+      const results = findLinksInText("See src/a.ts#L1 and 'My Dir/b.ts#L5-L10'", DEFAULT_DELIMITERS, logger);
 
       expect(results).toHaveLength(2);
       expect(results[0].linkText).toBe('src/a.ts#L1');
@@ -327,11 +282,7 @@ describe('findLinksInText', () => {
     });
 
     it('should detect both single- and double-quoted links in same text', () => {
-      const results = findLinksInText(
-        `Check 'My Dir/a.ts#L1' and "Other Dir/b.ts#L2"`,
-        DEFAULT_DELIMITERS,
-        logger,
-      );
+      const results = findLinksInText(`Check 'My Dir/a.ts#L1' and "Other Dir/b.ts#L2"`, DEFAULT_DELIMITERS, logger);
 
       expect(results).toHaveLength(2);
       expect(results[0].linkText).toBe('My Dir/a.ts#L1');
@@ -351,12 +302,7 @@ describe('findLinksInText', () => {
   describe('cancellation', () => {
     it('should respect cancellation token during unquoted pass', () => {
       const token = { isCancellationRequested: true };
-      const results = findLinksInText(
-        'src/a.ts#L1 and src/b.ts#L2',
-        DEFAULT_DELIMITERS,
-        logger,
-        token,
-      );
+      const results = findLinksInText('src/a.ts#L1 and src/b.ts#L2', DEFAULT_DELIMITERS, logger, token);
 
       expect(results).toHaveLength(0);
     });
@@ -378,17 +324,10 @@ describe('findLinksInText', () => {
       });
       mockParseLink.mockReturnValueOnce(CoreResult.err(mockError));
 
-      const results = findLinksInText(
-        'Check src/auth.ts#L10 for details',
-        DEFAULT_DELIMITERS,
-        logger,
-      );
+      const results = findLinksInText('Check src/auth.ts#L10 for details', DEFAULT_DELIMITERS, logger);
 
       expect(results).toHaveLength(0);
-      expect(logger.debug).toHaveBeenCalledWith(
-        { fn: 'detectUnquotedLinks', link: 'src/auth.ts#L10', error: mockError },
-        'Skipping link that failed to parse',
-      );
+      expect(logger.debug).toHaveBeenCalledWith({ fn: 'detectUnquotedLinks', link: 'src/auth.ts#L10', error: mockError }, 'Skipping link that failed to parse');
     });
 
     it('should count parse failures in summary log', () => {

--- a/packages/rangelink-core-ts/src/__tests__/fixtures/pathPatternInputs.ts
+++ b/packages/rangelink-core-ts/src/__tests__/fixtures/pathPatternInputs.ts
@@ -17,8 +17,7 @@
 export const URL_INPUTS = {
   HTTPS_NO_HASH: 'See https://example.com/path/file.ts for info',
   HTTPS_WITH_RANGELINK: 'Check https://github.com/org/repo/file.ts#L10',
-  HTTPS_WITH_QUERY_PARAM_AND_RANGELINK:
-    'https://github.com/nextjs/deploy-github-pages/blob/main/README.md?plain=1#L3-L9',
+  HTTPS_WITH_QUERY_PARAM_AND_RANGELINK: 'https://github.com/nextjs/deploy-github-pages/blob/main/README.md?plain=1#L3-L9',
   HTTPS_UPPERCASE_WITH_RANGELINK: 'Check HTTPS://GITHUB.COM/FILE.TS#L10',
   HTTP_NO_HASH: 'See http://example.com/file.ts for details',
   HTTP_WITH_RANGELINK: 'See http://example.com/file.ts#L5 for details',

--- a/packages/rangelink-core-ts/src/__tests__/formatting/buildAnchor.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/formatting/buildAnchor.test.ts
@@ -26,37 +26,17 @@ describe('buildAnchor', () => {
 
   describe('with positions', () => {
     it('should build anchor with positions', () => {
-      const result = buildAnchor(
-        startLine,
-        endLine,
-        startPosition,
-        endPosition,
-        DEFAULT_DELIMITERS,
-        RangeFormat.WithPositions,
-      );
+      const result = buildAnchor(startLine, endLine, startPosition, endPosition, DEFAULT_DELIMITERS, RangeFormat.WithPositions);
       expect(result).toBe(`L${startLine}C${startPosition}-L${endLine}C${endPosition}`);
     });
 
     it('should default to WithPositions format when not specified', () => {
-      const result = buildAnchor(
-        startLine,
-        endLine,
-        startPosition,
-        endPosition,
-        DEFAULT_DELIMITERS,
-      );
+      const result = buildAnchor(startLine, endLine, startPosition, endPosition, DEFAULT_DELIMITERS);
       expect(result).toBe(`L${startLine}C${startPosition}-L${endLine}C${endPosition}`);
     });
 
     it('should default to position 1 when positions are undefined', () => {
-      const result = buildAnchor(
-        startLine,
-        endLine,
-        undefined,
-        undefined,
-        DEFAULT_DELIMITERS,
-        RangeFormat.WithPositions,
-      );
+      const result = buildAnchor(startLine, endLine, undefined, undefined, DEFAULT_DELIMITERS, RangeFormat.WithPositions);
       expect(result).toBe(`L${startLine}C1-L${endLine}C1`);
     });
 
@@ -67,40 +47,19 @@ describe('buildAnchor', () => {
         hash: '#',
         range: 'TO',
       };
-      const result = buildAnchor(
-        startLine,
-        endLine,
-        startPosition,
-        endPosition,
-        customDelimiters,
-        RangeFormat.WithPositions,
-      );
+      const result = buildAnchor(startLine, endLine, startPosition, endPosition, customDelimiters, RangeFormat.WithPositions);
       expect(result).toBe(`LINE${startLine}COL${startPosition}TOLINE${endLine}COL${endPosition}`);
     });
   });
 
   describe('line only', () => {
     it('should build anchor without positions', () => {
-      const result = buildAnchor(
-        startLine,
-        endLine,
-        startPosition,
-        endPosition,
-        DEFAULT_DELIMITERS,
-        RangeFormat.LineOnly,
-      );
+      const result = buildAnchor(startLine, endLine, startPosition, endPosition, DEFAULT_DELIMITERS, RangeFormat.LineOnly);
       expect(result).toBe(`L${startLine}-L${endLine}`);
     });
 
     it('should ignore position values when format is LineOnly', () => {
-      const result = buildAnchor(
-        startLine,
-        endLine,
-        undefined,
-        undefined,
-        DEFAULT_DELIMITERS,
-        RangeFormat.LineOnly,
-      );
+      const result = buildAnchor(startLine, endLine, undefined, undefined, DEFAULT_DELIMITERS, RangeFormat.LineOnly);
       expect(result).toBe(`L${startLine}-L${endLine}`);
     });
 
@@ -111,40 +70,19 @@ describe('buildAnchor', () => {
         hash: '>',
         range: 'thru',
       };
-      const result = buildAnchor(
-        startLine,
-        endLine,
-        undefined,
-        undefined,
-        customDelimiters,
-        RangeFormat.LineOnly,
-      );
+      const result = buildAnchor(startLine, endLine, undefined, undefined, customDelimiters, RangeFormat.LineOnly);
       expect(result).toBe(`LINE${startLine}thruLINE${endLine}`);
     });
   });
 
   describe('single line', () => {
     it('should handle single-line selection with positions', () => {
-      const result = buildAnchor(
-        startLine,
-        startLine,
-        startPosition,
-        endPosition,
-        DEFAULT_DELIMITERS,
-        RangeFormat.WithPositions,
-      );
+      const result = buildAnchor(startLine, startLine, startPosition, endPosition, DEFAULT_DELIMITERS, RangeFormat.WithPositions);
       expect(result).toBe(`L${startLine}C${startPosition}-L${startLine}C${endPosition}`);
     });
 
     it('should handle single-line selection without positions', () => {
-      const result = buildAnchor(
-        startLine,
-        startLine,
-        undefined,
-        undefined,
-        DEFAULT_DELIMITERS,
-        RangeFormat.LineOnly,
-      );
+      const result = buildAnchor(startLine, startLine, undefined, undefined, DEFAULT_DELIMITERS, RangeFormat.LineOnly);
       expect(result).toBe(`L${startLine}-L${startLine}`);
     });
   });

--- a/packages/rangelink-core-ts/src/__tests__/formatting/finalizeLinkGeneration.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/formatting/finalizeLinkGeneration.test.ts
@@ -1,7 +1,4 @@
-import {
-  finalizeLinkGeneration,
-  LinkGenerationResult,
-} from '../../formatting/finalizeLinkGeneration';
+import { finalizeLinkGeneration, LinkGenerationResult } from '../../formatting/finalizeLinkGeneration';
 import { DelimiterConfig } from '../../types/DelimiterConfig';
 import { LinkType } from '../../types/LinkType';
 import { RangeFormat } from '../../types/RangeFormat';
@@ -43,14 +40,7 @@ describe('finalizeLinkGeneration', () => {
       selectionType: SelectionType.Normal,
     };
 
-    const result = finalizeLinkGeneration(
-      generateLink,
-      spec,
-      inputSelection,
-      LinkType.Regular,
-      defaultDelimiters,
-      'src/file.ts',
-    );
+    const result = finalizeLinkGeneration(generateLink, spec, inputSelection, LinkType.Regular, defaultDelimiters, 'src/file.ts');
 
     expect(result).toBeSuccess({
       link: 'src/file.ts#L10-L20',
@@ -86,14 +76,7 @@ describe('finalizeLinkGeneration', () => {
       selectionType: SelectionType.Normal,
     };
 
-    const result = finalizeLinkGeneration(
-      generateLink,
-      spec,
-      inputSelection,
-      LinkType.Portable,
-      defaultDelimiters,
-      'src/file.ts',
-    );
+    const result = finalizeLinkGeneration(generateLink, spec, inputSelection, LinkType.Portable, defaultDelimiters, 'src/file.ts');
 
     expect(result).toBeSuccess({
       link: 'src/file.ts#L10-L20~#~L~-~',
@@ -141,14 +124,7 @@ describe('finalizeLinkGeneration', () => {
       selectionType: SelectionType.Normal,
     };
 
-    const result = finalizeLinkGeneration(
-      maliciousGenerator,
-      spec,
-      inputSelection,
-      LinkType.Regular,
-      defaultDelimiters,
-      'src/test.ts',
-    );
+    const result = finalizeLinkGeneration(maliciousGenerator, spec, inputSelection, LinkType.Regular, defaultDelimiters, 'src/test.ts');
 
     expect(result).toBeSuccess({
       link: 'src/test.ts#L10',
@@ -200,14 +176,7 @@ describe('finalizeLinkGeneration', () => {
       selectionType: SelectionType.Rectangular,
     };
 
-    const result = finalizeLinkGeneration(
-      generateLink,
-      spec,
-      inputSelection,
-      LinkType.Regular,
-      defaultDelimiters,
-      'src/file.ts',
-    );
+    const result = finalizeLinkGeneration(generateLink, spec, inputSelection, LinkType.Regular, defaultDelimiters, 'src/file.ts');
 
     expect(result).toBeSuccess({
       link: 'src/file.ts#L5C10-L15C20',

--- a/packages/rangelink-core-ts/src/__tests__/formatting/formatLink.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/formatting/formatLink.test.ts
@@ -787,46 +787,43 @@ describe('formatLink', () => {
     it.each([
       { linkType: LinkType.Regular, suffix: '' },
       { linkType: LinkType.Portable, suffix: byodSuffix(DEFAULT_DELIMITERS, true) },
-    ])(
-      'should handle end-to-end link generation with linkType=$linkType',
-      ({ linkType, suffix }) => {
-        const expectedStartLine = startLine + 1;
-        const expectedEndLine = endLine + 1;
-        const expectedStartPosition = startPosition + 1;
-        const expectedEndPosition = endPosition + 1;
+    ])('should handle end-to-end link generation with linkType=$linkType', ({ linkType, suffix }) => {
+      const expectedStartLine = startLine + 1;
+      const expectedEndLine = endLine + 1;
+      const expectedStartPosition = startPosition + 1;
+      const expectedEndPosition = endPosition + 1;
 
-        const inputSelection: InputSelection = {
-          selections: [
-            {
-              start: { line: startLine, character: startPosition },
-              end: { line: endLine, character: endPosition },
-              coverage: SelectionCoverage.PartialLine,
-            },
-          ],
-          selectionType: SelectionType.Normal,
-        };
-
-        const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
-          linkType,
-        });
-
-        expect(result).toBeSuccess({
-          link: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}${suffix}`,
-          rawLink: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}${suffix}`,
-          linkType: linkType === LinkType.Regular ? 'regular' : 'portable',
-          rangeFormat: 'WithPositions',
-          selectionType: 'Normal',
-          delimiters: DEFAULT_DELIMITERS,
-          computedSelection: {
-            startLine: expectedStartLine,
-            endLine: expectedEndLine,
-            startPosition: expectedStartPosition,
-            endPosition: expectedEndPosition,
-            rangeFormat: 'WithPositions',
+      const inputSelection: InputSelection = {
+        selections: [
+          {
+            start: { line: startLine, character: startPosition },
+            end: { line: endLine, character: endPosition },
+            coverage: SelectionCoverage.PartialLine,
           },
-        });
-      },
-    );
+        ],
+        selectionType: SelectionType.Normal,
+      };
+
+      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
+        linkType,
+      });
+
+      expect(result).toBeSuccess({
+        link: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}${suffix}`,
+        rawLink: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}${suffix}`,
+        linkType: linkType === LinkType.Regular ? 'regular' : 'portable',
+        rangeFormat: 'WithPositions',
+        selectionType: 'Normal',
+        delimiters: DEFAULT_DELIMITERS,
+        computedSelection: {
+          startLine: expectedStartLine,
+          endLine: expectedEndLine,
+          startPosition: expectedStartPosition,
+          endPosition: expectedEndPosition,
+          rangeFormat: 'WithPositions',
+        },
+      });
+    });
 
     it.each([
       { linkType: LinkType.Regular, suffix: '' },
@@ -873,25 +870,22 @@ describe('formatLink', () => {
       });
     });
 
-    it.each([{ linkType: LinkType.Regular }, { linkType: LinkType.Portable }])(
-      'should propagate errors correctly with linkType=$linkType',
-      ({ linkType }) => {
-        const inputSelection: InputSelection = {
-          selections: [],
-          selectionType: SelectionType.Normal,
-        };
+    it.each([{ linkType: LinkType.Regular }, { linkType: LinkType.Portable }])('should propagate errors correctly with linkType=$linkType', ({ linkType }) => {
+      const inputSelection: InputSelection = {
+        selections: [],
+        selectionType: SelectionType.Normal,
+      };
 
-        const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
-          linkType,
-        });
+      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
+        linkType,
+      });
 
-        expect(result).toHaveDetailedError('SELECTION_EMPTY', {
-          message: 'Selections array must not be empty',
-          functionName: 'validateInputSelection',
-          details: { selectionsLength: 0 },
-        });
-      },
-    );
+      expect(result).toHaveDetailedError('SELECTION_EMPTY', {
+        message: 'Selections array must not be empty',
+        functionName: 'validateInputSelection',
+        details: { selectionsLength: 0 },
+      });
+    });
   });
 
   describe('quoting', () => {

--- a/packages/rangelink-core-ts/src/__tests__/formatting/joinWithHash.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/formatting/joinWithHash.test.ts
@@ -11,22 +11,12 @@ describe('joinWithHash', () => {
   };
 
   it('should use single hash for normal selection', () => {
-    const result = joinWithHash(
-      'src/file.ts',
-      'L10C5-L20C10',
-      defaultDelimiters,
-      SelectionType.Normal,
-    );
+    const result = joinWithHash('src/file.ts', 'L10C5-L20C10', defaultDelimiters, SelectionType.Normal);
     expect(result).toBe('src/file.ts#L10C5-L20C10');
   });
 
   it('should use double hash for rectangular selection', () => {
-    const result = joinWithHash(
-      'src/file.ts',
-      'L10C5-L20C10',
-      defaultDelimiters,
-      SelectionType.Rectangular,
-    );
+    const result = joinWithHash('src/file.ts', 'L10C5-L20C10', defaultDelimiters, SelectionType.Rectangular);
     expect(result).toBe('src/file.ts##L10C5-L20C10');
   });
 
@@ -53,12 +43,7 @@ describe('joinWithHash', () => {
       hash: '>>',
       range: '-',
     };
-    const result = joinWithHash(
-      'path/file.ts',
-      'L10C5-L20C10',
-      customDelimiters,
-      SelectionType.Rectangular,
-    );
+    const result = joinWithHash('path/file.ts', 'L10C5-L20C10', customDelimiters, SelectionType.Rectangular);
     expect(result).toBe('path/file.ts>>>>L10C5-L20C10');
   });
 });

--- a/packages/rangelink-core-ts/src/__tests__/parsing/parseLink.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/parsing/parseLink.test.ts
@@ -541,10 +541,7 @@ describe('parseLink', () => {
 
     describe('PARSE_URL_NOT_SUPPORTED', () => {
       it('should reject https:// URLs', () => {
-        const result = parseLink(
-          'https://github.com/org/repo/blob/main/file.ts#L10',
-          DEFAULT_DELIMITERS,
-        );
+        const result = parseLink('https://github.com/org/repo/blob/main/file.ts#L10', DEFAULT_DELIMITERS);
 
         expect(result).toHaveDetailedError('PARSE_URL_NOT_SUPPORTED', {
           message: 'Web URLs are not supported - use local file paths',
@@ -587,10 +584,7 @@ describe('parseLink', () => {
       });
 
       it('should reject GitHub permalink with query params', () => {
-        const result = parseLink(
-          'https://github.com/nextjs/deploy-github-pages/blob/main/README.md?plain=1#L3-L9',
-          DEFAULT_DELIMITERS,
-        );
+        const result = parseLink('https://github.com/nextjs/deploy-github-pages/blob/main/README.md?plain=1#L3-L9', DEFAULT_DELIMITERS);
 
         expect(result).toHaveDetailedError('PARSE_URL_NOT_SUPPORTED', {
           message: 'Web URLs are not supported - use local file paths',
@@ -941,17 +935,13 @@ describe('parseLink', () => {
     it('should handle path with special characters', () => {
       const result = parseLink('path/with spaces/file-name_2.ts#L10', DEFAULT_DELIMITERS);
 
-      expect(result).toBeSuccess(
-        expect.objectContaining({ path: 'path/with spaces/file-name_2.ts' }),
-      );
+      expect(result).toBeSuccess(expect.objectContaining({ path: 'path/with spaces/file-name_2.ts' }));
     });
 
     it('should handle path with dots', () => {
       const result = parseLink('../../relative/path/file.spec.ts#L10', DEFAULT_DELIMITERS);
 
-      expect(result).toBeSuccess(
-        expect.objectContaining({ path: '../../relative/path/file.spec.ts' }),
-      );
+      expect(result).toBeSuccess(expect.objectContaining({ path: '../../relative/path/file.spec.ts' }));
     });
 
     it('should handle Windows-style path', () => {

--- a/packages/rangelink-core-ts/src/__tests__/selection/computeRangeSpec.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/selection/computeRangeSpec.test.ts
@@ -413,11 +413,9 @@ describe('computeRangeSpec', () => {
 
       const expectedError = new TypeError('Unexpected validation error');
 
-      const spy = jest
-        .spyOn(validateInputSelectionModule, 'validateInputSelection')
-        .mockImplementationOnce(() => {
-          throw expectedError;
-        });
+      const spy = jest.spyOn(validateInputSelectionModule, 'validateInputSelection').mockImplementationOnce(() => {
+        throw expectedError;
+      });
 
       expect(() => computeRangeSpec(inputSelection)).toThrow(expectedError);
 

--- a/packages/rangelink-core-ts/src/__tests__/selection/validateInputSelection.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/selection/validateInputSelection.test.ts
@@ -13,9 +13,7 @@ jest.mock('../../selection/validateNormalMode');
 jest.mock('../../selection/validateRectangularMode');
 
 const mockValidateNormalMode = validateNormalMode as jest.MockedFunction<typeof validateNormalMode>;
-const mockValidateRectangularMode = validateRectangularMode as jest.MockedFunction<
-  typeof validateRectangularMode
->;
+const mockValidateRectangularMode = validateRectangularMode as jest.MockedFunction<typeof validateRectangularMode>;
 
 describe('validateInputSelection', () => {
   describe('Empty selections array', () => {
@@ -49,18 +47,15 @@ describe('validateInputSelection', () => {
         selectionType: SelectionType.Normal,
       };
 
-      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError(
-        'SELECTION_BACKWARD_LINE',
-        {
-          message: `Backward selection not allowed (startLine=${startLine} > endLine=${endLine})`,
-          functionName: 'validateInputSelection',
-          details: {
-            selectionIndex: 0,
-            startLine,
-            endLine,
-          },
+      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError('SELECTION_BACKWARD_LINE', {
+        message: `Backward selection not allowed (startLine=${startLine} > endLine=${endLine})`,
+        functionName: 'validateInputSelection',
+        details: {
+          selectionIndex: 0,
+          startLine,
+          endLine,
         },
-      );
+      });
     });
   });
 
@@ -81,19 +76,16 @@ describe('validateInputSelection', () => {
         selectionType: SelectionType.Normal,
       };
 
-      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError(
-        'SELECTION_BACKWARD_CHARACTER',
-        {
-          message: `Backward character selection not allowed (startCharacter=${startPosition} > endCharacter=${endPosition} on line ${line})`,
-          functionName: 'validateInputSelection',
-          details: {
-            selectionIndex: 0,
-            line,
-            startCharacter: startPosition,
-            endCharacter: endPosition,
-          },
+      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError('SELECTION_BACKWARD_CHARACTER', {
+        message: `Backward character selection not allowed (startCharacter=${startPosition} > endCharacter=${endPosition} on line ${line})`,
+        functionName: 'validateInputSelection',
+        details: {
+          selectionIndex: 0,
+          line,
+          startCharacter: startPosition,
+          endCharacter: endPosition,
         },
-      );
+      });
     });
 
     it('should allow startCharacter > endCharacter when on different lines', () => {
@@ -131,21 +123,17 @@ describe('validateInputSelection', () => {
         selectionType: SelectionType.Normal,
       };
 
-      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError(
-        'SELECTION_NEGATIVE_COORDINATES',
-        {
-          message:
-            'Negative coordinates not allowed (startLine=-1, endLine=10, startCharacter=0, endCharacter=10)',
-          functionName: 'validateInputSelection',
-          details: {
-            selectionIndex: 0,
-            startLine: -1,
-            endLine: 10,
-            startCharacter: 0,
-            endCharacter: 10,
-          },
+      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError('SELECTION_NEGATIVE_COORDINATES', {
+        message: 'Negative coordinates not allowed (startLine=-1, endLine=10, startCharacter=0, endCharacter=10)',
+        functionName: 'validateInputSelection',
+        details: {
+          selectionIndex: 0,
+          startLine: -1,
+          endLine: 10,
+          startCharacter: 0,
+          endCharacter: 10,
         },
-      );
+      });
     });
 
     it('should throw error for negative endLine', () => {
@@ -161,21 +149,17 @@ describe('validateInputSelection', () => {
         selectionType: SelectionType.Normal,
       };
 
-      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError(
-        'SELECTION_NEGATIVE_COORDINATES',
-        {
-          message:
-            'Negative coordinates not allowed (startLine=0, endLine=-1, startCharacter=0, endCharacter=10)',
-          functionName: 'validateInputSelection',
-          details: {
-            selectionIndex: 0,
-            startLine: 0,
-            endLine: -1,
-            startCharacter: 0,
-            endCharacter: 10,
-          },
+      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError('SELECTION_NEGATIVE_COORDINATES', {
+        message: 'Negative coordinates not allowed (startLine=0, endLine=-1, startCharacter=0, endCharacter=10)',
+        functionName: 'validateInputSelection',
+        details: {
+          selectionIndex: 0,
+          startLine: 0,
+          endLine: -1,
+          startCharacter: 0,
+          endCharacter: 10,
         },
-      );
+      });
     });
 
     it('should throw error for negative startCharacter', () => {
@@ -191,21 +175,17 @@ describe('validateInputSelection', () => {
         selectionType: SelectionType.Normal,
       };
 
-      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError(
-        'SELECTION_NEGATIVE_COORDINATES',
-        {
-          message:
-            'Negative coordinates not allowed (startLine=0, endLine=10, startCharacter=-1, endCharacter=10)',
-          functionName: 'validateInputSelection',
-          details: {
-            selectionIndex: 0,
-            startLine: 0,
-            endLine: 10,
-            startCharacter: -1,
-            endCharacter: 10,
-          },
+      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError('SELECTION_NEGATIVE_COORDINATES', {
+        message: 'Negative coordinates not allowed (startLine=0, endLine=10, startCharacter=-1, endCharacter=10)',
+        functionName: 'validateInputSelection',
+        details: {
+          selectionIndex: 0,
+          startLine: 0,
+          endLine: 10,
+          startCharacter: -1,
+          endCharacter: 10,
         },
-      );
+      });
     });
 
     it('should throw error for negative endCharacter', () => {
@@ -221,21 +201,17 @@ describe('validateInputSelection', () => {
         selectionType: SelectionType.Normal,
       };
 
-      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError(
-        'SELECTION_NEGATIVE_COORDINATES',
-        {
-          message:
-            'Negative coordinates not allowed (startLine=0, endLine=10, startCharacter=0, endCharacter=-1)',
-          functionName: 'validateInputSelection',
-          details: {
-            selectionIndex: 0,
-            startLine: 0,
-            endLine: 10,
-            startCharacter: 0,
-            endCharacter: -1,
-          },
+      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError('SELECTION_NEGATIVE_COORDINATES', {
+        message: 'Negative coordinates not allowed (startLine=0, endLine=10, startCharacter=0, endCharacter=-1)',
+        functionName: 'validateInputSelection',
+        details: {
+          selectionIndex: 0,
+          startLine: 0,
+          endLine: 10,
+          startCharacter: 0,
+          endCharacter: -1,
         },
-      );
+      });
     });
   });
 
@@ -253,14 +229,11 @@ describe('validateInputSelection', () => {
         selectionType: 'InvalidType' as any,
       };
 
-      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError(
-        'SELECTION_UNKNOWN_TYPE',
-        {
-          message: 'Unknown SelectionType: "InvalidType"',
-          functionName: 'validateInputSelection',
-          details: { selectionType: 'InvalidType' },
-        },
-      );
+      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError('SELECTION_UNKNOWN_TYPE', {
+        message: 'Unknown SelectionType: "InvalidType"',
+        functionName: 'validateInputSelection',
+        details: { selectionType: 'InvalidType' },
+      });
     });
   });
 
@@ -279,18 +252,15 @@ describe('validateInputSelection', () => {
         selectionType: SelectionType.Normal,
       };
 
-      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError(
-        'SELECTION_ZERO_WIDTH',
-        {
-          message: `Zero-width selection not allowed (cursor position at line ${line}, character ${position})`,
-          functionName: 'validateInputSelection',
-          details: {
-            selectionIndex: 0,
-            line,
-            character: position,
-          },
+      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError('SELECTION_ZERO_WIDTH', {
+        message: `Zero-width selection not allowed (cursor position at line ${line}, character ${position})`,
+        functionName: 'validateInputSelection',
+        details: {
+          selectionIndex: 0,
+          line,
+          character: position,
         },
-      );
+      });
     });
 
     it('should throw error for zero-width selection at line start', () => {
@@ -306,18 +276,15 @@ describe('validateInputSelection', () => {
         selectionType: SelectionType.Normal,
       };
 
-      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError(
-        'SELECTION_ZERO_WIDTH',
-        {
-          message: 'Zero-width selection not allowed (cursor position at line 0, character 0)',
-          functionName: 'validateInputSelection',
-          details: {
-            selectionIndex: 0,
-            line: 0,
-            character: 0,
-          },
+      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError('SELECTION_ZERO_WIDTH', {
+        message: 'Zero-width selection not allowed (cursor position at line 0, character 0)',
+        functionName: 'validateInputSelection',
+        details: {
+          selectionIndex: 0,
+          line: 0,
+          character: 0,
         },
-      );
+      });
     });
 
     it('should allow empty-line FullLine zero-width selection', () => {
@@ -351,18 +318,15 @@ describe('validateInputSelection', () => {
         selectionType: SelectionType.Normal,
       };
 
-      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError(
-        'SELECTION_ZERO_WIDTH',
-        {
-          message: 'Zero-width selection not allowed (cursor position at line 5, character 3)',
-          functionName: 'validateInputSelection',
-          details: {
-            selectionIndex: 0,
-            line: 5,
-            character: 3,
-          },
+      expect(() => validateInputSelection(inputSelection)).toThrowDetailedError('SELECTION_ZERO_WIDTH', {
+        message: 'Zero-width selection not allowed (cursor position at line 5, character 3)',
+        functionName: 'validateInputSelection',
+        details: {
+          selectionIndex: 0,
+          line: 5,
+          character: 3,
         },
-      );
+      });
     });
   });
 

--- a/packages/rangelink-core-ts/src/__tests__/selection/validateNormalMode.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/selection/validateNormalMode.test.ts
@@ -18,15 +18,11 @@ describe('validateNormalMode', () => {
         },
       ];
 
-      expect(() => validateNormalMode(selections)).toThrowDetailedError(
-        'SELECTION_NORMAL_MULTIPLE',
-        {
-          message:
-            'Normal mode does not support multiple selections (got 2). Multiple non-contiguous selections are not yet implemented.',
-          functionName: 'validateNormalMode',
-          details: { selectionsLength: 2 },
-        },
-      );
+      expect(() => validateNormalMode(selections)).toThrowDetailedError('SELECTION_NORMAL_MULTIPLE', {
+        message: 'Normal mode does not support multiple selections (got 2). Multiple non-contiguous selections are not yet implemented.',
+        functionName: 'validateNormalMode',
+        details: { selectionsLength: 2 },
+      });
     });
 
     it('should throw error for 3 selections', () => {
@@ -48,15 +44,11 @@ describe('validateNormalMode', () => {
         },
       ];
 
-      expect(() => validateNormalMode(selections)).toThrowDetailedError(
-        'SELECTION_NORMAL_MULTIPLE',
-        {
-          message:
-            'Normal mode does not support multiple selections (got 3). Multiple non-contiguous selections are not yet implemented.',
-          functionName: 'validateNormalMode',
-          details: { selectionsLength: 3 },
-        },
-      );
+      expect(() => validateNormalMode(selections)).toThrowDetailedError('SELECTION_NORMAL_MULTIPLE', {
+        message: 'Normal mode does not support multiple selections (got 3). Multiple non-contiguous selections are not yet implemented.',
+        functionName: 'validateNormalMode',
+        details: { selectionsLength: 3 },
+      });
     });
 
     it('should throw error for 10 selections', () => {
@@ -66,15 +58,11 @@ describe('validateNormalMode', () => {
         coverage: SelectionCoverage.PartialLine,
       }));
 
-      expect(() => validateNormalMode(selections)).toThrowDetailedError(
-        'SELECTION_NORMAL_MULTIPLE',
-        {
-          message:
-            'Normal mode does not support multiple selections (got 10). Multiple non-contiguous selections are not yet implemented.',
-          functionName: 'validateNormalMode',
-          details: { selectionsLength: 10 },
-        },
-      );
+      expect(() => validateNormalMode(selections)).toThrowDetailedError('SELECTION_NORMAL_MULTIPLE', {
+        message: 'Normal mode does not support multiple selections (got 10). Multiple non-contiguous selections are not yet implemented.',
+        functionName: 'validateNormalMode',
+        details: { selectionsLength: 10 },
+      });
     });
   });
 
@@ -82,15 +70,11 @@ describe('validateNormalMode', () => {
     it('should throw error for 0 selections', () => {
       const selections: InputSelection['selections'] = [];
 
-      expect(() => validateNormalMode(selections)).toThrowDetailedError(
-        'SELECTION_NORMAL_MULTIPLE',
-        {
-          message:
-            'Normal mode does not support multiple selections (got 0). Multiple non-contiguous selections are not yet implemented.',
-          functionName: 'validateNormalMode',
-          details: { selectionsLength: 0 },
-        },
-      );
+      expect(() => validateNormalMode(selections)).toThrowDetailedError('SELECTION_NORMAL_MULTIPLE', {
+        message: 'Normal mode does not support multiple selections (got 0). Multiple non-contiguous selections are not yet implemented.',
+        functionName: 'validateNormalMode',
+        details: { selectionsLength: 0 },
+      });
     });
   });
 

--- a/packages/rangelink-core-ts/src/__tests__/selection/validateRectangularMode.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/selection/validateRectangularMode.test.ts
@@ -23,19 +23,15 @@ describe('validateRectangularMode', () => {
         },
       ];
 
-      expect(() => validateRectangularMode(selections)).toThrowDetailedError(
-        'SELECTION_RECTANGULAR_MULTILINE',
-        {
-          message:
-            'Rectangular mode requires single-line selections (selection 0 spans lines 10-12)',
-          functionName: 'validateRectangularMode',
-          details: {
-            selectionIndex: 0,
-            startLine: 10,
-            endLine: 12,
-          },
+      expect(() => validateRectangularMode(selections)).toThrowDetailedError('SELECTION_RECTANGULAR_MULTILINE', {
+        message: 'Rectangular mode requires single-line selections (selection 0 spans lines 10-12)',
+        functionName: 'validateRectangularMode',
+        details: {
+          selectionIndex: 0,
+          startLine: 10,
+          endLine: 12,
         },
-      );
+      });
     });
 
     it('should throw error for second selection spanning multiple lines', () => {
@@ -52,19 +48,15 @@ describe('validateRectangularMode', () => {
         },
       ];
 
-      expect(() => validateRectangularMode(selections)).toThrowDetailedError(
-        'SELECTION_RECTANGULAR_MULTILINE',
-        {
-          message:
-            'Rectangular mode requires single-line selections (selection 1 spans lines 11-13)',
-          functionName: 'validateRectangularMode',
-          details: {
-            selectionIndex: 1,
-            startLine: 11,
-            endLine: 13,
-          },
+      expect(() => validateRectangularMode(selections)).toThrowDetailedError('SELECTION_RECTANGULAR_MULTILINE', {
+        message: 'Rectangular mode requires single-line selections (selection 1 spans lines 11-13)',
+        functionName: 'validateRectangularMode',
+        details: {
+          selectionIndex: 1,
+          startLine: 11,
+          endLine: 13,
         },
-      );
+      });
     });
 
     it('should not throw for valid single-line selection', () => {
@@ -95,21 +87,17 @@ describe('validateRectangularMode', () => {
         },
       ];
 
-      expect(() => validateRectangularMode(selections)).toThrowDetailedError(
-        'SELECTION_RECTANGULAR_MISMATCHED_COLUMNS',
-        {
-          message:
-            'Rectangular mode requires consistent column range (expected 5-15, got 7-15 at selection 1)',
-          functionName: 'validateRectangularMode',
-          details: {
-            selectionIndex: 1,
-            expectedStartCharacter: 5,
-            expectedEndCharacter: 15,
-            actualStartCharacter: 7,
-            actualEndCharacter: 15,
-          },
+      expect(() => validateRectangularMode(selections)).toThrowDetailedError('SELECTION_RECTANGULAR_MISMATCHED_COLUMNS', {
+        message: 'Rectangular mode requires consistent column range (expected 5-15, got 7-15 at selection 1)',
+        functionName: 'validateRectangularMode',
+        details: {
+          selectionIndex: 1,
+          expectedStartCharacter: 5,
+          expectedEndCharacter: 15,
+          actualStartCharacter: 7,
+          actualEndCharacter: 15,
         },
-      );
+      });
     });
 
     it('should throw error for mismatched endCharacter', () => {
@@ -126,21 +114,17 @@ describe('validateRectangularMode', () => {
         },
       ];
 
-      expect(() => validateRectangularMode(selections)).toThrowDetailedError(
-        'SELECTION_RECTANGULAR_MISMATCHED_COLUMNS',
-        {
-          message:
-            'Rectangular mode requires consistent column range (expected 5-15, got 5-17 at selection 1)',
-          functionName: 'validateRectangularMode',
-          details: {
-            selectionIndex: 1,
-            expectedStartCharacter: 5,
-            expectedEndCharacter: 15,
-            actualStartCharacter: 5,
-            actualEndCharacter: 17,
-          },
+      expect(() => validateRectangularMode(selections)).toThrowDetailedError('SELECTION_RECTANGULAR_MISMATCHED_COLUMNS', {
+        message: 'Rectangular mode requires consistent column range (expected 5-15, got 5-17 at selection 1)',
+        functionName: 'validateRectangularMode',
+        details: {
+          selectionIndex: 1,
+          expectedStartCharacter: 5,
+          expectedEndCharacter: 15,
+          actualStartCharacter: 5,
+          actualEndCharacter: 17,
         },
-      );
+      });
     });
 
     it('should throw error for both startCharacter and endCharacter mismatched', () => {
@@ -157,21 +141,17 @@ describe('validateRectangularMode', () => {
         },
       ];
 
-      expect(() => validateRectangularMode(selections)).toThrowDetailedError(
-        'SELECTION_RECTANGULAR_MISMATCHED_COLUMNS',
-        {
-          message:
-            'Rectangular mode requires consistent column range (expected 5-15, got 3-20 at selection 1)',
-          functionName: 'validateRectangularMode',
-          details: {
-            selectionIndex: 1,
-            expectedStartCharacter: 5,
-            expectedEndCharacter: 15,
-            actualStartCharacter: 3,
-            actualEndCharacter: 20,
-          },
+      expect(() => validateRectangularMode(selections)).toThrowDetailedError('SELECTION_RECTANGULAR_MISMATCHED_COLUMNS', {
+        message: 'Rectangular mode requires consistent column range (expected 5-15, got 3-20 at selection 1)',
+        functionName: 'validateRectangularMode',
+        details: {
+          selectionIndex: 1,
+          expectedStartCharacter: 5,
+          expectedEndCharacter: 15,
+          actualStartCharacter: 3,
+          actualEndCharacter: 20,
         },
-      );
+      });
     });
 
     it('should not throw for consistent column ranges', () => {
@@ -212,19 +192,15 @@ describe('validateRectangularMode', () => {
         },
       ];
 
-      expect(() => validateRectangularMode(selections)).toThrowDetailedError(
-        'SELECTION_RECTANGULAR_UNSORTED',
-        {
-          message:
-            'Rectangular mode selections must be sorted by line number (line 8 comes after line 10)',
-          functionName: 'validateRectangularMode',
-          details: {
-            selectionIndex: 1,
-            previousLine: 10,
-            currentLine: 8,
-          },
+      expect(() => validateRectangularMode(selections)).toThrowDetailedError('SELECTION_RECTANGULAR_UNSORTED', {
+        message: 'Rectangular mode selections must be sorted by line number (line 8 comes after line 10)',
+        functionName: 'validateRectangularMode',
+        details: {
+          selectionIndex: 1,
+          previousLine: 10,
+          currentLine: 8,
         },
-      );
+      });
     });
 
     it('should throw error when middle selection is out of order', () => {
@@ -246,19 +222,15 @@ describe('validateRectangularMode', () => {
         },
       ];
 
-      expect(() => validateRectangularMode(selections)).toThrowDetailedError(
-        'SELECTION_RECTANGULAR_UNSORTED',
-        {
-          message:
-            'Rectangular mode selections must be sorted by line number (line 12 comes after line 15)',
-          functionName: 'validateRectangularMode',
-          details: {
-            selectionIndex: 2,
-            previousLine: 15,
-            currentLine: 12,
-          },
+      expect(() => validateRectangularMode(selections)).toThrowDetailedError('SELECTION_RECTANGULAR_UNSORTED', {
+        message: 'Rectangular mode selections must be sorted by line number (line 12 comes after line 15)',
+        functionName: 'validateRectangularMode',
+        details: {
+          selectionIndex: 2,
+          previousLine: 15,
+          currentLine: 12,
         },
-      );
+      });
     });
 
     it('should not throw for properly sorted selections', () => {
@@ -299,19 +271,16 @@ describe('validateRectangularMode', () => {
         },
       ];
 
-      expect(() => validateRectangularMode(selections)).toThrowDetailedError(
-        'SELECTION_RECTANGULAR_NON_CONTIGUOUS',
-        {
-          message: 'Rectangular mode requires contiguous lines (gap between line 10 and 12)',
-          functionName: 'validateRectangularMode',
-          details: {
-            selectionIndex: 1,
-            previousLine: 10,
-            currentLine: 12,
-            gap: 1,
-          },
+      expect(() => validateRectangularMode(selections)).toThrowDetailedError('SELECTION_RECTANGULAR_NON_CONTIGUOUS', {
+        message: 'Rectangular mode requires contiguous lines (gap between line 10 and 12)',
+        functionName: 'validateRectangularMode',
+        details: {
+          selectionIndex: 1,
+          previousLine: 10,
+          currentLine: 12,
+          gap: 1,
         },
-      );
+      });
     });
 
     it('should throw error for non-contiguous lines (gap of 5)', () => {
@@ -328,19 +297,16 @@ describe('validateRectangularMode', () => {
         },
       ];
 
-      expect(() => validateRectangularMode(selections)).toThrowDetailedError(
-        'SELECTION_RECTANGULAR_NON_CONTIGUOUS',
-        {
-          message: 'Rectangular mode requires contiguous lines (gap between line 10 and 16)',
-          functionName: 'validateRectangularMode',
-          details: {
-            selectionIndex: 1,
-            previousLine: 10,
-            currentLine: 16,
-            gap: 5,
-          },
+      expect(() => validateRectangularMode(selections)).toThrowDetailedError('SELECTION_RECTANGULAR_NON_CONTIGUOUS', {
+        message: 'Rectangular mode requires contiguous lines (gap between line 10 and 16)',
+        functionName: 'validateRectangularMode',
+        details: {
+          selectionIndex: 1,
+          previousLine: 10,
+          currentLine: 16,
+          gap: 5,
         },
-      );
+      });
     });
 
     it('should not throw for contiguous lines', () => {

--- a/packages/rangelink-core-ts/src/__tests__/utils/buildFilePathPattern.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/utils/buildFilePathPattern.test.ts
@@ -28,45 +28,31 @@ describe('buildFilePathPattern', () => {
 
   describe('quoted paths — true positives', () => {
     it('should match double-quoted absolute path', () => {
-      expect(matchesPattern(QUOTED_TRUE_POSITIVES.DOUBLE_ABSOLUTE)).toStrictEqual([
-        '/path/to/file.ts',
-      ]);
+      expect(matchesPattern(QUOTED_TRUE_POSITIVES.DOUBLE_ABSOLUTE)).toStrictEqual(['/path/to/file.ts']);
     });
 
     it('should match single-quoted absolute path', () => {
-      expect(matchesPattern(QUOTED_TRUE_POSITIVES.SINGLE_ABSOLUTE)).toStrictEqual([
-        '/path/to/file.ts',
-      ]);
+      expect(matchesPattern(QUOTED_TRUE_POSITIVES.SINGLE_ABSOLUTE)).toStrictEqual(['/path/to/file.ts']);
     });
 
     it('should match double-quoted path with spaces', () => {
-      expect(matchesPattern(QUOTED_TRUE_POSITIVES.DOUBLE_WITH_SPACES)).toStrictEqual([
-        '/path/with spaces/file.ts',
-      ]);
+      expect(matchesPattern(QUOTED_TRUE_POSITIVES.DOUBLE_WITH_SPACES)).toStrictEqual(['/path/with spaces/file.ts']);
     });
 
     it('should match single-quoted path with spaces', () => {
-      expect(matchesPattern(QUOTED_TRUE_POSITIVES.SINGLE_WITH_SPACES)).toStrictEqual([
-        '/path/with spaces/file.ts',
-      ]);
+      expect(matchesPattern(QUOTED_TRUE_POSITIVES.SINGLE_WITH_SPACES)).toStrictEqual(['/path/with spaces/file.ts']);
     });
 
     it('should match double-quoted multi-extension path and capture last extension', () => {
-      expect(matchesPattern(QUOTED_TRUE_POSITIVES.DOUBLE_MULTI_EXTENSION)).toStrictEqual([
-        '/path/to/file.test.ts',
-      ]);
+      expect(matchesPattern(QUOTED_TRUE_POSITIVES.DOUBLE_MULTI_EXTENSION)).toStrictEqual(['/path/to/file.test.ts']);
     });
 
     it('should match single-quoted path when possessive apostrophe appears earlier in sentence', () => {
-      expect(
-        matchesPattern(QUOTED_TRUE_POSITIVES.POSSESSIVE_BEFORE_SINGLE_QUOTED_PATH),
-      ).toStrictEqual(['/path/to/out.ts']);
+      expect(matchesPattern(QUOTED_TRUE_POSITIVES.POSSESSIVE_BEFORE_SINGLE_QUOTED_PATH)).toStrictEqual(['/path/to/out.ts']);
     });
 
     it('should match double-quoted path when possessives surround the quoted expression', () => {
-      expect(
-        matchesPattern(QUOTED_TRUE_POSITIVES.POSSESSIVES_SURROUNDING_DOUBLE_QUOTED_PATH),
-      ).toStrictEqual(['/path/to/file.ts']);
+      expect(matchesPattern(QUOTED_TRUE_POSITIVES.POSSESSIVES_SURROUNDING_DOUBLE_QUOTED_PATH)).toStrictEqual(['/path/to/file.ts']);
     });
   });
 
@@ -112,9 +98,7 @@ describe('buildFilePathPattern', () => {
     });
 
     it('should NOT span across newline — the valid quoted path on the second line should match independently', () => {
-      expect(
-        matchesPattern(QUOTED_FALSE_POSITIVES.NEWLINE_BETWEEN_POSSESSIVES_WITH_VALID_SECOND_LINE),
-      ).toStrictEqual(['/path/to/file.ts']);
+      expect(matchesPattern(QUOTED_FALSE_POSITIVES.NEWLINE_BETWEEN_POSSESSIVES_WITH_VALID_SECOND_LINE)).toStrictEqual(['/path/to/file.ts']);
     });
   });
 
@@ -132,53 +116,37 @@ describe('buildFilePathPattern', () => {
     });
 
     it('should match the unquoted relative path when a contraction appears earlier on the same line', () => {
-      expect(matchesPattern(PROSE_INPUTS.CONTRACTION_WITH_VALID_RELATIVE_PATH)).toStrictEqual([
-        './src/component.tsx',
-      ]);
+      expect(matchesPattern(PROSE_INPUTS.CONTRACTION_WITH_VALID_RELATIVE_PATH)).toStrictEqual(['./src/component.tsx']);
     });
   });
 
   describe('absolute paths', () => {
     it('should match absolute path', () => {
-      expect(matchesPattern('See /path/to/file.ts for details')).toStrictEqual([
-        '/path/to/file.ts',
-      ]);
+      expect(matchesPattern('See /path/to/file.ts for details')).toStrictEqual(['/path/to/file.ts']);
     });
 
     it('should match absolute path with hyphens and dots in name', () => {
-      expect(matchesPattern(SPECIAL_CHAR_PATHS.MULTI_EXTENSION)).toStrictEqual([
-        '/path/to/my-file.test.ts',
-      ]);
+      expect(matchesPattern(SPECIAL_CHAR_PATHS.MULTI_EXTENSION)).toStrictEqual(['/path/to/my-file.test.ts']);
     });
 
     it('should match absolute path with @ in path component', () => {
-      expect(matchesPattern(SPECIAL_CHAR_PATHS.AT_IN_COMPONENT)).toStrictEqual([
-        '/home/user@hostname/project/file.ts',
-      ]);
+      expect(matchesPattern(SPECIAL_CHAR_PATHS.AT_IN_COMPONENT)).toStrictEqual(['/home/user@hostname/project/file.ts']);
     });
 
     it('should match absolute path with dot in directory name (version directory)', () => {
-      expect(matchesPattern(SPECIAL_CHAR_PATHS.DOT_IN_DIRECTORY)).toStrictEqual([
-        '/path/to/v1.2/config.ts',
-      ]);
+      expect(matchesPattern(SPECIAL_CHAR_PATHS.DOT_IN_DIRECTORY)).toStrictEqual(['/path/to/v1.2/config.ts']);
     });
 
     it('should match absolute path for dotfile', () => {
-      expect(matchesPattern(SPECIAL_CHAR_PATHS.DOTFILE_ABSOLUTE)).toStrictEqual([
-        '/repo/.eslintrc.js',
-      ]);
+      expect(matchesPattern(SPECIAL_CHAR_PATHS.DOTFILE_ABSOLUTE)).toStrictEqual(['/repo/.eslintrc.js']);
     });
 
     it('should match absolute path with numeric extension', () => {
-      expect(matchesPattern(SPECIAL_CHAR_PATHS.EXTENSION_DIGITS)).toStrictEqual([
-        '/path/to/output.mp4',
-      ]);
+      expect(matchesPattern(SPECIAL_CHAR_PATHS.EXTENSION_DIGITS)).toStrictEqual(['/path/to/output.mp4']);
     });
 
     it('should match absolute path with numbers in filename', () => {
-      expect(matchesPattern(SPECIAL_CHAR_PATHS.NUMBERS_IN_FILENAME)).toStrictEqual([
-        '/path/to/script2.sh',
-      ]);
+      expect(matchesPattern(SPECIAL_CHAR_PATHS.NUMBERS_IN_FILENAME)).toStrictEqual(['/path/to/script2.sh']);
     });
   });
 
@@ -192,29 +160,21 @@ describe('buildFilePathPattern', () => {
     });
 
     it('should match relative path with dot in directory name', () => {
-      expect(matchesPattern(SPECIAL_CHAR_PATHS.DOT_IN_DIRECTORY_RELATIVE)).toStrictEqual([
-        './src/v1.2/utils/helper.ts',
-      ]);
+      expect(matchesPattern(SPECIAL_CHAR_PATHS.DOT_IN_DIRECTORY_RELATIVE)).toStrictEqual(['./src/v1.2/utils/helper.ts']);
     });
 
     it('should match ./ shell script', () => {
-      expect(matchesPattern(SPECIAL_CHAR_PATHS.SHELL_SCRIPT_RELATIVE)).toStrictEqual([
-        './deploy.sh',
-      ]);
+      expect(matchesPattern(SPECIAL_CHAR_PATHS.SHELL_SCRIPT_RELATIVE)).toStrictEqual(['./deploy.sh']);
     });
   });
 
   describe('tilde paths', () => {
     it('should match ~/path', () => {
-      expect(matchesPattern('Open ~/projects/app/main.ts now')).toStrictEqual([
-        '~/projects/app/main.ts',
-      ]);
+      expect(matchesPattern('Open ~/projects/app/main.ts now')).toStrictEqual(['~/projects/app/main.ts']);
     });
 
     it('should match ~/path with yaml extension', () => {
-      expect(matchesPattern(SPECIAL_CHAR_PATHS.YAML_TILDE)).toStrictEqual([
-        '~/config/settings.yaml',
-      ]);
+      expect(matchesPattern(SPECIAL_CHAR_PATHS.YAML_TILDE)).toStrictEqual(['~/config/settings.yaml']);
     });
   });
 
@@ -270,21 +230,15 @@ describe('buildFilePathPattern', () => {
     });
 
     it('should match absolute path after a colon-label', () => {
-      expect(matchesPattern(BOUNDARY_INPUTS.PATH_AFTER_COLON_LABEL)).toStrictEqual([
-        '/path/to/file.ts',
-      ]);
+      expect(matchesPattern(BOUNDARY_INPUTS.PATH_AFTER_COLON_LABEL)).toStrictEqual(['/path/to/file.ts']);
     });
 
     it('should match absolute path wrapped in backticks without capturing backtick', () => {
-      expect(matchesPattern(BOUNDARY_INPUTS.ABS_PATH_IN_BACKTICKS)).toStrictEqual([
-        '/path/to/file.ts',
-      ]);
+      expect(matchesPattern(BOUNDARY_INPUTS.ABS_PATH_IN_BACKTICKS)).toStrictEqual(['/path/to/file.ts']);
     });
 
     it('should match single-quoted dotfile and capture full path', () => {
-      expect(matchesPattern(SPECIAL_CHAR_PATHS.DOTFILE_SINGLE_QUOTED)).toStrictEqual([
-        '/path/.gitignore',
-      ]);
+      expect(matchesPattern(SPECIAL_CHAR_PATHS.DOTFILE_SINGLE_QUOTED)).toStrictEqual(['/path/.gitignore']);
     });
   });
 
@@ -351,9 +305,7 @@ describe('buildFilePathPattern', () => {
       const pattern = buildFilePathPattern({ hash: '@', line: 'l', position: 'C', range: '-' });
       const results: string[] = [];
       let match;
-      while (
-        (match = pattern.exec(RANGELINK_COEXISTENCE.CUSTOM_DELIMITER_WITH_RANGELINK)) !== null
-      ) {
+      while ((match = pattern.exec(RANGELINK_COEXISTENCE.CUSTOM_DELIMITER_WITH_RANGELINK)) !== null) {
         results.push(extractFilePath(match));
       }
       expect(results).toStrictEqual([]);
@@ -362,31 +314,19 @@ describe('buildFilePathPattern', () => {
 
   describe('multiple matches', () => {
     it('should match multiple relative paths in one line', () => {
-      expect(matchesPattern(MULTI_MATCH_INPUTS.TWO_RELATIVE_PATHS)).toStrictEqual([
-        './src/a.ts',
-        './src/b.ts',
-      ]);
+      expect(matchesPattern(MULTI_MATCH_INPUTS.TWO_RELATIVE_PATHS)).toStrictEqual(['./src/a.ts', './src/b.ts']);
     });
 
     it('should match absolute and relative path on same line', () => {
-      expect(matchesPattern(MULTI_MATCH_INPUTS.ABS_AND_RELATIVE)).toStrictEqual([
-        '/abs/file.ts',
-        './rel/file.ts',
-      ]);
+      expect(matchesPattern(MULTI_MATCH_INPUTS.ABS_AND_RELATIVE)).toStrictEqual(['/abs/file.ts', './rel/file.ts']);
     });
 
     it('should match quoted and unquoted path on same line', () => {
-      expect(matchesPattern(MULTI_MATCH_INPUTS.QUOTED_AND_UNQUOTED)).toStrictEqual([
-        '/src/a.ts',
-        '/dst/b.ts',
-      ]);
+      expect(matchesPattern(MULTI_MATCH_INPUTS.QUOTED_AND_UNQUOTED)).toStrictEqual(['/src/a.ts', '/dst/b.ts']);
     });
 
     it('should match two double-quoted paths on same line', () => {
-      expect(matchesPattern(MULTI_MATCH_INPUTS.TWO_DOUBLE_QUOTED)).toStrictEqual([
-        '/src/a.ts',
-        '/src/b.ts',
-      ]);
+      expect(matchesPattern(MULTI_MATCH_INPUTS.TWO_DOUBLE_QUOTED)).toStrictEqual(['/src/a.ts', '/src/b.ts']);
     });
   });
 });

--- a/packages/rangelink-core-ts/src/__tests__/utils/buildLinkPattern.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/utils/buildLinkPattern.test.ts
@@ -1,14 +1,7 @@
 import { DEFAULT_DELIMITERS } from '../../constants/DEFAULT_DELIMITERS';
 import { DelimiterConfig } from '../../types/DelimiterConfig';
 import { buildLinkPattern } from '../../utils/buildLinkPattern';
-import {
-  BOUNDARY_INPUTS,
-  MULTI_MATCH_INPUTS,
-  PROSE_INPUTS,
-  RANGELINK_COEXISTENCE,
-  SPECIAL_CHAR_PATHS,
-  URL_INPUTS,
-} from '../fixtures/pathPatternInputs';
+import { BOUNDARY_INPUTS, MULTI_MATCH_INPUTS, PROSE_INPUTS, RANGELINK_COEXISTENCE, SPECIAL_CHAR_PATHS, URL_INPUTS } from '../fixtures/pathPatternInputs';
 
 describe('buildLinkPattern', () => {
   describe('default delimiters', () => {
@@ -409,8 +402,7 @@ describe('buildLinkPattern', () => {
       });
 
       it('should NOT match GitHub permalinks with query params', () => {
-        const line =
-          'https://github.com/nextjs/deploy-github-pages/blob/main/README.md?plain=1#L3-L9';
+        const line = 'https://github.com/nextjs/deploy-github-pages/blob/main/README.md?plain=1#L3-L9';
         const matches = [...line.matchAll(pattern)];
 
         expect(matches).toHaveLength(0);
@@ -757,26 +749,20 @@ describe('buildLinkPattern', () => {
       });
 
       it('should detect the correct path from a backtick-labelled markdown link', () => {
-        const line =
-          '[`RangeLinkService.ts:876`](packages/rangelink-vscode-extension/src/RangeLinkService.ts#L876)';
+        const line = '[`RangeLinkService.ts:876`](packages/rangelink-vscode-extension/src/RangeLinkService.ts#L876)';
         const matches = [...line.matchAll(pattern)];
 
         expect(matches).toHaveLength(1);
-        expect(matches[0][0]).toBe(
-          'packages/rangelink-vscode-extension/src/RangeLinkService.ts#L876',
-        );
+        expect(matches[0][0]).toBe('packages/rangelink-vscode-extension/src/RangeLinkService.ts#L876');
         expect(matches[0][1]).toBe('packages/rangelink-vscode-extension/src/RangeLinkService.ts');
       });
 
       it('should detect the correct path from a backtick-labelled markdown link embedded in prose', () => {
-        const line =
-          'See [`RangeLinkService.ts:876`](packages/rangelink-vscode-extension/src/RangeLinkService.ts#L876) in the codebase';
+        const line = 'See [`RangeLinkService.ts:876`](packages/rangelink-vscode-extension/src/RangeLinkService.ts#L876) in the codebase';
         const matches = [...line.matchAll(pattern)];
 
         expect(matches).toHaveLength(1);
-        expect(matches[0][0]).toBe(
-          'packages/rangelink-vscode-extension/src/RangeLinkService.ts#L876',
-        );
+        expect(matches[0][0]).toBe('packages/rangelink-vscode-extension/src/RangeLinkService.ts#L876');
         expect(matches[0][1]).toBe('packages/rangelink-vscode-extension/src/RangeLinkService.ts');
       });
 
@@ -989,9 +975,7 @@ describe('buildLinkPattern', () => {
       const customPattern = buildLinkPattern(customDelimiters);
 
       it('should match custom-delimiter path (FilePathProvider with custom delimiters rejects it)', () => {
-        const matches = [
-          ...RANGELINK_COEXISTENCE.CUSTOM_DELIMITER_WITH_RANGELINK.matchAll(customPattern),
-        ];
+        const matches = [...RANGELINK_COEXISTENCE.CUSTOM_DELIMITER_WITH_RANGELINK.matchAll(customPattern)];
         expect(matches).toHaveLength(1);
         expect(matches[0][1]).toBe('./src/a.ts');
       });

--- a/packages/rangelink-core-ts/src/__tests__/utils/escapeRegex.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/utils/escapeRegex.test.ts
@@ -149,9 +149,7 @@ describe('escapeRegex', () => {
       const escapedPosition = escapeRegex(position);
       const escapedRange = escapeRegex(range);
 
-      const pattern = new RegExp(
-        `^${escapedLine}(\\d+)${escapedPosition}(\\d+)${escapedRange}${escapedLine}(\\d+)$`,
-      );
+      const pattern = new RegExp(`^${escapedLine}(\\d+)${escapedPosition}(\\d+)${escapedRange}${escapedLine}(\\d+)$`);
 
       expect('L10.5+L20').toMatch(pattern);
     });

--- a/packages/rangelink-core-ts/src/__tests__/utils/quoteLink.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/utils/quoteLink.test.ts
@@ -9,9 +9,7 @@ describe('quoteLink', () => {
 
   describe('unsafe paths (wraps entire link)', () => {
     it('should wrap entire link when path has spaces', () => {
-      expect(quoteLink('My Folder/file.ts#L10', 'My Folder/file.ts')).toBe(
-        "'My Folder/file.ts#L10'",
-      );
+      expect(quoteLink('My Folder/file.ts#L10', 'My Folder/file.ts')).toBe("'My Folder/file.ts#L10'");
     });
 
     it('should wrap entire link when path has hash', () => {
@@ -19,9 +17,7 @@ describe('quoteLink', () => {
     });
 
     it('should wrap entire link when path has parentheses', () => {
-      expect(quoteLink('src/(group)/file.ts#L10', 'src/(group)/file.ts')).toBe(
-        "'src/(group)/file.ts#L10'",
-      );
+      expect(quoteLink('src/(group)/file.ts#L10', 'src/(group)/file.ts')).toBe("'src/(group)/file.ts#L10'");
     });
   });
 

--- a/packages/rangelink-core-ts/src/detection/classifyOverlap.ts
+++ b/packages/rangelink-core-ts/src/detection/classifyOverlap.ts
@@ -8,9 +8,7 @@ import type { OccupiedRange } from './types';
  * - 'encompassing': Candidate fully wraps one or more occupied ranges — replace them
  */
 export type OverlapClassification =
-  | { readonly type: 'none' }
-  | { readonly type: 'partial' }
-  | { readonly type: 'encompassing'; readonly encompassedIndices: number[] };
+  { readonly type: 'none' } | { readonly type: 'partial' } | { readonly type: 'encompassing'; readonly encompassedIndices: number[] };
 
 /**
  * Classify how a candidate range overlaps with existing occupied ranges.
@@ -28,11 +26,7 @@ export type OverlapClassification =
  * @param occupiedRanges - Array of already-occupied ranges
  * @returns Classification result
  */
-export const classifyOverlap = (
-  candidateStart: number,
-  candidateEnd: number,
-  occupiedRanges: readonly OccupiedRange[],
-): OverlapClassification => {
+export const classifyOverlap = (candidateStart: number, candidateEnd: number, occupiedRanges: readonly OccupiedRange[]): OverlapClassification => {
   const encompassedIndices: number[] = [];
 
   for (let i = 0; i < occupiedRanges.length; i++) {

--- a/packages/rangelink-core-ts/src/detection/detectUnquotedLinks.ts
+++ b/packages/rangelink-core-ts/src/detection/detectUnquotedLinks.ts
@@ -66,10 +66,7 @@ export const detectUnquotedLinks = (
     const parseResult = parseLink(trimmedMatch, delimiters);
     if (!parseResult.success) {
       parseFailures++;
-      logger.debug(
-        { fn: 'detectUnquotedLinks', link: trimmedMatch, error: parseResult.error },
-        'Skipping link that failed to parse',
-      );
+      logger.debug({ fn: 'detectUnquotedLinks', link: trimmedMatch, error: parseResult.error }, 'Skipping link that failed to parse');
       continue;
     }
 

--- a/packages/rangelink-core-ts/src/detection/findLinksInText.ts
+++ b/packages/rangelink-core-ts/src/detection/findLinksInText.ts
@@ -27,31 +27,13 @@ export type { Cancellable } from './types';
  * @param token - Optional cancellation token
  * @returns Array of detected links with parsed data
  */
-export const findLinksInText = (
-  text: string,
-  delimiters: DelimiterConfig,
-  logger: Logger,
-  token?: Cancellable,
-): DetectedLink[] => {
+export const findLinksInText = (text: string, delimiters: DelimiterConfig, logger: Logger, token?: Cancellable): DetectedLink[] => {
   const logCtx = { fn: 'findLinksInText' };
 
   const pattern = buildLinkPattern(delimiters);
-  const { links, occupiedRanges, unquotedMatches, parseFailures } = detectUnquotedLinks(
-    text,
-    pattern,
-    delimiters,
-    logger,
-    token,
-  );
+  const { links, occupiedRanges, unquotedMatches, parseFailures } = detectUnquotedLinks(text, pattern, delimiters, logger, token);
 
-  const { quotedCandidates, quotedParseFailures, quotedReplacements } = detectQuotedLinks(
-    text,
-    links,
-    occupiedRanges,
-    delimiters,
-    logger,
-    token,
-  );
+  const { quotedCandidates, quotedParseFailures, quotedReplacements } = detectQuotedLinks(text, links, occupiedRanges, delimiters, logger, token);
 
   const hasActivity = links.length > 0 || parseFailures > 0 || quotedCandidates > 0;
   if (hasActivity) {

--- a/packages/rangelink-core-ts/src/formatting/composePortableMetadata.ts
+++ b/packages/rangelink-core-ts/src/formatting/composePortableMetadata.ts
@@ -10,10 +10,7 @@ import { RangeFormat } from '../types/RangeFormat';
  * @param rangeFormat Whether to include the position delimiter in metadata
  * @returns Metadata string (e.g., "~#~L~-~C~" or "~#~L~-~")
  */
-export const composePortableMetadata = (
-  delimiters: DelimiterConfig,
-  rangeFormat: RangeFormat,
-): string => {
+export const composePortableMetadata = (delimiters: DelimiterConfig, rangeFormat: RangeFormat): string => {
   const { hash, line, range, position } = delimiters;
   const parts = [hash, line, range];
   if (rangeFormat === RangeFormat.WithPositions) {

--- a/packages/rangelink-core-ts/src/formatting/finalizeLinkGeneration.ts
+++ b/packages/rangelink-core-ts/src/formatting/finalizeLinkGeneration.ts
@@ -43,10 +43,7 @@ export const finalizeLinkGeneration = (
   const { link: baseLink, logContext } = generateLink();
 
   // Append BYOD metadata for portable links (creates new string, doesn't mutate)
-  const rawLink =
-    linkType === LinkType.Portable
-      ? baseLink + composePortableMetadata(delimiters, spec.rangeFormat)
-      : baseLink;
+  const rawLink = linkType === LinkType.Portable ? baseLink + composePortableMetadata(delimiters, spec.rangeFormat) : baseLink;
 
   const link = quoteLink(rawLink, path);
 

--- a/packages/rangelink-core-ts/src/formatting/formatLink.ts
+++ b/packages/rangelink-core-ts/src/formatting/formatLink.ts
@@ -20,12 +20,7 @@ import { joinWithHash } from './joinWithHash';
  * @param delimiters Delimiter configuration
  * @param options Optional formatting options
  */
-export function formatLink(
-  path: string,
-  inputSelection: InputSelection,
-  delimiters: DelimiterConfig,
-  options?: FormatOptions,
-): CoreResult<FormattedLink> {
+export function formatLink(path: string, inputSelection: InputSelection, delimiters: DelimiterConfig, options?: FormatOptions): CoreResult<FormattedLink> {
   // Validate and compute range spec
   const specResult = computeRangeSpec(inputSelection, options);
   if (!specResult.success) {
@@ -36,11 +31,7 @@ export function formatLink(
   const linkType = options?.linkType ?? LinkType.Regular;
 
   // Special case: single-line full-line selection
-  if (
-    spec.startLine === spec.endLine &&
-    spec.rangeFormat === 'LineOnly' &&
-    spec.startPosition === undefined
-  ) {
+  if (spec.startLine === spec.endLine && spec.rangeFormat === 'LineOnly' && spec.startPosition === undefined) {
     return finalizeLinkGeneration(
       () => ({
         link: formatSimpleLineReference(path, spec.startLine, delimiters),
@@ -57,14 +48,7 @@ export function formatLink(
   }
 
   // Build standard anchor
-  const anchor = buildAnchor(
-    spec.startLine,
-    spec.endLine,
-    spec.startPosition,
-    spec.endPosition,
-    delimiters,
-    spec.rangeFormat,
-  );
+  const anchor = buildAnchor(spec.startLine, spec.endLine, spec.startPosition, spec.endPosition, delimiters, spec.rangeFormat);
 
   return finalizeLinkGeneration(
     () => ({

--- a/packages/rangelink-core-ts/src/formatting/formatSimpleLineReference.ts
+++ b/packages/rangelink-core-ts/src/formatting/formatSimpleLineReference.ts
@@ -9,11 +9,7 @@ import { DelimiterConfig } from '../types/DelimiterConfig';
  * @param delimiters Delimiter configuration
  * @returns Formatted link (e.g., "src/file.ts#L10")
  */
-export function formatSimpleLineReference(
-  path: string,
-  line: number,
-  delimiters: DelimiterConfig,
-): string {
+export function formatSimpleLineReference(path: string, line: number, delimiters: DelimiterConfig): string {
   const { hash: delimHash, line: delimLine } = delimiters;
   return `${path}${delimHash}${delimLine}${line}`;
 }

--- a/packages/rangelink-core-ts/src/formatting/joinWithHash.ts
+++ b/packages/rangelink-core-ts/src/formatting/joinWithHash.ts
@@ -10,14 +10,8 @@ import { SelectionType } from '../types/SelectionType';
  * @param selectionType Selection type (Normal = single hash, Rectangular = double hash)
  * @returns Formatted link (e.g., "path#L10" or "path##L10C5-L20C10")
  */
-export function joinWithHash(
-  path: string,
-  anchor: string,
-  delimiters: DelimiterConfig,
-  selectionType: SelectionType = SelectionType.Normal,
-): string {
+export function joinWithHash(path: string, anchor: string, delimiters: DelimiterConfig, selectionType: SelectionType = SelectionType.Normal): string {
   const { hash: delimHash } = delimiters;
-  const prefix =
-    selectionType === SelectionType.Rectangular ? `${delimHash}${delimHash}` : `${delimHash}`;
+  const prefix = selectionType === SelectionType.Rectangular ? `${delimHash}${delimHash}` : `${delimHash}`;
   return `${path}${prefix}${anchor}`;
 }

--- a/packages/rangelink-core-ts/src/parsing/parseLink.ts
+++ b/packages/rangelink-core-ts/src/parsing/parseLink.ts
@@ -33,16 +33,11 @@ import { quotePath } from '../utils/quotePath';
  * @param link - The RangeLink string to parse (e.g., "src/auth.ts#L42C10-L58C25")
  * @param delimiters - Delimiter configuration to use for parsing
  */
-export const parseLink = (
-  linkInput: string,
-  delimiters: DelimiterConfig,
-): CoreResult<ParsedLink> => {
+export const parseLink = (linkInput: string, delimiters: DelimiterConfig): CoreResult<ParsedLink> => {
   // Strip surrounding quotes (single or double) so quoted links round-trip correctly
   const firstChar = linkInput[0];
   const lastChar = linkInput[linkInput.length - 1];
-  const isQuoted =
-    linkInput.length > 2 &&
-    ((firstChar === "'" && lastChar === "'") || (firstChar === '"' && lastChar === '"'));
+  const isQuoted = linkInput.length > 2 && ((firstChar === "'" && lastChar === "'") || (firstChar === '"' && lastChar === '"'));
   const link = isQuoted ? linkInput.slice(1, -1) : linkInput;
 
   // Check link length for safety
@@ -165,9 +160,7 @@ export const parseLink = (
   // Single hash (e.g., "#") → Normal mode
   // Double hash (e.g., "##") → Rectangular mode
   const isRectangular = capturedHash.length === delimiters.hash.length * 2;
-  const selectionType: SelectionType = isRectangular
-    ? SelectionType.Rectangular
-    : SelectionType.Normal;
+  const selectionType: SelectionType = isRectangular ? SelectionType.Rectangular : SelectionType.Normal;
 
   // Link type is always 'Regular' for now (BYOD parsing deferred to Phase 1C)
   const linkType: LinkType = LinkType.Regular;

--- a/packages/rangelink-core-ts/src/selection/computeRangeSpec.ts
+++ b/packages/rangelink-core-ts/src/selection/computeRangeSpec.ts
@@ -17,10 +17,7 @@ import { validateInputSelection } from './validateInputSelection';
  * @param inputSelection InputSelection containing selections array and selectionType
  * @param options Optional formatting parameters (notation, linkType, etc.)
  */
-export function computeRangeSpec(
-  inputSelection: InputSelection,
-  options?: FormatOptions,
-): CoreResult<ComputedSelection> {
+export function computeRangeSpec(inputSelection: InputSelection, options?: FormatOptions): CoreResult<ComputedSelection> {
   try {
     validateInputSelection(inputSelection);
   } catch (error) {
@@ -36,10 +33,7 @@ export function computeRangeSpec(
 
   // Convert to 1-based indexing
   const startLine = primary.start.line + 1;
-  const endLine =
-    (selectionType === SelectionType.Rectangular
-      ? selections[selections.length - 1].start.line
-      : primary.end.line) + 1;
+  const endLine = (selectionType === SelectionType.Rectangular ? selections[selections.length - 1].start.line : primary.end.line) + 1;
   const startPosition = primary.start.character + 1;
   const endPosition = primary.end.character + 1;
 

--- a/packages/rangelink-core-ts/src/selection/validateInputSelection.ts
+++ b/packages/rangelink-core-ts/src/selection/validateInputSelection.ts
@@ -31,12 +31,7 @@ export function validateInputSelection(inputSelection: InputSelection): void {
   for (let i = 0; i < selections.length; i++) {
     const sel = selections[i];
 
-    if (
-      sel.start.line < 0 ||
-      sel.end.line < 0 ||
-      sel.start.character < 0 ||
-      sel.end.character < 0
-    ) {
+    if (sel.start.line < 0 || sel.end.line < 0 || sel.start.character < 0 || sel.end.character < 0) {
       throw new RangeLinkError({
         code: RangeLinkErrorCodes.SELECTION_NEGATIVE_COORDINATES,
         message: `Negative coordinates not allowed (startLine=${sel.start.line}, endLine=${sel.end.line}, startCharacter=${sel.start.character}, endCharacter=${sel.end.character})`,
@@ -78,11 +73,7 @@ export function validateInputSelection(inputSelection: InputSelection): void {
       });
     }
 
-    if (
-      sel.start.line === sel.end.line &&
-      sel.start.character === sel.end.character &&
-      sel.coverage !== SelectionCoverage.FullLine
-    ) {
+    if (sel.start.line === sel.end.line && sel.start.character === sel.end.character && sel.coverage !== SelectionCoverage.FullLine) {
       throw new RangeLinkError({
         code: RangeLinkErrorCodes.SELECTION_ZERO_WIDTH,
         message: `Zero-width selection not allowed (cursor position at line ${sel.start.line}, character ${sel.start.character})`,

--- a/packages/rangelink-core-ts/src/selection/validateRectangularMode.ts
+++ b/packages/rangelink-core-ts/src/selection/validateRectangularMode.ts
@@ -44,10 +44,7 @@ export const validateRectangularMode = (selections: InputSelection['selections']
 
   for (let i = 1; i < selections.length; i++) {
     const sel = selections[i];
-    if (
-      sel.start.character !== expectedStartCharacter ||
-      sel.end.character !== expectedEndCharacter
-    ) {
+    if (sel.start.character !== expectedStartCharacter || sel.end.character !== expectedEndCharacter) {
       throw new RangeLinkError({
         code: RangeLinkErrorCodes.SELECTION_RECTANGULAR_MISMATCHED_COLUMNS,
         message: `Rectangular mode requires consistent column range (expected ${expectedStartCharacter}-${expectedEndCharacter}, got ${sel.start.character}-${sel.end.character} at selection ${i})`,

--- a/packages/rangelink-core-ts/src/utils/buildLinkPattern.ts
+++ b/packages/rangelink-core-ts/src/utils/buildLinkPattern.ts
@@ -109,8 +109,7 @@ export const buildLinkPattern = (delimiters: DelimiterConfig): RegExp => {
  * Single-quoted matches capture path content (without quotes) in named group `sq`.
  * All other patterns produce no named groups — match[0] is the full unquoted path.
  */
-export const extractFilePath = (match: RegExpExecArray): string =>
-  match.groups?.dq ?? match.groups?.sq ?? match[0];
+export const extractFilePath = (match: RegExpExecArray): string => match.groups?.dq ?? match.groups?.sq ?? match[0];
 
 // Quoted file-path patterns for buildFilePathPattern.
 //
@@ -178,8 +177,5 @@ export const buildFilePathPattern = (delimiters: DelimiterConfig): RegExp => {
   const relative = `${NOT_AFTER_URL_CHAR}\\.{1,2}/[\\w\\-./@]+\\.\\w+${notBeforeRangeLink}`;
   const tilde = `${NOT_AFTER_URL_CHAR}~/[\\w\\-./@]+\\.\\w+${notBeforeRangeLink}`;
 
-  return new RegExp(
-    `${DOUBLE_QUOTED_PATH}|${SINGLE_QUOTED_PATH}|${absolute}|${relative}|${tilde}`,
-    'g',
-  );
+  return new RegExp(`${DOUBLE_QUOTED_PATH}|${SINGLE_QUOTED_PATH}|${absolute}|${relative}|${tilde}`, 'g');
 };

--- a/packages/rangelink-vscode-extension/.vscode-test.base.mjs
+++ b/packages/rangelink-vscode-extension/.vscode-test.base.mjs
@@ -7,10 +7,7 @@ export const ASSISTED_TIMEOUT_MS = 600_000;
 // No human in CI — automated tests resolve in under 5s.
 export const CI_TIMEOUT_MS = 20_000;
 
-export const userDataDir = (suffix = '') => [
-  '--user-data-dir',
-  path.join(os.tmpdir(), `rl-vscode-test${suffix}`),
-];
+export const userDataDir = (suffix = '') => ['--user-data-dir', path.join(os.tmpdir(), `rl-vscode-test${suffix}`)];
 
 // grep and invert are driven by env vars set in test-release-run.sh.
 const envMocha = () => ({

--- a/packages/rangelink-vscode-extension/esbuild.config.mjs
+++ b/packages/rangelink-vscode-extension/esbuild.config.mjs
@@ -1,4 +1,5 @@
-const esbuild = require('esbuild');
+import esbuild from 'esbuild';
+import { fileURLToPath } from 'node:url';
 
 const config = {
   entryPoints: ['src/extension.ts'],
@@ -10,9 +11,8 @@ const config = {
   sourcemap: true,
 };
 
-// When run directly, execute the build
-if (require.main === module) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   esbuild.build(config).catch(() => process.exit(1));
 }
 
-module.exports = config;
+export default config;

--- a/packages/rangelink-vscode-extension/jest.config.js
+++ b/packages/rangelink-vscode-extension/jest.config.js
@@ -16,13 +16,7 @@ module.exports = {
   testMatch: ['**/__tests__/**/*.test.ts', '**/*.test.ts'],
   testPathIgnorePatterns: ['<rootDir>/src/__integration-tests__/'],
   setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup/matchers.ts'],
-  collectCoverageFrom: [
-    'src/**/*.ts',
-    '!src/**/*.test.ts',
-    '!src/__tests__/**',
-    '!src/__integration-tests__/**',
-    '!src/**/index.ts',
-  ],
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts', '!src/__tests__/**', '!src/__integration-tests__/**', '!src/**/index.ts'],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'text-summary', 'html', 'lcov', 'json-summary'],
   coverageThreshold: {

--- a/packages/rangelink-vscode-extension/package.json
+++ b/packages/rangelink-vscode-extension/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "clean": "rm -rf out dist coverage *.tsbuildinfo *.vsix",
     "clean:all": "pnpm clean && rm -rf node_modules .eslintcache *.log .vscode-test",
-    "compile": "pnpm compile:deps && pnpm generate-version:all && node esbuild.config.js",
+    "compile": "pnpm compile:deps && pnpm generate-version:all && node esbuild.config.mjs",
     "compile:deps": "cd ../rangelink-core-ts && pnpm clean && pnpm compile",
     "generate:publish-instructions": "./scripts/generate-publishing-instructions.sh",
     "generate:qa-issue": "./scripts/generate-qa-issue.sh",

--- a/packages/rangelink-vscode-extension/scripts/resolve-qa-labels.js
+++ b/packages/rangelink-vscode-extension/scripts/resolve-qa-labels.js
@@ -145,10 +145,7 @@ for (const rawLine of lines) {
   if (autoMatch) {
     const raw = autoMatch[1].trim();
     currentCase.automated =
-      raw.length >= 2 &&
-      ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'")))
-        ? raw.slice(1, -1)
-        : raw;
+      raw.length >= 2 && ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) ? raw.slice(1, -1) : raw;
     inLabels = false;
     continue;
   }
@@ -157,10 +154,7 @@ for (const rawLine of lines) {
   if (reasonMatch) {
     const raw = reasonMatch[1].trim();
     currentCase.nonAutomatableReason =
-      raw.length >= 2 &&
-      ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'")))
-        ? raw.slice(1, -1)
-        : raw;
+      raw.length >= 2 && ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) ? raw.slice(1, -1) : raw;
     inLabels = false;
     continue;
   }
@@ -169,9 +163,7 @@ for (const rawLine of lines) {
   if (featMatch) {
     const rawFeature = featMatch[1].trim();
     currentCase.feature =
-      rawFeature.length >= 2 &&
-      ((rawFeature.startsWith('"') && rawFeature.endsWith('"')) ||
-        (rawFeature.startsWith("'") && rawFeature.endsWith("'")))
+      rawFeature.length >= 2 && ((rawFeature.startsWith('"') && rawFeature.endsWith('"')) || (rawFeature.startsWith("'") && rawFeature.endsWith("'")))
         ? rawFeature.slice(1, -1)
         : rawFeature;
     inLabels = false;
@@ -182,9 +174,7 @@ for (const rawLine of lines) {
   if (scenarioMatch) {
     const rawScenario = scenarioMatch[1].trim();
     currentCase.scenario =
-      rawScenario.length >= 2 &&
-      ((rawScenario.startsWith('"') && rawScenario.endsWith('"')) ||
-        (rawScenario.startsWith("'") && rawScenario.endsWith("'")))
+      rawScenario.length >= 2 && ((rawScenario.startsWith('"') && rawScenario.endsWith('"')) || (rawScenario.startsWith("'") && rawScenario.endsWith("'")))
         ? rawScenario.slice(1, -1)
         : rawScenario;
     inLabels = false;

--- a/packages/rangelink-vscode-extension/scripts/setup-integration-test-settings.js
+++ b/packages/rangelink-vscode-extension/scripts/setup-integration-test-settings.js
@@ -43,9 +43,7 @@ const settings = {
     {
       extensionId: 'rangelink.dummy-ai-extension-template',
       extensionName: 'Dummy AI (Template)',
-      insertCommands: [
-        { command: 'dummyAi.insertWithArgs', args: [{ text: '${content}', source: 'rangelink' }] },
-      ],
+      insertCommands: [{ command: 'dummyAi.insertWithArgs', args: [{ text: '${content}', source: 'rangelink' }] }],
     },
     {
       extensionId: 'rangelink.dummy-ai-extension-fallback',
@@ -89,7 +87,5 @@ const merged = { ...existing, ...settings };
 fs.writeFileSync(SETTINGS_FILE, JSON.stringify(merged, null, 2));
 
 const assistantCount = settings['rangelink.customAiAssistants'].length;
-console.log(
-  `[setup-integration-test-settings] Wrote ${SETTINGS_FILE} with ${assistantCount} custom AI assistant(s)`,
-);
+console.log(`[setup-integration-test-settings] Wrote ${SETTINGS_FILE} with ${assistantCount} custom AI assistant(s)`);
 console.log(`CUSTOM_AI_COUNT=${assistantCount}`);

--- a/packages/rangelink-vscode-extension/src/SubscriptionRegistrar.ts
+++ b/packages/rangelink-vscode-extension/src/SubscriptionRegistrar.ts
@@ -10,37 +10,23 @@ import type * as vscode from 'vscode';
  */
 export interface SubscriptionRegistrar {
   registerCommand(id: string, handler: (...args: unknown[]) => unknown): void;
-  registerTerminalLinkProvider<T extends vscode.TerminalLink>(
-    provider: vscode.TerminalLinkProvider<T>,
-    logMessage: string,
-  ): void;
-  registerDocumentLinkProvider(
-    selector: vscode.DocumentSelector,
-    provider: vscode.DocumentLinkProvider,
-    logMessage: string,
-  ): void;
+  registerTerminalLinkProvider<T extends vscode.TerminalLink>(provider: vscode.TerminalLinkProvider<T>, logMessage: string): void;
+  registerDocumentLinkProvider(selector: vscode.DocumentSelector, provider: vscode.DocumentLinkProvider, logMessage: string): void;
   pushDisposable(disposable: { dispose(): void }): void;
 }
 
 /**
  * Production SubscriptionRegistrar that delegates to context.subscriptions and ideAdapter.
  */
-export const createSubscriptionRegistrar = (
-  context: vscode.ExtensionContext,
-  ideAdapter: VscodeAdapter,
-): SubscriptionRegistrar => ({
+export const createSubscriptionRegistrar = (context: vscode.ExtensionContext, ideAdapter: VscodeAdapter): SubscriptionRegistrar => ({
   registerCommand: (id, handler) => {
     context.subscriptions.push(ideAdapter.registerCommand(id, handler));
   },
   registerTerminalLinkProvider: (provider, logMessage) => {
-    context.subscriptions.push(
-      registerWithLogging(ideAdapter.registerTerminalLinkProvider(provider), logMessage),
-    );
+    context.subscriptions.push(registerWithLogging(ideAdapter.registerTerminalLinkProvider(provider), logMessage));
   },
   registerDocumentLinkProvider: (selector, provider, logMessage) => {
-    context.subscriptions.push(
-      registerWithLogging(ideAdapter.registerDocumentLinkProvider(selector, provider), logMessage),
-    );
+    context.subscriptions.push(registerWithLogging(ideAdapter.registerDocumentLinkProvider(selector, provider), logMessage));
   },
   pushDisposable: (disposable) => {
     context.subscriptions.push(disposable);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/assistedTestHelper.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/assistedTestHelper.ts
@@ -19,11 +19,7 @@ const SECTION_LINE = '─'.repeat(SECTION_LINE_WIDTH);
  * @param action - Short mechanical action the human should perform (notification title after TC ID)
  * @param consoleSteps - Optional extra step lines for multi-step actions (e.g., secondary picker flows)
  */
-export const waitForHuman = async (
-  tcId: string,
-  action: string,
-  consoleSteps?: string[],
-): Promise<void> => {
+export const waitForHuman = async (tcId: string, action: string, consoleSteps?: string[]): Promise<void> => {
   nodeConsole.log(`\n${SECTION_LINE}`);
   nodeConsole.log(`[${tcId}] ${action}`);
   if (consoleSteps !== undefined) {
@@ -104,11 +100,7 @@ let activeVerdictReject: ((reason: unknown) => void) | undefined;
  * @param consoleSteps - Optional bulleted steps (shown in the terminal console)
  * @returns `'pass'` if the human clicked the Pass status bar item, `'fail'` otherwise
  */
-export const waitForHumanVerdict = (
-  tcId: string,
-  action: string,
-  consoleSteps?: string[],
-): Promise<HumanVerdict> => {
+export const waitForHumanVerdict = (tcId: string, action: string, consoleSteps?: string[]): Promise<HumanVerdict> => {
   nodeConsole.log(`\n${SECTION_LINE}`);
   nodeConsole.log(`[${tcId}] ${action}`);
   if (consoleSteps !== undefined) {

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/capturingPtyHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/capturingPtyHelpers.ts
@@ -29,10 +29,7 @@ export interface CapturingTerminal {
  * running an assisted test can still see what arrived; the same input is
  * simultaneously appended to the captured buffer for assertion.
  */
-export const createCapturingTerminal = async (
-  name: string,
-  trackingArray?: vscode.Terminal[],
-): Promise<CapturingTerminal> => {
+export const createCapturingTerminal = async (name: string, trackingArray?: vscode.Terminal[]): Promise<CapturingTerminal> => {
   const writeEmitter = new vscode.EventEmitter<string>();
   let captured = '';
 
@@ -75,10 +72,7 @@ export const createCapturingTerminal = async (
  * Mirrors `createAndBindTerminal` but returns a `CapturingTerminal` so tests
  * can read back what the extension actually sent.
  */
-export const createAndBindCapturingTerminal = async (
-  name: string,
-  trackingArray?: vscode.Terminal[],
-): Promise<CapturingTerminal> => {
+export const createAndBindCapturingTerminal = async (name: string, trackingArray?: vscode.Terminal[]): Promise<CapturingTerminal> => {
   const capturing = await createCapturingTerminal(name, trackingArray);
   try {
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
@@ -96,11 +90,7 @@ export const createAndBindCapturingTerminal = async (
  */
 export const assertTerminalBufferEquals = (captured: string, expected: string): void => {
   const normalized = captured.replace(/\r\n/g, '\n').replace(/\r/g, '\n').replace(/\n$/, '');
-  assert.strictEqual(
-    normalized,
-    expected,
-    `Terminal buffer mismatch:\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(normalized)}`,
-  );
+  assert.strictEqual(normalized, expected, `Terminal buffer mismatch:\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(normalized)}`);
 };
 
 /**
@@ -114,18 +104,12 @@ export const assertTerminalBufferContains = (captured: string, expected: string)
   );
 };
 
-export const assertTerminalBufferEqualsGeneratedLink = (
-  capturing: CapturingTerminal,
-  marker: string,
-): void => {
+export const assertTerminalBufferEqualsGeneratedLink = (capturing: CapturingTerminal, marker: string): void => {
   const generatedLink = getGeneratedLink(marker, { smartPad: 'both' });
   assertTerminalBufferEquals(capturing.getCapturedText(), generatedLink);
 };
 
-export const assertTerminalBufferContainsGeneratedLink = (
-  capturing: CapturingTerminal,
-  marker: string,
-): void => {
+export const assertTerminalBufferContainsGeneratedLink = (capturing: CapturingTerminal, marker: string): void => {
   const generatedLink = getGeneratedLink(marker, { smartPad: 'both' });
   assertTerminalBufferContains(capturing.getCapturedText(), generatedLink);
 };

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/clipboardHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/clipboardHelpers.ts
@@ -13,35 +13,21 @@ export const writeClipboardSentinel = async (): Promise<void> => {
 
 export const assertClipboardChanged = async (context: string): Promise<string> => {
   const content = await vscode.env.clipboard.readText();
-  assert.notStrictEqual(
-    content,
-    CLIPBOARD_SENTINEL,
-    `${context}: clipboard should have changed from sentinel`,
-  );
+  assert.notStrictEqual(content, CLIPBOARD_SENTINEL, `${context}: clipboard should have changed from sentinel`);
   return content;
 };
 
 export const assertClipboardRestored = async (context: string): Promise<void> => {
   const content = await vscode.env.clipboard.readText();
-  assert.strictEqual(
-    content,
-    CLIPBOARD_SENTINEL,
-    `${context}: clipboard should be restored to sentinel`,
-  );
+  assert.strictEqual(content, CLIPBOARD_SENTINEL, `${context}: clipboard should be restored to sentinel`);
 };
 
 export const assertClipboardPreservationRan = (markName: string, operationLabel: string): void => {
   const lines = getLogCapture().getLinesSince(markName);
   const savedIdx = lines.findIndex((l) => parseLogContext(l)?.fn.endsWith('::read'));
   const restoredIdx = lines.findIndex((l) => parseLogContext(l)?.fn.endsWith('::restoreClipboard'));
-  assert.ok(
-    savedIdx >= 0,
-    'Expected "Clipboard current value read and saved" log entry — preservation must read clipboard',
-  );
-  assert.ok(
-    restoredIdx > savedIdx,
-    `Expected "Clipboard restored" log entry after ${operationLabel} operation`,
-  );
+  assert.ok(savedIdx >= 0, 'Expected "Clipboard current value read and saved" log entry — preservation must read clipboard');
+  assert.ok(restoredIdx > savedIdx, `Expected "Clipboard restored" log entry after ${operationLabel} operation`);
 };
 
 export const withClipboardSentinel = async (
@@ -61,20 +47,13 @@ export const withClipboardSentinel = async (
   await assertClipboardRestored(`${operationLabel}: clipboard sentinel check`);
 };
 
-export const withClipboardRestored = async (
-  context: string,
-  fn: () => Promise<void>,
-): Promise<void> => {
+export const withClipboardRestored = async (context: string, fn: () => Promise<void>): Promise<void> => {
   await writeClipboardSentinel();
   await fn();
   await assertClipboardRestored(context);
 };
 
-export const withClipboardChanged = async (
-  operationLabel: string,
-  fn: () => Promise<void>,
-  marker?: string,
-): Promise<string> => {
+export const withClipboardChanged = async (operationLabel: string, fn: () => Promise<void>, marker?: string): Promise<string> => {
   await writeClipboardSentinel();
   if (marker) {
     getLogCapture().mark(marker);
@@ -99,14 +78,8 @@ export const assertClipboardPreservationDidNotRun = (markName: string): void => 
 
 const PRIOR_CLIPBOARD_DIAG_MAX_LEN = 200;
 
-const buildPriorClipboardDiagNote = (
-  priorClipboard: string,
-  clipboardAfterAction: string,
-): string => {
-  const snippet =
-    priorClipboard.length > PRIOR_CLIPBOARD_DIAG_MAX_LEN
-      ? `${priorClipboard.substring(0, PRIOR_CLIPBOARD_DIAG_MAX_LEN)}…`
-      : priorClipboard;
+const buildPriorClipboardDiagNote = (priorClipboard: string, clipboardAfterAction: string): string => {
+  const snippet = priorClipboard.length > PRIOR_CLIPBOARD_DIAG_MAX_LEN ? `${priorClipboard.substring(0, PRIOR_CLIPBOARD_DIAG_MAX_LEN)}…` : priorClipboard;
 
   if (priorClipboard === clipboardAfterAction) {
     return `\nClipboard unchanged from prior value "${snippet}" — test action may not have written to clipboard.`;
@@ -114,21 +87,12 @@ const buildPriorClipboardDiagNote = (
   return `\nPrior clipboard (before sentinel write): "${snippet}"`;
 };
 
-export const assertClipboardEquals = async (
-  operationLabel: string,
-  fn: () => Promise<void>,
-  expected: string,
-  marker?: string,
-): Promise<string> => {
+export const assertClipboardEquals = async (operationLabel: string, fn: () => Promise<void>, expected: string, marker?: string): Promise<string> => {
   const priorClipboard = await vscode.env.clipboard.readText();
   const clipboard = await withClipboardChanged(operationLabel, fn, marker);
   const priorNote = buildPriorClipboardDiagNote(priorClipboard, clipboard);
 
-  assert.strictEqual(
-    clipboard,
-    expected,
-    `Expected clipboard to equal "${expected}", got: "${clipboard}"${priorNote}`,
-  );
+  assert.strictEqual(clipboard, expected, `Expected clipboard to equal "${expected}", got: "${clipboard}"${priorNote}`);
   return clipboard;
 };
 
@@ -142,10 +106,6 @@ export const assertClipboardEqualsGeneratedLink = async (
   const generatedLink = getGeneratedLink(marker);
   const priorNote = buildPriorClipboardDiagNote(priorClipboard, clipboard);
 
-  assert.strictEqual(
-    clipboard,
-    generatedLink,
-    `Expected clipboard to equal generated link "${generatedLink}", got: "${clipboard}"${priorNote}`,
-  );
+  assert.strictEqual(clipboard, generatedLink, `Expected clipboard to equal generated link "${generatedLink}", got: "${clipboard}"${priorNote}`);
   return { clipboard, generatedLink };
 };

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/editorHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/editorHelpers.ts
@@ -2,10 +2,7 @@ import { POLL_INTERVAL_MS, POLL_TIMEOUT_MS, settle } from './testEnv';
 
 import * as vscode from 'vscode';
 
-export const waitForActiveEditor = async (
-  expectedUri: string,
-  log: (msg: string) => void,
-): Promise<boolean> => {
+export const waitForActiveEditor = async (expectedUri: string, log: (msg: string) => void): Promise<boolean> => {
   const start = Date.now();
   while (Date.now() - start < POLL_TIMEOUT_MS) {
     const activeUri = vscode.window.activeTextEditor?.document.uri.toString();
@@ -38,16 +35,8 @@ export const clearEditorSelection = async (): Promise<void> => {
   }
 };
 
-export const openUntitledDoc = async (options?: {
-  content?: string;
-  language?: string;
-  viewColumn?: vscode.ViewColumn;
-}): Promise<vscode.TextDocument> => {
-  const {
-    content = '',
-    language = 'plaintext',
-    viewColumn = vscode.ViewColumn.One,
-  } = options ?? {};
+export const openUntitledDoc = async (options?: { content?: string; language?: string; viewColumn?: vscode.ViewColumn }): Promise<vscode.TextDocument> => {
+  const { content = '', language = 'plaintext', viewColumn = vscode.ViewColumn.One } = options ?? {};
   const doc = await vscode.workspace.openTextDocument({ content, language });
   await vscode.window.showTextDocument(doc, viewColumn);
   await settle();
@@ -57,8 +46,5 @@ export const openUntitledDoc = async (options?: {
 export const selectAll = (editor: vscode.TextEditor): void => {
   const lastLine = editor.document.lineCount - 1;
   const lastChar = editor.document.lineAt(lastLine).text.length;
-  editor.selection = new vscode.Selection(
-    new vscode.Position(0, 0),
-    new vscode.Position(lastLine, lastChar),
-  );
+  editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(lastLine, lastChar));
 };

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/fileHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/fileHelpers.ts
@@ -26,21 +26,14 @@ const ensureParentDir = (filePath: string): void => {
 
 export const createWorkspaceFile = (descriptor: string, content: string): vscode.Uri => {
   fileCounter++;
-  const filePath = path.join(
-    getWorkspaceRoot(),
-    `__rl-test-${descriptor}-${Date.now()}-${fileCounter}.txt`,
-  );
+  const filePath = path.join(getWorkspaceRoot(), `__rl-test-${descriptor}-${Date.now()}-${fileCounter}.txt`);
   fs.writeFileSync(filePath, content, 'utf8');
   const uri = vscode.Uri.file(filePath);
   registerFileForCleanup(uri);
   return uri;
 };
 
-export const createAndOpenFile = async (
-  descriptor: string,
-  content: string,
-  viewColumn?: vscode.ViewColumn,
-): Promise<vscode.Uri> => {
+export const createAndOpenFile = async (descriptor: string, content: string, viewColumn?: vscode.ViewColumn): Promise<vscode.Uri> => {
   const uri = createWorkspaceFile(descriptor, content);
   const doc = await vscode.workspace.openTextDocument(uri);
   await vscode.window.showTextDocument(doc, {
@@ -51,16 +44,8 @@ export const createAndOpenFile = async (
   return uri;
 };
 
-export const findTestItemsByPrefix = (
-  items: Record<string, unknown>[],
-  prefix: string,
-): Record<string, unknown>[] =>
-  items.filter(
-    (item) =>
-      item.itemKind === 'bindable' &&
-      typeof item.label === 'string' &&
-      (item.label as string).includes(prefix),
-  );
+export const findTestItemsByPrefix = (items: Record<string, unknown>[], prefix: string): Record<string, unknown>[] =>
+  items.filter((item) => item.itemKind === 'bindable' && typeof item.label === 'string' && (item.label as string).includes(prefix));
 
 export const createFileAt = (filename: string, content: string): vscode.Uri => {
   const filePath = path.join(getWorkspaceRoot(), filename);
@@ -75,21 +60,13 @@ const PNG_MAGIC_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a
 
 export type PngFixtureMode = 'real-image' | 'magic-only';
 
-export const createPngFixture = (
-  descriptor: string,
-  mode: PngFixtureMode = 'real-image',
-): vscode.Uri => {
+export const createPngFixture = (descriptor: string, mode: PngFixtureMode = 'real-image'): vscode.Uri => {
   fileCounter++;
-  const pngPath = path.join(
-    getWorkspaceRoot(),
-    `__rl-test-${descriptor}-${Date.now()}-${fileCounter}.png`,
-  );
+  const pngPath = path.join(getWorkspaceRoot(), `__rl-test-${descriptor}-${Date.now()}-${fileCounter}.png`);
   if (mode === 'real-image') {
     const extension = vscode.extensions.getExtension('couimet.rangelink-vscode-extension');
     if (!extension) {
-      throw new Error(
-        'createPngFixture(real-image) requires the RangeLink extension to be registered',
-      );
+      throw new Error('createPngFixture(real-image) requires the RangeLink extension to be registered');
     }
     fs.copyFileSync(path.join(extension.extensionPath, 'icon.png'), pngPath);
   } else {
@@ -100,10 +77,7 @@ export const createPngFixture = (
   return uri;
 };
 
-export const openEditor = async (
-  uri: vscode.Uri,
-  viewColumn?: vscode.ViewColumn,
-): Promise<vscode.TextEditor> => {
+export const openEditor = async (uri: vscode.Uri, viewColumn?: vscode.ViewColumn): Promise<vscode.TextEditor> => {
   const doc = await vscode.workspace.openTextDocument(uri);
   return vscode.window.showTextDocument(doc, viewColumn);
 };
@@ -132,10 +106,7 @@ export const closeAllEditors = async (): Promise<void> => {
  *
  * Returns the editor so callers can dispatch paste/navigate commands.
  */
-export const openSourceWithSelection = async (
-  uri: vscode.Uri,
-  viewColumn: vscode.ViewColumn,
-): Promise<vscode.TextEditor> => {
+export const openSourceWithSelection = async (uri: vscode.Uri, viewColumn: vscode.ViewColumn): Promise<vscode.TextEditor> => {
   const doc = await vscode.workspace.openTextDocument(uri);
   const editor = await vscode.window.showTextDocument(doc, viewColumn);
   const lastLine = doc.lineAt(doc.lineCount - 1);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/logBasedUiAssertions.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/logBasedUiAssertions.ts
@@ -96,11 +96,7 @@ export const assertInputBoxLogged = (lines: string[], opts: InputBoxAssertionOpt
         })
       | undefined;
 
-    return (
-      ctx?.fn === INPUT_BOX_FN &&
-      ctx.options?.prompt === opts.prompt &&
-      ctx.options?.placeHolder === opts.placeHolder
-    );
+    return ctx?.fn === INPUT_BOX_FN && ctx.options?.prompt === opts.prompt && ctx.options?.placeHolder === opts.placeHolder;
   });
   assert.ok(
     found,
@@ -112,10 +108,7 @@ export const assertInputBoxLogged = (lines: string[], opts: InputBoxAssertionOpt
  * Assert that a showQuickPick log entry contains the expected items in order.
  * Matches on the subset of fields provided in each expectation — omitted fields are not checked.
  */
-export const assertQuickPickItemsLogged = (
-  lines: string[],
-  expectedItems: QuickPickItemExpectation[],
-): void => {
+export const assertQuickPickItemsLogged = (lines: string[], expectedItems: QuickPickItemExpectation[]): void => {
   let loggedItems: Record<string, unknown>[] | undefined;
 
   for (const line of lines) {
@@ -126,27 +119,16 @@ export const assertQuickPickItemsLogged = (
     }
   }
 
-  assert.ok(
-    loggedItems !== undefined,
-    `Expected ${QUICK_PICK_FN} log entry with items but none found in ${lines.length} log lines`,
-  );
+  assert.ok(loggedItems !== undefined, `Expected ${QUICK_PICK_FN} log entry with items but none found in ${lines.length} log lines`);
 
-  assert.strictEqual(
-    loggedItems!.length,
-    expectedItems.length,
-    `Expected ${expectedItems.length} QuickPick items but logged ${loggedItems!.length}`,
-  );
+  assert.strictEqual(loggedItems!.length, expectedItems.length, `Expected ${expectedItems.length} QuickPick items but logged ${loggedItems!.length}`);
 
   for (let i = 0; i < expectedItems.length; i++) {
     const expected = expectedItems[i];
     const actual: Record<string, unknown> = loggedItems![i];
 
     for (const [key, value] of Object.entries(expected)) {
-      assert.strictEqual(
-        actual[key],
-        value,
-        `QuickPick item [${i}] field "${key}": expected "${value}" but got "${actual[key]}"`,
-      );
+      assert.strictEqual(actual[key], value, `QuickPick item [${i}] field "${key}": expected "${value}" but got "${actual[key]}"`);
     }
   }
 };
@@ -165,9 +147,7 @@ export const parseQuickPickItemsFromLogLine = (logLine: string): Record<string, 
   return ctx.items as Record<string, unknown>[];
 };
 
-export const extractQuickPickItemsLogged = (
-  lines: string[],
-): Record<string, unknown>[] | undefined => {
+export const extractQuickPickItemsLogged = (lines: string[]): Record<string, unknown>[] | undefined => {
   for (const line of lines) {
     const ctx = parseLogContext(line);
     if (ctx !== undefined && ctx.fn === QUICK_PICK_FN && Array.isArray(ctx.items)) {
@@ -177,16 +157,11 @@ export const extractQuickPickItemsLogged = (
   return undefined;
 };
 
-export const assertSuppressionLogged = (
-  lines: string[],
-  opts: SuppressionAssertionOptions,
-): void => {
+export const assertSuppressionLogged = (lines: string[], opts: SuppressionAssertionOptions): void => {
   assert.ok(
     lines.some((line) => {
       const ctx = parseLogContext(line);
-      return (
-        ctx !== undefined && ctx.fn === opts.fn && ctx.suppressedMessage === opts.suppressedMessage
-      );
+      return ctx !== undefined && ctx.fn === opts.fn && ctx.suppressedMessage === opts.suppressedMessage;
     }),
     `Expected suppression log with fn="${opts.fn}" and suppressedMessage="${opts.suppressedMessage}" but it was not found in ${lines.length} log lines`,
   );
@@ -201,12 +176,7 @@ export const assertFilePathLogged = (lines: string[], opts: FilePathAssertionOpt
           filePath?: unknown;
         })
       | undefined;
-    return (
-      ctx?.fn === FILE_PATH_FN &&
-      ctx.pathFormat === opts.pathFormat &&
-      ctx.uriSource === opts.uriSource &&
-      ctx.filePath === opts.filePath
-    );
+    return ctx?.fn === FILE_PATH_FN && ctx.pathFormat === opts.pathFormat && ctx.uriSource === opts.uriSource && ctx.filePath === opts.filePath;
   });
   assert.ok(
     found,
@@ -219,25 +189,17 @@ export const assertExecuteCommandLogged = (lines: string[], command: string): vo
     const ctx = parseLogContext(line) as (LoggingContext & { command?: unknown }) | undefined;
     return ctx?.fn === EXECUTE_COMMAND_FN && ctx.command === command;
   });
-  assert.ok(
-    found,
-    `Expected ${EXECUTE_COMMAND_FN} log with command="${command}" but it was not found in ${lines.length} log lines`,
-  );
+  assert.ok(found, `Expected ${EXECUTE_COMMAND_FN} log with command="${command}" but it was not found in ${lines.length} log lines`);
 };
 
-export const assertTerminalPasteLogged = (
-  lines: string[],
-  opts: TerminalPasteAssertionOptions,
-): void => {
+export const assertTerminalPasteLogged = (lines: string[], opts: TerminalPasteAssertionOptions): void => {
   const found = lines.some((line) => {
-    const ctx = parseLogContext(line) as
-      (LoggingContext & { terminalName?: unknown; textLength?: unknown }) | undefined;
+    const ctx = parseLogContext(line) as (LoggingContext & { terminalName?: unknown; textLength?: unknown }) | undefined;
     if (ctx?.fn !== TERMINAL_PASTE_FN || ctx.terminalName !== opts.terminalName) return false;
     if (opts.minTextLength === undefined) return true;
     return typeof ctx.textLength === 'number' && ctx.textLength >= opts.minTextLength;
   });
-  const lengthSuffix =
-    opts.minTextLength === undefined ? '' : ` and textLength >= ${opts.minTextLength}`;
+  const lengthSuffix = opts.minTextLength === undefined ? '' : ` and textLength >= ${opts.minTextLength}`;
   assert.ok(
     found,
     `Expected ${TERMINAL_PASTE_FN} log with terminalName="${opts.terminalName}"${lengthSuffix} but it was not found in ${lines.length} log lines`,
@@ -249,10 +211,7 @@ export const assertFnLogged = (lines: string[], opts: FnAssertionOptions): void 
     const ctx = parseLogContext(line);
     return ctx?.fn === opts.fn;
   });
-  assert.ok(
-    found,
-    `Expected log entry with fn="${opts.fn}" but it was not found in ${lines.length} log lines`,
-  );
+  assert.ok(found, `Expected log entry with fn="${opts.fn}" but it was not found in ${lines.length} log lines`);
 };
 
 export const assertPasteCommandSucceeded = (lines: string[]): void => {
@@ -270,24 +229,14 @@ export const assertPasteCommandSucceeded = (lines: string[]): void => {
         return `  ${i + 1}. [${fn}] ${msg}`;
       })
       .join('\n');
-    assert.ok(
-      false,
-      `Expected ${PASTE_TO_AI_ASSISTANT_FN} success log but it was not found in ${lines.length} log lines.\n\nCaptured lines:\n${dump}`,
-    );
+    assert.ok(false, `Expected ${PASTE_TO_AI_ASSISTANT_FN} success log but it was not found in ${lines.length} log lines.\n\nCaptured lines:\n${dump}`);
   }
 };
 
-export const assertCommandsPresent = (
-  lines: string[],
-  command: string,
-  ...moreCommands: string[]
-): void => {
+export const assertCommandsPresent = (lines: string[], command: string, ...moreCommands: string[]): void => {
   const allCommands = [command, ...moreCommands];
   const items = extractQuickPickItemsLogged(lines);
-  assert.ok(
-    items !== undefined,
-    `Expected ${QUICK_PICK_FN} log entry with items but none found in ${lines.length} log lines`,
-  );
+  assert.ok(items !== undefined, `Expected ${QUICK_PICK_FN} log entry with items but none found in ${lines.length} log lines`);
   for (const cmd of allCommands) {
     assert.ok(
       items!.some((item) => item.command === cmd),
@@ -296,61 +245,31 @@ export const assertCommandsPresent = (
   }
 };
 
-export const assertQuickPickFirstItem = (
-  lines: string[],
-  expected: QuickPickItemExpectation,
-): void => {
+export const assertQuickPickFirstItem = (lines: string[], expected: QuickPickItemExpectation): void => {
   const items = extractQuickPickItemsLogged(lines);
-  assert.ok(
-    items !== undefined,
-    `Expected ${QUICK_PICK_FN} log entry with items but none found in ${lines.length} log lines`,
-  );
+  assert.ok(items !== undefined, `Expected ${QUICK_PICK_FN} log entry with items but none found in ${lines.length} log lines`);
   assert.deepStrictEqual(items[0], expected);
 };
 
-export const assertQuickPickTrailingItems = (
-  lines: string[],
-  expectedItems: QuickPickItemExpectation[],
-): void => {
+export const assertQuickPickTrailingItems = (lines: string[], expectedItems: QuickPickItemExpectation[]): void => {
   const items = extractQuickPickItemsLogged(lines);
-  assert.ok(
-    items !== undefined,
-    `Expected ${QUICK_PICK_FN} log entry with items but none found in ${lines.length} log lines`,
-  );
+  assert.ok(items !== undefined, `Expected ${QUICK_PICK_FN} log entry with items but none found in ${lines.length} log lines`);
   assert.deepStrictEqual(items.slice(-expectedItems.length), expectedItems);
 };
 
-export const assertQuickPickContains = (
-  lines: string[],
-  first: QuickPickItemExpectation,
-  ...more: QuickPickItemExpectation[]
-): void => {
+export const assertQuickPickContains = (lines: string[], first: QuickPickItemExpectation, ...more: QuickPickItemExpectation[]): void => {
   const items = extractQuickPickItemsLogged(lines);
-  assert.ok(
-    items !== undefined,
-    `Expected ${QUICK_PICK_FN} log entry with items but none found in ${lines.length} log lines`,
-  );
+  assert.ok(items !== undefined, `Expected ${QUICK_PICK_FN} log entry with items but none found in ${lines.length} log lines`);
   for (const expected of [first, ...more]) {
-    const match = items.some((item) =>
-      Object.entries(expected).every(
-        ([key, value]) => (item as Record<string, unknown>)[key] === value,
-      ),
-    );
+    const match = items.some((item) => Object.entries(expected).every(([key, value]) => (item as Record<string, unknown>)[key] === value));
     assert.ok(match, `Expected picker to contain item matching ${JSON.stringify(expected)}`);
   }
 };
 
-export const assertCommandsAbsent = (
-  lines: string[],
-  command: string,
-  ...moreCommands: string[]
-): void => {
+export const assertCommandsAbsent = (lines: string[], command: string, ...moreCommands: string[]): void => {
   const allCommands = [command, ...moreCommands];
   const items = extractQuickPickItemsLogged(lines);
-  assert.ok(
-    items !== undefined,
-    `Expected ${QUICK_PICK_FN} log entry with items but none found in ${lines.length} log lines`,
-  );
+  assert.ok(items !== undefined, `Expected ${QUICK_PICK_FN} log entry with items but none found in ${lines.length} log lines`);
   for (const cmd of allCommands) {
     assert.strictEqual(
       items!.find((item) => item.command === cmd),
@@ -360,18 +279,12 @@ export const assertCommandsAbsent = (
   }
 };
 
-export const assertClipboardWriteLogged = (
-  lines: string[],
-  opts: ClipboardWriteAssertionOptions,
-): void => {
+export const assertClipboardWriteLogged = (lines: string[], opts: ClipboardWriteAssertionOptions): void => {
   const found = lines.some((line) => {
     const ctx = parseLogContext(line) as (LoggingContext & { textLength?: unknown }) | undefined;
     return ctx?.fn === CLIPBOARD_WRITE_FN && ctx.textLength === opts.textLength;
   });
-  assert.ok(
-    found,
-    `Expected ${CLIPBOARD_WRITE_FN} log with textLength=${opts.textLength} but it was not found in ${lines.length} log lines`,
-  );
+  assert.ok(found, `Expected ${CLIPBOARD_WRITE_FN} log with textLength=${opts.textLength} but it was not found in ${lines.length} log lines`);
 };
 
 export const assertNoClipboardWriteLogged = (lines: string[]): void => {

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/logHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/logHelpers.ts
@@ -37,10 +37,7 @@ export const extractSentLink = (lines: string[]): string | undefined => {
  * smartPadding settings. Clipboard assertions should NOT use this
  * option — the clipboard always contains raw (unpadded) content.
  */
-export const extractGeneratedLink = (
-  lines: string[],
-  options?: SmartPadOptions,
-): string | undefined => {
+export const extractGeneratedLink = (lines: string[], options?: SmartPadOptions): string | undefined => {
   const generatedLog = lines.find((l) => l.includes('Generated link:'));
   if (!generatedLog) return undefined;
   const linkMatch = generatedLog.match(/"link":"([^"]+)"/);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/menuConstants.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/menuConstants.ts
@@ -1,9 +1,4 @@
-import {
-  CMD_GO_TO_RANGELINK,
-  CMD_JUMP_TO_DESTINATION,
-  CMD_SHOW_VERSION,
-  CMD_UNBIND_DESTINATION,
-} from '../../constants/commandIds';
+import { CMD_GO_TO_RANGELINK, CMD_JUMP_TO_DESTINATION, CMD_SHOW_VERSION, CMD_UNBIND_DESTINATION } from '../../constants/commandIds';
 
 import * as vscode from 'vscode';
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/navigationHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/navigationHelpers.ts
@@ -28,11 +28,7 @@ export const navigateViaHandleLinkClick = (
       if (lastResult) {
         resolve(lastResult);
       } else {
-        reject(
-          new Error(
-            `No selection change event received within ${TIMEOUT_MS}ms for ${testFilename}`,
-          ),
-        );
+        reject(new Error(`No selection change event received within ${TIMEOUT_MS}ms for ${testFilename}`));
       }
     }, TIMEOUT_MS);
 
@@ -48,9 +44,7 @@ export const navigateViaHandleLinkClick = (
       }
     });
 
-    Promise.resolve(
-      vscode.commands.executeCommand(CMD_HANDLE_DOCUMENT_LINK_CLICK, { linkText, parsed }),
-    ).catch((error: unknown) => {
+    Promise.resolve(vscode.commands.executeCommand(CMD_HANDLE_DOCUMENT_LINK_CLICK, { linkText, parsed })).catch((error: unknown) => {
       clearTimeout(overallTimeout);
       if (stableTimer) clearTimeout(stableTimer);
       disposable.dispose();

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/settingsHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/settingsHelpers.ts
@@ -22,9 +22,7 @@ const getRangelinkKeys = (): string[] => {
     throw new Error(`getRangelinkKeys: Failed to parse package.json: ${err}`);
   }
 
-  cachedRangelinkKeys = Object.keys(pkg.contributes?.configuration?.properties ?? {}).filter((k) =>
-    k.startsWith('rangelink.'),
-  );
+  cachedRangelinkKeys = Object.keys(pkg.contributes?.configuration?.properties ?? {}).filter((k) => k.startsWith('rangelink.'));
 
   return cachedRangelinkKeys;
 };

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/ssContext.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/ssContext.ts
@@ -1,44 +1,22 @@
 import type { LogCapture } from '../../LogCapture';
 
-import {
-  CapturingTerminal,
-  createAndBindCapturingTerminal,
-  createCapturingTerminal,
-} from './capturingPtyHelpers';
-import {
-  createAndOpenFile,
-  createFileAt,
-  createPngFixture,
-  createWorkspaceFile,
-  openEditor,
-  type PngFixtureMode,
-} from './fileHelpers';
+import { CapturingTerminal, createAndBindCapturingTerminal, createCapturingTerminal } from './capturingPtyHelpers';
+import { createAndOpenFile, createFileAt, createPngFixture, createWorkspaceFile, openEditor, type PngFixtureMode } from './fileHelpers';
 import { getLogCapture } from './getLogCapture';
 import { SETTLE_MS, TERMINAL_READY_MS, waitForExtensionActive } from './testEnv';
-import {
-  type ModalDialogExpectation,
-  TEST_START_MARKER,
-  type TestWindow,
-  TestWindowImpl,
-  type ToastExpectation,
-} from './testWindow';
+import { type ModalDialogExpectation, TEST_START_MARKER, type TestWindow, TestWindowImpl, type ToastExpectation } from './testWindow';
 
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 
-export type CreateTerminalOptions =
-  Omit<vscode.TerminalOptions, 'name'> | Omit<vscode.ExtensionTerminalOptions, 'name'>;
+export type CreateTerminalOptions = Omit<vscode.TerminalOptions, 'name'> | Omit<vscode.ExtensionTerminalOptions, 'name'>;
 
 export interface SsContext {
   log: (msg: string) => void;
   createTerminal: (name: string, options?: CreateTerminalOptions) => Promise<vscode.Terminal>;
   createCapturingTerminal: (name: string) => Promise<CapturingTerminal>;
   createAndBindCapturingTerminal: (name: string) => Promise<CapturingTerminal>;
-  createContentFile: (
-    descriptor: string,
-    lineCount: number,
-    lineFactory: (index: number) => string,
-  ) => { uri: vscode.Uri; filename: string };
+  createContentFile: (descriptor: string, lineCount: number, lineFactory: (index: number) => string) => { uri: vscode.Uri; filename: string };
   /**
    * Create a tracked workspace file with a generated filename
    * (`__rl-test-<descriptor>-<timestamp>-<counter>.txt`).
@@ -58,11 +36,7 @@ export interface SsContext {
    * need a binary classification.
    */
   createPngFixture: (descriptor: string, mode?: PngFixtureMode) => vscode.Uri;
-  createAndOpenFile: (
-    descriptor: string,
-    content: string,
-    viewColumn?: vscode.ViewColumn,
-  ) => Promise<vscode.Uri>;
+  createAndOpenFile: (descriptor: string, content: string, viewColumn?: vscode.ViewColumn) => Promise<vscode.Uri>;
   settle: (ms?: number) => Promise<void>;
   getLogCapture: () => LogCapture;
   /**
@@ -126,12 +100,8 @@ export class SsContextImpl implements SsContext {
     this.suiteLog(msg);
   }
 
-  async createTerminal(
-    name: string,
-    options: CreateTerminalOptions = {},
-  ): Promise<vscode.Terminal> {
-    const t = vscode.window.createTerminal({ ...options, name } as
-      vscode.TerminalOptions | vscode.ExtensionTerminalOptions);
+  async createTerminal(name: string, options: CreateTerminalOptions = {}): Promise<vscode.Terminal> {
+    const t = vscode.window.createTerminal({ ...options, name } as vscode.TerminalOptions | vscode.ExtensionTerminalOptions);
     this.tmpTerminals.push(t);
     t.show(true);
     await this.settle(TERMINAL_READY_MS);
@@ -148,11 +118,7 @@ export class SsContextImpl implements SsContext {
     return capturing;
   }
 
-  createContentFile(
-    descriptor: string,
-    lineCount: number,
-    lineFactory: (index: number) => string,
-  ): { uri: vscode.Uri; filename: string } {
+  createContentFile(descriptor: string, lineCount: number, lineFactory: (index: number) => string): { uri: vscode.Uri; filename: string } {
     const lines = Array.from({ length: lineCount }, (_, i) => lineFactory(i));
     const uri = createWorkspaceFile(descriptor, lines.join('\n') + '\n');
     return { uri, filename: path.basename(uri.fsPath) };
@@ -170,11 +136,7 @@ export class SsContextImpl implements SsContext {
     return createPngFixture(descriptor, mode);
   }
 
-  createAndOpenFile(
-    descriptor: string,
-    content: string,
-    viewColumn?: vscode.ViewColumn,
-  ): Promise<vscode.Uri> {
+  createAndOpenFile(descriptor: string, content: string, viewColumn?: vscode.ViewColumn): Promise<vscode.Uri> {
     return createAndOpenFile(descriptor, content, viewColumn);
   }
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/standardSuite.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/standardSuite.ts
@@ -23,10 +23,7 @@ export const standardSuite = (name: string, fn: (ss: SsContext) => void): void =
     });
 
     setup(async () => {
-      assert.ok(
-        getLogCapture().isCapturing,
-        'RANGELINK_CAPTURE_LOGS must be true for toast assertions',
-      );
+      assert.ok(getLogCapture().isCapturing, 'RANGELINK_CAPTURE_LOGS must be true for toast assertions');
       await resetRangelinkSettings(log);
       await vscode.commands.executeCommand(CMD_UNBIND_DESTINATION);
       await closeAllEditors();

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/terminalHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/terminalHelpers.ts
@@ -13,10 +13,7 @@ export const disposeAllTerminals = (): void => {
   }
 };
 
-export const createTerminal = async (
-  name: string,
-  trackingArray?: vscode.Terminal[],
-): Promise<vscode.Terminal> => {
+export const createTerminal = async (name: string, trackingArray?: vscode.Terminal[]): Promise<vscode.Terminal> => {
   const t = vscode.window.createTerminal({ name });
   trackingArray?.push(t);
   t.show(true);
@@ -25,12 +22,7 @@ export const createTerminal = async (
 };
 
 export const findTerminalItems = (items: Record<string, unknown>[]): Record<string, unknown>[] =>
-  items.filter(
-    (item) =>
-      item.itemKind === 'bindable' &&
-      typeof item.label === 'string' &&
-      (item.label as string).includes('Terminal ('),
-  );
+  items.filter((item) => item.itemKind === 'bindable' && typeof item.label === 'string' && (item.label as string).includes('Terminal ('));
 
 export const createAndBindTerminal = async (name: string): Promise<vscode.Terminal> => {
   const terminal = vscode.window.createTerminal({ name });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/testEnv.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/testEnv.ts
@@ -27,8 +27,7 @@ export const getExtensionVersion = (): string => {
   return ext.packageJSON.version as string;
 };
 
-export const settle = (ms: number = SETTLE_MS): Promise<void> =>
-  new Promise<void>((resolve) => setTimeout(resolve, ms));
+export const settle = (ms: number = SETTLE_MS): Promise<void> => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 export const dismissQuickPick = async (): Promise<void> => {
   await vscode.commands.executeCommand('workbench.action.closeQuickOpen');
@@ -57,17 +56,13 @@ export const waitForExtensionActive = async (
     }
     const currentState = ext ? `found, isActive=${ext.isActive}` : 'not found';
     if (currentState !== lastState) {
-      log(
-        `[waitForExtensionActive] ${extensionId} → ${currentState} (${Date.now() - start}ms elapsed)`,
-      );
+      log(`[waitForExtensionActive] ${extensionId} → ${currentState} (${Date.now() - start}ms elapsed)`);
       lastState = currentState;
     }
     await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
   }
   const ext = vscode.extensions.getExtension(extensionId);
-  throw new Error(
-    `Extension ${extensionId} did not activate within ${timeoutMs}ms (found=${ext !== undefined}, isActive=${ext?.isActive ?? 'N/A'})`,
-  );
+  throw new Error(`Extension ${extensionId} did not activate within ${timeoutMs}ms (found=${ext !== undefined}, isActive=${ext?.isActive ?? 'N/A'})`);
 };
 
 /**
@@ -81,15 +76,10 @@ export const openAndDismiss = async (command: string): Promise<void> => {
   // Retry dismissal until the command resolves — the picker may be slow to render on loaded CI.
   for (;;) {
     await dismissQuickPick();
-    const done = await Promise.race([
-      promise.then(() => true),
-      settle(POLL_INTERVAL_MS).then(() => false),
-    ]);
+    const done = await Promise.race([promise.then(() => true), settle(POLL_INTERVAL_MS).then(() => false)]);
     if (done) break;
     if (Date.now() >= deadline) {
-      throw new Error(
-        `openAndDismiss: "${command}" did not resolve within ${POLL_TIMEOUT_MS}ms deadline`,
-      );
+      throw new Error(`openAndDismiss: "${command}" did not resolve within ${POLL_TIMEOUT_MS}ms deadline`);
     }
   }
   await promise;
@@ -104,10 +94,7 @@ export const openAndDismiss = async (command: string): Promise<void> => {
  * @param preAccept - Optional callback run after the InputBox opens but before accepting.
  *                    Use for programmatic clipboard paste (`editor.action.clipboardPasteAction`).
  */
-export const openAndAccept = async (
-  command: string,
-  preAccept?: () => Promise<void>,
-): Promise<void> => {
+export const openAndAccept = async (command: string, preAccept?: () => Promise<void>): Promise<void> => {
   const promise = vscode.commands.executeCommand(command);
   await settle();
   if (preAccept !== undefined) {
@@ -117,15 +104,10 @@ export const openAndAccept = async (
   const deadline = Date.now() + POLL_TIMEOUT_MS;
   for (;;) {
     await acceptQuickInput();
-    const done = await Promise.race([
-      promise.then(() => true),
-      settle(POLL_INTERVAL_MS).then(() => false),
-    ]);
+    const done = await Promise.race([promise.then(() => true), settle(POLL_INTERVAL_MS).then(() => false)]);
     if (done) break;
     if (Date.now() >= deadline) {
-      throw new Error(
-        `openAndAccept: "${command}" did not resolve within ${POLL_TIMEOUT_MS}ms deadline`,
-      );
+      throw new Error(`openAndAccept: "${command}" did not resolve within ${POLL_TIMEOUT_MS}ms deadline`);
     }
   }
   await promise;

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/testWindow.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/helpers/testWindow.ts
@@ -1,8 +1,4 @@
-import {
-  CONTEXT_IS_ACTIVE_TERMINAL_BINDABLE,
-  CONTEXT_IS_ACTIVE_TERMINAL_PASTE_DESTINATION,
-  CONTEXT_IS_BOUND,
-} from '../../constants/contextKeys';
+import { CONTEXT_IS_ACTIVE_TERMINAL_BINDABLE, CONTEXT_IS_ACTIVE_TERMINAL_PASTE_DESTINATION, CONTEXT_IS_BOUND } from '../../constants/contextKeys';
 import type { RangeLinkExtensionApi } from '../../types/RangeLinkExtensionApi';
 
 import { getLogCapture } from './getLogCapture';
@@ -11,29 +7,15 @@ import { parseLogContext } from './logBasedUiAssertions';
 import assert from 'node:assert';
 import * as vscode from 'vscode';
 
-const STATUS_BAR_FNS = [
-  'VscodeAdapter.setStatusBarMessage',
-  'VscodeAdapter.setSuccessfulStatusBarMessage',
-];
+const STATUS_BAR_FNS = ['VscodeAdapter.setStatusBarMessage', 'VscodeAdapter.setSuccessfulStatusBarMessage'];
 
-const TOAST_FNS = [
-  'VscodeAdapter.showInformationMessage',
-  'VscodeAdapter.showWarningMessage',
-  'VscodeAdapter.showErrorMessage',
-];
+const TOAST_FNS = ['VscodeAdapter.showInformationMessage', 'VscodeAdapter.showWarningMessage', 'VscodeAdapter.showErrorMessage'];
 
-const MODAL_DIALOG_FNS = [
-  'VscodeAdapter.showInformationMessage',
-  'VscodeAdapter.showWarningMessage',
-];
+const MODAL_DIALOG_FNS = ['VscodeAdapter.showInformationMessage', 'VscodeAdapter.showWarningMessage'];
 
 const EXTENSION_ID = 'couimet.rangelink-vscode-extension';
 
-const KNOWN_CONTEXT_KEYS = [
-  CONTEXT_IS_BOUND,
-  CONTEXT_IS_ACTIVE_TERMINAL_BINDABLE,
-  CONTEXT_IS_ACTIVE_TERMINAL_PASTE_DESTINATION,
-] as const;
+const KNOWN_CONTEXT_KEYS = [CONTEXT_IS_BOUND, CONTEXT_IS_ACTIVE_TERMINAL_BINDABLE, CONTEXT_IS_ACTIVE_TERMINAL_PASTE_DESTINATION] as const;
 
 const DEFAULT_CONTEXT_KEY_VALUES: Record<string, unknown> = {
   [CONTEXT_IS_BOUND]: false,
@@ -149,11 +131,7 @@ export class TestWindowImpl implements TestWindow {
     const logged: ModalDialogExpectation[] = [];
     for (const line of lines) {
       const ctx = parseLogContext(line);
-      if (
-        ctx !== undefined &&
-        MODAL_DIALOG_FNS.includes(ctx.fn) &&
-        typeof ctx.message === 'string'
-      ) {
+      if (ctx !== undefined && MODAL_DIALOG_FNS.includes(ctx.fn) && typeof ctx.message === 'string') {
         if (Array.isArray(ctx.items) && ctx.items.length > 0) {
           logged.push({
             level: this.fnToDialogLevel(ctx.fn),
@@ -173,12 +151,7 @@ export class TestWindowImpl implements TestWindow {
    * as formatted JSON so the developer can copy the actual block directly
    * into the test body without needing to re-run for template extraction.
    */
-  private dumpFailure(
-    category: string,
-    expected: unknown,
-    actual: unknown,
-    callName: string,
-  ): never {
+  private dumpFailure(category: string, expected: unknown, actual: unknown, callName: string): never {
     const expectedJson = JSON.stringify(expected, null, 2);
     const actualJson = JSON.stringify(actual, null, 2);
 
@@ -209,13 +182,8 @@ export class TestWindowImpl implements TestWindow {
     const expected = this.getExpectedContextKeys();
     for (const key of KNOWN_CONTEXT_KEYS) {
       const actualValue: unknown = key in values ? values[key] : undefined;
-      const expectedValue: unknown =
-        key in expected ? expected[key] : DEFAULT_CONTEXT_KEY_VALUES[key];
-      assert.strictEqual(
-        actualValue,
-        expectedValue,
-        `Context key "${key}": expected ${JSON.stringify(expectedValue)} but got ${JSON.stringify(actualValue)}`,
-      );
+      const expectedValue: unknown = key in expected ? expected[key] : DEFAULT_CONTEXT_KEY_VALUES[key];
+      assert.strictEqual(actualValue, expectedValue, `Context key "${key}": expected ${JSON.stringify(expectedValue)} but got ${JSON.stringify(actualValue)}`);
     }
   }
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/bindToDestination.test.ts
@@ -29,8 +29,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 standardSuite('R-D Bind to Destination', (ss) => {
-  const findFileItems = (items: Record<string, unknown>[]): Record<string, unknown>[] =>
-    findTestItemsByPrefix(items, '__rl-test-btd-');
+  const findFileItems = (items: Record<string, unknown>[]): Record<string, unknown>[] => findTestItemsByPrefix(items, '__rl-test-btd-');
 
   test('bind-to-destination-004: selecting a terminal destination binds it and shows success toast', async () => {
     await ss.createTerminal('rl-btd-004');
@@ -189,15 +188,11 @@ standardSuite('R-D Bind to Destination', (ss) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-btd-008');
 
-    await waitForHuman(
-      'bind-to-destination-008',
-      'Cmd+R Cmd+D → select "rl-btd-008-b" → click "Yes, replace"',
-      [
-        '1. Press Cmd+R Cmd+D',
-        '2. Select Terminal ("rl-btd-008-b") from the list',
-        '3. When the confirmation dialog appears, click "Yes, replace"',
-      ],
-    );
+    await waitForHuman('bind-to-destination-008', 'Cmd+R Cmd+D → select "rl-btd-008-b" → click "Yes, replace"', [
+      '1. Press Cmd+R Cmd+D',
+      '2. Select Terminal ("rl-btd-008-b") from the list',
+      '3. When the confirmation dialog appears, click "Yes, replace"',
+    ]);
 
     ss.log('✓ Replacement binding toast logged; old binding not re-confirmed');
   });
@@ -229,11 +224,7 @@ standardSuite('R-D Bind to Destination', (ss) => {
       ],
     );
 
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'Human reported the original binding was NOT preserved when clicking "No, keep current binding"',
-    );
+    assert.strictEqual(verdict, 'pass', 'Human reported the original binding was NOT preserved when clicking "No, keep current binding"');
 
     ss.log('✓ No rebind toast — original binding preserved (human verdict + state invariant)');
   });
@@ -283,25 +274,18 @@ standardSuite('R-D Bind to Destination', (ss) => {
     await vscode.commands.executeCommand(CMD_BIND_TO_GITHUB_COPILOT_CHAT);
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to GitHub Copilot Chat',
-      '✓ RangeLink: Unbound GitHub Copilot Chat, now bound to Dummy AI (Tier 3)',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to GitHub Copilot Chat', '✓ RangeLink: Unbound GitHub Copilot Chat, now bound to Dummy AI (Tier 3)']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     const logCapture = getLogCapture();
     logCapture.mark('before-btd-012');
 
-    await waitForHuman(
-      'bind-to-destination-012',
-      'Cmd+R Cmd+D → select Dummy AI (Tier 3) → click "Yes, replace"',
-      [
-        'The Dummy AI extension is loaded — its destinations appear in the picker.',
-        '1. Press Cmd+R Cmd+D',
-        '2. Select "Dummy AI (Tier 3)" (custom AI assistant) from the picker',
-        '3. When the confirmation dialog appears, click "Yes, replace"',
-      ],
-    );
+    await waitForHuman('bind-to-destination-012', 'Cmd+R Cmd+D → select Dummy AI (Tier 3) → click "Yes, replace"', [
+      'The Dummy AI extension is loaded — its destinations appear in the picker.',
+      '1. Press Cmd+R Cmd+D',
+      '2. Select "Dummy AI (Tier 3)" (custom AI assistant) from the picker',
+      '3. When the confirmation dialog appears, click "Yes, replace"',
+    ]);
 
     const lines = logCapture.getLinesSince('before-btd-012');
 
@@ -311,9 +295,7 @@ standardSuite('R-D Bind to Destination', (ss) => {
       `Expected at least 2 showQuickPick entries (destination picker + confirmation dialog), got ${quickPickEntries.length}`,
     );
 
-    const confirmItems = parseQuickPickItemsFromLogLine(
-      quickPickEntries[quickPickEntries.length - 1],
-    );
+    const confirmItems = parseQuickPickItemsFromLogLine(quickPickEntries[quickPickEntries.length - 1]);
     assert.deepStrictEqual(
       confirmItems.map(({ label }) => ({ label })),
       [{ label: 'Yes, replace' }, { label: 'No, keep current binding' }],

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/builtInAiAssistants.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/builtInAiAssistants.test.ts
@@ -8,14 +8,8 @@ import {
   CMD_COPY_LINK_RELATIVE,
   CMD_JUMP_TO_DESTINATION,
 } from '../../constants/commandIds';
-import {
-  DEFAULT_DESTINATIONS_GEMINI_COLD_REFOCUS_INTERVAL_MS,
-  DEFAULT_DESTINATIONS_GEMINI_COLD_START_DELAY_MS,
-} from '../../constants/settingDefaults';
-import {
-  EXTENSION_ID_CLAUDE_CODE,
-  EXTENSION_ID_GEMINI_CODE_ASSIST,
-} from '../../utils/aiAssistants/builtInAiAssistants';
+import { DEFAULT_DESTINATIONS_GEMINI_COLD_REFOCUS_INTERVAL_MS, DEFAULT_DESTINATIONS_GEMINI_COLD_START_DELAY_MS } from '../../constants/settingDefaults';
+import { EXTENSION_ID_CLAUDE_CODE, EXTENSION_ID_GEMINI_CODE_ASSIST } from '../../utils/aiAssistants/builtInAiAssistants';
 import {
   assertClipboardEqualsGeneratedLink,
   assertPasteCommandSucceeded,
@@ -38,10 +32,7 @@ const GEMINI_CODE_ASSIST_DISPLAY_NAME = 'Gemini Code Assist';
 
 standardSuite('Built-in AI Assistants', (ss) => {
   test('[assisted] claude-code-002: binding to Claude Code Chat and sending a link delivers content to chat', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Claude Code Chat',
-      '✓ RangeLink: RangeLink sent to Claude Code Chat',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Claude Code Chat', '✓ RangeLink: RangeLink sent to Claude Code Chat']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     const fileUri = ss.createWorkspaceFile('cc-002', 'line 1\nline 2\nline 3\n');
@@ -68,11 +59,10 @@ standardSuite('Built-in AI Assistants', (ss) => {
 
     assertPasteCommandSucceeded(sendLines);
 
-    const verdict = await waitForHumanVerdict(
-      'claude-code-002',
-      'Did the RangeLink + selected code appear in Claude Code chat?',
-      ['1. The RangeLink send was fired automatically', 'Verdict:'],
-    );
+    const verdict = await waitForHumanVerdict('claude-code-002', 'Did the RangeLink + selected code appear in Claude Code chat?', [
+      '1. The RangeLink send was fired automatically',
+      'Verdict:',
+    ]);
     assert.strictEqual(
       verdict,
       'pass',
@@ -83,10 +73,7 @@ standardSuite('Built-in AI Assistants', (ss) => {
   });
 
   test('[assisted] claude-code-004: cold panel paste — content arrives in Claude Code chat after first R-L since bind', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Claude Code Chat',
-      '✓ RangeLink: RangeLink sent to Claude Code Chat',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Claude Code Chat', '✓ RangeLink: RangeLink sent to Claude Code Chat']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     const fileUri = ss.createWorkspaceFile('cc-004', 'line 1\nline 2\nline 3\n');
@@ -108,15 +95,11 @@ standardSuite('Built-in AI Assistants', (ss) => {
 
     assertPasteCommandSucceeded(lines);
 
-    const verdict = await waitForHumanVerdict(
-      'claude-code-004',
-      'Cold paste: did the RangeLink appear in Claude Code chat?',
-      [
-        '1. Lines 1-2 of cc-004 are already selected',
-        '2. The send was fired automatically (no keypress needed)',
-        'Verdict:',
-      ],
-    );
+    const verdict = await waitForHumanVerdict('claude-code-004', 'Cold paste: did the RangeLink appear in Claude Code chat?', [
+      '1. Lines 1-2 of cc-004 are already selected',
+      '2. The send was fired automatically (no keypress needed)',
+      'Verdict:',
+    ]);
     assert.strictEqual(
       verdict,
       'pass',
@@ -147,16 +130,11 @@ standardSuite('Built-in AI Assistants', (ss) => {
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
     await ss.settle();
 
-    const coldVerdict = await waitForHumanVerdict(
-      'claude-code-005-cold',
-      'Cold send: did the RangeLink appear in Claude Code chat?',
-      ['1. Lines 1-2 of cc-005 are selected; cold send was fired automatically', 'Verdict:'],
-    );
-    assert.strictEqual(
-      coldVerdict,
-      'pass',
-      'Human reported the cold-send RangeLink did not appear in Claude Code chat',
-    );
+    const coldVerdict = await waitForHumanVerdict('claude-code-005-cold', 'Cold send: did the RangeLink appear in Claude Code chat?', [
+      '1. Lines 1-2 of cc-005 are selected; cold send was fired automatically',
+      'Verdict:',
+    ]);
+    assert.strictEqual(coldVerdict, 'pass', 'Human reported the cold-send RangeLink did not appear in Claude Code chat');
 
     // Select lines 3-4 for warm send. Re-focus the editor first — the cold
     // verdict dialog stole focus and the editor must be active for the send
@@ -180,20 +158,13 @@ standardSuite('Built-in AI Assistants', (ss) => {
       'Warm send: did the lines 3-4 RangeLink appear in Claude Code chat without refocus flicker?',
       ['1. Lines 3-4 of cc-005 are selected; warm send was fired automatically', 'Verdict:'],
     );
-    assert.strictEqual(
-      warmVerdict,
-      'pass',
-      'Human reported the warm-send RangeLink did not appear cleanly in Claude Code chat',
-    );
+    assert.strictEqual(warmVerdict, 'pass', 'Human reported the warm-send RangeLink did not appear cleanly in Claude Code chat');
 
     ss.log('✓ Warm paste: content delivered to Claude Code (cold + warm both PASS)');
   });
 
   test('[assisted] gemini-code-assist-002: binding to Gemini Code Assist and sending a link delivers content to chat', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Gemini Code Assist',
-      '✓ RangeLink: RangeLink sent to Gemini Code Assist',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Gemini Code Assist', '✓ RangeLink: RangeLink sent to Gemini Code Assist']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     const fileUri = ss.createWorkspaceFile('gc-002', 'line 1\nline 2\nline 3\n');
@@ -222,11 +193,10 @@ standardSuite('Built-in AI Assistants', (ss) => {
 
     assertPasteCommandSucceeded(sendLines);
 
-    const verdict = await waitForHumanVerdict(
-      'gemini-code-assist-002',
-      'Did the RangeLink + selected code appear in Gemini Code Assist chat?',
-      ['1. The RangeLink send was fired automatically', 'Verdict:'],
-    );
+    const verdict = await waitForHumanVerdict('gemini-code-assist-002', 'Did the RangeLink + selected code appear in Gemini Code Assist chat?', [
+      '1. The RangeLink send was fired automatically',
+      'Verdict:',
+    ]);
     assert.strictEqual(
       verdict,
       'pass',
@@ -237,10 +207,7 @@ standardSuite('Built-in AI Assistants', (ss) => {
   });
 
   test('[assisted] gemini-code-assist-003: cold panel paste — content arrives in Gemini Code Assist chat after first R-L since bind', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Gemini Code Assist',
-      '✓ RangeLink: RangeLink sent to Gemini Code Assist',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Gemini Code Assist', '✓ RangeLink: RangeLink sent to Gemini Code Assist']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     const fileUri = ss.createWorkspaceFile('gc-003', 'line 1\nline 2\nline 3\n');
@@ -264,15 +231,11 @@ standardSuite('Built-in AI Assistants', (ss) => {
 
     assertPasteCommandSucceeded(lines);
 
-    const verdict = await waitForHumanVerdict(
-      'gemini-code-assist-003',
-      'Cold paste: did the RangeLink appear in Gemini Code Assist chat?',
-      [
-        '1. Lines 1-2 of gc-003 are already selected',
-        '2. The send was fired automatically (no keypress needed)',
-        'Verdict:',
-      ],
-    );
+    const verdict = await waitForHumanVerdict('gemini-code-assist-003', 'Cold paste: did the RangeLink appear in Gemini Code Assist chat?', [
+      '1. Lines 1-2 of gc-003 are already selected',
+      '2. The send was fired automatically (no keypress needed)',
+      'Verdict:',
+    ]);
     assert.strictEqual(
       verdict,
       'pass',
@@ -305,16 +268,11 @@ standardSuite('Built-in AI Assistants', (ss) => {
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
     await ss.settle();
 
-    const coldVerdict = await waitForHumanVerdict(
-      'gemini-code-assist-004-cold',
-      'Cold send: did the RangeLink appear in Gemini Code Assist chat?',
-      ['1. Lines 1-2 of gc-004 are selected; cold send was fired automatically', 'Verdict:'],
-    );
-    assert.strictEqual(
-      coldVerdict,
-      'pass',
-      'Human reported the cold-send RangeLink did not appear in Gemini Code Assist chat',
-    );
+    const coldVerdict = await waitForHumanVerdict('gemini-code-assist-004-cold', 'Cold send: did the RangeLink appear in Gemini Code Assist chat?', [
+      '1. Lines 1-2 of gc-004 are selected; cold send was fired automatically',
+      'Verdict:',
+    ]);
+    assert.strictEqual(coldVerdict, 'pass', 'Human reported the cold-send RangeLink did not appear in Gemini Code Assist chat');
 
     // Select lines 3-4 for warm send
     await vscode.window.showTextDocument(doc);
@@ -336,20 +294,13 @@ standardSuite('Built-in AI Assistants', (ss) => {
       'Warm send: did the lines 3-4 RangeLink appear in Gemini Code Assist chat without refocus flicker?',
       ['1. Lines 3-4 of gc-004 are selected; warm send was fired automatically', 'Verdict:'],
     );
-    assert.strictEqual(
-      warmVerdict,
-      'pass',
-      'Human reported the warm-send RangeLink did not appear cleanly in Gemini Code Assist chat',
-    );
+    assert.strictEqual(warmVerdict, 'pass', 'Human reported the warm-send RangeLink did not appear cleanly in Gemini Code Assist chat');
 
     ss.log('✓ Warm paste: content delivered to Gemini Code Assist (cold + warm both PASS)');
   });
 
   test('[assisted] github-copilot-chat-002: binding to GitHub Copilot Chat and sending a link delivers content to chat', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to GitHub Copilot Chat',
-      '✓ RangeLink: RangeLink sent to GitHub Copilot Chat',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to GitHub Copilot Chat', '✓ RangeLink: RangeLink sent to GitHub Copilot Chat']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     const fileUri = ss.createWorkspaceFile('ghc-002', 'line 1\nline 2\nline 3\n');
@@ -376,11 +327,10 @@ standardSuite('Built-in AI Assistants', (ss) => {
 
     assertPasteCommandSucceeded(sendLines);
 
-    const verdict = await waitForHumanVerdict(
-      'github-copilot-chat-002',
-      'Did the RangeLink + selected code appear in GitHub Copilot Chat?',
-      ['1. The RangeLink send was fired automatically', 'Verdict:'],
-    );
+    const verdict = await waitForHumanVerdict('github-copilot-chat-002', 'Did the RangeLink + selected code appear in GitHub Copilot Chat?', [
+      '1. The RangeLink send was fired automatically',
+      'Verdict:',
+    ]);
     assert.strictEqual(
       verdict,
       'pass',
@@ -391,10 +341,7 @@ standardSuite('Built-in AI Assistants', (ss) => {
   });
 
   test('[assisted] github-copilot-chat-003: cold panel paste — content arrives in GitHub Copilot Chat after first R-L since bind', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to GitHub Copilot Chat',
-      '✓ RangeLink: RangeLink sent to GitHub Copilot Chat',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to GitHub Copilot Chat', '✓ RangeLink: RangeLink sent to GitHub Copilot Chat']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     const fileUri = ss.createWorkspaceFile('ghc-003', 'line 1\nline 2\nline 3\n');
@@ -416,15 +363,11 @@ standardSuite('Built-in AI Assistants', (ss) => {
 
     assertPasteCommandSucceeded(lines);
 
-    const verdict = await waitForHumanVerdict(
-      'github-copilot-chat-003',
-      'Cold paste: did the RangeLink appear in GitHub Copilot Chat?',
-      [
-        '1. Lines 1-2 of ghc-003 are already selected',
-        '2. The send was fired automatically (no keypress needed)',
-        'Verdict:',
-      ],
-    );
+    const verdict = await waitForHumanVerdict('github-copilot-chat-003', 'Cold paste: did the RangeLink appear in GitHub Copilot Chat?', [
+      '1. Lines 1-2 of ghc-003 are already selected',
+      '2. The send was fired automatically (no keypress needed)',
+      'Verdict:',
+    ]);
     assert.strictEqual(
       verdict,
       'pass',
@@ -455,16 +398,11 @@ standardSuite('Built-in AI Assistants', (ss) => {
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
     await ss.settle();
 
-    const coldVerdict = await waitForHumanVerdict(
-      'github-copilot-chat-004-cold',
-      'Cold send: did the RangeLink appear in GitHub Copilot Chat?',
-      ['1. Lines 1-2 of ghc-004 are selected; cold send was fired automatically', 'Verdict:'],
-    );
-    assert.strictEqual(
-      coldVerdict,
-      'pass',
-      'Human reported the cold-send RangeLink did not appear in GitHub Copilot Chat',
-    );
+    const coldVerdict = await waitForHumanVerdict('github-copilot-chat-004-cold', 'Cold send: did the RangeLink appear in GitHub Copilot Chat?', [
+      '1. Lines 1-2 of ghc-004 are selected; cold send was fired automatically',
+      'Verdict:',
+    ]);
+    assert.strictEqual(coldVerdict, 'pass', 'Human reported the cold-send RangeLink did not appear in GitHub Copilot Chat');
 
     // Select lines 3-4 for warm send
     await vscode.window.showTextDocument(doc);
@@ -486,20 +424,13 @@ standardSuite('Built-in AI Assistants', (ss) => {
       'Warm send: did the lines 3-4 RangeLink appear in GitHub Copilot Chat without refocus flicker?',
       ['1. Lines 3-4 of ghc-004 are selected; warm send was fired automatically', 'Verdict:'],
     );
-    assert.strictEqual(
-      warmVerdict,
-      'pass',
-      'Human reported the warm-send RangeLink did not appear cleanly in GitHub Copilot Chat',
-    );
+    assert.strictEqual(warmVerdict, 'pass', 'Human reported the warm-send RangeLink did not appear cleanly in GitHub Copilot Chat');
 
     ss.log('✓ Warm paste: content delivered to GitHub Copilot Chat (cold + warm both PASS)');
   });
 
   test('clipboard-preservation-011: cold paste to Claude Code — prior clipboard restored', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Claude Code Chat',
-      '✓ RangeLink: RangeLink sent to Claude Code Chat',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Claude Code Chat', '✓ RangeLink: RangeLink sent to Claude Code Chat']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     const fileUri = ss.createWorkspaceFile('cp-011', 'line 1\nline 2\nline 3\n');
@@ -556,16 +487,11 @@ standardSuite('Built-in AI Assistants', (ss) => {
 
   test('clipboard-preservation-013: cold paste to Cursor AI — prior clipboard restored', async function (this: MochaContext) {
     if (!vscode.extensions.getExtension('cursor.cursor')) {
-      ss.log(
-        'Skipping clipboard-preservation-013 — Cursor AI extension not installed in this test config',
-      );
+      ss.log('Skipping clipboard-preservation-013 — Cursor AI extension not installed in this test config');
       this.skip();
     }
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Cursor AI Assistant',
-      '✓ RangeLink: RangeLink sent to Cursor AI Assistant',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Cursor AI Assistant', '✓ RangeLink: RangeLink sent to Cursor AI Assistant']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     const fileUri = ss.createWorkspaceFile('cp-013', 'line 1\nline 2\nline 3\n');
@@ -621,10 +547,7 @@ standardSuite('Built-in AI Assistants', (ss) => {
   });
 
   test('clipboard-preservation-015: cold paste to Copilot Chat — prior clipboard restored', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to GitHub Copilot Chat',
-      '✓ RangeLink: RangeLink sent to GitHub Copilot Chat',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to GitHub Copilot Chat', '✓ RangeLink: RangeLink sent to GitHub Copilot Chat']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
     const fileUri = ss.createWorkspaceFile('cp-015', 'line 1\nline 2\nline 3\n');
     const editor = await ss.openEditor(fileUri);
@@ -683,14 +606,9 @@ standardSuite('Built-in AI Assistants', (ss) => {
     const editor = await ss.openEditor(fileUri);
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Dummy AI (Focus-Fail)',
-      '✓ RangeLink: RangeLink copied to clipboard',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Dummy AI (Focus-Fail)', '✓ RangeLink: RangeLink copied to clipboard']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
-    ss.expectToastMessages([
-      { level: 'warning', message: 'Paste (Cmd/Ctrl+V) in Dummy AI (Focus-Fail) to use.' },
-    ]);
+    ss.expectToastMessages([{ level: 'warning', message: 'Paste (Cmd/Ctrl+V) in Dummy AI (Focus-Fail) to use.' }]);
 
     await vscode.commands.executeCommand(CMD_BIND_TO_CUSTOM_AI_BY_ID, {
       extensionId: 'rangelink.dummy-ai-extension-focus-fail',
@@ -748,21 +666,11 @@ standardSuite('Built-in AI Assistants', (ss) => {
     const verdict = await waitForHumanVerdict(
       'clipboard-preservation-018',
       'Two rapid R-L: did both RangeLinks appear in Claude Code chat (lines 1-2 first and then lines 3-4)?',
-      [
-        '1. Two rapid sends were fired automatically',
-        '2. Check Claude Code chat for BOTH RangeLinks (lines 1-2 and lines 3-4)',
-        'Verdict:',
-      ],
+      ['1. Two rapid sends were fired automatically', '2. Check Claude Code chat for BOTH RangeLinks (lines 1-2 and lines 3-4)', 'Verdict:'],
     );
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'Human reported rapid R-L did not deliver both links or clipboard was corrupted',
-    );
+    assert.strictEqual(verdict, 'pass', 'Human reported rapid R-L did not deliver both links or clipboard was corrupted');
 
-    ss.log(
-      '✓ clipboard-preservation-018: rapid R-L — both links delivered, clipboard restored once',
-    );
+    ss.log('✓ clipboard-preservation-018: rapid R-L — both links delivered, clipboard restored once');
   });
 });
 
@@ -807,15 +715,8 @@ standardSuite('Built-in AI Assistants — Destination Picker', (ss) => {
       }
     }
 
-    assert.ok(
-      aiSectionItems.length > 0,
-      `Expected at least one item under the "${AI_ASSISTANTS_GROUP_LABEL}" separator`,
-    );
-    assert.strictEqual(
-      aiSectionItems[0].displayName,
-      CLAUDE_CODE_DISPLAY_NAME,
-      `Expected "${CLAUDE_CODE_DISPLAY_NAME}" to be the first AI Assistant item`,
-    );
+    assert.ok(aiSectionItems.length > 0, `Expected at least one item under the "${AI_ASSISTANTS_GROUP_LABEL}" separator`);
+    assert.strictEqual(aiSectionItems[0].displayName, CLAUDE_CODE_DISPLAY_NAME, `Expected "${CLAUDE_CODE_DISPLAY_NAME}" to be the first AI Assistant item`);
     assert.strictEqual(aiSectionItems[0].itemKind, 'bindable');
 
     ss.log('✓ Claude Code Chat appears first in the AI Assistants group');
@@ -845,10 +746,7 @@ standardSuite('Built-in AI Assistants — Destination Picker', (ss) => {
 
     assert.strictEqual(totalMs, 1500, 'Expected default coldStartDelayMs to be 1500');
     assert.strictEqual(intervalMs, 300, 'Expected default coldRefocusIntervalMs to be 300');
-    assert.ok(
-      totalMs > intervalMs,
-      `Expected coldStartDelayMs (${totalMs}) > coldRefocusIntervalMs (${intervalMs})`,
-    );
+    assert.ok(totalMs > intervalMs, `Expected coldStartDelayMs (${totalMs}) > coldRefocusIntervalMs (${intervalMs})`);
 
     ss.log('✓ Default cold-start config produces valid ColdRefocusConfig');
   });
@@ -859,10 +757,7 @@ standardSuite('Built-in AI Assistants — Destination Picker', (ss) => {
       this.skip();
     }
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Claude Code Chat',
-      '✓ RangeLink: Focused Claude Code Chat',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Claude Code Chat', '✓ RangeLink: Focused Claude Code Chat']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     const config = vscode.workspace.getConfiguration('rangelink.destinations.claudeCode');
@@ -872,11 +767,7 @@ standardSuite('Built-in AI Assistants — Destination Picker', (ss) => {
 
     // Set invalid config: delay (100) <= interval (400)
     await config.update('coldStartDelayMs', INVALID_DELAY_MS, vscode.ConfigurationTarget.Workspace);
-    await config.update(
-      'coldRefocusIntervalMs',
-      INVALID_INTERVAL_MS,
-      vscode.ConfigurationTarget.Workspace,
-    );
+    await config.update('coldRefocusIntervalMs', INVALID_INTERVAL_MS, vscode.ConfigurationTarget.Workspace);
     await ss.settle();
 
     const logCapture = getLogCapture();
@@ -892,11 +783,7 @@ standardSuite('Built-in AI Assistants — Destination Picker', (ss) => {
     const ccCtx = parseLogContext(
       ccLines.find((l) => {
         const c = parseLogContext(l);
-        return (
-          c?.fn === 'claudeCode.getColdRefocus' &&
-          c.totalMs === INVALID_DELAY_MS &&
-          c.intervalMs === INVALID_INTERVAL_MS
-        );
+        return c?.fn === 'claudeCode.getColdRefocus' && c.totalMs === INVALID_DELAY_MS && c.intervalMs === INVALID_INTERVAL_MS;
       }) ?? '',
     );
     assert.ok(ccCtx, 'Expected claudeCode.getColdRefocus warning with totalMs=100, intervalMs=400');
@@ -906,9 +793,7 @@ standardSuite('Built-in AI Assistants — Destination Picker', (ss) => {
 
   test('gemini-code-assist-001: Gemini Code Assist appears in destination picker when available', async function (this: MochaContext) {
     if (!vscode.extensions.getExtension(EXTENSION_ID_GEMINI_CODE_ASSIST)) {
-      ss.log(
-        `Skipping gemini-code-assist-001 — "${EXTENSION_ID_GEMINI_CODE_ASSIST}" extension is not installed in this test config.`,
-      );
+      ss.log(`Skipping gemini-code-assist-001 — "${EXTENSION_ID_GEMINI_CODE_ASSIST}" extension is not installed in this test config.`);
       this.skip();
     }
 
@@ -924,10 +809,7 @@ standardSuite('Built-in AI Assistants — Destination Picker', (ss) => {
     assert.ok(items, 'Expected showQuickPick log entry from destination picker');
 
     const geminiItem = items!.find((item) => item.displayName === GEMINI_CODE_ASSIST_DISPLAY_NAME);
-    assert.ok(
-      geminiItem,
-      `Expected "${GEMINI_CODE_ASSIST_DISPLAY_NAME}" in the destination picker items`,
-    );
+    assert.ok(geminiItem, `Expected "${GEMINI_CODE_ASSIST_DISPLAY_NAME}" in the destination picker items`);
     assert.strictEqual(geminiItem!.itemKind, 'bindable');
 
     ss.log('✓ gemini-code-assist-001 — Gemini Code Assist appears in the destination picker');
@@ -935,38 +817,19 @@ standardSuite('Built-in AI Assistants — Destination Picker', (ss) => {
 
   test('gemini-code-assist-005: Cold-start default settings produce correct ColdRefocusConfig', () => {
     const config = vscode.workspace.getConfiguration('rangelink.destinations.gemini');
-    const totalMs = config.get<number>(
-      'coldStartDelayMs',
-      DEFAULT_DESTINATIONS_GEMINI_COLD_START_DELAY_MS,
-    );
-    const intervalMs = config.get<number>(
-      'coldRefocusIntervalMs',
-      DEFAULT_DESTINATIONS_GEMINI_COLD_REFOCUS_INTERVAL_MS,
-    );
+    const totalMs = config.get<number>('coldStartDelayMs', DEFAULT_DESTINATIONS_GEMINI_COLD_START_DELAY_MS);
+    const intervalMs = config.get<number>('coldRefocusIntervalMs', DEFAULT_DESTINATIONS_GEMINI_COLD_REFOCUS_INTERVAL_MS);
 
-    assert.strictEqual(
-      totalMs,
-      DEFAULT_DESTINATIONS_GEMINI_COLD_START_DELAY_MS,
-      'Expected default coldStartDelayMs',
-    );
-    assert.strictEqual(
-      intervalMs,
-      DEFAULT_DESTINATIONS_GEMINI_COLD_REFOCUS_INTERVAL_MS,
-      'Expected default coldRefocusIntervalMs',
-    );
-    assert.ok(
-      totalMs > intervalMs,
-      `Expected coldStartDelayMs (${totalMs}) > coldRefocusIntervalMs (${intervalMs})`,
-    );
+    assert.strictEqual(totalMs, DEFAULT_DESTINATIONS_GEMINI_COLD_START_DELAY_MS, 'Expected default coldStartDelayMs');
+    assert.strictEqual(intervalMs, DEFAULT_DESTINATIONS_GEMINI_COLD_REFOCUS_INTERVAL_MS, 'Expected default coldRefocusIntervalMs');
+    assert.ok(totalMs > intervalMs, `Expected coldStartDelayMs (${totalMs}) > coldRefocusIntervalMs (${intervalMs})`);
 
     ss.log('✓ Default Gemini cold-start config produces valid ColdRefocusConfig');
   });
 
   test('gemini-code-assist-006: Cold-start validation rejects invalid config and falls back to defaults', async function (this: MochaContext) {
     if (!vscode.extensions.getExtension(EXTENSION_ID_GEMINI_CODE_ASSIST)) {
-      ss.log(
-        'Skipping gemini-code-assist-006 — Gemini Code Assist extension not installed in this test config',
-      );
+      ss.log('Skipping gemini-code-assist-006 — Gemini Code Assist extension not installed in this test config');
       this.skip();
     }
 
@@ -978,19 +841,12 @@ standardSuite('Built-in AI Assistants — Destination Picker', (ss) => {
     // Set delay <= interval so the validation rejects it (by default, delay >
     // interval so the config is valid; flipping that relationship makes it invalid).
     await config.update('coldStartDelayMs', INVALID_DELAY_MS, vscode.ConfigurationTarget.Workspace);
-    await config.update(
-      'coldRefocusIntervalMs',
-      INVALID_INTERVAL_MS,
-      vscode.ConfigurationTarget.Workspace,
-    );
+    await config.update('coldRefocusIntervalMs', INVALID_INTERVAL_MS, vscode.ConfigurationTarget.Workspace);
     await ss.settle();
 
     await ss.waitForExtensionActive(EXTENSION_ID_GEMINI_CODE_ASSIST);
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Gemini Code Assist',
-      '✓ RangeLink: Focused Gemini Code Assist',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Gemini Code Assist', '✓ RangeLink: Focused Gemini Code Assist']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     const logCapture = getLogCapture();
@@ -1009,11 +865,7 @@ standardSuite('Built-in AI Assistants — Destination Picker', (ss) => {
     const gcCtx = parseLogContext(
       gcLines.find((l) => {
         const c = parseLogContext(l);
-        return (
-          c?.fn === 'gemini.getColdRefocus' &&
-          c.totalMs === INVALID_DELAY_MS &&
-          c.intervalMs === INVALID_INTERVAL_MS
-        );
+        return c?.fn === 'gemini.getColdRefocus' && c.totalMs === INVALID_DELAY_MS && c.intervalMs === INVALID_INTERVAL_MS;
       }) ?? '',
     );
     assert.ok(gcCtx, 'Expected gemini.getColdRefocus warning with totalMs=100, intervalMs=400');

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/clipboardPreservation.test.ts
@@ -44,18 +44,13 @@ standardSuite('Clipboard Preservation', (ss) => {
   });
 
   test('clipboard-preservation-003: R-F with preserve=always restores clipboard to sentinel after send', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-clipboard-test")',
-      '✓ RangeLink: File path sent to Terminal ("rl-clipboard-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-clipboard-test")', '✓ RangeLink: File path sent to Terminal ("rl-clipboard-test")']);
     ss.expectContextKeys({
       'rangelink.isBound': true,
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
     });
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('clipboard.preserve', 'always', vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration('rangelink').update('clipboard.preserve', 'always', vscode.ConfigurationTarget.Global);
 
     capturing.clearCaptured();
     await withClipboardSentinel('before-003', 'R-F', async () => {
@@ -66,18 +61,13 @@ standardSuite('Clipboard Preservation', (ss) => {
   });
 
   test('clipboard-preservation-006: R-L with preserve=never leaves clipboard with the generated link', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-clipboard-test")',
-      '✓ RangeLink: RangeLink sent to Terminal ("rl-clipboard-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-clipboard-test")', '✓ RangeLink: RangeLink sent to Terminal ("rl-clipboard-test")']);
     ss.expectContextKeys({
       'rangelink.isBound': true,
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
     });
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('clipboard.preserve', 'never', vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration('rangelink').update('clipboard.preserve', 'never', vscode.ConfigurationTarget.Global);
 
     capturing.clearCaptured();
     await assertClipboardEqualsGeneratedLink(
@@ -93,18 +83,13 @@ standardSuite('Clipboard Preservation', (ss) => {
   });
 
   test('clipboard-preservation-008: R-C writes link to clipboard with preserve=always (R-C is exempt from preserve)', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-clipboard-test")',
-      '✓ RangeLink: RangeLink copied to clipboard',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-clipboard-test")', '✓ RangeLink: RangeLink copied to clipboard']);
     ss.expectContextKeys({
       'rangelink.isBound': true,
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
     });
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('clipboard.preserve', 'always', vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration('rangelink').update('clipboard.preserve', 'always', vscode.ConfigurationTarget.Global);
 
     await assertClipboardEqualsGeneratedLink(
       'R-C with preserve=always',
@@ -117,10 +102,7 @@ standardSuite('Clipboard Preservation', (ss) => {
   });
 
   test('clipboard-preservation-019: R-C writes link to clipboard with default preserve setting', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-clipboard-test")',
-      '✓ RangeLink: RangeLink copied to clipboard',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-clipboard-test")', '✓ RangeLink: RangeLink copied to clipboard']);
     ss.expectContextKeys({
       'rangelink.isBound': true,
       'rangelink.isActiveTerminalBindable': true,
@@ -137,18 +119,13 @@ standardSuite('Clipboard Preservation', (ss) => {
   });
 
   test('clipboard-preservation-020: R-C writes link to clipboard with preserve=never', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-clipboard-test")',
-      '✓ RangeLink: RangeLink copied to clipboard',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-clipboard-test")', '✓ RangeLink: RangeLink copied to clipboard']);
     ss.expectContextKeys({
       'rangelink.isBound': true,
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
     });
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('clipboard.preserve', 'never', vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration('rangelink').update('clipboard.preserve', 'never', vscode.ConfigurationTarget.Global);
 
     await assertClipboardEqualsGeneratedLink(
       'R-C with preserve=never',
@@ -180,10 +157,7 @@ standardSuite('Clipboard Preservation', (ss) => {
 
 standardSuite('Clipboard Preservation — Assisted', (ss) => {
   test('clipboard-preservation-001: always mode — R-L to terminal restores clipboard', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("cbp-001-dest")',
-      '✓ RangeLink: RangeLink sent to Terminal ("cbp-001-dest")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("cbp-001-dest")', '✓ RangeLink: RangeLink sent to Terminal ("cbp-001-dest")']);
     ss.expectContextKeys({
       'rangelink.isBound': true,
       'rangelink.isActiveTerminalBindable': true,
@@ -195,10 +169,7 @@ standardSuite('Clipboard Preservation — Assisted', (ss) => {
 
     const editor001 = await ss.openEditor(fileUri);
     const lastSelectedLine = editor001.document.lineAt(3);
-    editor001.selection = new vscode.Selection(
-      new vscode.Position(1, 0),
-      lastSelectedLine.range.end,
-    );
+    editor001.selection = new vscode.Selection(new vscode.Position(1, 0), lastSelectedLine.range.end);
     await ss.settle();
 
     await assertClipboardPreservedAndTerminalLink(capturing, 'before-001', 'R-L', async () => {
@@ -213,10 +184,7 @@ standardSuite('Clipboard Preservation — Assisted', (ss) => {
 
     const fileUri = ss.createWorkspaceFile('cbp-002', '');
     const destBasename = path.basename(fileUri.fsPath);
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Text Editor ("${destBasename}")`,
-      `✓ RangeLink: Selected text sent to Text Editor ("${destBasename}")`,
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Text Editor ("${destBasename}")`, `✓ RangeLink: Selected text sent to Text Editor ("${destBasename}")`]);
     ss.expectContextKeys({
       'rangelink.isBound': true,
       'rangelink.isActiveTerminalBindable': true,
@@ -242,18 +210,12 @@ standardSuite('Clipboard Preservation — Assisted', (ss) => {
     });
 
     const destContent = (await vscode.workspace.openTextDocument(fileUri)).getText();
-    assert.ok(
-      destContent.replace(/[\r\n]/g, '').includes(PHRASE),
-      `Expected "${PHRASE}" in destination file, got: ${JSON.stringify(destContent)}`,
-    );
+    assert.ok(destContent.replace(/[\r\n]/g, '').includes(PHRASE), `Expected "${PHRASE}" in destination file, got: ${JSON.stringify(destContent)}`);
     ss.log('✓ Clipboard restored to sentinel and phrase landed in destination file after R-V');
   });
 
   test('clipboard-preservation-004: always mode — AI assistant paste restores clipboard', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Dummy AI (Tier 1)',
-      '✓ RangeLink: RangeLink sent to Dummy AI (Tier 1)',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Dummy AI (Tier 1)', '✓ RangeLink: RangeLink sent to Dummy AI (Tier 1)']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
     const { uri: fileUri } = ss.createContentFile('cbp-004', 10, (i) => `line ${i + 1} content`);
 
@@ -278,19 +240,12 @@ standardSuite('Clipboard Preservation — Assisted', (ss) => {
       tier1: string;
       tier2: string;
     };
-    assert.strictEqual(
-      dummyText.tier1,
-      ` ${expectedLink} `,
-      `Expected Dummy AI tier1=" ${expectedLink} ", got: ${JSON.stringify(dummyText.tier1)}`,
-    );
+    assert.strictEqual(dummyText.tier1, ` ${expectedLink} `, `Expected Dummy AI tier1=" ${expectedLink} ", got: ${JSON.stringify(dummyText.tier1)}`);
     ss.log('✓ Clipboard restored to sentinel and link landed in Dummy AI after R-L');
   });
 
   test('clipboard-preservation-005: always mode — terminal paste (fresh bind) restores clipboard', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("cbp-005-dest")',
-      '✓ RangeLink: RangeLink sent to Terminal ("cbp-005-dest")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("cbp-005-dest")', '✓ RangeLink: RangeLink sent to Terminal ("cbp-005-dest")']);
     ss.expectContextKeys({
       'rangelink.isBound': true,
       'rangelink.isActiveTerminalBindable': true,
@@ -302,10 +257,7 @@ standardSuite('Clipboard Preservation — Assisted', (ss) => {
 
     const editor005 = await ss.openEditor(fileUri);
     const lastSelectedLine = editor005.document.lineAt(2);
-    editor005.selection = new vscode.Selection(
-      new vscode.Position(1, 0),
-      lastSelectedLine.range.end,
-    );
+    editor005.selection = new vscode.Selection(new vscode.Position(1, 0), lastSelectedLine.range.end);
     await ss.settle();
 
     await assertClipboardPreservedAndTerminalLink(capturing, 'before-005', 'R-L', async () => {
@@ -329,10 +281,7 @@ standardSuite('Clipboard Preservation — Assisted', (ss) => {
     await ss.settle();
 
     const destBasename = path.basename(fileUri.fsPath);
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Text Editor ("${destBasename}")`,
-      `✓ RangeLink: Selected text sent to Text Editor ("${destBasename}")`,
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Text Editor ("${destBasename}")`, `✓ RangeLink: Selected text sent to Text Editor ("${destBasename}")`]);
     ss.expectContextKeys({
       'rangelink.isBound': true,
       'rangelink.isActiveTerminalBindable': true,
@@ -354,10 +303,7 @@ standardSuite('Clipboard Preservation — Assisted', (ss) => {
     });
 
     const destContent = (await vscode.workspace.openTextDocument(fileUri)).getText();
-    assert.ok(
-      destContent.replace(/[\r\n]/g, '').includes(PHRASE),
-      `Expected "${PHRASE}" in destination file, got: ${JSON.stringify(destContent)}`,
-    );
+    assert.ok(destContent.replace(/[\r\n]/g, '').includes(PHRASE), `Expected "${PHRASE}" in destination file, got: ${JSON.stringify(destContent)}`);
     ss.log('✓ Clipboard changed from sentinel and phrase landed in destination file after R-V');
   });
 
@@ -394,13 +340,8 @@ standardSuite('Clipboard Preservation — Assisted', (ss) => {
     editor.selection = new vscode.Selection(0, 0, 3, 0);
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Dummy AI (Focus-Fail)',
-      '✓ RangeLink: RangeLink copied to clipboard',
-    ]);
-    ss.expectToastMessages([
-      { level: 'warning', message: 'Paste (Cmd/Ctrl+V) in Dummy AI (Focus-Fail) to use.' },
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Dummy AI (Focus-Fail)', '✓ RangeLink: RangeLink copied to clipboard']);
+    ss.expectToastMessages([{ level: 'warning', message: 'Paste (Cmd/Ctrl+V) in Dummy AI (Focus-Fail) to use.' }]);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     await vscode.commands.executeCommand(CMD_BIND_TO_CUSTOM_AI_BY_ID, {
@@ -423,9 +364,7 @@ standardSuite('Clipboard Preservation — Assisted', (ss) => {
       return ctx?.fn?.endsWith('.pasteLink') && ctx?.reason !== undefined;
     });
     assert.ok(focusFailed010, 'Expected focus failure log with reason field');
-    ss.log(
-      '✓ Clipboard not restored after focus failure — link stays in clipboard for manual paste',
-    );
+    ss.log('✓ Clipboard not restored after focus failure — link stays in clipboard for manual paste');
   });
 
   test('clipboard-preservation-022: focus command failure preserves portable link in clipboard for manual paste with portable content type in UI', async () => {
@@ -435,13 +374,8 @@ standardSuite('Clipboard Preservation — Assisted', (ss) => {
     editor.selection = new vscode.Selection(0, 0, 3, 0);
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Dummy AI (Focus-Fail)',
-      '✓ RangeLink: Portable RangeLink copied to clipboard',
-    ]);
-    ss.expectToastMessages([
-      { level: 'warning', message: 'Paste (Cmd/Ctrl+V) in Dummy AI (Focus-Fail) to use.' },
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Dummy AI (Focus-Fail)', '✓ RangeLink: Portable RangeLink copied to clipboard']);
+    ss.expectToastMessages([{ level: 'warning', message: 'Paste (Cmd/Ctrl+V) in Dummy AI (Focus-Fail) to use.' }]);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     await vscode.commands.executeCommand(CMD_BIND_TO_CUSTOM_AI_BY_ID, {

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/commandRegistration.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/commandRegistration.test.ts
@@ -69,10 +69,7 @@ standardSuite('Command Registration', (_ss) => {
 
   for (const commandId of EXPECTED_COMMAND_IDS) {
     test(`${commandId} is registered`, () => {
-      assert.ok(
-        registeredCommands.includes(commandId),
-        `Expected command '${commandId}' to be registered but it was not found`,
-      );
+      assert.ok(registeredCommands.includes(commandId), `Expected command '${commandId}' to be registered but it was not found`);
     });
   }
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorContent.test.ts
@@ -28,24 +28,14 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     // multi-line-paste warning dialog by default; set to 'never' so
     // TC 005's selection delivers deterministically in the test host.
     const terminalConfig = vscode.workspace.getConfiguration('terminal.integrated');
-    originalMultiLinePasteWarning = terminalConfig.inspect(
-      'enableMultiLinePasteWarning',
-    )?.globalValue;
-    await terminalConfig.update(
-      'enableMultiLinePasteWarning',
-      'never',
-      vscode.ConfigurationTarget.Global,
-    );
+    originalMultiLinePasteWarning = terminalConfig.inspect('enableMultiLinePasteWarning')?.globalValue;
+    await terminalConfig.update('enableMultiLinePasteWarning', 'never', vscode.ConfigurationTarget.Global);
   });
 
   suiteTeardown(async () => {
     await vscode.workspace
       .getConfiguration('terminal.integrated')
-      .update(
-        'enableMultiLinePasteWarning',
-        originalMultiLinePasteWarning,
-        vscode.ConfigurationTarget.Global,
-      );
+      .update('enableMultiLinePasteWarning', originalMultiLinePasteWarning, vscode.ConfigurationTarget.Global);
   });
 
   test('[assisted] context-menus-editor-content-001: Editor content "Send RangeLink" sends workspace-relative link to bound terminal', async () => {
@@ -59,10 +49,7 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(1, 6));
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-ctxmenu-ed-001")',
-      '✓ RangeLink: RangeLink sent to Terminal ("rl-ctxmenu-ed-001")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-ctxmenu-ed-001")', '✓ RangeLink: RangeLink sent to Terminal ("rl-ctxmenu-ed-001")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -73,16 +60,12 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     logCapture.mark('before-ed-001');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'context-menus-editor-content-001',
-      `Right-click INSIDE the selected text in "${fn}" → "RangeLink: Send RangeLink"`,
-      [
-        `The file "${fn}" has lines 1–2 already selected for you.`,
-        `A Terminal "${terminalName}" is bound as the destination.`,
-        '1. Right-click INSIDE the highlighted selection',
-        '2. Select "RangeLink: Send RangeLink"',
-      ],
-    );
+    await waitForHuman('context-menus-editor-content-001', `Right-click INSIDE the selected text in "${fn}" → "RangeLink: Send RangeLink"`, [
+      `The file "${fn}" has lines 1–2 already selected for you.`,
+      `A Terminal "${terminalName}" is bound as the destination.`,
+      '1. Right-click INSIDE the highlighted selection',
+      '2. Select "RangeLink: Send RangeLink"',
+    ]);
 
     assertTerminalBufferContainsGeneratedLink(capturing, 'before-ed-001');
 
@@ -100,10 +83,7 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(1, 6));
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-ctxmenu-ed-002")',
-      '✓ RangeLink: RangeLink sent to Terminal ("rl-ctxmenu-ed-002")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-ctxmenu-ed-002")', '✓ RangeLink: RangeLink sent to Terminal ("rl-ctxmenu-ed-002")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -114,21 +94,15 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     logCapture.mark('before-ed-002');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'context-menus-editor-content-002',
-      `Right-click INSIDE the selected text in "${fn}" → "RangeLink: Send RangeLink (Absolute)"`,
-      [
-        `The file "${fn}" has lines 1–2 already selected for you.`,
-        '1. Right-click INSIDE the highlighted selection',
-        '2. Select "RangeLink: Send RangeLink (Absolute)"',
-      ],
-    );
+    await waitForHuman('context-menus-editor-content-002', `Right-click INSIDE the selected text in "${fn}" → "RangeLink: Send RangeLink (Absolute)"`, [
+      `The file "${fn}" has lines 1–2 already selected for you.`,
+      '1. Right-click INSIDE the highlighted selection',
+      '2. Select "RangeLink: Send RangeLink (Absolute)"',
+    ]);
 
     assertTerminalBufferContainsGeneratedLink(capturing, 'before-ed-002');
 
-    ss.log(
-      '✓ Editor-content "Send RangeLink (Absolute)" delivered absolute link to bound terminal',
-    );
+    ss.log('✓ Editor-content "Send RangeLink (Absolute)" delivered absolute link to bound terminal');
   });
 
   test('[assisted] context-menus-editor-content-003: Editor content "Send Portable Link" sends portable link with workspace-relative path', async () => {
@@ -156,15 +130,11 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     logCapture.mark('before-ed-003');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'context-menus-editor-content-003',
-      `Right-click INSIDE the selected text in "${fn}" → "RangeLink: Send Portable Link"`,
-      [
-        `The file "${fn}" has lines 1–2 already selected for you.`,
-        '1. Right-click INSIDE the highlighted selection',
-        '2. Select "RangeLink: Send Portable Link"',
-      ],
-    );
+    await waitForHuman('context-menus-editor-content-003', `Right-click INSIDE the selected text in "${fn}" → "RangeLink: Send Portable Link"`, [
+      `The file "${fn}" has lines 1–2 already selected for you.`,
+      '1. Right-click INSIDE the highlighted selection',
+      '2. Select "RangeLink: Send Portable Link"',
+    ]);
 
     assertTerminalBufferContainsGeneratedLink(capturing, 'before-ed-003');
 
@@ -196,21 +166,15 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     logCapture.mark('before-ed-004');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'context-menus-editor-content-004',
-      `Right-click INSIDE the selected text in "${fn}" → "RangeLink: Send Portable Link (Absolute)"`,
-      [
-        `The file "${fn}" has lines 1–2 already selected for you.`,
-        '1. Right-click INSIDE the highlighted selection',
-        '2. Select "RangeLink: Send Portable Link (Absolute)"',
-      ],
-    );
+    await waitForHuman('context-menus-editor-content-004', `Right-click INSIDE the selected text in "${fn}" → "RangeLink: Send Portable Link (Absolute)"`, [
+      `The file "${fn}" has lines 1–2 already selected for you.`,
+      '1. Right-click INSIDE the highlighted selection',
+      '2. Select "RangeLink: Send Portable Link (Absolute)"',
+    ]);
 
     assertTerminalBufferContainsGeneratedLink(capturing, 'before-ed-004');
 
-    ss.log(
-      '✓ Editor-content "Send Portable Link (Absolute)" delivered portable link with absolute path',
-    );
+    ss.log('✓ Editor-content "Send Portable Link (Absolute)" delivered portable link with absolute path');
   });
 
   test('[assisted] context-menus-editor-content-005: Editor content "Send Selected Text" sends raw selected text to bound terminal', async () => {
@@ -224,10 +188,7 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(2, 6));
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-ctxmenu-ed-005")',
-      '✓ RangeLink: Selected text sent to Terminal ("rl-ctxmenu-ed-005")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-ctxmenu-ed-005")', '✓ RangeLink: Selected text sent to Terminal ("rl-ctxmenu-ed-005")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -238,20 +199,16 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     logCapture.mark('before-ed-005');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'context-menus-editor-content-005',
-      `Right-click INSIDE the selected text in "${fn}" → "RangeLink: Send Selected Text"`,
-      [
-        `The file "${fn}" has lines 1–3 already selected for you.`,
-        '1. Right-click INSIDE the highlighted selection',
-        '2. Select "RangeLink: Send Selected Text"',
-        'Visual note: the test terminal will LOOK like it only shows "line 3" — that is correct.',
-        "VS Code's terminal paste converts newlines to carriage returns so each line",
-        'would execute separately in a real shell. Our capturing pty has no shell, so',
-        'successive `\\r`s overwrite the same screen row. All three lines ARE delivered',
-        '(the test reads the raw captured buffer, not the rendered display).',
-      ],
-    );
+    await waitForHuman('context-menus-editor-content-005', `Right-click INSIDE the selected text in "${fn}" → "RangeLink: Send Selected Text"`, [
+      `The file "${fn}" has lines 1–3 already selected for you.`,
+      '1. Right-click INSIDE the highlighted selection',
+      '2. Select "RangeLink: Send Selected Text"',
+      'Visual note: the test terminal will LOOK like it only shows "line 3" — that is correct.',
+      "VS Code's terminal paste converts newlines to carriage returns so each line",
+      'would execute separately in a real shell. Our capturing pty has no shell, so',
+      'successive `\\r`s overwrite the same screen row. All three lines ARE delivered',
+      '(the test reads the raw captured buffer, not the rendered display).',
+    ]);
 
     // Normalize both `\r\n` and lone `\r` to `\n` so the contiguous-substring
     // check passes regardless of VS Code's line-ending choice. `workbench.action.terminal.paste`
@@ -273,18 +230,10 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     const verdict = await waitForHumanVerdict(
       'context-menus-editor-content-006',
       `Right-click in "${fn}" — is there a visual separator line between the RangeLink block and the rest of the menu?`,
-      [
-        '1. Right-click anywhere inside the editor',
-        '2. Look at the RangeLink commands as a group (grouped together in the menu)',
-        'Verdict:',
-      ],
+      ['1. Right-click anywhere inside the editor', '2. Look at the RangeLink commands as a group (grouped together in the menu)', 'Verdict:'],
     );
 
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'Human reported the RangeLink block has no visual separator — group prefixes in package.json may have drifted',
-    );
+    assert.strictEqual(verdict, 'pass', 'Human reported the RangeLink block has no visual separator — group prefixes in package.json may have drifted');
 
     ss.log('✓ Editor-content context menu renders a visual separator for the RangeLink block');
   });
@@ -299,10 +248,7 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     await ss.openEditor(uri);
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-ctxmenu-ed-007")',
-      '✓ RangeLink: File path sent to Terminal ("rl-ctxmenu-ed-007")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-ctxmenu-ed-007")', '✓ RangeLink: File path sent to Terminal ("rl-ctxmenu-ed-007")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -313,14 +259,10 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     logCapture.mark('before-ed-007');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'context-menus-editor-content-007',
-      `Right-click in "${fn}" → "RangeLink: Send This File's Path"`,
-      [
-        '1. Right-click anywhere inside the editor (no selection needed)',
-        '2. Select "RangeLink: Send This File\'s Path"',
-      ],
-    );
+    await waitForHuman('context-menus-editor-content-007', `Right-click in "${fn}" → "RangeLink: Send This File's Path"`, [
+      '1. Right-click anywhere inside the editor (no selection needed)',
+      '2. Select "RangeLink: Send This File\'s Path"',
+    ]);
 
     const lines = logCapture.getLinesSince('before-ed-007');
 
@@ -347,10 +289,7 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     await ss.openEditor(uri);
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-ctxmenu-ed-008")',
-      '✓ RangeLink: File path sent to Terminal ("rl-ctxmenu-ed-008")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-ctxmenu-ed-008")', '✓ RangeLink: File path sent to Terminal ("rl-ctxmenu-ed-008")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -361,14 +300,10 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     logCapture.mark('before-ed-008');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'context-menus-editor-content-008',
-      `Right-click in "${fn}" → "RangeLink: Send This File's Relative Path"`,
-      [
-        '1. Right-click anywhere inside the editor (no selection needed)',
-        '2. Select "RangeLink: Send This File\'s Relative Path"',
-      ],
-    );
+    await waitForHuman('context-menus-editor-content-008', `Right-click in "${fn}" → "RangeLink: Send This File's Relative Path"`, [
+      '1. Right-click anywhere inside the editor (no selection needed)',
+      '2. Select "RangeLink: Send This File\'s Relative Path"',
+    ]);
 
     const lines = logCapture.getLinesSince('before-ed-008');
 
@@ -381,9 +316,7 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     assertClipboardWriteLogged(lines, { textLength: expectedPath.length });
     assertTerminalBufferContains(capturing.getCapturedText(), relativePath);
 
-    ss.log(
-      '✓ Editor-content "Send This File\'s Relative Path" delivered relative path to bound terminal',
-    );
+    ss.log('✓ Editor-content "Send This File\'s Relative Path" delivered relative path to bound terminal');
   });
 
   test('[assisted] context-menus-editor-content-009: Editor content "Bind Here" binds the current file as the text editor destination', async () => {
@@ -396,14 +329,10 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-ed-009');
 
-    await waitForHuman(
-      'context-menus-editor-content-009',
-      `Right-click in "${fn}" → "RangeLink: Bind Here"`,
-      [
-        '1. Right-click anywhere inside the editor (no selection needed)',
-        '2. Select "RangeLink: Bind Here"',
-      ],
-    );
+    await waitForHuman('context-menus-editor-content-009', `Right-click in "${fn}" → "RangeLink: Bind Here"`, [
+      '1. Right-click anywhere inside the editor (no selection needed)',
+      '2. Select "RangeLink: Bind Here"',
+    ]);
 
     ss.log('✓ Editor-content "Bind Here" committed a text-editor binding for the current file');
   });
@@ -418,24 +347,17 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     await ss.openEditor(uri);
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-ctxmenu-ed-010")',
-      '✓ RangeLink: Unbound from Terminal ("rl-ctxmenu-ed-010")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-ctxmenu-ed-010")', '✓ RangeLink: Unbound from Terminal ("rl-ctxmenu-ed-010")']);
     ss.expectContextKeys({ 'rangelink.isActiveTerminalBindable': true });
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ed-010');
 
-    await waitForHuman(
-      'context-menus-editor-content-010',
-      `Right-click in "${fn}", then select "RangeLink: Unbind" from the menu.`,
-      [
-        `A Terminal "${terminalName}" is bound as the current destination.`,
-        '1. Right-click anywhere inside the editor',
-        '2. Select "RangeLink: Unbind" from the context menu',
-      ],
-    );
+    await waitForHuman('context-menus-editor-content-010', `Right-click in "${fn}", then select "RangeLink: Unbind" from the menu.`, [
+      `A Terminal "${terminalName}" is bound as the current destination.`,
+      '1. Right-click anywhere inside the editor',
+      '2. Select "RangeLink: Unbind" from the context menu',
+    ]);
 
     ss.log('✓ Editor-content "Unbind" was visible (clicked it) and fired the unbind path');
   });
@@ -480,17 +402,10 @@ standardSuite('Context Menus — Editor Content', (ss) => {
       'pass',
       'Human reported selection-dependent items WERE visible without a selection — the `when: editorHasSelection` clause is not working',
     );
-    const pasteFired = lines.some(
-      (line) => parseLogContext(line)?.fn === 'VscodeAdapter.writeTextToClipboard',
-    );
-    assert.ok(
-      !pasteFired,
-      'Expected no clipboard write log — nothing should have been sent during observation',
-    );
+    const pasteFired = lines.some((line) => parseLogContext(line)?.fn === 'VscodeAdapter.writeTextToClipboard');
+    assert.ok(!pasteFired, 'Expected no clipboard write log — nothing should have been sent during observation');
 
-    ss.log(
-      '✓ No-selection state: selection-dependent items hidden (human verdict + state invariant)',
-    );
+    ss.log('✓ No-selection state: selection-dependent items hidden (human verdict + state invariant)');
   });
 
   test('context-menus-editor-content-012: R-V same file same column blocked — toast shown, clipboard untouched, editor unchanged', async () => {
@@ -515,14 +430,8 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     });
 
     const doc = await vscode.workspace.openTextDocument(fileUri);
-    assert.strictEqual(
-      doc.getText(),
-      'line 1\nline 2\nline 3\n',
-      'Expected file to remain unmodified after blocked R-V',
-    );
-    ss.log(
-      '✓ R-V same file same column: blocked, toast shown, clipboard untouched, editor unchanged',
-    );
+    assert.strictEqual(doc.getText(), 'line 1\nline 2\nline 3\n', 'Expected file to remain unmodified after blocked R-V');
+    ss.log('✓ R-V same file same column: blocked, toast shown, clipboard untouched, editor unchanged');
   });
 
   test('context-menus-editor-content-013: R-V multi-selection same file blocked — toast shown, clipboard untouched', async () => {
@@ -550,11 +459,7 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     });
 
     const doc = await vscode.workspace.openTextDocument(fileUri);
-    assert.strictEqual(
-      doc.getText(),
-      'line 1\nline 2\nline 3\nline 4\n',
-      'Expected file to remain unmodified after blocked R-V multi-selection',
-    );
+    assert.strictEqual(doc.getText(), 'line 1\nline 2\nline 3\nline 4\n', 'Expected file to remain unmodified after blocked R-V multi-selection');
     ss.log('✓ R-V multi-selection same file: blocked, toast shown, clipboard untouched');
   });
 
@@ -570,10 +475,7 @@ standardSuite('Context Menus — Editor Content', (ss) => {
       viewColumn: vscode.ViewColumn.Two,
       preview: false,
     });
-    destEditor.selection = new vscode.Selection(
-      new vscode.Position(1, 0),
-      new vscode.Position(1, 0),
-    );
+    destEditor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 0));
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
     await ss.settle();
 
@@ -581,10 +483,7 @@ standardSuite('Context Menus — Editor Content', (ss) => {
     await openSourceWithSelection(sourceUri, vscode.ViewColumn.Three);
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Text Editor ("${destBasename}")`,
-      `✓ RangeLink: Selected text sent to Text Editor ("${destBasename}")`,
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Text Editor ("${destBasename}")`, `✓ RangeLink: Selected text sent to Text Editor ("${destBasename}")`]);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorTab.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuEditorTab.test.ts
@@ -1,12 +1,5 @@
 import { CMD_BIND_TO_TERMINAL_HERE } from '../../constants/commandIds';
-import {
-  assertClipboardWriteLogged,
-  assertFilePathLogged,
-  assertTerminalBufferEquals,
-  getLogCapture,
-  standardSuite,
-  waitForHuman,
-} from '../helpers';
+import { assertClipboardWriteLogged, assertFilePathLogged, assertTerminalBufferEquals, getLogCapture, standardSuite, waitForHuman } from '../helpers';
 
 import * as path from 'node:path';
 import * as vscode from 'vscode';
@@ -23,10 +16,7 @@ standardSuite('Context Menus — Editor Tab', (ss) => {
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-ctxmenu-tab-001")',
-      '✓ RangeLink: File path sent to Terminal ("rl-ctxmenu-tab-001")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-ctxmenu-tab-001")', '✓ RangeLink: File path sent to Terminal ("rl-ctxmenu-tab-001")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -37,15 +27,11 @@ standardSuite('Context Menus — Editor Tab', (ss) => {
     logCapture.mark('before-ctxmenu-tab-001');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'context-menus-editor-tab-001',
-      `Right-click tab "${fn}" → "RangeLink: Send File Path"`,
-      [
-        `1. Locate the "${fn}" tab in the editor tab bar`,
-        '2. Right-click the tab',
-        '3. Select "RangeLink: Send File Path"',
-      ],
-    );
+    await waitForHuman('context-menus-editor-tab-001', `Right-click tab "${fn}" → "RangeLink: Send File Path"`, [
+      `1. Locate the "${fn}" tab in the editor tab bar`,
+      '2. Right-click the tab',
+      '3. Select "RangeLink: Send File Path"',
+    ]);
 
     const lines = logCapture.getLinesSince('before-ctxmenu-tab-001');
 
@@ -58,9 +44,7 @@ standardSuite('Context Menus — Editor Tab', (ss) => {
     assertClipboardWriteLogged(lines, { textLength: expectedPath.length });
     assertTerminalBufferEquals(capturing.getCapturedText(), expectedPath);
 
-    ss.log(
-      '✓ Editor-tab absolute path landed in bound terminal buffer (pty capture verified content)',
-    );
+    ss.log('✓ Editor-tab absolute path landed in bound terminal buffer (pty capture verified content)');
   });
 
   test('[assisted] context-menus-editor-tab-002: Editor tab "Send Relative File Path" sends relative path to bound terminal', async () => {
@@ -73,10 +57,7 @@ standardSuite('Context Menus — Editor Tab', (ss) => {
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-ctxmenu-tab-002")',
-      '✓ RangeLink: File path sent to Terminal ("rl-ctxmenu-tab-002")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-ctxmenu-tab-002")', '✓ RangeLink: File path sent to Terminal ("rl-ctxmenu-tab-002")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -87,15 +68,11 @@ standardSuite('Context Menus — Editor Tab', (ss) => {
     logCapture.mark('before-ctxmenu-tab-002');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'context-menus-editor-tab-002',
-      `Right-click tab "${fn}" → "RangeLink: Send Relative File Path"`,
-      [
-        `1. Locate the "${fn}" tab in the editor tab bar`,
-        '2. Right-click the tab',
-        '3. Select "RangeLink: Send Relative File Path"',
-      ],
-    );
+    await waitForHuman('context-menus-editor-tab-002', `Right-click tab "${fn}" → "RangeLink: Send Relative File Path"`, [
+      `1. Locate the "${fn}" tab in the editor tab bar`,
+      '2. Right-click the tab',
+      '3. Select "RangeLink: Send Relative File Path"',
+    ]);
 
     const lines = logCapture.getLinesSince('before-ctxmenu-tab-002');
 
@@ -108,9 +85,7 @@ standardSuite('Context Menus — Editor Tab', (ss) => {
     assertClipboardWriteLogged(lines, { textLength: expectedPath.length });
     assertTerminalBufferEquals(capturing.getCapturedText(), expectedPath);
 
-    ss.log(
-      '✓ Editor-tab relative path landed in bound terminal buffer (pty capture verified content)',
-    );
+    ss.log('✓ Editor-tab relative path landed in bound terminal buffer (pty capture verified content)');
   });
 
   test('[assisted] context-menus-editor-tab-003: Editor tab "Bind Here" binds that editor as text editor destination', async () => {
@@ -123,15 +98,11 @@ standardSuite('Context Menus — Editor Tab', (ss) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-tab-003');
 
-    await waitForHuman(
-      'context-menus-editor-tab-003',
-      `Right-click tab "${fn}" → "RangeLink: Bind Here"`,
-      [
-        `1. Locate the "${fn}" tab in the editor tab bar`,
-        '2. Right-click the tab',
-        '3. Select "RangeLink: Bind Here"',
-      ],
-    );
+    await waitForHuman('context-menus-editor-tab-003', `Right-click tab "${fn}" → "RangeLink: Bind Here"`, [
+      `1. Locate the "${fn}" tab in the editor tab bar`,
+      '2. Right-click the tab',
+      '3. Select "RangeLink: Bind Here"',
+    ]);
 
     ss.log('✓ Editor-tab "Bind Here" committed a text-editor binding with correct displayName');
   });
@@ -145,25 +116,18 @@ standardSuite('Context Menus — Editor Tab', (ss) => {
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-ctxmenu-tab-004")',
-      '✓ RangeLink: Unbound from Terminal ("rl-ctxmenu-tab-004")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-ctxmenu-tab-004")', '✓ RangeLink: Unbound from Terminal ("rl-ctxmenu-tab-004")']);
     ss.expectContextKeys({ 'rangelink.isActiveTerminalBindable': true });
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-tab-004');
 
-    await waitForHuman(
-      'context-menus-editor-tab-004',
-      `Right-click tab "${fn}" → "RangeLink: Unbind"`,
-      [
-        `1. Locate the "${fn}" tab in the editor tab bar`,
-        '2. Right-click the tab',
-        '3. Verify "RangeLink: Unbind" IS present in the menu',
-        '4. Select "RangeLink: Unbind"',
-      ],
-    );
+    await waitForHuman('context-menus-editor-tab-004', `Right-click tab "${fn}" → "RangeLink: Unbind"`, [
+      `1. Locate the "${fn}" tab in the editor tab bar`,
+      '2. Right-click the tab',
+      '3. Verify "RangeLink: Unbind" IS present in the menu',
+      '4. Select "RangeLink: Unbind"',
+    ]);
 
     ss.log('✓ Editor-tab "Unbind" fired the unbind path; context key flipped to false');
   });
@@ -175,9 +139,7 @@ standardSuite('Context Menus — Editor Tab', (ss) => {
     const terminalName = 'rl-ctxmenu-tab-005';
     const capturing = await ss.createCapturingTerminal(terminalName);
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-ctxmenu-tab-005") — File path sent',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-ctxmenu-tab-005") — File path sent']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -210,9 +172,7 @@ standardSuite('Context Menus — Editor Tab', (ss) => {
     assertClipboardWriteLogged(lines, { textLength: expectedPath.length });
     assertTerminalBufferEquals(capturing.getCapturedText(), expectedPath);
 
-    ss.log(
-      '✓ Unbound editor-tab absolute path → picker → bind+send (merged message, pty capture verified content)',
-    );
+    ss.log('✓ Unbound editor-tab absolute path → picker → bind+send (merged message, pty capture verified content)');
   });
 
   test('[assisted] context-menus-editor-tab-006: Editor tab "Send Relative File Path" (unbound) opens picker and sends relative path to selected terminal', async () => {
@@ -223,9 +183,7 @@ standardSuite('Context Menus — Editor Tab', (ss) => {
     const terminalName = 'rl-ctxmenu-tab-006';
     const capturing = await ss.createCapturingTerminal(terminalName);
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-ctxmenu-tab-006") — File path sent',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-ctxmenu-tab-006") — File path sent']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -258,8 +216,6 @@ standardSuite('Context Menus — Editor Tab', (ss) => {
     assertClipboardWriteLogged(lines, { textLength: expectedPath.length });
     assertTerminalBufferEquals(capturing.getCapturedText(), expectedPath);
 
-    ss.log(
-      '✓ Unbound editor-tab relative path → picker → bind+send (merged message, pty capture verified content)',
-    );
+    ss.log('✓ Unbound editor-tab relative path → picker → bind+send (merged message, pty capture verified content)');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuExplorer.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuExplorer.test.ts
@@ -24,10 +24,7 @@ standardSuite('Context Menus — Explorer', (ss) => {
     const capturing = await ss.createCapturingTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await ss.settle();
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-ctxmenu-exp-001")',
-      '✓ RangeLink: File path sent to Terminal ("rl-ctxmenu-exp-001")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-ctxmenu-exp-001")', '✓ RangeLink: File path sent to Terminal ("rl-ctxmenu-exp-001")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -38,15 +35,11 @@ standardSuite('Context Menus — Explorer', (ss) => {
     logCapture.mark('before-ctxmenu-exp-001');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'context-menus-explorer-001',
-      `Right-click "${fn}" in Explorer → "RangeLink: Send File Path"`,
-      [
-        `1. Locate "${fn}" in the Explorer panel`,
-        '2. Right-click it',
-        '3. Select "RangeLink: Send File Path"',
-      ],
-    );
+    await waitForHuman('context-menus-explorer-001', `Right-click "${fn}" in Explorer → "RangeLink: Send File Path"`, [
+      `1. Locate "${fn}" in the Explorer panel`,
+      '2. Right-click it',
+      '3. Select "RangeLink: Send File Path"',
+    ]);
 
     const lines = logCapture.getLinesSince('before-ctxmenu-exp-001');
 
@@ -71,10 +64,7 @@ standardSuite('Context Menus — Explorer', (ss) => {
     const capturing = await ss.createCapturingTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await ss.settle();
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-ctxmenu-exp-002")',
-      '✓ RangeLink: File path sent to Terminal ("rl-ctxmenu-exp-002")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-ctxmenu-exp-002")', '✓ RangeLink: File path sent to Terminal ("rl-ctxmenu-exp-002")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -85,15 +75,11 @@ standardSuite('Context Menus — Explorer', (ss) => {
     logCapture.mark('before-ctxmenu-exp-002');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'context-menus-explorer-002',
-      `Right-click "${fn}" in Explorer → "RangeLink: Send Relative File Path"`,
-      [
-        `1. Locate "${fn}" in the Explorer panel`,
-        '2. Right-click it',
-        '3. Select "RangeLink: Send Relative File Path"',
-      ],
-    );
+    await waitForHuman('context-menus-explorer-002', `Right-click "${fn}" in Explorer → "RangeLink: Send Relative File Path"`, [
+      `1. Locate "${fn}" in the Explorer panel`,
+      '2. Right-click it',
+      '3. Select "RangeLink: Send Relative File Path"',
+    ]);
 
     const lines = logCapture.getLinesSince('before-ctxmenu-exp-002');
 
@@ -106,9 +92,7 @@ standardSuite('Context Menus — Explorer', (ss) => {
     assertClipboardWriteLogged(lines, { textLength: expectedPath.length });
     assertTerminalBufferEquals(capturing.getCapturedText(), expectedPath);
 
-    ss.log(
-      '✓ Workspace-relative path landed in bound terminal buffer (pty capture verified content)',
-    );
+    ss.log('✓ Workspace-relative path landed in bound terminal buffer (pty capture verified content)');
   });
 
   test('[assisted] context-menus-explorer-003: Explorer "Bind Here" opens the file and binds it as text editor destination', async () => {
@@ -120,15 +104,11 @@ standardSuite('Context Menus — Explorer', (ss) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-exp-003');
 
-    await waitForHuman(
-      'context-menus-explorer-003',
-      `Right-click "${fn}" in Explorer → "RangeLink: Bind Here"`,
-      [
-        `1. Locate "${fn}" in the Explorer panel`,
-        '2. Right-click it',
-        '3. Select "RangeLink: Bind Here"',
-      ],
-    );
+    await waitForHuman('context-menus-explorer-003', `Right-click "${fn}" in Explorer → "RangeLink: Bind Here"`, [
+      `1. Locate "${fn}" in the Explorer panel`,
+      '2. Right-click it',
+      '3. Select "RangeLink: Bind Here"',
+    ]);
 
     ss.log('✓ Explorer "Bind Here" committed a text-editor binding with correct displayName');
   });
@@ -141,25 +121,18 @@ standardSuite('Context Menus — Explorer', (ss) => {
     await ss.createTerminal(terminalName);
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await ss.settle();
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-ctxmenu-exp-004")',
-      '✓ RangeLink: Unbound from Terminal ("rl-ctxmenu-exp-004")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-ctxmenu-exp-004")', '✓ RangeLink: Unbound from Terminal ("rl-ctxmenu-exp-004")']);
     ss.expectContextKeys({ 'rangelink.isActiveTerminalBindable': true });
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-exp-004');
 
-    await waitForHuman(
-      'context-menus-explorer-004',
-      `Right-click "${fn}" in Explorer → "RangeLink: Unbind"`,
-      [
-        `1. Locate "${fn}" in the Explorer panel`,
-        '2. Right-click it',
-        '3. Verify "RangeLink: Unbind" IS present in the menu',
-        '4. Select "RangeLink: Unbind"',
-      ],
-    );
+    await waitForHuman('context-menus-explorer-004', `Right-click "${fn}" in Explorer → "RangeLink: Unbind"`, [
+      `1. Locate "${fn}" in the Explorer panel`,
+      '2. Right-click it',
+      '3. Verify "RangeLink: Unbind" IS present in the menu',
+      '4. Select "RangeLink: Unbind"',
+    ]);
 
     ss.log('✓ Explorer "Unbind" fired the unbind path; context key flipped to false');
   });
@@ -173,11 +146,11 @@ standardSuite('Context Menus — Explorer', (ss) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-exp-005');
 
-    const verdict = await waitForHumanVerdict(
-      'context-menus-explorer-005',
-      `Right-click "${fn}" in Explorer — is "RangeLink: Unbind" ABSENT from the menu?`,
-      [`1. Locate "${fn}" in the Explorer panel`, '2. Right-click it', 'Verdict:'],
-    );
+    const verdict = await waitForHumanVerdict('context-menus-explorer-005', `Right-click "${fn}" in Explorer — is "RangeLink: Unbind" ABSENT from the menu?`, [
+      `1. Locate "${fn}" in the Explorer panel`,
+      '2. Right-click it',
+      'Verdict:',
+    ]);
 
     assert.strictEqual(
       verdict,
@@ -185,9 +158,7 @@ standardSuite('Context Menus — Explorer', (ss) => {
       'Human reported "RangeLink: Unbind" WAS visible in Explorer when unbound — the `when: rangelink.isBound` clause is not working',
     );
 
-    ss.log(
-      '✓ Unbound state: "Unbind" absent from Explorer context menu (human verdict + state invariant)',
-    );
+    ss.log('✓ Unbound state: "Unbind" absent from Explorer context menu (human verdict + state invariant)');
   });
 
   test('[assisted] context-menus-explorer-006: Explorer "Send File Path" (unbound) opens picker and sends absolute path to selected terminal', async () => {
@@ -197,9 +168,7 @@ standardSuite('Context Menus — Explorer', (ss) => {
     const terminalName = 'rl-ctxmenu-exp-006';
     const capturing = await ss.createCapturingTerminal(terminalName);
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-ctxmenu-exp-006") — File path sent',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-ctxmenu-exp-006") — File path sent']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -232,9 +201,7 @@ standardSuite('Context Menus — Explorer', (ss) => {
     assertClipboardWriteLogged(lines, { textLength: expectedPath.length });
     assertTerminalBufferEquals(capturing.getCapturedText(), expectedPath);
 
-    ss.log(
-      '✓ Unbound explorer absolute path → picker → bind+send (merged message, pty capture verified content)',
-    );
+    ss.log('✓ Unbound explorer absolute path → picker → bind+send (merged message, pty capture verified content)');
   });
 
   test('[assisted] context-menus-explorer-007: Explorer "Send Relative File Path" (unbound) opens picker and sends relative path to selected terminal', async () => {
@@ -245,9 +212,7 @@ standardSuite('Context Menus — Explorer', (ss) => {
     const terminalName = 'rl-ctxmenu-exp-007';
     const capturing = await ss.createCapturingTerminal(terminalName);
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-ctxmenu-exp-007") — File path sent',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-ctxmenu-exp-007") — File path sent']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -280,8 +245,6 @@ standardSuite('Context Menus — Explorer', (ss) => {
     assertClipboardWriteLogged(lines, { textLength: expectedPath.length });
     assertTerminalBufferEquals(capturing.getCapturedText(), expectedPath);
 
-    ss.log(
-      '✓ Unbound explorer relative path → picker → bind+send (merged message, pty capture verified content)',
-    );
+    ss.log('✓ Unbound explorer relative path → picker → bind+send (merged message, pty capture verified content)');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/contextMenuTerminal.test.ts
@@ -1,8 +1,4 @@
-import {
-  CMD_BIND_TO_TERMINAL,
-  CMD_BIND_TO_TERMINAL_HERE,
-  CMD_CONTEXT_EDITOR_CONTENT_BIND,
-} from '../../constants/commandIds';
+import { CMD_BIND_TO_TERMINAL, CMD_BIND_TO_TERMINAL_HERE, CMD_CONTEXT_EDITOR_CONTENT_BIND } from '../../constants/commandIds';
 import {
   assertQuickPickContains,
   assertTerminalBufferContains,
@@ -34,15 +30,11 @@ standardSuite('Context Menus — Terminal', (ss) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-term-001');
 
-    await waitForHuman(
-      'context-menus-terminal-001',
-      `Right-click the "${terminalName}" terminal TAB → "RangeLink: Bind Here"`,
-      [
-        `1. Locate the "${terminalName}" tab in the terminal panel's tab bar`,
-        '2. Right-click the tab (NOT the terminal content area)',
-        '3. Select "RangeLink: Bind Here"',
-      ],
-    );
+    await waitForHuman('context-menus-terminal-001', `Right-click the "${terminalName}" terminal TAB → "RangeLink: Bind Here"`, [
+      `1. Locate the "${terminalName}" tab in the terminal panel's tab bar`,
+      '2. Right-click the tab (NOT the terminal content area)',
+      '3. Select "RangeLink: Bind Here"',
+    ]);
 
     ss.log('✓ Terminal-tab context menu bound the terminal destination');
   });
@@ -61,15 +53,11 @@ standardSuite('Context Menus — Terminal', (ss) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-term-002');
 
-    await waitForHuman(
-      'context-menus-terminal-002',
-      `Right-click INSIDE the "${terminalName}" terminal content area → "RangeLink: Bind Here"`,
-      [
-        `1. Focus the "${terminalName}" terminal`,
-        '2. Right-click INSIDE the terminal output area (NOT the tab)',
-        '3. Select "RangeLink: Bind Here"',
-      ],
-    );
+    await waitForHuman('context-menus-terminal-002', `Right-click INSIDE the "${terminalName}" terminal content area → "RangeLink: Bind Here"`, [
+      `1. Focus the "${terminalName}" terminal`,
+      '2. Right-click INSIDE the terminal output area (NOT the tab)',
+      '3. Select "RangeLink: Bind Here"',
+    ]);
 
     ss.log('✓ Terminal content-area context menu bound the terminal destination');
   });
@@ -80,25 +68,18 @@ standardSuite('Context Menus — Terminal', (ss) => {
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-ctxmenu-term-003")',
-      '✓ RangeLink: Unbound from Terminal ("rl-ctxmenu-term-003")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-ctxmenu-term-003")', '✓ RangeLink: Unbound from Terminal ("rl-ctxmenu-term-003")']);
     ss.expectContextKeys({ 'rangelink.isActiveTerminalBindable': true });
 
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-term-003');
 
-    await waitForHuman(
-      'context-menus-terminal-003',
-      `Right-click INSIDE the "${terminalName}" terminal content area → "RangeLink: Unbind"`,
-      [
-        `1. Focus the "${terminalName}" terminal`,
-        '2. Right-click INSIDE the terminal CONTENT AREA (not the tab — the tab menu does not render Unbind on VSCode)',
-        '3. Verify "RangeLink: Unbind" IS present in the menu (clicking it proves visibility)',
-        '4. Select "RangeLink: Unbind"',
-      ],
-    );
+    await waitForHuman('context-menus-terminal-003', `Right-click INSIDE the "${terminalName}" terminal content area → "RangeLink: Unbind"`, [
+      `1. Focus the "${terminalName}" terminal`,
+      '2. Right-click INSIDE the terminal CONTENT AREA (not the tab — the tab menu does not render Unbind on VSCode)',
+      '3. Verify "RangeLink: Unbind" IS present in the menu (clicking it proves visibility)',
+      '4. Select "RangeLink: Unbind"',
+    ]);
 
     ss.log('✓ Terminal content-area "Unbind" was visible (clicked it) and fired the unbind path');
   });
@@ -119,17 +100,13 @@ standardSuite('Context Menus — Terminal', (ss) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-term-004');
 
-    await waitForHuman(
-      'context-menus-terminal-004',
-      `Right-click the "${targetName}" TAB → "RangeLink: Bind Here"`,
-      [
-        `Two terminals exist: "${otherName}" and "${targetName}"`,
-        `1. In the terminal panel's tab bar, locate the "${targetName}" tab specifically`,
-        '2. Right-click THAT tab',
-        '3. Select "RangeLink: Bind Here"',
-        'The TARGET terminal should bind — not the OTHER one.',
-      ],
-    );
+    await waitForHuman('context-menus-terminal-004', `Right-click the "${targetName}" TAB → "RangeLink: Bind Here"`, [
+      `Two terminals exist: "${otherName}" and "${targetName}"`,
+      `1. In the terminal panel's tab bar, locate the "${targetName}" tab specifically`,
+      '2. Right-click THAT tab',
+      '3. Select "RangeLink: Bind Here"',
+      'The TARGET terminal should bind — not the OTHER one.',
+    ]);
 
     ss.log('✓ Right-clicked TAB bound the target terminal directly (picker bypassed)');
   });
@@ -150,17 +127,13 @@ standardSuite('Context Menus — Terminal', (ss) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-term-005');
 
-    await waitForHuman(
-      'context-menus-terminal-005',
-      `Right-click INSIDE the "${targetName}" CONTENT AREA → "RangeLink: Bind Here"`,
-      [
-        `Two terminals exist: "${otherName}" and "${targetName}"`,
-        `1. Click to focus the "${targetName}" terminal`,
-        '2. Right-click INSIDE its content area (not the tab)',
-        '3. Select "RangeLink: Bind Here"',
-        'The TARGET terminal should bind — not the OTHER one.',
-      ],
-    );
+    await waitForHuman('context-menus-terminal-005', `Right-click INSIDE the "${targetName}" CONTENT AREA → "RangeLink: Bind Here"`, [
+      `Two terminals exist: "${otherName}" and "${targetName}"`,
+      `1. Click to focus the "${targetName}" terminal`,
+      '2. Right-click INSIDE its content area (not the tab)',
+      '3. Select "RangeLink: Bind Here"',
+      'The TARGET terminal should bind — not the OTHER one.',
+    ]);
 
     ss.log('✓ Right-clicked CONTENT AREA bound the target terminal directly (picker bypassed)');
   });
@@ -187,17 +160,9 @@ standardSuite('Context Menus — Terminal', (ss) => {
     const verdict = await waitForHumanVerdict(
       'context-menus-terminal-006',
       `Right-click the "${terminalName}" pty terminal TAB. Is "RangeLink: Bind Here" ABSENT from the menu?`,
-      [
-        `1. Locate the "${terminalName}" tab in the terminal panel's tab bar`,
-        '2. Right-click the tab (NOT the content area)',
-        'Verdict:',
-      ],
+      [`1. Locate the "${terminalName}" tab in the terminal panel's tab bar`, '2. Right-click the tab (NOT the content area)', 'Verdict:'],
     );
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'Expected "RangeLink: Bind Here" to be absent from the pty terminal tab menu',
-    );
+    assert.strictEqual(verdict, 'pass', 'Expected "RangeLink: Bind Here" to be absent from the pty terminal tab menu');
 
     ss.log('✓ "Bind Here" absent from pty terminal tab menu');
   });
@@ -217,17 +182,9 @@ standardSuite('Context Menus — Terminal', (ss) => {
     const verdict = await waitForHumanVerdict(
       'context-menus-terminal-007',
       `Right-click INSIDE the "${terminalName}" pty terminal content area. Is "RangeLink: Bind Here" ABSENT from the menu?`,
-      [
-        `1. Focus the "${terminalName}" pty terminal`,
-        '2. Right-click INSIDE the terminal output area (NOT the tab)',
-        'Verdict:',
-      ],
+      [`1. Focus the "${terminalName}" pty terminal`, '2. Right-click INSIDE the terminal output area (NOT the tab)', 'Verdict:'],
     );
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'Expected "RangeLink: Bind Here" to be absent from the pty terminal content-area menu',
-    );
+    assert.strictEqual(verdict, 'pass', 'Expected "RangeLink: Bind Here" to be absent from the pty terminal content-area menu');
 
     ss.log('✓ "Bind Here" absent from pty terminal content-area menu');
   });
@@ -256,17 +213,13 @@ standardSuite('Context Menus — Terminal', (ss) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-ctxmenu-term-008');
 
-    await waitForHuman(
-      'context-menus-terminal-008',
-      `Right-click the "${shellName}" shell terminal TAB → "RangeLink: Bind Here"`,
-      [
-        `A pty terminal "${ptyName}" and a shell terminal "${shellName}" both exist`,
-        `1. Locate the "${shellName}" tab in the terminal panel's tab bar`,
-        '2. Right-click the tab (NOT the pty tab, NOT the content area)',
-        '3. Select "RangeLink: Bind Here"',
-        `The "${shellName}" terminal should bind — NOT the pty.`,
-      ],
-    );
+    await waitForHuman('context-menus-terminal-008', `Right-click the "${shellName}" shell terminal TAB → "RangeLink: Bind Here"`, [
+      `A pty terminal "${ptyName}" and a shell terminal "${shellName}" both exist`,
+      `1. Locate the "${shellName}" tab in the terminal panel's tab bar`,
+      '2. Right-click the tab (NOT the pty tab, NOT the content area)',
+      '3. Select "RangeLink: Bind Here"',
+      `The "${shellName}" terminal should bind — NOT the pty.`,
+    ]);
 
     ss.log('✓ Shell tab "Bind Here" present and bound the shell (not the pty) when both open');
   });
@@ -299,11 +252,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
       `Right-click inside the "${ptyName}" pty terminal content area. Is "RangeLink: Unbind" PRESENT and "RangeLink: Bind Here" ABSENT?`,
       ['1. Right-click INSIDE the pty terminal content area', 'Verdict:'],
     );
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'Expected "Unbind" present and "Bind Here" absent on the pty content-area menu when bound to a different terminal',
-    );
+    assert.strictEqual(verdict, 'pass', 'Expected "Unbind" present and "Bind Here" absent on the pty content-area menu when bound to a different terminal');
 
     ss.log('✓ Pty content menu: Unbind present, Bind Here absent (when bound to shell)');
   });
@@ -323,9 +272,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
     terminal.show(true);
     await ss.settle(TERMINAL_READY_MS);
 
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Terminal ("${destName}") — Selected text sent`,
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Terminal ("${destName}") — Selected text sent`]);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -347,9 +294,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
       ],
     );
 
-    ss.log(
-      '✓ Terminal content-area "Send Selected Text" visible when terminal has selection and is not bound',
-    );
+    ss.log('✓ Terminal content-area "Send Selected Text" visible when terminal has selection and is not bound');
   });
 
   // TC context-menus-terminal-011: R-V HIDDEN from both terminal menus when
@@ -393,9 +338,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
       'Expected "Send Selected Text" to be hidden from the terminal content-area menu when the terminal IS the bound destination',
     );
 
-    ss.log(
-      '✓ Self-paste gate: R-V hidden from terminal content-area menu when terminal IS the bound destination',
-    );
+    ss.log('✓ Self-paste gate: R-V hidden from terminal content-area menu when terminal IS the bound destination');
   });
 
   // ---------------------------------------------------------------------------
@@ -421,11 +364,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
         'Verdict:',
       ],
     );
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'Expected "Send Selected Text" to be absent from terminal content-area menu when no text is selected',
-    );
+    assert.strictEqual(verdict, 'pass', 'Expected "Send Selected Text" to be absent from terminal content-area menu when no text is selected');
 
     ss.log('✓ No-selection negative: R-V absent from terminal content-area menu');
   });
@@ -438,10 +377,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
   // ---------------------------------------------------------------------------
 
   test('[assisted] send-terminal-selection-005: Terminal content-area "Send Selected Text" sends selected text to bound editor', async () => {
-    const editorUri = await ss.createAndOpenFile(
-      'ctxmenu-term-sts-005',
-      'destination file — terminal selection arrives here\n',
-    );
+    const editorUri = await ss.createAndOpenFile('ctxmenu-term-sts-005', 'destination file — terminal selection arrives here\n');
     const editorFn = path.basename(editorUri.fsPath);
 
     await vscode.commands.executeCommand(CMD_CONTEXT_EDITOR_CONTENT_BIND, editorUri);
@@ -454,10 +390,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
     echoToTerminal(terminal, markerText);
     await ss.settle(TERMINAL_READY_MS);
 
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Text Editor ("${editorFn}")`,
-      `✓ RangeLink: Selected text sent to Text Editor ("${editorFn}")`,
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Text Editor ("${editorFn}")`, `✓ RangeLink: Selected text sent to Text Editor ("${editorFn}")`]);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isBound': true,
@@ -466,26 +399,19 @@ standardSuite('Context Menus — Terminal', (ss) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-sts-005');
 
-    await waitForHuman(
-      'send-terminal-selection-005',
-      `Select "${markerText}" in terminal "${terminalName}" → right-click → "RangeLink: Send Selected Text"`,
-      [
-        `A Text Editor "${editorFn}" is currently bound as the destination.`,
-        `The terminal "${terminalName}" has "${markerText}" in its output.`,
-        `1. Select the "${markerText}" text in the terminal content area`,
-        '2. Right-click INSIDE the terminal content area (not the tab)',
-        '3. Verify "RangeLink: Send Selected Text" is present',
-        '4. Select "RangeLink: Send Selected Text"',
-        `The selected text should appear in the "${editorFn}" editor.`,
-      ],
-    );
+    await waitForHuman('send-terminal-selection-005', `Select "${markerText}" in terminal "${terminalName}" → right-click → "RangeLink: Send Selected Text"`, [
+      `A Text Editor "${editorFn}" is currently bound as the destination.`,
+      `The terminal "${terminalName}" has "${markerText}" in its output.`,
+      `1. Select the "${markerText}" text in the terminal content area`,
+      '2. Right-click INSIDE the terminal content area (not the tab)',
+      '3. Verify "RangeLink: Send Selected Text" is present',
+      '4. Select "RangeLink: Send Selected Text"',
+      `The selected text should appear in the "${editorFn}" editor.`,
+    ]);
 
     const editor = await ss.openEditor(editorUri);
     const editorText = editor.document.getText();
-    assert.ok(
-      editorText.includes(markerText),
-      `Expected editor to contain "${markerText}" but got: ${editorText}`,
-    );
+    assert.ok(editorText.includes(markerText), `Expected editor to contain "${markerText}" but got: ${editorText}`);
 
     ss.log('✓ Terminal context-menu "Send Selected Text" routed selection to bound editor');
   });
@@ -506,10 +432,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
     echoToTerminal(sourceTerminal, markerText);
     await ss.settle(TERMINAL_READY_MS);
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-sts-008-BOUND")',
-      '✓ RangeLink: Selected text sent to Terminal ("rl-sts-008-BOUND")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-sts-008-BOUND")', '✓ RangeLink: Selected text sent to Terminal ("rl-sts-008-BOUND")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -520,19 +443,15 @@ standardSuite('Context Menus — Terminal', (ss) => {
     logCapture.mark('before-sts-008');
     capturingBound.clearCaptured();
 
-    await waitForHuman(
-      'send-terminal-selection-008',
-      `Select "${markerText}" in SOURCE terminal "${sourceName}" → right-click → "Send Selected Text"`,
-      [
-        `Destination: Terminal "${boundName}" is bound (pty-captured — the test reads its buffer to verify content).`,
-        `Source: Terminal "${sourceName}" contains "${markerText}".`,
-        `1. Click the "${sourceName}" terminal to focus it`,
-        `2. Select the "${markerText}" text in its output`,
-        '3. Right-click INSIDE the source terminal content area (not the tab)',
-        '4. Select "RangeLink: Send Selected Text"',
-        `The selection should paste into "${boundName}" and focus should shift there.`,
-      ],
-    );
+    await waitForHuman('send-terminal-selection-008', `Select "${markerText}" in SOURCE terminal "${sourceName}" → right-click → "Send Selected Text"`, [
+      `Destination: Terminal "${boundName}" is bound (pty-captured — the test reads its buffer to verify content).`,
+      `Source: Terminal "${sourceName}" contains "${markerText}".`,
+      `1. Click the "${sourceName}" terminal to focus it`,
+      `2. Select the "${markerText}" text in its output`,
+      '3. Right-click INSIDE the source terminal content area (not the tab)',
+      '4. Select "RangeLink: Send Selected Text"',
+      `The selection should paste into "${boundName}" and focus should shift there.`,
+    ]);
 
     const stsLines = getLogCapture().getLinesSince('before-sts-008');
     const focusLogged = stsLines.some((l) => {
@@ -543,9 +462,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
 
     assertTerminalBufferContains(capturingBound.getCapturedText(), markerText);
 
-    ss.log(
-      '✓ Cross-terminal send: source selection landed in bound terminal buffer (pty-captured) with focus shift',
-    );
+    ss.log('✓ Cross-terminal send: source selection landed in bound terminal buffer (pty-captured) with focus shift');
   });
 
   test('[assisted] send-terminal-selection-009: "Send Selected Text" is NOT in the terminal TAB menu', async () => {
@@ -577,11 +494,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
       ],
     );
 
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'Human reported "Send Selected Text" WAS visible in the tab menu — this is a bug',
-    );
+    assert.strictEqual(verdict, 'pass', 'Human reported "Send Selected Text" WAS visible in the tab menu — this is a bug');
 
     ss.log('✓ Tab menu did NOT offer "Send Selection" (human verdict)');
   });
@@ -597,9 +510,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
     echoToTerminal(sourceTerminal, markerText);
     await ss.settle(TERMINAL_READY_MS);
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-sts-011-DEST") — Selected text sent',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-sts-011-DEST") — Selected text sent']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -632,9 +543,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
 
     assertTerminalBufferContains(capturingDest.getCapturedText(), markerText);
 
-    ss.log(
-      '✓ Unbound state: menu item shown; click opened picker; selection landed in picked destination buffer (pty-captured)',
-    );
+    ss.log('✓ Unbound state: menu item shown; click opened picker; selection landed in picked destination buffer (pty-captured)');
   });
 
   // ---------------------------------------------------------------------------
@@ -686,15 +595,11 @@ standardSuite('Context Menus — Terminal', (ss) => {
   // ---------------------------------------------------------------------------
 
   test('[assisted] send-terminal-selection-013: Terminal content-area "Send Selection" delivers selected text to bound AI-assistant destination', async () => {
-    await waitForHuman(
-      'send-terminal-selection-013-bind',
-      'Cmd+R Cmd+D → select "Dummy AI (Tier 1)"',
-      [
-        'Setup: bind the Dummy AI test extension as the destination.',
-        '1. Press Cmd+R Cmd+D',
-        '2. Select "Dummy AI (Tier 1)" from the destination picker',
-      ],
-    );
+    await waitForHuman('send-terminal-selection-013-bind', 'Cmd+R Cmd+D → select "Dummy AI (Tier 1)"', [
+      'Setup: bind the Dummy AI test extension as the destination.',
+      '1. Press Cmd+R Cmd+D',
+      '2. Select "Dummy AI (Tier 1)" from the destination picker',
+    ]);
 
     const terminalName = 'rl-sts-013';
     const terminal = await ss.createTerminal(terminalName);
@@ -702,10 +607,7 @@ standardSuite('Context Menus — Terminal', (ss) => {
     echoToTerminal(terminal, markerText);
     await ss.settle(TERMINAL_READY_MS);
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Dummy AI (Tier 1)',
-      '✓ RangeLink: Selected text sent to Dummy AI (Tier 1)',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Dummy AI (Tier 1)', '✓ RangeLink: Selected text sent to Dummy AI (Tier 1)']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isBound': true,
@@ -714,30 +616,20 @@ standardSuite('Context Menus — Terminal', (ss) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-sts-013');
 
-    await waitForHuman(
-      'send-terminal-selection-013',
-      `Select "${markerText}" in "${terminalName}" → right-click content area → "Send Selected Text"`,
-      [
-        'Destination: Dummy AI (Tier 1) is bound.',
-        `Source: "${terminalName}" has "${markerText}" in its output.`,
-        `1. Click the "${terminalName}" terminal to focus it`,
-        `2. Select "${markerText}" in its output`,
-        '3. Right-click INSIDE the terminal content area (not the tab)',
-        '4. Select "RangeLink: Send Selected Text"',
-        'The selection should be delivered to the Dummy AI extension via direct insert.',
-      ],
-    );
+    await waitForHuman('send-terminal-selection-013', `Select "${markerText}" in "${terminalName}" → right-click content area → "Send Selected Text"`, [
+      'Destination: Dummy AI (Tier 1) is bound.',
+      `Source: "${terminalName}" has "${markerText}" in its output.`,
+      `1. Click the "${terminalName}" terminal to focus it`,
+      `2. Select "${markerText}" in its output`,
+      '3. Right-click INSIDE the terminal content area (not the tab)',
+      '4. Select "RangeLink: Send Selected Text"',
+      'The selection should be delivered to the Dummy AI extension via direct insert.',
+    ]);
 
-    const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as
-      { tier1: string; tier2: string } | undefined;
+    const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as { tier1: string; tier2: string } | undefined;
     assert.ok(textResult, 'Expected dummyAi.getText to return a result');
-    assert.ok(
-      textResult!.tier1.includes(markerText),
-      `Expected Dummy AI tier1 textarea to contain "${markerText}" but got: ${textResult!.tier1}`,
-    );
+    assert.ok(textResult!.tier1.includes(markerText), `Expected Dummy AI tier1 textarea to contain "${markerText}" but got: ${textResult!.tier1}`);
 
-    ss.log(
-      '✓ Terminal context-menu "Send Selection" delivered selection to Dummy AI via Tier 1 direct insert',
-    );
+    ss.log('✓ Terminal context-menu "Send Selection" delivered selection to Dummy AI via Tier 1 direct insert');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/coreSendCommands.test.ts
@@ -36,16 +36,10 @@ const NO_TERMINAL_SELECTION_MSG = 'No text selected in the terminal. Select text
 
 standardSuite('Core Send Commands', (ss) => {
   test('core-send-commands-r-l-002: R-L sends RangeLink to bound text editor destination', async () => {
-    const srcUri = ss.createWorkspaceFile(
-      'csc-r-l-002-src',
-      'line 1\nline 2\nline 3\nline 4\nline 5\n',
-    );
+    const srcUri = ss.createWorkspaceFile('csc-r-l-002-src', 'line 1\nline 2\nline 3\nline 4\nline 5\n');
     const destUri = ss.createWorkspaceFile('csc-r-l-002-dest', '');
     const destBasename = path.basename(destUri.fsPath);
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Text Editor ("${destBasename}")`,
-      `✓ RangeLink: RangeLink sent to Text Editor ("${destBasename}")`,
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Text Editor ("${destBasename}")`, `✓ RangeLink: RangeLink sent to Text Editor ("${destBasename}")`]);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     const destDoc = await vscode.workspace.openTextDocument(destUri);
@@ -56,10 +50,7 @@ standardSuite('Core Send Commands', (ss) => {
 
     const srcDoc = await vscode.workspace.openTextDocument(srcUri);
     const srcEditor = await vscode.window.showTextDocument(srcDoc, vscode.ViewColumn.Beside);
-    srcEditor.selection = new vscode.Selection(
-      new vscode.Position(1, 0),
-      new vscode.Position(3, 0),
-    );
+    srcEditor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(3, 0));
     await ss.settle();
 
     const logCapture = getLogCapture();
@@ -72,28 +63,17 @@ standardSuite('Core Send Commands', (ss) => {
 
     const updatedDestDoc = await vscode.workspace.openTextDocument(destUri);
     const destText = updatedDestDoc.getText();
-    assert.strictEqual(
-      destText,
-      generatedLink,
-      `Expected dest editor to contain exactly the generated link, got: ${JSON.stringify(destText)}`,
-    );
+    assert.strictEqual(destText, generatedLink, `Expected dest editor to contain exactly the generated link, got: ${JSON.stringify(destText)}`);
 
     ss.log('✓ R-L sent exact RangeLink to bound text editor destination');
   });
 
   test('core-send-commands-r-l-003: R-L sends RangeLink to bound AI assistant destination', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Dummy AI (Tier 1)',
-      '✓ RangeLink: RangeLink sent to Dummy AI (Tier 1)',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Dummy AI (Tier 1)', '✓ RangeLink: RangeLink sent to Dummy AI (Tier 1)']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     const CSC_R_L_003_LINE_COUNT = 10;
-    const { uri: fileUri } = ss.createContentFile(
-      'csc-r-l-003',
-      CSC_R_L_003_LINE_COUNT,
-      (i) => `line ${i + 1} content`,
-    );
+    const { uri: fileUri } = ss.createContentFile('csc-r-l-003', CSC_R_L_003_LINE_COUNT, (i) => `line ${i + 1} content`);
 
     const doc = await vscode.workspace.openTextDocument(fileUri);
     const editor = await vscode.window.showTextDocument(doc);
@@ -117,19 +97,12 @@ standardSuite('Core Send Commands', (ss) => {
       tier1: string;
       tier2: string;
     };
-    assert.strictEqual(
-      dummyText.tier1,
-      generatedLink,
-      `Expected Dummy AI tier1="${generatedLink}", got: ${JSON.stringify(dummyText.tier1)}`,
-    );
+    assert.strictEqual(dummyText.tier1, generatedLink, `Expected Dummy AI tier1="${generatedLink}", got: ${JSON.stringify(dummyText.tier1)}`);
     ss.log('✓ R-L sent RangeLink to Dummy AI (Tier 1) destination');
   });
 
   test('core-send-commands-r-c-001: R-C copies RangeLink to clipboard and does NOT send to terminal', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("csc-r-c-001-dest")',
-      '✓ RangeLink: RangeLink copied to clipboard',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("csc-r-c-001-dest")', '✓ RangeLink: RangeLink copied to clipboard']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -137,8 +110,7 @@ standardSuite('Core Send Commands', (ss) => {
     });
     const fileUri = ss.createWorkspaceFile('csc-r-c-001', 'line 1\nline 2\nline 3\n');
 
-    const capturing: CapturingTerminal =
-      await ss.createAndBindCapturingTerminal('csc-r-c-001-dest');
+    const capturing: CapturingTerminal = await ss.createAndBindCapturingTerminal('csc-r-c-001-dest');
 
     const editor = await ss.openEditor(fileUri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(2, 0));
@@ -153,20 +125,13 @@ standardSuite('Core Send Commands', (ss) => {
       'before-r-c-001',
     );
 
-    assert.strictEqual(
-      capturing.getCapturedText(),
-      '',
-      'Terminal should not have received anything from R-C',
-    );
+    assert.strictEqual(capturing.getCapturedText(), '', 'Terminal should not have received anything from R-C');
 
     ss.log('✓ R-C wrote link to clipboard; terminal received nothing');
   });
 
   test('core-send-commands-r-l-004: Command dispatch "Send RangeLink" behaves identically to R-L keybinding', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("csc-r-l-004-dest")',
-      '✓ RangeLink: RangeLink sent to Terminal ("csc-r-l-004-dest")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("csc-r-l-004-dest")', '✓ RangeLink: RangeLink sent to Terminal ("csc-r-l-004-dest")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -174,8 +139,7 @@ standardSuite('Core Send Commands', (ss) => {
     });
     const fileUri = ss.createWorkspaceFile('csc-r-l-004', 'line 1\nline 2\nline 3\n');
 
-    const capturing: CapturingTerminal =
-      await ss.createAndBindCapturingTerminal('csc-r-l-004-dest');
+    const capturing: CapturingTerminal = await ss.createAndBindCapturingTerminal('csc-r-l-004-dest');
 
     const editor = await ss.openEditor(fileUri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(2, 0));
@@ -189,16 +153,11 @@ standardSuite('Core Send Commands', (ss) => {
 
     assertTerminalBufferEqualsGeneratedLink(capturing, 'before-r-l-004');
 
-    ss.log(
-      '✓ Command dispatch "Send RangeLink" delivered exact link to bound terminal destination',
-    );
+    ss.log('✓ Command dispatch "Send RangeLink" delivered exact link to bound terminal destination');
   });
 
   test('core-send-commands-r-c-002: Command dispatch "Copy RangeLink" behaves identically to R-C keybinding', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("csc-r-c-002-dest")',
-      '✓ RangeLink: RangeLink copied to clipboard',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("csc-r-c-002-dest")', '✓ RangeLink: RangeLink copied to clipboard']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -206,8 +165,7 @@ standardSuite('Core Send Commands', (ss) => {
     });
     const fileUri = ss.createWorkspaceFile('csc-r-c-002', 'line 1\nline 2\nline 3\n');
 
-    const capturing: CapturingTerminal =
-      await ss.createAndBindCapturingTerminal('csc-r-c-002-dest');
+    const capturing: CapturingTerminal = await ss.createAndBindCapturingTerminal('csc-r-c-002-dest');
 
     const editor = await ss.openEditor(fileUri);
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(2, 0));
@@ -222,27 +180,17 @@ standardSuite('Core Send Commands', (ss) => {
       'before-r-c-002',
     );
 
-    assert.strictEqual(
-      capturing.getCapturedText(),
-      '',
-      'Terminal should not have received anything from "Copy RangeLink"',
-    );
-    ss.log(
-      '✓ Command dispatch "Copy RangeLink" wrote exact link to clipboard; terminal received nothing',
-    );
+    assert.strictEqual(capturing.getCapturedText(), '', 'Terminal should not have received anything from "Copy RangeLink"');
+    ss.log('✓ Command dispatch "Copy RangeLink" wrote exact link to clipboard; terminal received nothing');
   });
 
   test('[assisted] send-terminal-selection-001: Cmd+R Cmd+V with terminal text selected sends to bound destination', async () => {
     const MARKER = 'rl-sts-001-marker';
 
-    const capturing: CapturingTerminal =
-      await ss.createAndBindCapturingTerminal('csc-sts-001-dest');
+    const capturing: CapturingTerminal = await ss.createAndBindCapturingTerminal('csc-sts-001-dest');
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("csc-sts-001-dest")',
-      '✓ RangeLink: Selected text sent to Terminal ("csc-sts-001-dest")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("csc-sts-001-dest")', '✓ RangeLink: Selected text sent to Terminal ("csc-sts-001-dest")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -257,11 +205,10 @@ standardSuite('Core Send Commands', (ss) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-sts-001');
 
-    await waitForHuman(
-      'send-terminal-selection-001',
-      `In "csc-sts-001-src", select "${MARKER}" and press Cmd+R Cmd+V.`,
-      [`1. Click into "csc-sts-001-src", drag-select "${MARKER}"`, '2. Press Cmd+R Cmd+V'],
-    );
+    await waitForHuman('send-terminal-selection-001', `In "csc-sts-001-src", select "${MARKER}" and press Cmd+R Cmd+V.`, [
+      `1. Click into "csc-sts-001-src", drag-select "${MARKER}"`,
+      '2. Press Cmd+R Cmd+V',
+    ]);
 
     assertTerminalBufferContains(capturing.getCapturedText(), MARKER);
 
@@ -336,10 +283,7 @@ standardSuite('Core Send Commands', (ss) => {
     capturing.terminal.sendText(markerText, false);
     await ss.settle(TERMINAL_READY_MS);
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-sts-010")',
-      '✓ RangeLink: Selected text sent to Terminal ("rl-sts-010")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-sts-010")', '✓ RangeLink: Selected text sent to Terminal ("rl-sts-010")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -350,17 +294,13 @@ standardSuite('Core Send Commands', (ss) => {
     logCapture.mark('before-sts-010');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'send-terminal-selection-010',
-      `In "${terminalName}", select "${markerText}" and press Cmd+R Cmd+V (R-V).`,
-      [
-        `Destination: Terminal "${terminalName}" IS the bound destination (the SAME terminal we will select from).`,
-        `1. Click into "${terminalName}" to give it focus`,
-        `2. Drag-select "${markerText}" in the terminal buffer`,
-        '3. Press Cmd+R Cmd+V',
-        'The right-click menu intentionally hides "Send Selected Text" here (self-paste gate). The R-V keybinding bypasses that gate and pastes the selection BACK into the same terminal.',
-      ],
-    );
+    await waitForHuman('send-terminal-selection-010', `In "${terminalName}", select "${markerText}" and press Cmd+R Cmd+V (R-V).`, [
+      `Destination: Terminal "${terminalName}" IS the bound destination (the SAME terminal we will select from).`,
+      `1. Click into "${terminalName}" to give it focus`,
+      `2. Drag-select "${markerText}" in the terminal buffer`,
+      '3. Press Cmd+R Cmd+V',
+      'The right-click menu intentionally hides "Send Selected Text" here (self-paste gate). The R-V keybinding bypasses that gate and pastes the selection BACK into the same terminal.',
+    ]);
 
     assertTerminalBufferContains(capturing.getCapturedText(), markerText);
 
@@ -405,8 +345,7 @@ standardSuite('Core Send Commands', (ss) => {
   });
 
   test('send-terminal-selection-006: R-L with terminal focus shows no-active-editor error', async () => {
-    const capturing: CapturingTerminal =
-      await ss.createAndBindCapturingTerminal('csc-sts-006-dest');
+    const capturing: CapturingTerminal = await ss.createAndBindCapturingTerminal('csc-sts-006-dest');
 
     ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("csc-sts-006-dest")']);
     ss.expectContextKeys({
@@ -430,8 +369,7 @@ standardSuite('Core Send Commands', (ss) => {
   });
 
   test('send-terminal-selection-007: R-C with terminal focus shows no-active-editor error', async () => {
-    const capturing: CapturingTerminal =
-      await ss.createAndBindCapturingTerminal('csc-sts-007-dest');
+    const capturing: CapturingTerminal = await ss.createAndBindCapturingTerminal('csc-sts-007-dest');
 
     ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("csc-sts-007-dest")']);
     ss.expectContextKeys({
@@ -455,23 +393,16 @@ standardSuite('Core Send Commands', (ss) => {
   });
 
   test('core-send-commands-r-l-001: R-L sends RangeLink to bound terminal', async () => {
-    const capturing: CapturingTerminal =
-      await ss.createAndBindCapturingTerminal('csc-r-l-001-dest');
+    const capturing: CapturingTerminal = await ss.createAndBindCapturingTerminal('csc-r-l-001-dest');
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("csc-r-l-001-dest")',
-      '✓ RangeLink: RangeLink sent to Terminal ("csc-r-l-001-dest")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("csc-r-l-001-dest")', '✓ RangeLink: RangeLink sent to Terminal ("csc-r-l-001-dest")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
       'rangelink.isBound': true,
     });
 
-    const fileUri = ss.createWorkspaceFile(
-      'csc-r-l-001',
-      'line 1\nline 2\nline 3\nline 4\nline 5\n',
-    );
+    const fileUri = ss.createWorkspaceFile('csc-r-l-001', 'line 1\nline 2\nline 3\nline 4\nline 5\n');
     const editor = await ss.openEditor(fileUri);
     editor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(4, 0));
     await ss.settle();
@@ -498,8 +429,7 @@ standardSuite('Core Send Commands', (ss) => {
       'rangelink.isBound': true,
     });
 
-    const capturing: CapturingTerminal =
-      await ss.createAndBindCapturingTerminal('csc-fullline-001-dest');
+    const capturing: CapturingTerminal = await ss.createAndBindCapturingTerminal('csc-fullline-001-dest');
 
     const fileUri = ss.createWorkspaceFile('csc-fullline-001', 'line 1\nline 2\nline 3\n');
     await ss.openEditor(fileUri);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/customAiAssistants.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/customAiAssistants.test.ts
@@ -1,9 +1,4 @@
-import {
-  CMD_BIND_TO_CUSTOM_AI_BY_ID,
-  CMD_BIND_TO_DESTINATION,
-  CMD_BIND_TO_GITHUB_COPILOT_CHAT,
-  CMD_COPY_LINK_RELATIVE,
-} from '../../constants/commandIds';
+import { CMD_BIND_TO_CUSTOM_AI_BY_ID, CMD_BIND_TO_DESTINATION, CMD_BIND_TO_GITHUB_COPILOT_CHAT, CMD_COPY_LINK_RELATIVE } from '../../constants/commandIds';
 import {
   assertClipboardEqualsGeneratedLink,
   extractQuickPickItemsLogged,
@@ -22,9 +17,7 @@ const EXPECTED_CUSTOM_AI_REGISTRATIONS = 6;
 const getExpectedCustomAssistantsCount = (): number => {
   const raw = process.env.RANGELINK_CUSTOM_AI_COUNT;
   if (raw === undefined) {
-    throw new Error(
-      'RANGELINK_CUSTOM_AI_COUNT env var is not set — the test runner must export this via setup-integration-test-settings.js',
-    );
+    throw new Error('RANGELINK_CUSTOM_AI_COUNT env var is not set — the test runner must export this via setup-integration-test-settings.js');
   }
   const count = parseInt(raw, 10);
   if (isNaN(count)) {
@@ -52,11 +45,7 @@ standardSuite('Custom AI Assistants', (_ss) => {
     const rawCtx = parseLogContext(parseLogLine!);
     const count = rawCtx?.count as number;
     const ids = rawCtx?.ids as string[];
-    assert.strictEqual(
-      count,
-      expectedCount,
-      `Expected ${expectedCount} custom AI assistants loaded but got count: ${count}`,
-    );
+    assert.strictEqual(count, expectedCount, `Expected ${expectedCount} custom AI assistants loaded but got count: ${count}`);
     assert.ok(
       ids.includes('rangelink.dummy-ai-extension'),
       `Expected log to mention 'rangelink.dummy-ai-extension' extensionId but got ids: ${JSON.stringify(ids)}`,
@@ -69,9 +58,7 @@ standardSuite('Custom AI Assistants', (_ss) => {
 
     const registrationLogs = allLines.filter((line) => {
       const ctx = parseLogContext(line);
-      return (
-        ctx?.fn === 'DestinationRegistry.register' && String(ctx?.kind).startsWith('custom-ai:')
-      );
+      return ctx?.fn === 'DestinationRegistry.register' && String(ctx?.kind).startsWith('custom-ai:');
     });
 
     assert.strictEqual(
@@ -82,60 +69,42 @@ standardSuite('Custom AI Assistants', (_ss) => {
     assert.ok(
       registrationLogs.some((l) => {
         const ctx = parseLogContext(l);
-        return (
-          ctx?.fn === 'DestinationRegistry.register' &&
-          ctx?.kind === 'custom-ai:rangelink.dummy-ai-extension'
-        );
+        return ctx?.fn === 'DestinationRegistry.register' && ctx?.kind === 'custom-ai:rangelink.dummy-ai-extension';
       }),
       'Expected registration for Tier 1 (rangelink.dummy-ai-extension)',
     );
     assert.ok(
       registrationLogs.some((l) => {
         const ctx = parseLogContext(l);
-        return (
-          ctx?.fn === 'DestinationRegistry.register' &&
-          ctx?.kind === 'custom-ai:rangelink.dummy-ai-extension-tier2'
-        );
+        return ctx?.fn === 'DestinationRegistry.register' && ctx?.kind === 'custom-ai:rangelink.dummy-ai-extension-tier2';
       }),
       'Expected registration for Tier 2 (rangelink.dummy-ai-extension-tier2)',
     );
     assert.ok(
       registrationLogs.some((l) => {
         const ctx = parseLogContext(l);
-        return (
-          ctx?.fn === 'DestinationRegistry.register' &&
-          ctx?.kind === 'custom-ai:rangelink.dummy-ai-extension-tier3'
-        );
+        return ctx?.fn === 'DestinationRegistry.register' && ctx?.kind === 'custom-ai:rangelink.dummy-ai-extension-tier3';
       }),
       'Expected registration for Tier 3 (rangelink.dummy-ai-extension-tier3)',
     );
     assert.ok(
       registrationLogs.some((l) => {
         const ctx = parseLogContext(l);
-        return (
-          ctx?.fn === 'DestinationRegistry.register' &&
-          ctx?.kind === 'custom-ai:rangelink.dummy-ai-extension-template'
-        );
+        return ctx?.fn === 'DestinationRegistry.register' && ctx?.kind === 'custom-ai:rangelink.dummy-ai-extension-template';
       }),
       'Expected registration for Template (rangelink.dummy-ai-extension-template)',
     );
     assert.ok(
       registrationLogs.some((l) => {
         const ctx = parseLogContext(l);
-        return (
-          ctx?.fn === 'DestinationRegistry.register' &&
-          ctx?.kind === 'custom-ai:rangelink.dummy-ai-extension-fallback'
-        );
+        return ctx?.fn === 'DestinationRegistry.register' && ctx?.kind === 'custom-ai:rangelink.dummy-ai-extension-fallback';
       }),
       'Expected registration for Fallback (rangelink.dummy-ai-extension-fallback)',
     );
     assert.ok(
       registrationLogs.some((l) => {
         const ctx = parseLogContext(l);
-        return (
-          ctx?.fn === 'DestinationRegistry.register' &&
-          ctx?.kind === 'custom-ai:rangelink.dummy-ai-extension-focus-fail'
-        );
+        return ctx?.fn === 'DestinationRegistry.register' && ctx?.kind === 'custom-ai:rangelink.dummy-ai-extension-focus-fail';
       }),
       'Expected registration for Focus-Fail (rangelink.dummy-ai-extension-focus-fail)',
     );
@@ -143,10 +112,7 @@ standardSuite('Custom AI Assistants', (_ss) => {
 
   test('custom-ai-assistant-004: dummy extension insertText command is detectable', async () => {
     const commands = await vscode.commands.getCommands(true);
-    assert.ok(
-      commands.includes('dummyAi.insertText'),
-      'Expected dummyAi.insertText to be registered — dummy-ai-extension should be loaded',
-    );
+    assert.ok(commands.includes('dummyAi.insertText'), 'Expected dummyAi.insertText to be registered — dummy-ai-extension should be loaded');
   });
 
   test('custom-ai-assistant-005: tier 1 entry has its insertCommand registered', async () => {
@@ -160,25 +126,16 @@ standardSuite('Custom AI Assistants', (_ss) => {
     const allLines = logCapture.getAllLines();
     const registrationLog = allLines.find((line) => {
       const ctx = parseLogContext(line);
-      return (
-        ctx?.fn === 'DestinationRegistry.register' &&
-        ctx?.kind === 'custom-ai:rangelink.dummy-ai-extension'
-      );
+      return ctx?.fn === 'DestinationRegistry.register' && ctx?.kind === 'custom-ai:rangelink.dummy-ai-extension';
     });
-    assert.ok(
-      registrationLog,
-      'Expected Tier 1 entry (rangelink.dummy-ai-extension) to be registered as a destination kind',
-    );
+    assert.ok(registrationLog, 'Expected Tier 1 entry (rangelink.dummy-ai-extension) to be registered as a destination kind');
   });
 
   test('custom-ai-assistant-006: dummy extension commands are all registered', async () => {
     const commands = await vscode.commands.getCommands(true);
 
     assert.ok(commands.includes('dummyAi.insertText'), 'Expected dummyAi.insertText command');
-    assert.ok(
-      commands.includes('dummyAi.insertWithArgs'),
-      'Expected dummyAi.insertWithArgs command',
-    );
+    assert.ok(commands.includes('dummyAi.insertWithArgs'), 'Expected dummyAi.insertWithArgs command');
     assert.ok(commands.includes('dummyAi.focusForPaste'), 'Expected dummyAi.focusForPaste command');
     assert.ok(commands.includes('dummyAi.focusFail'), 'Expected dummyAi.focusFail command');
     assert.ok(commands.includes('dummyAi.focusPanel'), 'Expected dummyAi.focusPanel command');
@@ -192,16 +149,10 @@ standardSuite('Custom AI Assistants', (_ss) => {
 
     const registrationLog = allLines.find((line) => {
       const ctx = parseLogContext(line);
-      return (
-        ctx?.fn === 'DestinationRegistry.register' &&
-        ctx?.kind === 'custom-ai:rangelink.dummy-ai-extension-template'
-      );
+      return ctx?.fn === 'DestinationRegistry.register' && ctx?.kind === 'custom-ai:rangelink.dummy-ai-extension-template';
     });
 
-    assert.ok(
-      registrationLog,
-      'Expected registration for template entry (rangelink.dummy-ai-extension-template)',
-    );
+    assert.ok(registrationLog, 'Expected registration for template entry (rangelink.dummy-ai-extension-template)');
   });
 
   const EXPECTED_GITHUB_COPILOT_CHAT_REGISTRATION_COUNT = 1;
@@ -234,9 +185,7 @@ standardSuite('Custom AI Assistants', (_ss) => {
 
     const noSeparateCustomRegistration = allLines.filter((line) => {
       const ctx = parseLogContext(line);
-      return (
-        ctx?.fn === 'DestinationRegistry.register' && ctx?.kind === 'custom-ai:github.copilot-chat'
-      );
+      return ctx?.fn === 'DestinationRegistry.register' && ctx?.kind === 'custom-ai:github.copilot-chat';
     });
     assert.strictEqual(
       noSeparateCustomRegistration.length,
@@ -254,10 +203,7 @@ standardSuite('Custom AI Assistants', (_ss) => {
       return ctx?.fn === 'parseCustomAiAssistants';
     });
 
-    assert.ok(
-      parseLog,
-      'Expected parseCustomAiAssistants to load assistants with insertCommands configured as plain strings',
-    );
+    assert.ok(parseLog, 'Expected parseCustomAiAssistants to load assistants with insertCommands configured as plain strings');
     const rawCtx2 = parseLogContext(parseLog!);
     const ids = rawCtx2?.ids as string[];
     assert.ok(
@@ -295,17 +241,9 @@ standardSuite('Custom AI Assistants — Destination Picker', (ss) => {
     const items = extractQuickPickItemsLogged(lines);
     assert.ok(items, 'Expected showQuickPick log entry — was the picker opened?');
 
-    const EXPECTED_ORDER = [
-      'Dummy AI (Tier 1)',
-      'Dummy AI (Tier 2)',
-      'Dummy AI (Tier 3)',
-      'Dummy AI (Template)',
-      'Dummy AI (Fallback)',
-    ];
+    const EXPECTED_ORDER = ['Dummy AI (Tier 1)', 'Dummy AI (Tier 2)', 'Dummy AI (Tier 3)', 'Dummy AI (Template)', 'Dummy AI (Fallback)'];
 
-    const indices = EXPECTED_ORDER.map((name) =>
-      items!.findIndex((item) => item.displayName === name),
-    );
+    const indices = EXPECTED_ORDER.map((name) => items!.findIndex((item) => item.displayName === name));
 
     for (const [i, name] of EXPECTED_ORDER.entries()) {
       assert.notStrictEqual(indices[i], -1, `Expected "${name}" in the destination picker items`);
@@ -318,9 +256,7 @@ standardSuite('Custom AI Assistants — Destination Picker', (ss) => {
       );
     }
 
-    ss.log(
-      '✓ custom-ai-assistant-007 — log confirms custom AI assistants appear in settings.json order',
-    );
+    ss.log('✓ custom-ai-assistant-007 — log confirms custom AI assistants appear in settings.json order');
   });
 });
 
@@ -329,10 +265,7 @@ standardSuite('Custom AI Assistants — Cold Start', (ss) => {
     await ss.createAndOpenFile('__rl-test-cold-start', 'cold start test');
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Dummy AI (Tier 1)',
-      '✓ RangeLink: RangeLink sent to Dummy AI (Tier 1)',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Dummy AI (Tier 1)', '✓ RangeLink: RangeLink sent to Dummy AI (Tier 1)']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
     await vscode.commands.executeCommand(CMD_BIND_TO_CUSTOM_AI_BY_ID, {
       extensionId: 'rangelink.dummy-ai-extension',
@@ -345,18 +278,10 @@ standardSuite('Custom AI Assistants — Cold Start', (ss) => {
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
     await ss.settle();
 
-    const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as
-      { tier1: string; tier2: string } | undefined;
+    const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as { tier1: string; tier2: string } | undefined;
     assert.ok(textResult, 'Expected dummyAi.getText to return a result');
-    assert.ok(
-      textResult!.tier1.length > 0,
-      'Expected tier1 textarea to contain the link even though panel was not pre-opened',
-    );
-    assert.strictEqual(
-      textResult!.tier2,
-      '',
-      'Expected tier2 textarea to be empty (no cross-contamination)',
-    );
+    assert.ok(textResult!.tier1.length > 0, 'Expected tier1 textarea to contain the link even though panel was not pre-opened');
+    assert.strictEqual(textResult!.tier2, '', 'Expected tier2 textarea to be empty (no cross-contamination)');
 
     ss.log('✓ Tier 1 cold start — panel auto-initialized, text delivered');
   });
@@ -373,10 +298,7 @@ standardSuite('Custom AI Assistants — Paste Flow', (ss) => {
     await ss.createAndOpenFile('__rl-test-tier1', 'hello world\nline two\nline three');
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Dummy AI (Tier 1)',
-      '✓ RangeLink: RangeLink sent to Dummy AI (Tier 1)',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Dummy AI (Tier 1)', '✓ RangeLink: RangeLink sent to Dummy AI (Tier 1)']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
     await vscode.commands.executeCommand(CMD_BIND_TO_CUSTOM_AI_BY_ID, {
       extensionId: 'rangelink.dummy-ai-extension',
@@ -389,27 +311,16 @@ standardSuite('Custom AI Assistants — Paste Flow', (ss) => {
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
     await ss.settle();
 
-    const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as
-      { tier1: string; tier2: string } | undefined;
+    const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as { tier1: string; tier2: string } | undefined;
     assert.ok(textResult, 'Expected dummyAi.getText to return a result');
-    assert.ok(
-      textResult!.tier1.length > 0,
-      `Expected tier1 textarea to contain the link but got empty string`,
-    );
-    assert.strictEqual(
-      textResult!.tier2,
-      '',
-      'Expected tier2 textarea to be empty (no cross-contamination)',
-    );
+    assert.ok(textResult!.tier1.length > 0, `Expected tier1 textarea to contain the link but got empty string`);
+    assert.strictEqual(textResult!.tier2, '', 'Expected tier2 textarea to be empty (no cross-contamination)');
 
     ss.log('✓ Tier 1 direct insert delivered text to dummy textarea');
   });
 
   test('custom-ai-assistant-011: Tier 1 clipboard isolation — sentinel preserved', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Dummy AI (Tier 1)',
-      '✓ RangeLink: RangeLink sent to Dummy AI (Tier 1)',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Dummy AI (Tier 1)', '✓ RangeLink: RangeLink sent to Dummy AI (Tier 1)']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
     await ss.createAndOpenFile('__rl-test-tier1-clip', 'clipboard test');
     await ss.settle();
@@ -428,14 +339,9 @@ standardSuite('Custom AI Assistants — Paste Flow', (ss) => {
   });
 
   test('custom-ai-assistant-012: Tier 3 shows manual-paste toast and clipboard not restored', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Dummy AI (Tier 3)',
-      '✓ RangeLink: RangeLink copied to clipboard',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Dummy AI (Tier 3)', '✓ RangeLink: RangeLink copied to clipboard']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
-    ss.expectToastMessages([
-      { level: 'info', message: 'Paste (Cmd/Ctrl+V) in Dummy AI (Tier 3) to use.' },
-    ]);
+    ss.expectToastMessages([{ level: 'info', message: 'Paste (Cmd/Ctrl+V) in Dummy AI (Tier 3) to use.' }]);
     await ss.createAndOpenFile('__rl-test-tier3', 'tier three test');
     await ss.settle();
 
@@ -453,27 +359,17 @@ standardSuite('Custom AI Assistants — Paste Flow', (ss) => {
       'before-tier3-paste',
     );
 
-    const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as
-      { tier1: string; tier2: string } | undefined;
+    const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as { tier1: string; tier2: string } | undefined;
     assert.ok(textResult, 'Expected dummyAi.getText to return a result');
-    assert.strictEqual(
-      textResult!.tier1,
-      '',
-      'Expected tier1 textarea to be empty (Tier 3 uses manual paste, not direct insert)',
-    );
+    assert.strictEqual(textResult!.tier1, '', 'Expected tier1 textarea to be empty (Tier 3 uses manual paste, not direct insert)');
 
     ss.log('✓ Tier 3 shows manual-paste toast, clipboard not restored (link stays)');
   });
 
   test('custom-ai-assistant-013: Tier 2→3 fallback — clipboard not restored and manual paste works', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Dummy AI (Fallback)',
-      '✓ RangeLink: RangeLink copied to clipboard',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Dummy AI (Fallback)', '✓ RangeLink: RangeLink copied to clipboard']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
-    ss.expectToastMessages([
-      { level: 'info', message: 'Paste (Cmd/Ctrl+V) in Dummy AI (Fallback) to use.' },
-    ]);
+    ss.expectToastMessages([{ level: 'info', message: 'Paste (Cmd/Ctrl+V) in Dummy AI (Fallback) to use.' }]);
     await ss.createAndOpenFile('__rl-test-fallback', 'fallback test');
     await ss.settle();
 
@@ -491,23 +387,15 @@ standardSuite('Custom AI Assistants — Paste Flow', (ss) => {
       'before-fallback-paste',
     );
 
-    const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as
-      { tier1: string; tier2: string } | undefined;
+    const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as { tier1: string; tier2: string } | undefined;
     assert.ok(textResult, 'Expected dummyAi.getText to return a result');
-    assert.strictEqual(
-      textResult!.tier1,
-      '',
-      'Expected tier1 textarea to be empty (fallback resolved to focusCommands, not direct insert)',
-    );
+    assert.strictEqual(textResult!.tier1, '', 'Expected tier1 textarea to be empty (fallback resolved to focusCommands, not direct insert)');
 
     ss.log('✓ Tier 2→3 fallback: clipboard not restored, manual paste verified');
   });
 
   test('custom-ai-assistant-014: ${content} template delivers text via insertWithArgs', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Dummy AI (Template)',
-      '✓ RangeLink: RangeLink sent to Dummy AI (Template)',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Dummy AI (Template)', '✓ RangeLink: RangeLink sent to Dummy AI (Template)']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
     await ss.createAndOpenFile('__rl-test-template', 'template test content');
     await ss.settle();
@@ -523,17 +411,11 @@ standardSuite('Custom AI Assistants — Paste Flow', (ss) => {
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
     await ss.settle();
 
-    const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as
-      { tier1: string; tier2: string } | undefined;
+    const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as { tier1: string; tier2: string } | undefined;
     assert.ok(textResult, 'Expected dummyAi.getText to return a result');
-    assert.ok(
-      textResult!.tier1.length > 0,
-      'Expected tier1 textarea to contain the link via template interpolation',
-    );
+    assert.ok(textResult!.tier1.length > 0, 'Expected tier1 textarea to contain the link via template interpolation');
 
-    ss.log(
-      '✓ ${content} template interpolation delivered text to dummy textarea via insertWithArgs',
-    );
+    ss.log('✓ ${content} template interpolation delivered text to dummy textarea via insertWithArgs');
   });
 });
 
@@ -542,10 +424,7 @@ standardSuite('Custom AI Assistants — Copilot Override', (ss) => {
     await ss.createAndOpenFile('__rl-test-copilot-override', 'copilot override test');
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to GitHub Copilot Chat',
-      '✓ RangeLink: RangeLink sent to GitHub Copilot Chat',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to GitHub Copilot Chat', '✓ RangeLink: RangeLink sent to GitHub Copilot Chat']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
     await vscode.commands.executeCommand(CMD_BIND_TO_GITHUB_COPILOT_CHAT);
     await ss.settle();
@@ -554,31 +433,18 @@ standardSuite('Custom AI Assistants — Copilot Override', (ss) => {
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
     await ss.settle();
 
-    const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as
-      { tier1: string; tier2: string } | undefined;
+    const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as { tier1: string; tier2: string } | undefined;
     assert.ok(textResult, 'Expected dummyAi.getText to return a result');
-    assert.ok(
-      textResult!.tier1.length > 0,
-      'Expected tier1 textarea to contain the link (Copilot override should route to Dummy AI)',
-    );
-    assert.strictEqual(
-      textResult!.tier2,
-      '',
-      'Expected tier2 textarea to be empty (no cross-contamination)',
-    );
+    assert.ok(textResult!.tier1.length > 0, 'Expected tier1 textarea to contain the link (Copilot override should route to Dummy AI)');
+    assert.strictEqual(textResult!.tier2, '', 'Expected tier2 textarea to be empty (no cross-contamination)');
 
     ss.log('✓ Copilot override routes content to Dummy AI Tier 1');
   });
 
   test('custom-ai-assistant-019: misconfigured override (focusCommands-only) leaves link in clipboard with manual-paste toast', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Gemini Code Assist',
-      '✓ RangeLink: RangeLink copied to clipboard',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Gemini Code Assist', '✓ RangeLink: RangeLink copied to clipboard']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
-    ss.expectToastMessages([
-      { level: 'info', message: 'Paste (Cmd/Ctrl+V) in Gemini Code Assist to use.' },
-    ]);
+    ss.expectToastMessages([{ level: 'info', message: 'Paste (Cmd/Ctrl+V) in Gemini Code Assist to use.' }]);
     await ss.createAndOpenFile('__rl-test-gemini-override', 'gemini override test');
     await ss.settle();
 
@@ -596,17 +462,10 @@ standardSuite('Custom AI Assistants — Copilot Override', (ss) => {
       'before-gemini-override',
     );
 
-    const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as
-      { tier1: string; tier2: string } | undefined;
+    const textResult = (await vscode.commands.executeCommand('dummyAi.getText')) as { tier1: string; tier2: string } | undefined;
     assert.ok(textResult, 'Expected dummyAi.getText to return a result');
-    assert.strictEqual(
-      textResult!.tier1,
-      '',
-      'Expected tier1 to be empty (focusCommands-only, no direct insert)',
-    );
+    assert.strictEqual(textResult!.tier1, '', 'Expected tier1 to be empty (focusCommands-only, no direct insert)');
 
-    ss.log(
-      '✓ Misconfigured override (focusCommands-only) leaves link in clipboard, human confirmed',
-    );
+    ss.log('✓ Misconfigured override (focusCommands-only) leaves link in clipboard, human confirmed');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/dirtyBufferWarning.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/dirtyBufferWarning.test.ts
@@ -28,9 +28,7 @@ standardSuite('Dirty Buffer Warning', (ss) => {
 
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 8));
 
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('warnOnDirtyBuffer', false, vscode.ConfigurationTarget.Workspace);
+    await vscode.workspace.getConfiguration('rangelink').update('warnOnDirtyBuffer', false, vscode.ConfigurationTarget.Workspace);
 
     ss.expectStatusBarMessages(['✓ RangeLink: RangeLink copied to clipboard']);
     await assertClipboardEqualsGeneratedLink(
@@ -41,19 +39,14 @@ standardSuite('Dirty Buffer Warning', (ss) => {
       },
       'before-004',
     );
-    assert.ok(
-      editor.document.isDirty,
-      'Expected document to remain dirty — setting disabled should not trigger a save',
-    );
+    assert.ok(editor.document.isDirty, 'Expected document to remain dirty — setting disabled should not trigger a save');
   });
 
   test('[assisted] dirty-buffer-warning-008: warnOnDirtyBuffer=false — R-F sends file path without showing warning dialog', async () => {
     const testFileUri = ss.createWorkspaceFile('dirty', 'const x = 1;\n');
     const capturing = await ss.createCapturingTerminal('dirty-buffer-test');
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("dirty-buffer-test") — File path sent',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("dirty-buffer-test") — File path sent']);
     ss.expectContextKeys({
       'rangelink.isBound': true,
       'rangelink.isActiveTerminalBindable': true,
@@ -67,61 +60,39 @@ standardSuite('Dirty Buffer Warning', (ss) => {
     });
     assert.ok(editor.document.isDirty, 'Expected document to be dirty after edit');
 
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('warnOnDirtyBuffer', false, vscode.ConfigurationTarget.Workspace);
+    await vscode.workspace.getConfiguration('rangelink').update('warnOnDirtyBuffer', false, vscode.ConfigurationTarget.Workspace);
 
     const logCapture = getLogCapture();
     logCapture.mark('before-008');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'dirty-buffer-warning-008',
-      'R-F on dirty file with warnOnDirtyBuffer=false, bind to "dirty-buffer-test" terminal',
-      [
-        'Press Cmd+R Cmd+F to send the file path.',
-        'When the destination picker appears, select "dirty-buffer-test" terminal.',
-      ],
-    );
+    await waitForHuman('dirty-buffer-warning-008', 'R-F on dirty file with warnOnDirtyBuffer=false, bind to "dirty-buffer-test" terminal', [
+      'Press Cmd+R Cmd+F to send the file path.',
+      'When the destination picker appears, select "dirty-buffer-test" terminal.',
+    ]);
 
     await ss.settle();
 
-    assert.ok(
-      editor.document.isDirty,
-      'Expected document to remain dirty — setting disabled should not trigger a save',
-    );
+    assert.ok(editor.document.isDirty, 'Expected document to remain dirty — setting disabled should not trigger a save');
 
     const relativePath = vscode.workspace.asRelativePath(testFileUri, false);
     assertTerminalBufferEquals(capturing.getCapturedText(), ` ${relativePath} `);
 
     const lines = logCapture.getLinesSince('before-008');
     const disabledLog = lines.some(
-      (l) =>
-        parseLogContext(l)?.fn === 'handleDirtyBufferWarning' &&
-        l.includes('Document has unsaved changes but warning is disabled by setting'),
+      (l) => parseLogContext(l)?.fn === 'handleDirtyBufferWarning' && l.includes('Document has unsaved changes but warning is disabled by setting'),
     );
-    assert.ok(
-      disabledLog,
-      'Expected "disabled by setting" log — setting should short-circuit the dialog',
-    );
+    assert.ok(disabledLog, 'Expected "disabled by setting" log — setting should short-circuit the dialog');
     const dialogLogged = lines.some(
-      (l) =>
-        parseLogContext(l)?.fn === 'handleDirtyBufferWarning' &&
-        l.includes('Document has unsaved changes, showing warning'),
+      (l) => parseLogContext(l)?.fn === 'handleDirtyBufferWarning' && l.includes('Document has unsaved changes, showing warning'),
     );
-    assert.strictEqual(
-      dialogLogged,
-      false,
-      'Expected no dialog log — setting should bypass the dialog',
-    );
+    assert.strictEqual(dialogLogged, false, 'Expected no dialog log — setting should bypass the dialog');
   });
 
   test('[assisted] dirty-buffer-warning-009: R-F on clean file sends path without warning', async () => {
     const capturing = await ss.createCapturingTerminal('dirty-buffer-test');
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("dirty-buffer-test") — File path sent',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("dirty-buffer-test") — File path sent']);
     ss.expectContextKeys({
       'rangelink.isBound': true,
       'rangelink.isActiveTerminalBindable': true,
@@ -155,10 +126,7 @@ standardSuite('Dirty Buffer Warning', (ss) => {
   });
 
   test('[assisted] dirty-buffer-warning-018: warnOnDirtyBuffer=false — R-L sends link to bound destination without warning dialog', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("dirty-buffer-test")',
-      '✓ RangeLink: RangeLink sent to Terminal ("dirty-buffer-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("dirty-buffer-test")', '✓ RangeLink: RangeLink sent to Terminal ("dirty-buffer-test")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -176,49 +144,32 @@ standardSuite('Dirty Buffer Warning', (ss) => {
 
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 8));
 
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('warnOnDirtyBuffer', false, vscode.ConfigurationTarget.Workspace);
+    await vscode.workspace.getConfiguration('rangelink').update('warnOnDirtyBuffer', false, vscode.ConfigurationTarget.Workspace);
 
     capturing.clearCaptured();
 
     const logCapture = getLogCapture();
     await withClipboardSentinel('before-018', 'R-L', async () => {
-      await waitForHuman(
-        'dirty-buffer-warning-018-dispatch',
-        'R-L on dirty file with warnOnDirtyBuffer=false',
-        [
-          'Click in the editor and select some text (the first word is fine).',
-          'Press Cmd+R Cmd+L (Send RangeLink).',
-        ],
-      );
+      await waitForHuman('dirty-buffer-warning-018-dispatch', 'R-L on dirty file with warnOnDirtyBuffer=false', [
+        'Click in the editor and select some text (the first word is fine).',
+        'Press Cmd+R Cmd+L (Send RangeLink).',
+      ]);
       await ss.settle();
     });
 
     const lines = logCapture.getLinesSince('before-018');
     const disabledLog = lines.some(
-      (l) =>
-        parseLogContext(l)?.fn === 'handleDirtyBufferWarning' &&
-        l.includes('Document has unsaved changes but warning is disabled by setting'),
+      (l) => parseLogContext(l)?.fn === 'handleDirtyBufferWarning' && l.includes('Document has unsaved changes but warning is disabled by setting'),
     );
-    assert.ok(
-      disabledLog,
-      'Expected "disabled by setting" log — R-L path should short-circuit through handleDirtyBufferWarning',
-    );
+    assert.ok(disabledLog, 'Expected "disabled by setting" log — R-L path should short-circuit through handleDirtyBufferWarning');
 
     assertTerminalBufferContains(capturing.getCapturedText(), 'dirty');
 
-    assert.ok(
-      editor.document.isDirty,
-      'Expected document to remain dirty — setting disabled should not trigger a save',
-    );
+    assert.ok(editor.document.isDirty, 'Expected document to remain dirty — setting disabled should not trigger a save');
   });
 
   test('dirty-buffer-warning-006: warnOnDirtyBuffer=false — R-L sends link to bound destination without dialog', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("dirty-buffer-test")',
-      '✓ RangeLink: RangeLink sent to Terminal ("dirty-buffer-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("dirty-buffer-test")', '✓ RangeLink: RangeLink sent to Terminal ("dirty-buffer-test")']);
     ss.expectContextKeys({
       'rangelink.isBound': true,
       'rangelink.isActiveTerminalBindable': true,
@@ -237,9 +188,7 @@ standardSuite('Dirty Buffer Warning', (ss) => {
 
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 8));
 
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('warnOnDirtyBuffer', false, vscode.ConfigurationTarget.Workspace);
+    await vscode.workspace.getConfiguration('rangelink').update('warnOnDirtyBuffer', false, vscode.ConfigurationTarget.Workspace);
 
     capturing.clearCaptured();
 
@@ -251,32 +200,18 @@ standardSuite('Dirty Buffer Warning', (ss) => {
 
     const lines = logCapture.getLinesSince('before-006');
     const disabledLog = lines.some(
-      (l) =>
-        parseLogContext(l)?.fn === 'handleDirtyBufferWarning' &&
-        l.includes('Document has unsaved changes but warning is disabled by setting'),
+      (l) => parseLogContext(l)?.fn === 'handleDirtyBufferWarning' && l.includes('Document has unsaved changes but warning is disabled by setting'),
     );
-    assert.ok(
-      disabledLog,
-      'Expected "disabled by setting" log — warnOnDirtyBuffer=false must short-circuit the dialog',
-    );
+    assert.ok(disabledLog, 'Expected "disabled by setting" log — warnOnDirtyBuffer=false must short-circuit the dialog');
 
     const dialogLogged = lines.some(
-      (l) =>
-        parseLogContext(l)?.fn === 'handleDirtyBufferWarning' &&
-        l.includes('Document has unsaved changes, showing warning'),
+      (l) => parseLogContext(l)?.fn === 'handleDirtyBufferWarning' && l.includes('Document has unsaved changes, showing warning'),
     );
-    assert.strictEqual(
-      dialogLogged,
-      false,
-      'Expected no dialog log — setting should bypass dialog',
-    );
+    assert.strictEqual(dialogLogged, false, 'Expected no dialog log — setting should bypass dialog');
 
     assertTerminalBufferEqualsGeneratedLink(capturing, 'before-006');
 
-    assert.ok(
-      editor.document.isDirty,
-      'Expected document to remain dirty — bypass must not trigger save',
-    );
+    assert.ok(editor.document.isDirty, 'Expected document to remain dirty — bypass must not trigger save');
   });
 
   test('dirty-buffer-warning-019: R-C on clean file generates link without warning dialog', async () => {
@@ -300,18 +235,11 @@ standardSuite('Dirty Buffer Warning', (ss) => {
 
     const lines = getLogCapture().getLinesSince('before-019');
     const warningLogged = lines.some((l) => parseLogContext(l)?.fn === 'handleDirtyBufferWarning');
-    assert.strictEqual(
-      warningLogged,
-      false,
-      'Expected no dirty buffer warning log for clean file — Clean early-return must not emit logs',
-    );
+    assert.strictEqual(warningLogged, false, 'Expected no dirty buffer warning log for clean file — Clean early-return must not emit logs');
   });
 
   test('dirty-buffer-warning-007: clean file generates link immediately without dialog', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("dirty-buffer-test")',
-      '✓ RangeLink: RangeLink sent to Terminal ("dirty-buffer-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("dirty-buffer-test")', '✓ RangeLink: RangeLink sent to Terminal ("dirty-buffer-test")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -376,15 +304,11 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
       'before-002',
       'R-L',
       async () => {
-        await waitForHuman(
-          'dirty-buffer-warning-002',
-          'R-L on dirty file → dismiss the dialog (press Escape or click X)',
-          [
-            'Click in the editor and select some text (the first word is fine).',
-            'Press Cmd+R Cmd+L — the dirty buffer dialog should appear.',
-            'Press Escape or click the X to dismiss.',
-          ],
-        );
+        await waitForHuman('dirty-buffer-warning-002', 'R-L on dirty file → dismiss the dialog (press Escape or click X)', [
+          'Click in the editor and select some text (the first word is fine).',
+          'Press Cmd+R Cmd+L — the dirty buffer dialog should appear.',
+          'Press Escape or click the X to dismiss.',
+        ]);
         await ss.settle();
       },
       { expectPreserved: false },
@@ -396,10 +320,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
   });
 
   test('[assisted] dirty-buffer-warning-003: R-L Save & Generate saves file and sends link to bound destination', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("dirty-buffer-test")',
-      '✓ RangeLink: RangeLink sent to Terminal ("dirty-buffer-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("dirty-buffer-test")', '✓ RangeLink: RangeLink sent to Terminal ("dirty-buffer-test")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -427,15 +348,11 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
     capturing.clearCaptured();
 
     await withClipboardSentinel('before-003', 'R-L', async () => {
-      await waitForHuman(
-        'dirty-buffer-warning-003',
-        'R-L on dirty file → click "Save & Generate"',
-        [
-          'Click in the editor and select some text (the first word is fine).',
-          'Press Cmd+R Cmd+L — the dirty buffer dialog should appear.',
-          'Click "Save & Generate".',
-        ],
-      );
+      await waitForHuman('dirty-buffer-warning-003', 'R-L on dirty file → click "Save & Generate"', [
+        'Click in the editor and select some text (the first word is fine).',
+        'Press Cmd+R Cmd+L — the dirty buffer dialog should appear.',
+        'Click "Save & Generate".',
+      ]);
       await ss.settle();
     });
 
@@ -484,15 +401,11 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
       'before-005',
       'R-L',
       async () => {
-        await waitForHuman(
-          'dirty-buffer-warning-005',
-          'R-L on dirty file → dismiss the dialog (press Escape or click X)',
-          [
-            'Click in the editor and ensure some text is selected.',
-            'Press Cmd+R Cmd+L — the dirty buffer dialog should appear.',
-            'Press Escape or click the X to dismiss.',
-          ],
-        );
+        await waitForHuman('dirty-buffer-warning-005', 'R-L on dirty file → dismiss the dialog (press Escape or click X)', [
+          'Click in the editor and ensure some text is selected.',
+          'Press Cmd+R Cmd+L — the dirty buffer dialog should appear.',
+          'Press Escape or click the X to dismiss.',
+        ]);
         await ss.settle();
       },
       { expectPreserved: false },
@@ -526,15 +439,11 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
     await assertClipboardEqualsGeneratedLink(
       'R-C Save & Generate should write link to clipboard',
       async () => {
-        await waitForHuman(
-          'dirty-buffer-warning-010',
-          'R-C on dirty file → click "Save & Generate"',
-          [
-            'Click in the editor and select some text (the first word is fine).',
-            'Press Cmd+R Cmd+C (Copy RangeLink) — the dirty buffer dialog should appear.',
-            'Click "Save & Generate".',
-          ],
-        );
+        await waitForHuman('dirty-buffer-warning-010', 'R-C on dirty file → click "Save & Generate"', [
+          'Click in the editor and select some text (the first word is fine).',
+          'Press Cmd+R Cmd+C (Copy RangeLink) — the dirty buffer dialog should appear.',
+          'Click "Save & Generate".',
+        ]);
         await ss.settle();
       },
       'before-010',
@@ -566,15 +475,11 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
     await assertClipboardEqualsGeneratedLink(
       'R-C Generate Anyway should write link to clipboard',
       async () => {
-        await waitForHuman(
-          'dirty-buffer-warning-011',
-          'R-C on dirty file → click "Generate Anyway"',
-          [
-            'Click in the editor and select some text (the first word is fine).',
-            'Press Cmd+R Cmd+C (Copy RangeLink) — the dirty buffer dialog should appear.',
-            'Click "Generate Anyway".',
-          ],
-        );
+        await waitForHuman('dirty-buffer-warning-011', 'R-C on dirty file → click "Generate Anyway"', [
+          'Click in the editor and select some text (the first word is fine).',
+          'Press Cmd+R Cmd+C (Copy RangeLink) — the dirty buffer dialog should appear.',
+          'Click "Generate Anyway".',
+        ]);
         await ss.settle();
       },
       'before-011',
@@ -609,15 +514,11 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 10));
 
     await withClipboardRestored('dismiss should abort — clipboard unchanged', async () => {
-      await waitForHuman(
-        'dirty-buffer-warning-012',
-        'R-C on dirty file → dismiss the dialog (press Escape or click X)',
-        [
-          'Click in the editor and select some text (the first word is fine).',
-          'Press Cmd+R Cmd+C (Copy RangeLink) — the dirty buffer dialog should appear.',
-          'Press Escape or click the X to dismiss.',
-        ],
-      );
+      await waitForHuman('dirty-buffer-warning-012', 'R-C on dirty file → dismiss the dialog (press Escape or click X)', [
+        'Click in the editor and select some text (the first word is fine).',
+        'Press Cmd+R Cmd+C (Copy RangeLink) — the dirty buffer dialog should appear.',
+        'Press Escape or click the X to dismiss.',
+      ]);
       await ss.settle();
     });
     assert.ok(editor.document.isDirty, 'Expected document to remain dirty');
@@ -626,9 +527,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
   });
 
   test('[assisted] dirty-buffer-warning-013: R-F Save & Send saves file and sends path', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("dirty-buffer-test") — File path sent',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("dirty-buffer-test") — File path sent']);
     ss.expectContextKeys({
       'rangelink.isBound': true,
       'rangelink.isActiveTerminalBindable': true,
@@ -655,15 +554,11 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
     logCapture.mark('before-rf-save');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'dirty-buffer-warning-013',
-      'R-F on dirty file → click "Save & Send" → pick the terminal',
-      [
-        'Press Cmd+R Cmd+F — the dirty buffer dialog should appear.',
-        'Click "Save & Send".',
-        'A destination picker will appear — select "dirty-buffer-test" terminal.',
-      ],
-    );
+    await waitForHuman('dirty-buffer-warning-013', 'R-F on dirty file → click "Save & Send" → pick the terminal', [
+      'Press Cmd+R Cmd+F — the dirty buffer dialog should appear.',
+      'Click "Save & Send".',
+      'A destination picker will appear — select "dirty-buffer-test" terminal.',
+    ]);
 
     await ss.settle();
 
@@ -676,9 +571,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
   });
 
   test('[assisted] dirty-buffer-warning-014: R-F Send Anyway sends path without saving', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("dirty-buffer-test") — File path sent',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("dirty-buffer-test") — File path sent']);
     ss.expectContextKeys({
       'rangelink.isBound': true,
       'rangelink.isActiveTerminalBindable': true,
@@ -705,15 +598,11 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
     logCapture.mark('before-rf-anyway');
     capturing.clearCaptured();
 
-    await waitForHuman(
-      'dirty-buffer-warning-014',
-      'R-F on dirty file → click "Send Anyway" → pick the terminal',
-      [
-        'Press Cmd+R Cmd+F — the dirty buffer dialog should appear.',
-        'Click "Send Anyway".',
-        'A destination picker will appear — select "dirty-buffer-test" terminal.',
-      ],
-    );
+    await waitForHuman('dirty-buffer-warning-014', 'R-F on dirty file → click "Send Anyway" → pick the terminal', [
+      'Press Cmd+R Cmd+F — the dirty buffer dialog should appear.',
+      'Click "Send Anyway".',
+      'A destination picker will appear — select "dirty-buffer-test" terminal.',
+    ]);
 
     await ss.settle();
 
@@ -748,14 +637,10 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
     assert.ok(editor.document.isDirty, 'Expected document to be dirty');
 
     await withClipboardRestored('dismiss should abort — clipboard unchanged', async () => {
-      await waitForHuman(
-        'dirty-buffer-warning-015',
-        'R-F on dirty file → dismiss the dialog (press Escape or click X)',
-        [
-          'Press Cmd+R Cmd+F — the dirty buffer dialog should appear.',
-          'Press Escape or click the X to dismiss.',
-        ],
-      );
+      await waitForHuman('dirty-buffer-warning-015', 'R-F on dirty file → dismiss the dialog (press Escape or click X)', [
+        'Press Cmd+R Cmd+F — the dirty buffer dialog should appear.',
+        'Press Escape or click the X to dismiss.',
+      ]);
       await ss.settle();
     });
     assert.ok(editor.document.isDirty, 'Expected document to remain dirty');
@@ -764,10 +649,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
   });
 
   test('[assisted] dirty-buffer-warning-016: R-L clipboard preserved after dirty buffer dialog with bound destination', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("dirty-buffer-test")',
-      '✓ RangeLink: RangeLink sent to Terminal ("dirty-buffer-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("dirty-buffer-test")', '✓ RangeLink: RangeLink sent to Terminal ("dirty-buffer-test")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -795,11 +677,10 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
     capturing.clearCaptured();
 
     await withClipboardSentinel('before -rl-clipboard-preserve', 'R-L', async () => {
-      await waitForHuman(
-        'dirty-buffer-warning-016-dialog',
-        'R-L on dirty file → click "Generate Anyway"',
-        ['Press Cmd+R Cmd+L — the dirty buffer dialog should appear.', 'Click "Generate Anyway".'],
-      );
+      await waitForHuman('dirty-buffer-warning-016-dialog', 'R-L on dirty file → click "Generate Anyway"', [
+        'Press Cmd+R Cmd+L — the dirty buffer dialog should appear.',
+        'Click "Generate Anyway".',
+      ]);
       await ss.settle();
     });
 
@@ -807,16 +688,11 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
 
     assert.ok(editor.document.isDirty, 'Expected document to remain dirty after Generate Anyway');
 
-    ss.log(
-      '✓ R-L dirty + bound destination: link landed in terminal; clipboard preserved after Generate Anyway',
-    );
+    ss.log('✓ R-L dirty + bound destination: link landed in terminal; clipboard preserved after Generate Anyway');
   });
 
   test('[assisted] dirty-buffer-warning-017: R-F clipboard preserved after dirty buffer dialog with bound destination', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("dirty-buffer-test")',
-      '✓ RangeLink: File path sent to Terminal ("dirty-buffer-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("dirty-buffer-test")', '✓ RangeLink: File path sent to Terminal ("dirty-buffer-test")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -842,11 +718,10 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
     capturing.clearCaptured();
 
     await withClipboardSentinel('before-rf-clipboard-preserve', 'R-F', async () => {
-      await waitForHuman(
-        'dirty-buffer-warning-017-dialog',
-        'R-F on dirty file → click "Send Anyway"',
-        ['Press Cmd+R Cmd+F — the dirty buffer dialog should appear.', 'Click "Send Anyway".'],
-      );
+      await waitForHuman('dirty-buffer-warning-017-dialog', 'R-F on dirty file → click "Send Anyway"', [
+        'Press Cmd+R Cmd+F — the dirty buffer dialog should appear.',
+        'Click "Send Anyway".',
+      ]);
       await ss.settle();
     });
 
@@ -855,16 +730,11 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
 
     assert.ok(editor.document.isDirty, 'Expected document to remain dirty after Send Anyway');
 
-    ss.log(
-      '✓ R-F dirty + bound destination: path landed in terminal; clipboard preserved after Send Anyway',
-    );
+    ss.log('✓ R-F dirty + bound destination: path landed in terminal; clipboard preserved after Send Anyway');
   });
 
   test('[assisted] dirty-buffer-warning-020: R-L Save & Generate saves file and sends link to bound destination', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("dirty-buffer-test")',
-      '✓ RangeLink: RangeLink sent to Terminal ("dirty-buffer-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("dirty-buffer-test")', '✓ RangeLink: RangeLink sent to Terminal ("dirty-buffer-test")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -892,15 +762,11 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
     capturing.clearCaptured();
 
     await withClipboardSentinel('before-020', 'R-L', async () => {
-      await waitForHuman(
-        'dirty-buffer-warning-020-dialog',
-        'R-L on dirty file → click "Save & Generate"',
-        [
-          'Click in the editor and select some text (the first word is fine).',
-          'Press Cmd+R Cmd+L (Send RangeLink) — the dirty buffer dialog should appear.',
-          'Click "Save & Generate".',
-        ],
-      );
+      await waitForHuman('dirty-buffer-warning-020-dialog', 'R-L on dirty file → click "Save & Generate"', [
+        'Click in the editor and select some text (the first word is fine).',
+        'Press Cmd+R Cmd+L (Send RangeLink) — the dirty buffer dialog should appear.',
+        'Click "Save & Generate".',
+      ]);
       await ss.settle();
     });
 
@@ -912,10 +778,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
   });
 
   test('[assisted] dirty-buffer-warning-021: R-L Generate Anyway sends link without saving', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("dirty-buffer-test")',
-      '✓ RangeLink: RangeLink sent to Terminal ("dirty-buffer-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("dirty-buffer-test")', '✓ RangeLink: RangeLink sent to Terminal ("dirty-buffer-test")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -943,15 +806,11 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
     capturing.clearCaptured();
 
     await withClipboardSentinel('before-021', 'R-L', async () => {
-      await waitForHuman(
-        'dirty-buffer-warning-021-dialog',
-        'R-L on dirty file → click "Generate Anyway"',
-        [
-          'Click in the editor and select some text (the first word is fine).',
-          'Press Cmd+R Cmd+L (Send RangeLink) — the dirty buffer dialog should appear.',
-          'Click "Generate Anyway".',
-        ],
-      );
+      await waitForHuman('dirty-buffer-warning-021-dialog', 'R-L on dirty file → click "Generate Anyway"', [
+        'Click in the editor and select some text (the first word is fine).',
+        'Press Cmd+R Cmd+L (Send RangeLink) — the dirty buffer dialog should appear.',
+        'Click "Generate Anyway".',
+      ]);
       await ss.settle();
     });
 
@@ -1000,15 +859,11 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
       'before-022',
       'R-L',
       async () => {
-        await waitForHuman(
-          'dirty-buffer-warning-022-dialog',
-          'R-L on dirty file → dismiss the dialog (press Escape or click X)',
-          [
-            'Click in the editor and select some text (the first word is fine).',
-            'Press Cmd+R Cmd+L (Send RangeLink) — the dirty buffer dialog should appear.',
-            'Press Escape or click the X to dismiss.',
-          ],
-        );
+        await waitForHuman('dirty-buffer-warning-022-dialog', 'R-L on dirty file → dismiss the dialog (press Escape or click X)', [
+          'Click in the editor and select some text (the first word is fine).',
+          'Press Cmd+R Cmd+L (Send RangeLink) — the dirty buffer dialog should appear.',
+          'Press Escape or click the X to dismiss.',
+        ]);
         await ss.settle();
       },
       { expectPreserved: false },
@@ -1022,10 +877,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
   });
 
   test('[assisted] dirty-buffer-warning-023: R-L Save & Generate re-reads selections after save mutates document', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("dirty-buffer-test")',
-      '✓ RangeLink: RangeLink sent to Terminal ("dirty-buffer-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("dirty-buffer-test")', '✓ RangeLink: RangeLink sent to Terminal ("dirty-buffer-test")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -1054,8 +906,7 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
     const capturing = await ss.createAndBindCapturingTerminal('dirty-buffer-test');
 
     const filesConfig = vscode.workspace.getConfiguration('files');
-    const originalTrimTrailingWhitespace =
-      filesConfig.inspect('trimTrailingWhitespace')?.workspaceValue;
+    const originalTrimTrailingWhitespace = filesConfig.inspect('trimTrailingWhitespace')?.workspaceValue;
     await filesConfig.update('trimTrailingWhitespace', true, vscode.ConfigurationTarget.Workspace);
 
     try {
@@ -1076,15 +927,11 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
 
       const logCapture = getLogCapture();
       await withClipboardSentinel('before-023', 'R-L', async () => {
-        await waitForHuman(
-          'dirty-buffer-warning-023-dialog',
-          'R-L on dirty file with trim-on-save → click "Save & Generate"',
-          [
-            'The editor is focused with a precise column range selected on line 2 (not the full line).',
-            'Press Cmd+R Cmd+L (Send RangeLink) — the dirty buffer dialog should appear.',
-            'Click "Save & Generate".',
-          ],
-        );
+        await waitForHuman('dirty-buffer-warning-023-dialog', 'R-L on dirty file with trim-on-save → click "Save & Generate"', [
+          'The editor is focused with a precise column range selected on line 2 (not the full line).',
+          'Press Cmd+R Cmd+L (Send RangeLink) — the dirty buffer dialog should appear.',
+          'Click "Save & Generate".',
+        ]);
         await ss.settle();
       });
 
@@ -1094,31 +941,19 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
         const ctx = parseLogContext(l);
         return ctx?.fn === 'generateLinkFromSelection' && l.includes('Re-read selections');
       });
-      assert.ok(
-        reReadLine,
-        'Expected LinkGenerator to log the post-save re-read — the fix path was not taken',
-      );
+      assert.ok(reReadLine, 'Expected LinkGenerator to log the post-save re-read — the fix path was not taken');
 
       const reReadCtx = parseLogContext(reReadLine!);
-      const preSelections = reReadCtx?.preSaveSelections as
-        Array<{ end: { line: number; char: number } }> | undefined;
-      const postSelections = reReadCtx?.postSaveSelections as
-        Array<{ end: { line: number; char: number } }> | undefined;
-      assert.ok(
-        preSelections !== undefined && postSelections !== undefined,
-        `Expected pre/post selections in log, got: ${reReadLine}`,
-      );
+      const preSelections = reReadCtx?.preSaveSelections as Array<{ end: { line: number; char: number } }> | undefined;
+      const postSelections = reReadCtx?.postSaveSelections as Array<{ end: { line: number; char: number } }> | undefined;
+      assert.ok(preSelections !== undefined && postSelections !== undefined, `Expected pre/post selections in log, got: ${reReadLine}`);
 
       assert.strictEqual(
         preSelections[0].end.char,
         SELECTION_END_COL_PRE_TRIM,
         `Pre-save end column should be ${SELECTION_END_COL_PRE_TRIM} (within trailing whitespace)`,
       );
-      assert.strictEqual(
-        preSelections[0].end.line,
-        targetLineIdx,
-        'Pre-save end line should match source line',
-      );
+      assert.strictEqual(preSelections[0].end.line, targetLineIdx, 'Pre-save end line should match source line');
 
       const postEndChar = postSelections[0].end.char;
       const postEndLine = postSelections[0].end.line;
@@ -1127,26 +962,15 @@ standardSuite('Dirty Buffer Warning — Dialog Interaction', (ss) => {
         `Post-save end column (${postEndChar}) should be less than pre-save (${SELECTION_END_COL_PRE_TRIM}) after ${TRAILING_SPACES} spaces trimmed`,
       );
       assert.strictEqual(postEndLine, targetLineIdx, 'Post-save end line should be unchanged');
-      assert.ok(
-        postEndChar >= TARGET_LINE_BASE_LEN,
-        `Post-save end column (${postEndChar}) should be >= text-only line length (${TARGET_LINE_BASE_LEN})`,
-      );
+      assert.ok(postEndChar >= TARGET_LINE_BASE_LEN, `Post-save end column (${postEndChar}) should be >= text-only line length (${TARGET_LINE_BASE_LEN})`);
 
       assert.ok(!editor.document.isDirty, 'Expected document to be saved after Save & Generate');
 
       assertTerminalBufferEqualsGeneratedLink(capturing, 'before-023');
 
-      ss.log(
-        '✓ R-L Save & Generate with trim-on-save: selections re-read, link coordinates correct',
-      );
+      ss.log('✓ R-L Save & Generate with trim-on-save: selections re-read, link coordinates correct');
     } finally {
-      await vscode.workspace
-        .getConfiguration('files')
-        .update(
-          'trimTrailingWhitespace',
-          originalTrimTrailingWhitespace,
-          vscode.ConfigurationTarget.Workspace,
-        );
+      await vscode.workspace.getConfiguration('files').update('trimTrailingWhitespace', originalTrimTrailingWhitespace, vscode.ConfigurationTarget.Workspace);
     }
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/editorBindingValidation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/editorBindingValidation.test.ts
@@ -1,12 +1,5 @@
 import { CMD_BIND_TO_DESTINATION } from '../../constants/commandIds';
-import {
-  extractQuickPickItemsLogged,
-  findTestItemsByPrefix,
-  getLogCapture,
-  openAndDismiss,
-  standardSuite,
-  waitForHumanVerdict,
-} from '../helpers';
+import { extractQuickPickItemsLogged, findTestItemsByPrefix, getLogCapture, openAndDismiss, standardSuite, waitForHumanVerdict } from '../helpers';
 
 import assert from 'node:assert';
 import * as path from 'node:path';
@@ -26,11 +19,7 @@ standardSuite('Editor Binding Validation', (ss) => {
       ],
     );
 
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'Link or bind commands were visible in the search editor content area context menu',
-    );
+    assert.strictEqual(verdict, 'pass', 'Link or bind commands were visible in the search editor content area context menu');
     ss.log('✓ Search editor content hides link/bind commands (human verdict)');
   });
 
@@ -48,11 +37,7 @@ standardSuite('Editor Binding Validation', (ss) => {
       ],
     );
 
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'File path or bind commands were visible in the output panel context menu',
-    );
+    assert.strictEqual(verdict, 'pass', 'File path or bind commands were visible in the output panel context menu');
     ss.log('✓ Output panel hides file path/bind commands (human verdict)');
   });
 
@@ -104,17 +89,10 @@ standardSuite('Editor Binding Validation', (ss) => {
     const txtFileName = path.basename(txtUri.fsPath);
 
     const pngItems = findTestItemsByPrefix(items!, pngFileName);
-    assert.strictEqual(
-      pngItems.length,
-      0,
-      `Binary .png file "${pngFileName}" must not appear in R-D picker`,
-    );
+    assert.strictEqual(pngItems.length, 0, `Binary .png file "${pngFileName}" must not appear in R-D picker`);
 
     const txtItems = findTestItemsByPrefix(items!, 'ebv-004-txt');
-    assert.ok(
-      txtItems.length > 0,
-      `Plain .txt file "${txtFileName}" must appear in R-D picker as positive control`,
-    );
+    assert.ok(txtItems.length > 0, `Plain .txt file "${txtFileName}" must appear in R-D picker as positive control`);
 
     ss.log('✓ Binary .png excluded from R-D picker; .txt control file present (log verified)');
   });
@@ -132,11 +110,7 @@ standardSuite('Editor Binding Validation', (ss) => {
       ],
     );
 
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'File path commands were visible in the search editor tab context menu',
-    );
+    assert.strictEqual(verdict, 'pass', 'File path commands were visible in the search editor tab context menu');
     ss.log('✓ Search editor tab hides file path commands (human verdict)');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filePathDetection.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filePathDetection.test.ts
@@ -1,10 +1,5 @@
 import assert from 'node:assert';
-import {
-  buildFilePathPattern,
-  DEFAULT_DELIMITERS,
-  DelimiterConfig,
-  extractFilePath,
-} from 'rangelink-core-ts';
+import { buildFilePathPattern, DEFAULT_DELIMITERS, DelimiterConfig, extractFilePath } from 'rangelink-core-ts';
 
 const matchPaths = (text: string, delimiters: DelimiterConfig = DEFAULT_DELIMITERS): string[] => {
   const pattern = buildFilePathPattern(delimiters);
@@ -30,21 +25,15 @@ suite('File Path Detection', () => {
   });
 
   test('clickable-file-paths-004: detects tilde home path (~/projects/app.ts)', () => {
-    assert.deepStrictEqual(matchPaths('Open ~/projects/app.ts in the editor'), [
-      '~/projects/app.ts',
-    ]);
+    assert.deepStrictEqual(matchPaths('Open ~/projects/app.ts in the editor'), ['~/projects/app.ts']);
   });
 
   test('clickable-file-paths-005: detects double-quoted path with spaces and strips quotes', () => {
-    assert.deepStrictEqual(matchPaths('Open "/path/with spaces/file.ts" now'), [
-      '/path/with spaces/file.ts',
-    ]);
+    assert.deepStrictEqual(matchPaths('Open "/path/with spaces/file.ts" now'), ['/path/with spaces/file.ts']);
   });
 
   test('clickable-file-paths-006: detects single-quoted path and strips quotes', () => {
-    assert.deepStrictEqual(matchPaths("Check '/path/to/file.ts' for details"), [
-      '/path/to/file.ts',
-    ]);
+    assert.deepStrictEqual(matchPaths("Check '/path/to/file.ts' for details"), ['/path/to/file.ts']);
   });
 
   test('clickable-file-paths-007: does NOT detect HTTP URL as a file path', () => {

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filePathNavigation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filePathNavigation.test.ts
@@ -16,11 +16,7 @@ standardSuite('File Path Navigation', (ss) => {
     });
 
     const activeUri = vscode.window.activeTextEditor?.document.uri.fsPath;
-    assert.strictEqual(
-      activeUri,
-      testFileUri.fsPath,
-      `Expected active editor to be ${testFileUri.fsPath} but got ${activeUri}`,
-    );
+    assert.strictEqual(activeUri, testFileUri.fsPath, `Expected active editor to be ${testFileUri.fsPath} but got ${activeUri}`);
   });
 
   test('clickable-file-paths-011: handleFilePathClick with non-existent path does not change active editor', async () => {
@@ -30,9 +26,7 @@ standardSuite('File Path Navigation', (ss) => {
 
     const nonExistentPath = path.join(getWorkspaceRoot(), '__rl-nonexistent-file-12345.ts');
 
-    ss.expectToastMessages([
-      { level: 'warning', message: `File does not exist at: ${nonExistentPath}` },
-    ]);
+    ss.expectToastMessages([{ level: 'warning', message: `File does not exist at: ${nonExistentPath}` }]);
 
     void vscode.commands.executeCommand(CMD_HANDLE_FILE_PATH_CLICK, {
       filePath: nonExistentPath,
@@ -41,10 +35,6 @@ standardSuite('File Path Navigation', (ss) => {
     await ss.settle(NON_EXISTENT_PATH_SETTLE_MS);
 
     const editorAfter = vscode.window.activeTextEditor?.document.uri.fsPath;
-    assert.strictEqual(
-      editorAfter,
-      editorBefore,
-      `Expected active editor to remain ${editorBefore} but got ${editorAfter}`,
-    );
+    assert.strictEqual(editorAfter, editorBefore, `Expected active editor to remain ${editorBefore} but got ${editorAfter}`);
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filePicker.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filePicker.test.ts
@@ -1,8 +1,4 @@
-import {
-  CMD_BIND_TO_DESTINATION,
-  CMD_BIND_TO_TEXT_EDITOR_HERE,
-  CMD_OPEN_STATUS_BAR_MENU,
-} from '../../constants/commandIds';
+import { CMD_BIND_TO_DESTINATION, CMD_BIND_TO_TEXT_EDITOR_HERE, CMD_OPEN_STATUS_BAR_MENU } from '../../constants/commandIds';
 import {
   createFileAt,
   extractQuickPickItemsLogged,
@@ -23,8 +19,7 @@ const SEPARATOR_KIND = -1;
 const FILE_OVERFLOW_THRESHOLD = 5;
 
 standardSuite('File Picker', (ss) => {
-  const findTestFileItems = (items: Record<string, unknown>[]): Record<string, unknown>[] =>
-    findTestItemsByPrefix(items, '__rl-test-fp-');
+  const findTestFileItems = (items: Record<string, unknown>[]): Record<string, unknown>[] => findTestItemsByPrefix(items, '__rl-test-fp-');
 
   test('file-picker-001: bound file appears first with bound badge', async () => {
     const uriA = await ss.createAndOpenFile('fp-001-a', 'line 1\nline 2\n', vscode.ViewColumn.One);
@@ -144,19 +139,12 @@ standardSuite('File Picker', (ss) => {
     const items = extractQuickPickItemsLogged(lines);
     assert.ok(items, 'Expected showQuickPick log entry');
 
-    const sharedNameItems = findTestFileItems(items!).filter((i) =>
-      (i.label as string).includes('fp-003-shared'),
-    );
+    const sharedNameItems = findTestFileItems(items!).filter((i) => (i.label as string).includes('fp-003-shared'));
 
     const descriptions = sharedNameItems.map(({ description }) => description as string);
-    assert.strictEqual(
-      sharedNameItems.length,
-      2,
-      `Expected exactly 2 disambiguated items but got ${sharedNameItems.length}`,
-    );
+    assert.strictEqual(sharedNameItems.length, 2, `Expected exactly 2 disambiguated items but got ${sharedNameItems.length}`);
     assert.ok(
-      descriptions.some((d) => d && d.includes('dirA')) &&
-        descriptions.some((d) => d && d.includes('dirB')),
+      descriptions.some((d) => d && d.includes('dirA')) && descriptions.some((d) => d && d.includes('dirB')),
       `Expected disambiguator paths containing "dirA" and "dirB" but got: ${JSON.stringify(descriptions)}`,
     );
 
@@ -237,9 +225,7 @@ standardSuite('File Picker', (ss) => {
     assert.ok(items, 'Expected showQuickPick log entry');
 
     const EXPECTED_FILE_OVERFLOW = FILE_OVERFLOW_THRESHOLD - 1;
-    const moreItem = items!.find(
-      (i) => typeof i.label === 'string' && (i.label as string).includes('More files...'),
-    );
+    const moreItem = items!.find((i) => typeof i.label === 'string' && (i.label as string).includes('More files...'));
     assert.ok(moreItem, 'Expected "More files..." overflow item');
     assert.deepStrictEqual(
       {
@@ -281,25 +267,14 @@ standardSuite('File Picker', (ss) => {
 
     const lines = logCapture.getLinesSince('before-fp-006');
     const quickPickEntries = getQuickPickLines(lines);
-    assert.ok(
-      quickPickEntries.length >= 2,
-      `Expected at least 2 showQuickPick entries (primary + secondary) but got ${quickPickEntries.length}`,
-    );
+    assert.ok(quickPickEntries.length >= 2, `Expected at least 2 showQuickPick entries (primary + secondary) but got ${quickPickEntries.length}`);
 
     const secondaryItems = parseQuickPickItemsFromLogLine(quickPickEntries[1]);
-    const activeFilesSeparator = secondaryItems.find(
-      (i) => i.kind === SEPARATOR_KIND && i.label === 'Active Files',
-    );
+    const activeFilesSeparator = secondaryItems.find((i) => i.kind === SEPARATOR_KIND && i.label === 'Active Files');
     assert.ok(activeFilesSeparator, 'Expected "Active Files" separator in secondary picker');
 
-    const testFiles = secondaryItems.filter(
-      (i) => typeof i.label === 'string' && (i.label as string).includes('__rl-test-fp-006'),
-    );
-    assert.strictEqual(
-      testFiles.length,
-      FILE_OVERFLOW_THRESHOLD,
-      `Expected ${FILE_OVERFLOW_THRESHOLD} test files in secondary picker`,
-    );
+    const testFiles = secondaryItems.filter((i) => typeof i.label === 'string' && (i.label as string).includes('__rl-test-fp-006'));
+    assert.strictEqual(testFiles.length, FILE_OVERFLOW_THRESHOLD, `Expected ${FILE_OVERFLOW_THRESHOLD} test files in secondary picker`);
 
     const activeFile = testFiles.find((i) => i.label === lastFileName);
     assert.ok(activeFile, `Expected active file "${lastFileName}" in secondary picker`);
@@ -322,11 +297,7 @@ standardSuite('File Picker', (ss) => {
 
     const nonActiveFile = testFiles.find((i) => i.label !== lastFileName);
     assert.ok(nonActiveFile, 'Expected at least one non-active file');
-    assert.strictEqual(
-      nonActiveFile!.description,
-      undefined,
-      'Non-active file should have no description badge',
-    );
+    assert.strictEqual(nonActiveFile!.description, undefined, 'Non-active file should have no description badge');
 
     ss.log('✓ Secondary picker: active file has "active" badge, non-active has none');
   });
@@ -337,11 +308,7 @@ standardSuite('File Picker', (ss) => {
 
     const extraNames: string[] = [];
     for (let i = 1; i <= 3; i++) {
-      const uri = await ss.createAndOpenFile(
-        `fp-007-extra-${i}`,
-        `extra ${i}\n`,
-        vscode.ViewColumn.One,
-      );
+      const uri = await ss.createAndOpenFile(`fp-007-extra-${i}`, `extra ${i}\n`, vscode.ViewColumn.One);
       extraNames.push(path.basename(uri.fsPath));
     }
     await ss.createAndOpenFile('fp-007-g2b', 'group 2 extra\n', vscode.ViewColumn.Two);
@@ -358,29 +325,17 @@ standardSuite('File Picker', (ss) => {
 
     const lines = logCapture.getLinesSince('before-fp-007');
     const quickPickEntries = getQuickPickLines(lines);
-    assert.ok(
-      quickPickEntries.length >= 2,
-      `Expected at least 2 showQuickPick entries but got ${quickPickEntries.length}`,
-    );
+    assert.ok(quickPickEntries.length >= 2, `Expected at least 2 showQuickPick entries but got ${quickPickEntries.length}`);
 
     const secondaryItems = parseQuickPickItemsFromLogLine(quickPickEntries[1]);
 
-    const tabGroup1 = secondaryItems.find(
-      (i) => i.kind === SEPARATOR_KIND && i.label === 'Tab Group 1',
-    );
-    const tabGroup2 = secondaryItems.find(
-      (i) => i.kind === SEPARATOR_KIND && i.label === 'Tab Group 2',
-    );
+    const tabGroup1 = secondaryItems.find((i) => i.kind === SEPARATOR_KIND && i.label === 'Tab Group 1');
+    const tabGroup2 = secondaryItems.find((i) => i.kind === SEPARATOR_KIND && i.label === 'Tab Group 2');
     assert.ok(tabGroup1, 'Expected "Tab Group 1" separator in secondary picker');
     assert.ok(tabGroup2, 'Expected "Tab Group 2" separator in secondary picker');
 
-    const testFiles = secondaryItems.filter(
-      (i) => typeof i.label === 'string' && (i.label as string).includes('__rl-test-fp-007'),
-    );
-    assert.ok(
-      testFiles.length >= 5,
-      `Expected at least 5 test files in secondary picker but got ${testFiles.length}`,
-    );
+    const testFiles = secondaryItems.filter((i) => typeof i.label === 'string' && (i.label as string).includes('__rl-test-fp-007'));
+    assert.ok(testFiles.length >= 5, `Expected at least 5 test files in secondary picker but got ${testFiles.length}`);
     assert.ok(
       testFiles.every((f) => f.itemKind === 'bindable' && f.boundState === 'not-bound'),
       'Expected all test files to be bindable and not-bound',
@@ -459,19 +414,12 @@ standardSuite('File Picker', (ss) => {
     assert.ok(quickPickEntries.length >= 2, 'Expected at least 2 showQuickPick entries');
 
     const secondaryItems = parseQuickPickItemsFromLogLine(quickPickEntries[1]);
-    const sharedItems = secondaryItems.filter(
-      (i) => typeof i.label === 'string' && (i.label as string).includes('fp-010-shared'),
-    );
-    assert.strictEqual(
-      sharedItems.length,
-      2,
-      `Expected 2 same-name items in secondary picker but got ${sharedItems.length}`,
-    );
+    const sharedItems = secondaryItems.filter((i) => typeof i.label === 'string' && (i.label as string).includes('fp-010-shared'));
+    assert.strictEqual(sharedItems.length, 2, `Expected 2 same-name items in secondary picker but got ${sharedItems.length}`);
 
     const descriptions = sharedItems.map((i) => i.description as string);
     assert.ok(
-      descriptions.some((d) => d && d.includes('fp010A')) &&
-        descriptions.some((d) => d && d.includes('fp010B')),
+      descriptions.some((d) => d && d.includes('fp010A')) && descriptions.some((d) => d && d.includes('fp010B')),
       `Expected disambiguator paths in secondary picker descriptions but got: ${JSON.stringify(descriptions)}`,
     );
 
@@ -510,14 +458,8 @@ standardSuite('File Picker', (ss) => {
     const items = extractQuickPickItemsLogged(lines);
     assert.ok(items, 'Expected showQuickPick log entry');
 
-    const sharedItems = findTestFileItems(items!).filter((i) =>
-      (i.label as string).includes('fp-011-shared'),
-    );
-    assert.strictEqual(
-      sharedItems.length,
-      3,
-      `Expected 3 same-name items but got ${sharedItems.length}`,
-    );
+    const sharedItems = findTestFileItems(items!).filter((i) => (i.label as string).includes('fp-011-shared'));
+    assert.strictEqual(sharedItems.length, 3, `Expected 3 same-name items but got ${sharedItems.length}`);
 
     assert.deepStrictEqual(
       sharedItems.map(({ label, displayName, boundState, itemKind }) => ({

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filenameOnlyNavigation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/filenameOnlyNavigation.test.ts
@@ -1,10 +1,5 @@
 import { CMD_HANDLE_DOCUMENT_LINK_CLICK } from '../../constants/commandIds';
-import {
-  clearEditorSelection,
-  getWorkspaceRoot,
-  navigateViaHandleLinkClick,
-  standardSuite,
-} from '../helpers';
+import { clearEditorSelection, getWorkspaceRoot, navigateViaHandleLinkClick, standardSuite } from '../helpers';
 
 import assert from 'node:assert';
 import * as fs from 'node:fs';
@@ -72,11 +67,7 @@ standardSuite('Filename-Only Navigation Fallback', (ss) => {
     ss.expectToastMessages([{ level: 'info', message: `Navigated to ${uniqueFilename} @ 5` }]);
 
     await clearEditorSelection();
-    const { sel, doc } = await navigateViaHandleLinkClick(
-      linkText,
-      parseResult.value,
-      uniqueFilename,
-    );
+    const { sel, doc } = await navigateViaHandleLinkClick(linkText, parseResult.value, uniqueFilename);
 
     const lineLength = doc.lineAt(4).text.length;
     assert.deepStrictEqual(
@@ -95,9 +86,7 @@ standardSuite('Filename-Only Navigation Fallback', (ss) => {
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
     assert.ok(parseResult.success, `Expected parseLink to succeed for: ${linkText}`);
 
-    ss.expectToastMessages([
-      { level: 'warning', message: `Multiple files match: ${duplicateFilename}` },
-    ]);
+    ss.expectToastMessages([{ level: 'warning', message: `Multiple files match: ${duplicateFilename}` }]);
 
     // VscodeAdapter logs the message before awaiting showWarningMessage. The notification
     // itself never auto-dismisses in the test host, so we fire-and-forget the command and
@@ -134,11 +123,7 @@ standardSuite('Filename-Only Navigation Fallback', (ss) => {
     ss.expectToastMessages([{ level: 'info', message: `Navigated to ${relativeFilePath} @ 10` }]);
 
     await clearEditorSelection();
-    const { sel, doc } = await navigateViaHandleLinkClick(
-      linkText,
-      parseResult.value,
-      uniqueFilename,
-    );
+    const { sel, doc } = await navigateViaHandleLinkClick(linkText, parseResult.value, uniqueFilename);
 
     const lineLength = doc.lineAt(9).text.length;
     assert.deepStrictEqual(

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/goToRangeLink.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/goToRangeLink.test.ts
@@ -1,13 +1,5 @@
 import { CMD_GO_TO_RANGELINK } from '../../constants/commandIds';
-import {
-  assertInputBoxLogged,
-  getLogCapture,
-  openAndAccept,
-  openAndDismiss,
-  pasteIntoQuickInput,
-  standardSuite,
-  waitForHuman,
-} from '../helpers';
+import { assertInputBoxLogged, getLogCapture, openAndAccept, openAndDismiss, pasteIntoQuickInput, standardSuite, waitForHuman } from '../helpers';
 
 import assert from 'node:assert';
 import * as path from 'node:path';
@@ -20,8 +12,7 @@ const INPUT_BOX_OPTS = {
   prompt: 'Enter RangeLink to navigate',
   placeHolder: 'recipes/baking/chickenpie.ts#L3C14-L15C9',
 };
-const buildFileContent = (lineCount: number): string =>
-  Array.from({ length: lineCount }, (_, i) => `${i + 1}: ${LINE_CONTENT}`).join('\n') + '\n';
+const buildFileContent = (lineCount: number): string => Array.from({ length: lineCount }, (_, i) => `${i + 1}: ${LINE_CONTENT}`).join('\n') + '\n';
 
 const submitLink = (text: string): Promise<void> =>
   openAndAccept(CMD_GO_TO_RANGELINK, async () => {
@@ -67,11 +58,7 @@ standardSuite('R-G Go to Link', (ss) => {
 
     const editor = vscode.window.activeTextEditor;
     assert.ok(editor, 'Expected an active text editor after navigation');
-    assert.strictEqual(
-      editor!.document.uri.fsPath,
-      uri.fsPath,
-      'Navigation opened a different document than expected',
-    );
+    assert.strictEqual(editor!.document.uri.fsPath, uri.fsPath, 'Navigation opened a different document than expected');
 
     const sel = editor!.selection;
     const endLineLength = editor!.document.lineAt(6).text.length;
@@ -112,11 +99,7 @@ standardSuite('R-G Go to Link', (ss) => {
 
     const editor = vscode.window.activeTextEditor;
     assert.ok(editor, 'Expected an active text editor after navigation');
-    assert.strictEqual(
-      editor!.document.uri.fsPath,
-      uri.fsPath,
-      'Navigation opened a different document than expected',
-    );
+    assert.strictEqual(editor!.document.uri.fsPath, uri.fsPath, 'Navigation opened a different document than expected');
 
     const sel = editor!.selection;
     assert.deepStrictEqual(

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/linkGeneration.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/linkGeneration.test.ts
@@ -1,10 +1,5 @@
 import { CMD_COPY_LINK_ONLY_RELATIVE } from '../../constants/commandIds';
-import {
-  assertClipboardEqualsGeneratedLink,
-  echoToTerminal,
-  standardSuite,
-  waitForHumanVerdict,
-} from '../helpers';
+import { assertClipboardEqualsGeneratedLink, echoToTerminal, standardSuite, waitForHumanVerdict } from '../helpers';
 
 import assert from 'node:assert';
 import * as vscode from 'vscode';
@@ -27,18 +22,9 @@ standardSuite('Link Generation', (ss) => {
       'before-full-line-001',
     );
 
-    assert.ok(
-      generatedLink.includes('#L20'),
-      `Expected link to contain #L20, got: ${generatedLink}`,
-    );
-    assert.ok(
-      !generatedLink.includes('#L20-L21'),
-      `Expected no #L20-L21 in link but got: ${generatedLink}`,
-    );
-    assert.ok(
-      !generatedLink.includes('#L21'),
-      `Expected no #L21 in link but got: ${generatedLink}`,
-    );
+    assert.ok(generatedLink.includes('#L20'), `Expected link to contain #L20, got: ${generatedLink}`);
+    assert.ok(!generatedLink.includes('#L20-L21'), `Expected no #L20-L21 in link but got: ${generatedLink}`);
+    assert.ok(!generatedLink.includes('#L21'), `Expected no #L21 in link but got: ${generatedLink}`);
   });
 
   const WRAPPER_CASES = [
@@ -102,10 +88,7 @@ standardSuite('Link Generation', (ss) => {
 
   for (const { tcId, label, wrapperDesc, open, close, suffix } of WRAPPER_CASES) {
     test(`[assisted] wrapped-link-navigation-${tcId}: ${label} RangeLink in terminal is clickable and navigates correctly`, async () => {
-      const targetUri = ss.createWorkspaceFile(
-        `wln-${tcId}-target`,
-        'line 1\nline 2\nline 3\nline 4\nTARGET LINE 5\nline 6\n',
-      );
+      const targetUri = ss.createWorkspaceFile(`wln-${tcId}-target`, 'line 1\nline 2\nline 3\nline 4\nTARGET LINE 5\nline 6\n');
       const relativePath = vscode.workspace.asRelativePath(targetUri, false);
       const displayLink = `${open}${relativePath}#L5${close}${suffix}`;
 
@@ -127,28 +110,18 @@ standardSuite('Link Generation', (ss) => {
         ],
       );
 
-      assert.strictEqual(
-        verdict,
-        'pass',
-        `Human reported FAIL: ${label} RangeLink did not navigate correctly`,
-      );
+      assert.strictEqual(verdict, 'pass', `Human reported FAIL: ${label} RangeLink did not navigate correctly`);
       ss.log(`✓ wrapped-link-navigation-${tcId} — ${label} RangeLink navigated (human verified)`);
     });
   }
 
   test('[assisted] markdown-link-navigation-001: Markdown link [label](path#L5) in a document is clickable and navigates correctly', async () => {
-    const targetUri = ss.createWorkspaceFile(
-      'mln-001-target',
-      'line 1\nline 2\nline 3\nline 4\nTARGET LINE 5\nline 6\n',
-    );
+    const targetUri = ss.createWorkspaceFile('mln-001-target', 'line 1\nline 2\nline 3\nline 4\nTARGET LINE 5\nline 6\n');
     const relativePath = vscode.workspace.asRelativePath(targetUri, false);
 
     ss.expectToastMessages([{ level: 'info', message: `Navigated to ${relativePath} @ 5` }]);
 
-    await ss.createAndOpenFile(
-      '__rl-test-markdown-link',
-      `Click [here](${relativePath}#L5) for details\n`,
-    );
+    await ss.createAndOpenFile('__rl-test-markdown-link', `Click [here](${relativePath}#L5) for details\n`);
     await ss.settle();
 
     const verdict = await waitForHumanVerdict(
@@ -162,11 +135,7 @@ standardSuite('Link Generation', (ss) => {
       ],
     );
 
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'Human reported FAIL: Markdown link did not navigate correctly',
-    );
+    assert.strictEqual(verdict, 'pass', 'Human reported FAIL: Markdown link did not navigate correctly');
     ss.log('✓ markdown-link-navigation-001 — Markdown link navigated (human verified)');
   });
 
@@ -188,46 +157,28 @@ standardSuite('Link Generation', (ss) => {
       ],
     );
 
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'Human reported FAIL: HTTPS URL was incorrectly intercepted as a RangeLink',
-    );
+    assert.strictEqual(verdict, 'pass', 'Human reported FAIL: HTTPS URL was incorrectly intercepted as a RangeLink');
     ss.log('✓ url-exclusion-001 — HTTPS URL not intercepted (human verified)');
   });
 });
 
 standardSuite('Link Generation — Clickable Links (Assisted)', (ss) => {
   test('[assisted] url-exclusion-002: https:// URL in document does not receive a RangeLink document link', async () => {
-    await ss.createAndOpenFile(
-      '__rl-test-url-exclusion',
-      'Some text\nhttps://example.com/path/file.ts#L10\nMore text\n',
-    );
+    await ss.createAndOpenFile('__rl-test-url-exclusion', 'Some text\nhttps://example.com/path/file.ts#L10\nMore text\n');
     await ss.settle();
 
-    const verdict = await waitForHumanVerdict(
-      'url-exclusion-002',
-      "Is RangeLink's hover/tooltip ABSENT from the https:// URL?",
-      [
-        '1. Hover your cursor over https://example.com/path/file.ts#L10 in the editor',
-        '2. The URL will show a regular VS Code browser-style link hover — that is expected and fine',
-        'Verdict:',
-      ],
-    );
+    const verdict = await waitForHumanVerdict('url-exclusion-002', "Is RangeLink's hover/tooltip ABSENT from the https:// URL?", [
+      '1. Hover your cursor over https://example.com/path/file.ts#L10 in the editor',
+      '2. The URL will show a regular VS Code browser-style link hover — that is expected and fine',
+      'Verdict:',
+    ]);
 
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'Human reported FAIL: RangeLink document link appeared on https:// URL',
-    );
+    assert.strictEqual(verdict, 'pass', 'Human reported FAIL: RangeLink document link appeared on https:// URL');
     ss.log('✓ url-exclusion-002 — no RangeLink document link on https:// URL (human verified)');
   });
 
   test('[assisted] document-link-tooltip-001: hovering a clickable RangeLink shows clean tooltip', async () => {
-    await ss.createAndOpenFile(
-      '__rl-test-doc-link-tooltip',
-      'See code at src/utils/helper.ts#L5 for details\n',
-    );
+    await ss.createAndOpenFile('__rl-test-doc-link-tooltip', 'See code at src/utils/helper.ts#L5 for details\n');
     await ss.settle();
 
     const verdict = await waitForHumanVerdict(
@@ -241,8 +192,6 @@ standardSuite('Link Generation — Clickable Links (Assisted)', (ss) => {
     );
 
     assert.strictEqual(verdict, 'pass', 'Human reported FAIL: document link tooltip was not clean');
-    ss.log(
-      '✓ document-link-tooltip-001 — clean tooltip on RangeLink document link (human verified)',
-    );
+    ss.log('✓ document-link-tooltip-001 — clean tooltip on RangeLink document link (human verified)');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationClamping.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationClamping.test.ts
@@ -8,11 +8,7 @@ const LINE_CONTENT = 'abcdefghijklmnopqrst';
 
 standardSuite('Navigation Clamping', (ss) => {
   test('navigation-clamping-001: #L50 on 10-line file — selection clamped to last line', async () => {
-    const { filename: testFilename } = ss.createContentFile(
-      'clamp-001',
-      LINE_COUNT,
-      () => LINE_CONTENT,
-    );
+    const { filename: testFilename } = ss.createContentFile('clamp-001', LINE_COUNT, () => LINE_CONTENT);
 
     const linkText = `${testFilename}#L50`;
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
@@ -26,11 +22,7 @@ standardSuite('Navigation Clamping', (ss) => {
     ]);
 
     await clearEditorSelection();
-    const { sel, doc } = await navigateViaHandleLinkClick(
-      linkText,
-      parseResult.value,
-      testFilename,
-    );
+    const { sel, doc } = await navigateViaHandleLinkClick(linkText, parseResult.value, testFilename);
 
     const lastLine = doc.lineCount - 1;
     const lastLineLength = doc.lineAt(lastLine).text.length;
@@ -46,11 +38,7 @@ standardSuite('Navigation Clamping', (ss) => {
   });
 
   test('navigation-clamping-002: #L1C200 on 20-char line — character clamped to line length', async () => {
-    const { filename: testFilename } = ss.createContentFile(
-      'clamp-002',
-      LINE_COUNT,
-      () => LINE_CONTENT,
-    );
+    const { filename: testFilename } = ss.createContentFile('clamp-002', LINE_COUNT, () => LINE_CONTENT);
 
     const linkText = `${testFilename}#L1C200`;
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
@@ -64,11 +52,7 @@ standardSuite('Navigation Clamping', (ss) => {
     ]);
 
     await clearEditorSelection();
-    const { sel, doc } = await navigateViaHandleLinkClick(
-      linkText,
-      parseResult.value,
-      testFilename,
-    );
+    const { sel, doc } = await navigateViaHandleLinkClick(linkText, parseResult.value, testFilename);
 
     const lineLength = doc.lineAt(0).text.length;
     assert.deepStrictEqual(
@@ -83,11 +67,7 @@ standardSuite('Navigation Clamping', (ss) => {
   });
 
   test('navigation-clamping-003: #L5C10 within bounds — selection at exact position', async () => {
-    const { filename: testFilename } = ss.createContentFile(
-      'clamp-003',
-      LINE_COUNT,
-      () => LINE_CONTENT,
-    );
+    const { filename: testFilename } = ss.createContentFile('clamp-003', LINE_COUNT, () => LINE_CONTENT);
 
     const linkText = `${testFilename}#L5C10`;
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
@@ -108,11 +88,7 @@ standardSuite('Navigation Clamping', (ss) => {
   });
 
   test('navigation-clamping-004: #L50C200 — both line and column clamped', async () => {
-    const { filename: testFilename } = ss.createContentFile(
-      'clamp-004',
-      LINE_COUNT,
-      () => LINE_CONTENT,
-    );
+    const { filename: testFilename } = ss.createContentFile('clamp-004', LINE_COUNT, () => LINE_CONTENT);
 
     const linkText = `${testFilename}#L50C200`;
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
@@ -124,11 +100,7 @@ standardSuite('Navigation Clamping', (ss) => {
         message: `Navigated to ${testFilename} @ 50:200 (clamped: line and column exceeded bounds)`,
       },
     ]);
-    const { sel, doc } = await navigateViaHandleLinkClick(
-      linkText,
-      parseResult.value,
-      testFilename,
-    );
+    const { sel, doc } = await navigateViaHandleLinkClick(linkText, parseResult.value, testFilename);
 
     const lastLine = doc.lineCount - 1;
     const lastLineLength = doc.lineAt(lastLine).text.length;

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationPrecision.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationPrecision.test.ts
@@ -7,11 +7,7 @@ standardSuite('Navigation Precision', (ss) => {
   const NAV_TEST_LINE_COUNT = 25;
 
   test('full-line-navigation-001: #L10 navigates to full line 10 — selection spans col 0 to end of line', async () => {
-    const { filename: testFilename } = ss.createContentFile(
-      'nav-001',
-      NAV_TEST_LINE_COUNT,
-      (i) => `line ${i + 1} content`,
-    );
+    const { filename: testFilename } = ss.createContentFile('nav-001', NAV_TEST_LINE_COUNT, (i) => `line ${i + 1} content`);
 
     const linkText = `${testFilename}#L10`;
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
@@ -20,11 +16,7 @@ standardSuite('Navigation Precision', (ss) => {
     ss.expectToastMessages([{ level: 'info', message: `Navigated to ${testFilename} @ 10` }]);
 
     await clearEditorSelection();
-    const { sel, doc } = await navigateViaHandleLinkClick(
-      linkText,
-      parseResult.value,
-      testFilename,
-    );
+    const { sel, doc } = await navigateViaHandleLinkClick(linkText, parseResult.value, testFilename);
 
     const lineLength = doc.lineAt(9).text.length;
     assert.deepStrictEqual(
@@ -39,11 +31,7 @@ standardSuite('Navigation Precision', (ss) => {
   });
 
   test('full-line-navigation-002: #L10-L15 navigates to range — anchor (9,0), active at end of line 15', async () => {
-    const { filename: testFilename } = ss.createContentFile(
-      'nav-002',
-      NAV_TEST_LINE_COUNT,
-      (i) => `line ${i + 1} content`,
-    );
+    const { filename: testFilename } = ss.createContentFile('nav-002', NAV_TEST_LINE_COUNT, (i) => `line ${i + 1} content`);
 
     const linkText = `${testFilename}#L10-L15`;
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
@@ -52,11 +40,7 @@ standardSuite('Navigation Precision', (ss) => {
     ss.expectToastMessages([{ level: 'info', message: `Navigated to ${testFilename} @ 10-15` }]);
 
     await clearEditorSelection();
-    const { sel, doc } = await navigateViaHandleLinkClick(
-      linkText,
-      parseResult.value,
-      testFilename,
-    );
+    const { sel, doc } = await navigateViaHandleLinkClick(linkText, parseResult.value, testFilename);
 
     const endLineLength = doc.lineAt(14).text.length;
     assert.deepStrictEqual(
@@ -71,11 +55,7 @@ standardSuite('Navigation Precision', (ss) => {
   });
 
   test('char-navigation-001: #L10C5 navigates to cursor position (9,4)', async () => {
-    const { filename: testFilename } = ss.createContentFile(
-      'nav-003',
-      NAV_TEST_LINE_COUNT,
-      (i) => `line ${i + 1} content`,
-    );
+    const { filename: testFilename } = ss.createContentFile('nav-003', NAV_TEST_LINE_COUNT, (i) => `line ${i + 1} content`);
 
     const linkText = `${testFilename}#L10C5`;
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
@@ -98,19 +78,13 @@ standardSuite('Navigation Precision', (ss) => {
   });
 
   test('char-navigation-002: #L10C5-L15C10 navigates to range (9,4)→(14,9)', async () => {
-    const { filename: testFilename } = ss.createContentFile(
-      'nav-004',
-      NAV_TEST_LINE_COUNT,
-      (i) => `line ${i + 1} content`,
-    );
+    const { filename: testFilename } = ss.createContentFile('nav-004', NAV_TEST_LINE_COUNT, (i) => `line ${i + 1} content`);
 
     const linkText = `${testFilename}#L10C5-L15C10`;
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
     assert.ok(parseResult.success, `Expected parseLink to succeed for: ${linkText}`);
 
-    ss.expectToastMessages([
-      { level: 'info', message: `Navigated to ${testFilename} @ 10:5-15:10` },
-    ]);
+    ss.expectToastMessages([{ level: 'info', message: `Navigated to ${testFilename} @ 10:5-15:10` }]);
 
     await clearEditorSelection();
     const { sel } = await navigateViaHandleLinkClick(linkText, parseResult.value, testFilename);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationToastSettings.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/navigationToastSettings.test.ts
@@ -1,9 +1,4 @@
-import {
-  assertSuppressionLogged,
-  getLogCapture,
-  navigateViaHandleLinkClick,
-  standardSuite,
-} from '../helpers';
+import { assertSuppressionLogged, getLogCapture, navigateViaHandleLinkClick, standardSuite } from '../helpers';
 
 import assert from 'node:assert';
 import { DEFAULT_DELIMITERS, parseLink } from 'rangelink-core-ts';
@@ -12,28 +7,14 @@ import * as vscode from 'vscode';
 standardSuite('Navigation Toast Settings', (ss) => {
   teardown(async () => {
     const config = vscode.workspace.getConfiguration('rangelink');
-    await config.update(
-      'navigation.showNavigatedToast',
-      undefined,
-      vscode.ConfigurationTarget.Workspace,
-    );
-    await config.update(
-      'navigation.showClampingWarning',
-      undefined,
-      vscode.ConfigurationTarget.Workspace,
-    );
+    await config.update('navigation.showNavigatedToast', undefined, vscode.ConfigurationTarget.Workspace);
+    await config.update('navigation.showClampingWarning', undefined, vscode.ConfigurationTarget.Workspace);
   });
 
   test('navigation-toast-settings-001: showNavigatedToast=false suppresses info toast but navigation still works', async () => {
-    const { filename: testFilename } = ss.createContentFile(
-      'toast-settings-001',
-      10,
-      (i) => `line ${i + 1} content here`,
-    );
+    const { filename: testFilename } = ss.createContentFile('toast-settings-001', 10, (i) => `line ${i + 1} content here`);
 
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('navigation.showNavigatedToast', false, vscode.ConfigurationTarget.Workspace);
+    await vscode.workspace.getConfiguration('rangelink').update('navigation.showNavigatedToast', false, vscode.ConfigurationTarget.Workspace);
 
     const linkText = `${testFilename}#L5`;
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
@@ -55,15 +36,9 @@ standardSuite('Navigation Toast Settings', (ss) => {
   });
 
   test('navigation-toast-settings-002: showClampingWarning=false suppresses clamping warning but navigation still works', async () => {
-    const { filename: testFilename } = ss.createContentFile(
-      'toast-settings-002',
-      10,
-      (i) => `line ${i + 1} content here`,
-    );
+    const { filename: testFilename } = ss.createContentFile('toast-settings-002', 10, (i) => `line ${i + 1} content here`);
 
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('navigation.showClampingWarning', false, vscode.ConfigurationTarget.Workspace);
+    await vscode.workspace.getConfiguration('rangelink').update('navigation.showClampingWarning', false, vscode.ConfigurationTarget.Workspace);
 
     const linkText = `${testFilename}#L50`;
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
@@ -72,11 +47,7 @@ standardSuite('Navigation Toast Settings', (ss) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-toast-settings-002');
 
-    const { sel, doc } = await navigateViaHandleLinkClick(
-      linkText,
-      parseResult.value,
-      testFilename,
-    );
+    const { sel, doc } = await navigateViaHandleLinkClick(linkText, parseResult.value, testFilename);
     await ss.settle();
 
     const lastLine = doc.lineCount - 1;
@@ -90,11 +61,7 @@ standardSuite('Navigation Toast Settings', (ss) => {
   });
 
   test('navigation-toast-settings-003: default settings show info toast after successful navigation', async () => {
-    const { filename: testFilename } = ss.createContentFile(
-      'toast-settings-003',
-      10,
-      (i) => `line ${i + 1} content here`,
-    );
+    const { filename: testFilename } = ss.createContentFile('toast-settings-003', 10, (i) => `line ${i + 1} content here`);
 
     const linkText = `${testFilename}#L3`;
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/platformKeybindings.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/platformKeybindings.test.ts
@@ -5,25 +5,18 @@ import * as vscode from 'vscode';
 
 standardSuite('Platform Keybindings', (ss) => {
   test('[assisted] ubuntu-ctrl-keybindings-001: Ctrl+R chords work on Ubuntu/Linux', async () => {
-    const testFileUri = ss.createWorkspaceFile(
-      'ubuntu-ctrl-test',
-      'line 1\nline 2\nline 3\nline 4\nline 5\n',
-    );
+    const testFileUri = ss.createWorkspaceFile('ubuntu-ctrl-test', 'line 1\nline 2\nline 3\nline 4\nline 5\n');
     const doc = await vscode.workspace.openTextDocument(testFileUri);
     await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
     await ss.settle();
 
-    const verdict = await waitForHumanVerdict(
-      'ubuntu-ctrl-keybindings-001',
-      'Verify Ctrl+R chords work on Ubuntu/Linux',
-      [
-        '1. Press Ctrl+R Ctrl+M — verify the RangeLink menu opens, then Escape',
-        '2. Press Ctrl+R Ctrl+D — verify the destination picker opens, then Escape',
-        '3. Select lines 2-4, press Ctrl+R Ctrl+L — verify RangeLink is sent',
-        '4. Press Ctrl+R Ctrl+G — verify Go to Link input box opens, then Escape',
-        '5. Bind a destination, press Ctrl+R Ctrl+U — verify destination unbound',
-      ],
-    );
+    const verdict = await waitForHumanVerdict('ubuntu-ctrl-keybindings-001', 'Verify Ctrl+R chords work on Ubuntu/Linux', [
+      '1. Press Ctrl+R Ctrl+M — verify the RangeLink menu opens, then Escape',
+      '2. Press Ctrl+R Ctrl+D — verify the destination picker opens, then Escape',
+      '3. Select lines 2-4, press Ctrl+R Ctrl+L — verify RangeLink is sent',
+      '4. Press Ctrl+R Ctrl+G — verify Go to Link input box opens, then Escape',
+      '5. Bind a destination, press Ctrl+R Ctrl+U — verify destination unbound',
+    ]);
 
     assert.ok(verdict, 'Human confirmed Ubuntu Ctrl+R keybindings work correctly');
   });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/releaseNotifier.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/releaseNotifier.test.ts
@@ -37,11 +37,7 @@ standardSuite('Release Notifier', (ss) => {
       }),
       'Expected no upgrade log on first install',
     );
-    assert.notStrictEqual(
-      notifier.getLastNotifiedVersion(),
-      undefined,
-      'Expected version to be stored in globalState after first install',
-    );
+    assert.notStrictEqual(notifier.getLastNotifiedVersion(), undefined, 'Expected version to be stored in globalState after first install');
     ss.log('✓ First install: version stored silently, no notification shown');
   });
 
@@ -71,11 +67,7 @@ standardSuite('Release Notifier', (ss) => {
       }),
       'Expected no upgrade log when version unchanged',
     );
-    assert.strictEqual(
-      notifier.getLastNotifiedVersion(),
-      versionAfterFirstInstall,
-      'Expected stored version to remain unchanged after same-version skip',
-    );
+    assert.strictEqual(notifier.getLastNotifiedVersion(), versionAfterFirstInstall, 'Expected stored version to remain unchanged after same-version skip');
     ss.log('✓ Same version: notification skipped, globalState unchanged');
   });
 
@@ -129,14 +121,8 @@ standardSuite('Release Notifier', (ss) => {
       1,
       'Expected exactly 1 non-upgrade maybeNotify log — no "opened release notes"',
     );
-    assert.strictEqual(
-      notifier.getLastNotifiedVersion(),
-      '0.0.0',
-      'Expected globalState to remain at "0.0.0" — dismiss must not store the new version',
-    );
-    ss.log(
-      '✓ Upgrade notification dismissed; version not stored (still "0.0.0"), will reappear on next activation',
-    );
+    assert.strictEqual(notifier.getLastNotifiedVersion(), '0.0.0', 'Expected globalState to remain at "0.0.0" — dismiss must not store the new version');
+    ss.log('✓ Upgrade notification dismissed; version not stored (still "0.0.0"), will reappear on next activation');
   });
 
   test("[assisted] release-notifier-004: clicking What's New stores version and opens GitHub releases in browser", async () => {
@@ -154,15 +140,11 @@ standardSuite('Release Notifier', (ss) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-004');
 
-    await waitForHuman(
-      'release-notifier-004',
-      'Click Cancel here. A "RangeLink updated" notification will appear immediately — click "What\'s New".',
-      [
-        '1. Click Cancel on THIS notification',
-        '2. When "RangeLink updated to vX.Y.Z. See what changed!" appears, click "What\'s New"',
-        '3. Confirm your browser opens to the GitHub releases page for that version',
-      ],
-    );
+    await waitForHuman('release-notifier-004', 'Click Cancel here. A "RangeLink updated" notification will appear immediately — click "What\'s New".', [
+      '1. Click Cancel on THIS notification',
+      '2. When "RangeLink updated to vX.Y.Z. See what changed!" appears, click "What\'s New"',
+      '3. Confirm your browser opens to the GitHub releases page for that version',
+    ]);
 
     await notifier.maybeNotify();
 
@@ -205,9 +187,7 @@ standardSuite('Release Notifier', (ss) => {
       }),
       'Expected no second upgrade notification — version must have been stored',
     );
-    ss.log(
-      '✓ Upgrade notification: "What\'s New" stored version and opened browser; re-run confirmed no second popup',
-    );
+    ss.log('✓ Upgrade notification: "What\'s New" stored version and opened browser; re-run confirmed no second popup');
   });
 
   test('[assisted] release-notifier-005: clicking Skip for this version stores version without opening browser', async () => {
@@ -284,8 +264,6 @@ standardSuite('Release Notifier', (ss) => {
       }),
       'Expected no second upgrade notification — version must have been stored',
     );
-    ss.log(
-      '✓ Upgrade notification: "Skip for this version" stored version without opening browser; re-run confirmed no second popup',
-    );
+    ss.log('✓ Upgrade notification: "Skip for this version" stored version without opening browser; re-run confirmed no second popup');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/sendFilePath.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/sendFilePath.test.ts
@@ -26,10 +26,7 @@ import * as vscode from 'vscode';
 standardSuite('Send File Path', (ss) => {
   test('send-file-path-001: R-F sends workspace-relative path to bound terminal', async () => {
     const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("sfp-test")',
-      '✓ RangeLink: File path sent to Terminal ("sfp-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("sfp-test")', '✓ RangeLink: File path sent to Terminal ("sfp-test")']);
     ss.expectContextKeys({
       'rangelink.isBound': true,
       'rangelink.isActiveTerminalBindable': true,
@@ -60,10 +57,7 @@ standardSuite('Send File Path', (ss) => {
 
   test('send-file-path-002: Cmd+R Cmd+Shift+F sends absolute path to bound terminal', async () => {
     const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("sfp-test")',
-      '✓ RangeLink: File path sent to Terminal ("sfp-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("sfp-test")', '✓ RangeLink: File path sent to Terminal ("sfp-test")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -94,10 +88,7 @@ standardSuite('Send File Path', (ss) => {
 
   test('send-file-path-004: terminal destination — path with spaces is auto-quoted in single quotes', async () => {
     const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("sfp-test")',
-      '✓ RangeLink: File path sent to Terminal ("sfp-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("sfp-test")', '✓ RangeLink: File path sent to Terminal ("sfp-test")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -131,20 +122,14 @@ standardSuite('Send File Path', (ss) => {
         ctx?.after === `'${relativePath}'`
       );
     });
-    assert.ok(
-      quotedLog,
-      'Expected "Quoted path for unsafe characters" log — path with spaces must be quoted before terminal send',
-    );
+    assert.ok(quotedLog, 'Expected "Quoted path for unsafe characters" log — path with spaces must be quoted before terminal send');
     assertTerminalBufferEquals(capturing.getCapturedText(), ` '${relativePath}' `);
     ss.log('✓ Path with spaces auto-quoted for terminal destination');
   });
 
   test('send-file-path-005: terminal destination — path with parentheses is auto-quoted in single quotes', async () => {
     const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("sfp-test")',
-      '✓ RangeLink: File path sent to Terminal ("sfp-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("sfp-test")', '✓ RangeLink: File path sent to Terminal ("sfp-test")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -178,10 +163,7 @@ standardSuite('Send File Path', (ss) => {
         ctx?.after === `'${relativePath}'`
       );
     });
-    assert.ok(
-      quotedLog,
-      'Expected "Quoted path for unsafe characters" log — path with parentheses must be quoted before terminal send',
-    );
+    assert.ok(quotedLog, 'Expected "Quoted path for unsafe characters" log — path with parentheses must be quoted before terminal send');
     assertTerminalBufferEquals(capturing.getCapturedText(), ` '${relativePath}' `);
     ss.log('✓ Path with parentheses auto-quoted for terminal destination');
   });
@@ -191,25 +173,16 @@ standardSuite('Send File Path', (ss) => {
     const ANCHOR_END = 'ANCHOR_END';
     const destUri = ss.createWorkspaceFile('sfp-006-dest', `${ANCHOR_START}\n${ANCHOR_END}\n`);
     const destBasename = path.basename(destUri.fsPath);
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Text Editor ("${destBasename}")`,
-      `✓ RangeLink: File path sent to Text Editor ("${destBasename}")`,
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Text Editor ("${destBasename}")`, `✓ RangeLink: File path sent to Text Editor ("${destBasename}")`]);
     ss.expectContextKeys({ 'rangelink.isBound': true });
     const sourceUri = ss.createTrackedFile('__rl-test-source with spaces.ts', 'content\n');
 
     const destEditor = await openEditor(destUri, vscode.ViewColumn.Two);
-    destEditor.selection = new vscode.Selection(
-      new vscode.Position(1, 0),
-      new vscode.Position(1, 0),
-    );
+    destEditor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 0));
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
     await ss.settle();
 
-    await vscode.window.showTextDocument(
-      await vscode.workspace.openTextDocument(sourceUri),
-      vscode.ViewColumn.Beside,
-    );
+    await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(sourceUri), vscode.ViewColumn.Beside);
     await ss.settle();
 
     const logCapture = getLogCapture();
@@ -234,10 +207,7 @@ standardSuite('Send File Path', (ss) => {
         ctx?.after === `'${relativePath}'`
       );
     });
-    assert.ok(
-      quotedLog,
-      'Expected "Quoted path for unsafe characters" log — path with spaces must be quoted for text editor destination',
-    );
+    assert.ok(quotedLog, 'Expected "Quoted path for unsafe characters" log — path with spaces must be quoted for text editor destination');
     const destDoc = await vscode.workspace.openTextDocument(destUri);
     const content = destDoc.getText();
     assert.ok(
@@ -248,15 +218,10 @@ standardSuite('Send File Path', (ss) => {
   });
 
   test('send-file-path-007: clipboard and terminal both receive the quoted path (clipboard.preserve=never)', async () => {
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('clipboard.preserve', 'never', vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration('rangelink').update('clipboard.preserve', 'never', vscode.ConfigurationTarget.Global);
 
     const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("sfp-test")',
-      '✓ RangeLink: File path sent to Terminal ("sfp-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("sfp-test")', '✓ RangeLink: File path sent to Terminal ("sfp-test")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -296,38 +261,25 @@ standardSuite('Send File Path', (ss) => {
         ctx?.after === `'${relativePath}'`
       );
     });
-    assert.ok(
-      quotedLog,
-      'Expected "Quoted path for unsafe characters" log — path with spaces must be quoted for terminal safety',
-    );
+    assert.ok(quotedLog, 'Expected "Quoted path for unsafe characters" log — path with spaces must be quoted for terminal safety');
     assertTerminalBufferContains(capturing.getCapturedText(), `'${relativePath}'`);
     ss.log('✓ Both terminal and clipboard receive the quoted path');
   });
 
   test('send-file-path-008: self-paste with no selection inserts path at cursor and shows normal feedback (clipboard.preserve=never)', async () => {
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('clipboard.preserve', 'never', vscode.ConfigurationTarget.Global);
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('smartPadding.pasteFilePath', 'both', vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration('rangelink').update('clipboard.preserve', 'never', vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration('rangelink').update('smartPadding.pasteFilePath', 'both', vscode.ConfigurationTarget.Global);
 
     const fileUri = ss.createWorkspaceFile('sfp-008-self', 'original content\n');
     const destBasename = path.basename(fileUri.fsPath);
     const destEditor = await openEditor(fileUri);
     // Place cursor at beginning — no selection, so R-F is allowed
-    destEditor.selection = new vscode.Selection(
-      new vscode.Position(0, 0),
-      new vscode.Position(0, 0),
-    );
+    destEditor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0));
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
     await ss.settle();
 
     const relativePath = vscode.workspace.asRelativePath(fileUri, false);
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Text Editor ("${destBasename}")`,
-      `✓ RangeLink: File path sent to Text Editor ("${destBasename}")`,
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Text Editor ("${destBasename}")`, `✓ RangeLink: File path sent to Text Editor ("${destBasename}")`]);
     ss.expectContextKeys({ 'rangelink.isBound': true });
     await assertClipboardEquals(
       'Send File Path — self-paste with no selection should write path to clipboard',
@@ -340,20 +292,13 @@ standardSuite('Send File Path', (ss) => {
     );
     const doc = await vscode.workspace.openTextDocument(fileUri);
     const expectedContent = ` ${relativePath} original content\n`;
-    assert.strictEqual(
-      doc.getText(),
-      expectedContent,
-      `Expected file to have path inserted at cursor, got: ${JSON.stringify(doc.getText())}`,
-    );
+    assert.strictEqual(doc.getText(), expectedContent, `Expected file to have path inserted at cursor, got: ${JSON.stringify(doc.getText())}`);
     ss.log('✓ Self-paste with no selection: path inserted at cursor, normal status bar feedback');
   });
 
   test('send-file-path-009: unbound — R-F opens destination picker before sending', async () => {
     const capturing = await ss.createCapturingTerminal('sfp-picker-test');
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("sfp-picker-test")',
-      '✓ RangeLink: File path sent to Terminal ("sfp-picker-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("sfp-picker-test")', '✓ RangeLink: File path sent to Terminal ("sfp-picker-test")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -377,10 +322,7 @@ standardSuite('Send File Path', (ss) => {
     const items = extractQuickPickItemsLogged(lines);
     assert.ok(items !== undefined, 'Expected destination picker to be shown via log');
     const terminalItem = items?.find(
-      (item) =>
-        item.itemKind === 'bindable' &&
-        typeof item.displayName === 'string' &&
-        (item.displayName as string).includes('sfp-picker-test'),
+      (item) => item.itemKind === 'bindable' && typeof item.displayName === 'string' && (item.displayName as string).includes('sfp-picker-test'),
     );
     assert.ok(terminalItem !== undefined, 'Expected "sfp-picker-test" to appear in the picker');
 
@@ -397,10 +339,7 @@ standardSuite('Send File Path', (ss) => {
 
   test('send-file-path-010: Command Palette "Send Current File Path" sends workspace-relative path', async () => {
     const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("sfp-test")',
-      '✓ RangeLink: File path sent to Terminal ("sfp-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("sfp-test")', '✓ RangeLink: File path sent to Terminal ("sfp-test")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -431,10 +370,7 @@ standardSuite('Send File Path', (ss) => {
 
   test('send-file-path-011: Command Palette "Send Current File Path (Absolute)" sends absolute path', async () => {
     const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("sfp-test")',
-      '✓ RangeLink: File path sent to Terminal ("sfp-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("sfp-test")', '✓ RangeLink: File path sent to Terminal ("sfp-test")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -470,20 +406,14 @@ standardSuite('Send File Path', (ss) => {
     const destBasename = path.basename(destUri.fsPath);
     const sourceUri = ss.createWorkspaceFile('sfp-012-source', 'content\n');
 
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Text Editor ("${destBasename}")`,
-      `✓ RangeLink: File path sent to Text Editor ("${destBasename}")`,
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Text Editor ("${destBasename}")`, `✓ RangeLink: File path sent to Text Editor ("${destBasename}")`]);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
-    const destEditor = await vscode.window.showTextDocument(
-      await vscode.workspace.openTextDocument(destUri),
-      { viewColumn: vscode.ViewColumn.One, preview: false },
-    );
-    destEditor.selection = new vscode.Selection(
-      new vscode.Position(1, 0),
-      new vscode.Position(1, 0),
-    );
+    const destEditor = await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(destUri), {
+      viewColumn: vscode.ViewColumn.One,
+      preview: false,
+    });
+    destEditor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 0));
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
     await ss.settle();
 
@@ -499,11 +429,7 @@ standardSuite('Send File Path', (ss) => {
     await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE);
     await ss.settle();
 
-    assert.strictEqual(
-      vscode.window.activeTextEditor?.document.uri.toString(),
-      destUri.toString(),
-      'Expected bound editor to be active after paste',
-    );
+    assert.strictEqual(vscode.window.activeTextEditor?.document.uri.toString(), destUri.toString(), 'Expected bound editor to be active after paste');
 
     const relativePath = vscode.workspace.asRelativePath(sourceUri, false);
     const lines = logCapture.getLinesSince('before-012');
@@ -514,33 +440,21 @@ standardSuite('Send File Path', (ss) => {
     });
     const destDoc = await vscode.workspace.openTextDocument(destUri);
     const expectedContent = `${ANCHOR_START}\n ${relativePath} ${ANCHOR_END}\n`;
-    assert.strictEqual(
-      destDoc.getText(),
-      expectedContent,
-      `Expected exact dest content, got: ${JSON.stringify(destDoc.getText())}`,
-    );
+    assert.strictEqual(destDoc.getText(), expectedContent, `Expected exact dest content, got: ${JSON.stringify(destDoc.getText())}`);
     ss.log('✓ Bound editor brought to foreground and received exact file path');
   });
 
   test('send-file-path-013: same file, same column, no selection — absolute path inserted at cursor (clipboard.preserve=never)', async () => {
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('clipboard.preserve', 'never', vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration('rangelink').update('clipboard.preserve', 'never', vscode.ConfigurationTarget.Global);
 
     const fileUri = ss.createWorkspaceFile('sfp-013-self', 'line 1\nline 2\n');
     const destBasename = path.basename(fileUri.fsPath);
     const destEditor = await openEditor(fileUri);
-    destEditor.selection = new vscode.Selection(
-      new vscode.Position(1, 0),
-      new vscode.Position(1, 0),
-    );
+    destEditor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 0));
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Text Editor ("${destBasename}")`,
-      `✓ RangeLink: File path sent to Text Editor ("${destBasename}")`,
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Text Editor ("${destBasename}")`, `✓ RangeLink: File path sent to Text Editor ("${destBasename}")`]);
     ss.expectContextKeys({ 'rangelink.isBound': true });
     await assertClipboardEquals(
       'Send File Path — self-paste absolute path should write path to clipboard',
@@ -553,39 +467,26 @@ standardSuite('Send File Path', (ss) => {
     );
     const doc = await vscode.workspace.openTextDocument(fileUri);
     const expectedContent = `line 1\n ${fileUri.fsPath} line 2\n`;
-    assert.strictEqual(
-      doc.getText(),
-      expectedContent,
-      `Expected absolute path inserted at cursor, got: ${JSON.stringify(doc.getText())}`,
-    );
+    assert.strictEqual(doc.getText(), expectedContent, `Expected absolute path inserted at cursor, got: ${JSON.stringify(doc.getText())}`);
     ss.log('✓ Same file, no selection: absolute path inserted at cursor, normal feedback');
   });
 
   test('send-file-path-014: same file, same column, with active selection — blocked with toast and clipboard copy (clipboard.preserve=never)', async () => {
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('clipboard.preserve', 'never', vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration('rangelink').update('clipboard.preserve', 'never', vscode.ConfigurationTarget.Global);
 
     const fileUri = ss.createWorkspaceFile('sfp-014-self', 'original content\n');
     const destBasename = path.basename(fileUri.fsPath);
     const destEditor = await openEditor(fileUri);
-    destEditor.selection = new vscode.Selection(
-      new vscode.Position(0, 0),
-      new vscode.Position(0, 5),
-    );
+    destEditor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 5));
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Text Editor ("${destBasename}")`,
-      '✓ RangeLink: File path copied to clipboard',
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Text Editor ("${destBasename}")`, '✓ RangeLink: File path copied to clipboard']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
     ss.expectToastMessages([
       {
         level: 'info',
-        message:
-          'Cannot paste when bound editor has an active selection. File path copied to clipboard.',
+        message: 'Cannot paste when bound editor has an active selection. File path copied to clipboard.',
       },
     ]);
     await assertClipboardEquals(
@@ -598,14 +499,8 @@ standardSuite('Send File Path', (ss) => {
       'before-sfp-014',
     );
     const doc = await vscode.workspace.openTextDocument(fileUri);
-    assert.strictEqual(
-      doc.getText(),
-      'original content\n',
-      'Expected file to remain unmodified after blocked self-paste',
-    );
-    ss.log(
-      '✓ Self-paste with active selection: blocked, toast shown, path on clipboard, file unchanged',
-    );
+    assert.strictEqual(doc.getText(), 'original content\n', 'Expected file to remain unmodified after blocked self-paste');
+    ss.log('✓ Self-paste with active selection: blocked, toast shown, path on clipboard, file unchanged');
   });
 
   test('send-file-path-015: same file, different view column — allowed', async () => {
@@ -616,10 +511,7 @@ standardSuite('Send File Path', (ss) => {
     const sourceUri = ss.createWorkspaceFile('sfp-015-source', 'source content\n');
 
     const destEditor = await openEditor(destUri, vscode.ViewColumn.Two);
-    destEditor.selection = new vscode.Selection(
-      new vscode.Position(1, 0),
-      new vscode.Position(1, 0),
-    );
+    destEditor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 0));
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
     await ss.settle();
 
@@ -629,10 +521,7 @@ standardSuite('Send File Path', (ss) => {
     await openSourceWithSelection(sourceUri, vscode.ViewColumn.Three);
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Text Editor ("${destBasename}")`,
-      `✓ RangeLink: File path sent to Text Editor ("${destBasename}")`,
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Text Editor ("${destBasename}")`, `✓ RangeLink: File path sent to Text Editor ("${destBasename}")`]);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE);
@@ -648,49 +537,32 @@ standardSuite('Send File Path', (ss) => {
   });
 
   test('send-file-path-016: self-paste with no selection inserts path at cursor (no clipboard.preserve override, no clipboard assertion)', async () => {
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('smartPadding.pasteFilePath', 'both', vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration('rangelink').update('smartPadding.pasteFilePath', 'both', vscode.ConfigurationTarget.Global);
 
     const fileUri = ss.createWorkspaceFile('sfp-016-self', 'original content\n');
     const destBasename = path.basename(fileUri.fsPath);
     const destEditor = await openEditor(fileUri);
     // Place cursor at beginning — no selection, so R-F is allowed
-    destEditor.selection = new vscode.Selection(
-      new vscode.Position(0, 0),
-      new vscode.Position(0, 0),
-    );
+    destEditor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0));
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
     await ss.settle();
 
     const relativePath = vscode.workspace.asRelativePath(fileUri, false);
     ss.expectContextKeys({ 'rangelink.isBound': true });
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Text Editor ("${destBasename}")`,
-      `✓ RangeLink: File path sent to Text Editor ("${destBasename}")`,
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Text Editor ("${destBasename}")`, `✓ RangeLink: File path sent to Text Editor ("${destBasename}")`]);
 
     await vscode.commands.executeCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE);
     await ss.settle();
 
     const doc = await vscode.workspace.openTextDocument(fileUri);
     const expectedContent = ` ${relativePath} original content\n`;
-    assert.strictEqual(
-      doc.getText(),
-      expectedContent,
-      `Expected file to have path inserted at cursor, got: ${JSON.stringify(doc.getText())}`,
-    );
-    ss.log(
-      '✓ Self-paste with no selection: path inserted at cursor, normal status bar feedback (no clipboard assertion)',
-    );
+    assert.strictEqual(doc.getText(), expectedContent, `Expected file to have path inserted at cursor, got: ${JSON.stringify(doc.getText())}`);
+    ss.log('✓ Self-paste with no selection: path inserted at cursor, normal status bar feedback (no clipboard assertion)');
   });
 
   test('send-file-path-017: R-F sends workspace-relative path when active tab is an image preview', async () => {
     const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("sfp-test")',
-      '✓ RangeLink: File path sent to Terminal ("sfp-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("sfp-test")', '✓ RangeLink: File path sent to Terminal ("sfp-test")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -702,11 +574,7 @@ standardSuite('Send File Path', (ss) => {
     await vscode.commands.executeCommand('vscode.open', pngUri);
     await ss.settle();
 
-    assert.strictEqual(
-      vscode.window.activeTextEditor,
-      undefined,
-      'Expected activeTextEditor to be undefined when active tab is an image preview',
-    );
+    assert.strictEqual(vscode.window.activeTextEditor, undefined, 'Expected activeTextEditor to be undefined when active tab is an image preview');
 
     capturing.clearCaptured();
 
@@ -720,10 +588,7 @@ standardSuite('Send File Path', (ss) => {
 
   test('send-file-path-018: R-F sends modified-side path when active tab is a text diff view', async () => {
     const capturing = await ss.createAndBindCapturingTerminal('sfp-test');
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("sfp-test")',
-      '✓ RangeLink: File path sent to Terminal ("sfp-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("sfp-test")', '✓ RangeLink: File path sent to Terminal ("sfp-test")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/smartPadding.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/smartPadding.test.ts
@@ -56,10 +56,7 @@ standardSuite('Smart Padding — Editor-to-Editor R-V: 001-untitled', (ss) => {
     const destDoc = await vscode.workspace.openTextDocument({ content: '', language: 'plaintext' });
     await vscode.window.showTextDocument(destDoc, vscode.ViewColumn.Two);
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Text Editor ("Untitled-1")',
-      '✓ RangeLink: Selected text sent to Text Editor ("Untitled-1")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Text Editor ("Untitled-1")', '✓ RangeLink: Selected text sent to Text Editor ("Untitled-1")']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE, destDoc.uri);
     await ss.settle();
@@ -70,19 +67,13 @@ standardSuite('Smart Padding — Editor-to-Editor R-V: 001-untitled', (ss) => {
 
     const lastLine = sourceEditor.document.lineCount - 1;
     const lastChar = sourceEditor.document.lineAt(lastLine).text.length;
-    sourceEditor.selection = new vscode.Selection(
-      new vscode.Position(0, 0),
-      new vscode.Position(lastLine, lastChar),
-    );
+    sourceEditor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(lastLine, lastChar));
 
     await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
     await ss.settle();
 
     const destContent = destDoc.getText();
-    assert.ok(
-      destContent.length > 0,
-      `Expected untitled dest to have content, but it was empty. isClosed=${destDoc.isClosed}`,
-    );
+    assert.ok(destContent.length > 0, `Expected untitled dest to have content, but it was empty. isClosed=${destDoc.isClosed}`);
   });
 });
 
@@ -113,10 +104,7 @@ standardSuite('Smart Padding — Editor-to-Editor R-V: langswitch', (ss) => {
     const destDoc = await openUntitledDoc({ viewColumn: vscode.ViewColumn.Two });
     const originalLanguage = destDoc.languageId;
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Text Editor ("Untitled-1")',
-      '✓ RangeLink: Selected text sent to Text Editor ("Untitled-1")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Text Editor ("Untitled-1")', '✓ RangeLink: Selected text sent to Text Editor ("Untitled-1")']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE, destDoc.uri);
     await ss.settle();
@@ -128,10 +116,7 @@ standardSuite('Smart Padding — Editor-to-Editor R-V: langswitch', (ss) => {
     const sourceEditor = await vscode.window.showTextDocument(sourceDoc, vscode.ViewColumn.Three);
     await ss.settle();
 
-    sourceEditor.selection = new vscode.Selection(
-      new vscode.Position(0, 0),
-      new vscode.Position(0, sourceContent.length),
-    );
+    sourceEditor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, sourceContent.length));
 
     await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
     await ss.settle();
@@ -144,10 +129,7 @@ standardSuite('Smart Padding — Editor-to-Editor R-V: langswitch', (ss) => {
   });
 
   test('langswitch-binding-002: binding survives language change after content insertion', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Text Editor ("Untitled-1")',
-      '✓ RangeLink: Selected text sent to Text Editor ("Untitled-1")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Text Editor ("Untitled-1")', '✓ RangeLink: Selected text sent to Text Editor ("Untitled-1")']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     const sourceContent = 'hello world';
@@ -176,10 +158,7 @@ standardSuite('Smart Padding — Editor-to-Editor R-V: langswitch', (ss) => {
     const sourceEditor = await vscode.window.showTextDocument(sourceDoc, vscode.ViewColumn.Three);
     await ss.settle();
 
-    sourceEditor.selection = new vscode.Selection(
-      new vscode.Position(0, 0),
-      new vscode.Position(0, sourceContent.length),
-    );
+    sourceEditor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, sourceContent.length));
 
     await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
     await ss.settle();
@@ -203,10 +182,7 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
     const sourceUri = ss.createWorkspaceFile('pad-001', whitespaceContent);
 
     const capturing = await ss.createAndBindCapturingTerminal('pad-001-dest');
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("pad-001-dest")',
-      '✓ RangeLink: Selected text sent to Terminal ("pad-001-dest")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("pad-001-dest")', '✓ RangeLink: Selected text sent to Terminal ("pad-001-dest")']);
     ss.expectContextKeys({
       'rangelink.isBound': true,
       'rangelink.isActiveTerminalBindable': true,
@@ -217,10 +193,7 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
     const sourceEditor = await openEditor(sourceUri);
     const lastLine = sourceEditor.document.lineCount - 1;
     const lastChar = sourceEditor.document.lineAt(lastLine).text.length;
-    sourceEditor.selection = new vscode.Selection(
-      new vscode.Position(0, 0),
-      new vscode.Position(lastLine, lastChar),
-    );
+    sourceEditor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(lastLine, lastChar));
     await ss.settle();
 
     capturing.clearCaptured();
@@ -228,22 +201,13 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
     await ss.settle();
 
     const captured = capturing.getCapturedText();
-    assert.ok(
-      captured.length > 0,
-      `Expected whitespace content to be sent, but captured was empty`,
-    );
-    assert.ok(
-      captured.includes('\t'),
-      `Expected captured content to contain tab, got: ${JSON.stringify(captured)}`,
-    );
+    assert.ok(captured.length > 0, `Expected whitespace content to be sent, but captured was empty`);
+    assert.ok(captured.includes('\t'), `Expected captured content to contain tab, got: ${JSON.stringify(captured)}`);
     ss.log('✓ smart-padding-001: whitespace preserved');
   });
 
   test('smart-padding-003: multiline content preserved through destination', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Text Editor ("Untitled-1")',
-      '✓ RangeLink: Selected text sent to Text Editor ("Untitled-1")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Text Editor ("Untitled-1")', '✓ RangeLink: Selected text sent to Text Editor ("Untitled-1")']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     const expected = 'line 1\nline 2\nline 3';
@@ -256,37 +220,25 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
     await ss.settle();
 
     const sourceEditor = await openEditor(sourceUri, vscode.ViewColumn.Beside);
-    sourceEditor.selection = new vscode.Selection(
-      new vscode.Position(0, 0),
-      new vscode.Position(2, 6),
-    );
+    sourceEditor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(2, 6));
     await ss.settle();
 
     await vscode.commands.executeCommand(CMD_PASTE_TO_DESTINATION);
     await ss.settle();
 
     const destContent = destDoc.getText();
-    assert.strictEqual(
-      destContent,
-      expected,
-      `Expected multiline content to arrive intact, got: ${JSON.stringify(destContent)}`,
-    );
+    assert.strictEqual(destContent, expected, `Expected multiline content to arrive intact, got: ${JSON.stringify(destContent)}`);
     ss.log('✓ smart-padding-003: multiline content preserved through destination');
   });
 
   test('smart-padding-005: pasteContent=before adds leading space only', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("pad-005-dest")',
-      '✓ RangeLink: Selected text sent to Terminal ("pad-005-dest")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("pad-005-dest")', '✓ RangeLink: Selected text sent to Terminal ("pad-005-dest")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
       'rangelink.isBound': true,
     });
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('smartPadding.pasteContent', 'before', vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration('rangelink').update('smartPadding.pasteContent', 'before', vscode.ConfigurationTarget.Global);
 
     const sourceUri = ss.createWorkspaceFile('pad-005', 'hello\n');
 
@@ -306,18 +258,13 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
   });
 
   test('smart-padding-006: pasteContent=after adds trailing space only', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("pad-006-dest")',
-      '✓ RangeLink: Selected text sent to Terminal ("pad-006-dest")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("pad-006-dest")', '✓ RangeLink: Selected text sent to Terminal ("pad-006-dest")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
       'rangelink.isBound': true,
     });
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('smartPadding.pasteContent', 'after', vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration('rangelink').update('smartPadding.pasteContent', 'after', vscode.ConfigurationTarget.Global);
 
     const sourceUri = ss.createWorkspaceFile('pad-006', 'hello\n');
 
@@ -337,14 +284,9 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
   });
 
   test('smart-padding-007: pasteContent=both — text selection sent to destination has leading and trailing space', async () => {
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('smartPadding.pasteContent', 'both', vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration('rangelink').update('smartPadding.pasteContent', 'both', vscode.ConfigurationTarget.Global);
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("pad-007-dest")',
-      '✓ RangeLink: Selected text sent to Terminal ("pad-007-dest")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("pad-007-dest")', '✓ RangeLink: Selected text sent to Terminal ("pad-007-dest")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -368,17 +310,12 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
   });
 
   test('smart-padding-008: pasteFilePath=both — file path sent to terminal has leading and trailing space', async () => {
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('smartPadding.pasteFilePath', 'both', vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration('rangelink').update('smartPadding.pasteFilePath', 'both', vscode.ConfigurationTarget.Global);
 
     const fileUri = ss.createWorkspaceFile('pad-008', 'content\n');
 
     const capturing = await ss.createAndBindCapturingTerminal('pad-008-dest');
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("pad-008-dest")',
-      '✓ RangeLink: File path sent to Terminal ("pad-008-dest")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("pad-008-dest")', '✓ RangeLink: File path sent to Terminal ("pad-008-dest")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,
@@ -399,10 +336,7 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
   });
 
   test('smart-padding-009: pasteLink=both — RangeLink sent to Dummy AI has leading and trailing space', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Dummy AI (Tier 1)',
-      '✓ RangeLink: RangeLink sent to Dummy AI (Tier 1)',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Dummy AI (Tier 1)', '✓ RangeLink: RangeLink sent to Dummy AI (Tier 1)']);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     const fileUri = ss.createWorkspaceFile('pad-009', 'line 1\nline 2\nline 3\n');
@@ -417,24 +351,17 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
     editor.selection = new vscode.Selection(0, 0, 1, 6);
     await ss.settle();
     const logCapture = ss.getLogCapture();
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('smartPadding.pasteLink', 'both', vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration('rangelink').update('smartPadding.pasteLink', 'both', vscode.ConfigurationTarget.Global);
     logCapture.mark('before-pad-009');
     await vscode.commands.executeCommand(CMD_COPY_LINK_RELATIVE);
     await ss.settle();
-    const textResult = (await vscode.commands.executeCommand(DUMMY_AI_GET_TEXT_COMMAND)) as
-      { tier1: string; tier2: string } | undefined;
+    const textResult = (await vscode.commands.executeCommand(DUMMY_AI_GET_TEXT_COMMAND)) as { tier1: string; tier2: string } | undefined;
     assert.ok(textResult, `Expected ${DUMMY_AI_GET_TEXT_COMMAND} to return a result`);
     assert.ok(
       textResult!.tier1.startsWith(' ') && textResult!.tier1.endsWith(' '),
       `Expected padded RangeLink (leading + trailing space), got: "${textResult!.tier1}"`,
     );
-    assert.strictEqual(
-      textResult!.tier2,
-      '',
-      'Expected tier2 textarea to be empty (no cross-contamination)',
-    );
+    assert.strictEqual(textResult!.tier2, '', 'Expected tier2 textarea to be empty (no cross-contamination)');
 
     const generatedLink = getGeneratedLink('before-pad-009', { smartPad: 'both' });
     assert.strictEqual(generatedLink, textResult!.tier1);
@@ -443,17 +370,12 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
   });
 
   test('[assisted] smart-padding-010: terminal selection sent to editor with padding=both', async () => {
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('smartPadding.pasteContent', 'both', vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration('rangelink').update('smartPadding.pasteContent', 'both', vscode.ConfigurationTarget.Global);
 
     const destUri = ss.createWorkspaceFile('pad-010-dest', '');
     const destFileName = path.basename(destUri.fsPath);
 
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Text Editor ("${destFileName}")`,
-      `✓ RangeLink: Selected text sent to Text Editor ("${destFileName}")`,
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Text Editor ("${destFileName}")`, `✓ RangeLink: Selected text sent to Text Editor ("${destFileName}")`]);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isBound': true,
@@ -468,34 +390,22 @@ standardSuite('Smart Padding — Single-Write Architecture', (ss) => {
     echoToTerminal(terminal, 'hello');
     await ss.settle();
 
-    await waitForHuman(
-      'smart-padding-010',
-      'Select "hello" in the terminal and press R-V to paste to the bound editor',
-      [
-        '1. In terminal "pad-010-src", mouse-select the output "hello"',
-        '2. Press R-C to copy the terminal selection, then press R-V to send',
-        '3. The bound editor (pad-010-dest) will receive the padded text',
-        '4. Click the notification Cancel button when done',
-      ],
-    );
+    await waitForHuman('smart-padding-010', 'Select "hello" in the terminal and press R-V to paste to the bound editor', [
+      '1. In terminal "pad-010-src", mouse-select the output "hello"',
+      '2. Press R-C to copy the terminal selection, then press R-V to send',
+      '3. The bound editor (pad-010-dest) will receive the padded text',
+      '4. Click the notification Cancel button when done',
+    ]);
 
     const destContent = (await vscode.workspace.openTextDocument(destUri)).getText();
-    assert.ok(
-      destContent.includes(' hello '),
-      `Expected dest to contain padded text " hello ", got: "${destContent}"`,
-    );
+    assert.ok(destContent.includes(' hello '), `Expected dest to contain padded text " hello ", got: "${destContent}"`);
     ss.log('✓ smart-padding-010: terminal selection sent to editor with padding (code verified)');
   });
 
   test('smart-padding-011: pasteContent=none — no padding applied when setting is off', async () => {
-    await vscode.workspace
-      .getConfiguration('rangelink')
-      .update('smartPadding.pasteContent', 'none', vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration('rangelink').update('smartPadding.pasteContent', 'none', vscode.ConfigurationTarget.Global);
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("pad-011-dest")',
-      '✓ RangeLink: Selected text sent to Terminal ("pad-011-dest")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("pad-011-dest")', '✓ RangeLink: Selected text sent to Terminal ("pad-011-dest")']);
     ss.expectContextKeys({
       'rangelink.isActiveTerminalBindable': true,
       'rangelink.isActiveTerminalPasteDestination': true,

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/statusBarMenu.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/statusBarMenu.test.ts
@@ -61,11 +61,7 @@ standardSuite('R-M Status Bar Menu', (ss) => {
     const lines = logCapture.getLinesSince('before-menu-002');
     assertQuickPickFirstItem(lines, MENU_ITEM_UNBOUND);
     assertCommandsAbsent(lines, CMD_JUMP_TO_DESTINATION);
-    assertQuickPickTrailingItems(lines, [
-      MENU_ITEM_SEPARATOR,
-      MENU_ITEM_GO_TO_LINK,
-      MENU_ITEM_VERSION_INFO,
-    ]);
+    assertQuickPickTrailingItems(lines, [MENU_ITEM_SEPARATOR, MENU_ITEM_GO_TO_LINK, MENU_ITEM_VERSION_INFO]);
 
     ss.log('✓ Unbound menu: no Jump item, correct structure');
   });
@@ -84,11 +80,7 @@ standardSuite('R-M Status Bar Menu', (ss) => {
     const lines = logCapture.getLinesSince('before-menu-003');
     assertQuickPickFirstItem(lines, MENU_ITEM_UNBOUND);
     assertCommandsAbsent(lines, CMD_JUMP_TO_DESTINATION);
-    assertQuickPickTrailingItems(lines, [
-      MENU_ITEM_SEPARATOR,
-      MENU_ITEM_GO_TO_LINK,
-      MENU_ITEM_VERSION_INFO,
-    ]);
+    assertQuickPickTrailingItems(lines, [MENU_ITEM_SEPARATOR, MENU_ITEM_GO_TO_LINK, MENU_ITEM_VERSION_INFO]);
 
     ss.log('✓ Direct command menu: no Jump item, correct structure');
   });
@@ -126,11 +118,7 @@ standardSuite('R-M Status Bar Menu', (ss) => {
     const verdict = await waitForHumanVerdict(
       'status-bar-menu-001',
       'Look at the VS Code status bar (bottom right). Does it show "$(link) RangeLink" with tooltip "RangeLink — no destination bound" on hover? (No destination should be bound at this point.)',
-      [
-        '1. Locate the RangeLink item in the bottom-right status bar',
-        '2. Hover over it to reveal the tooltip',
-        'Verdict:',
-      ],
+      ['1. Locate the RangeLink item in the bottom-right status bar', '2. Hover over it to reveal the tooltip', 'Verdict:'],
     );
     assert.strictEqual(verdict, 'pass', 'Human reported status bar text or tooltip was incorrect');
     ss.log('✓ Status bar item shows correct text and tooltip');
@@ -149,10 +137,7 @@ standardSuite('R-M Status Bar Menu', (ss) => {
   });
 
   test('status-bar-menu-007: R-M menu reflects bound and unbound state', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-sbm-007")',
-      '✓ RangeLink: Unbound from Terminal ("rl-sbm-007")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-sbm-007")', '✓ RangeLink: Unbound from Terminal ("rl-sbm-007")']);
     ss.expectContextKeys({ 'rangelink.isActiveTerminalBindable': true });
     await ss.createTerminal('rl-sbm-007');
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
@@ -182,11 +167,7 @@ standardSuite('R-M Status Bar Menu', (ss) => {
     const postLines = logCapture.getLinesSince('after-unbind-007');
     assertQuickPickFirstItem(postLines, MENU_ITEM_UNBOUND);
     assertCommandsAbsent(postLines, CMD_JUMP_TO_DESTINATION);
-    assertQuickPickTrailingItems(postLines, [
-      MENU_ITEM_SEPARATOR,
-      MENU_ITEM_GO_TO_LINK,
-      MENU_ITEM_VERSION_INFO,
-    ]);
+    assertQuickPickTrailingItems(postLines, [MENU_ITEM_SEPARATOR, MENU_ITEM_GO_TO_LINK, MENU_ITEM_VERSION_INFO]);
     ss.log('✓ Bound menu showed Jump + Unbind; unbind removed Jump item');
   });
 
@@ -197,11 +178,7 @@ standardSuite('R-M Status Bar Menu', (ss) => {
     await waitForHuman(
       'status-bar-menu-008',
       'Open the R-M menu (Cmd+R Cmd+M), select "$(link-external) Go to Link", then dismiss the R-G input box (Escape).',
-      [
-        '1. Press Cmd+R Cmd+M to open the R-M menu',
-        '2. Select "$(link-external) Go to Link"',
-        '3. The R-G input box opens — press Escape to dismiss it',
-      ],
+      ['1. Press Cmd+R Cmd+M to open the R-M menu', '2. Select "$(link-external) Go to Link"', '3. The R-G input box opens — press Escape to dismiss it'],
     );
 
     const lines = logCapture.getLinesSince('before-008');
@@ -253,14 +230,8 @@ standardSuite('R-M Status Bar Menu', (ss) => {
     });
     assert.ok(commandDispatchLog, 'Expected command dispatch log for Show Version Info');
 
-    assert.strictEqual(
-      verdict,
-      'pass',
-      'Human reported version info notification was missing fields',
-    );
-    ss.log(
-      '✓ Show Version Info dispatched and notification displayed all required fields (human verified)',
-    );
+    assert.strictEqual(verdict, 'pass', 'Human reported version info notification was missing fields');
+    ss.log('✓ Show Version Info dispatched and notification displayed all required fields (human verified)');
   });
 
   // Status bar appearance tests (bind/unbind → tooltip + color)
@@ -292,10 +263,7 @@ standardSuite('R-M Status Bar Menu', (ss) => {
   });
 
   test('status-bar-appearance-002: status bar appearance updates to unbound state after unbind', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-sba-002")',
-      '✓ RangeLink: Unbound from Terminal ("rl-sba-002")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-sba-002")', '✓ RangeLink: Unbound from Terminal ("rl-sba-002")']);
     ss.expectContextKeys({ 'rangelink.isActiveTerminalBindable': true });
     await ss.createTerminal('rl-sba-002');
 
@@ -318,10 +286,7 @@ standardSuite('R-M Status Bar Menu', (ss) => {
   });
 
   test('[assisted] status-bar-appearance-003: status bar tooltip and color reflect bind state', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-sba-003")',
-      '✓ RangeLink: Unbound from Terminal ("rl-sba-003")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-sba-003")', '✓ RangeLink: Unbound from Terminal ("rl-sba-003")']);
     ss.expectContextKeys({ 'rangelink.isActiveTerminalBindable': true });
     const terminalName = 'rl-sba-003';
     await ss.createTerminal(terminalName);
@@ -336,11 +301,7 @@ standardSuite('R-M Status Bar Menu', (ss) => {
         'Verdict:',
       ],
     );
-    assert.strictEqual(
-      verdictUnbound,
-      'pass',
-      'Human reported unbound tooltip or color was incorrect',
-    );
+    assert.strictEqual(verdictUnbound, 'pass', 'Human reported unbound tooltip or color was incorrect');
 
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
     await ss.settle();
@@ -370,11 +331,7 @@ standardSuite('R-M Status Bar Menu', (ss) => {
         'Verdict:',
       ],
     );
-    assert.strictEqual(
-      verdictAfterUnbind,
-      'pass',
-      'Human reported tooltip or color was incorrect after unbind',
-    );
+    assert.strictEqual(verdictAfterUnbind, 'pass', 'Human reported tooltip or color was incorrect after unbind');
 
     ss.log('✓ Status bar tooltip and color correctly reflect bind/unbind state (human verified)');
   });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/terminalPicker.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/terminalPicker.test.ts
@@ -1,9 +1,4 @@
-import {
-  CMD_BIND_TO_DESTINATION,
-  CMD_BIND_TO_TERMINAL,
-  CMD_BIND_TO_TERMINAL_HERE,
-  CMD_OPEN_STATUS_BAR_MENU,
-} from '../../constants/commandIds';
+import { CMD_BIND_TO_DESTINATION, CMD_BIND_TO_TERMINAL, CMD_BIND_TO_TERMINAL_HERE, CMD_OPEN_STATUS_BAR_MENU } from '../../constants/commandIds';
 import {
   extractQuickPickItemsLogged,
   findTerminalItems,
@@ -365,11 +360,7 @@ standardSuite('Terminal Picker', (ss) => {
     );
 
     const termItems = findTerminalItems(items!);
-    assert.strictEqual(
-      termItems.length,
-      MAX_INLINE_DEFAULT,
-      `Expected ${MAX_INLINE_DEFAULT} inline items`,
-    );
+    assert.strictEqual(termItems.length, MAX_INLINE_DEFAULT, `Expected ${MAX_INLINE_DEFAULT} inline items`);
     const activeInline = termItems.find((i) => i.isActive === true);
     assert.ok(activeInline, 'Expected one active terminal in inline items');
     assert.deepStrictEqual(
@@ -401,25 +392,19 @@ standardSuite('Terminal Picker', (ss) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-009');
 
-    await waitForHuman(
-      'terminal-picker-009',
-      'Cmd+R Cmd+D → "More terminals..." → Escape → Escape again',
-      [
-        '1. Press Cmd+R Cmd+D',
-        '2. Click "More terminals..."',
-        '3. Escape the secondary picker (parent reopens)',
-        '4. Escape the parent picker',
-      ],
-    );
+    await waitForHuman('terminal-picker-009', 'Cmd+R Cmd+D → "More terminals..." → Escape → Escape again', [
+      '1. Press Cmd+R Cmd+D',
+      '2. Click "More terminals..."',
+      '3. Escape the secondary picker (parent reopens)',
+      '4. Escape the parent picker',
+    ]);
 
     const lines = logCapture.getLinesSince('before-tp-009');
     const quickPickEntries = getQuickPickLines(lines);
     assert.ok(quickPickEntries.length >= 2, 'Expected at least 2 showQuickPick entries');
 
     const secondaryItems = parseQuickPickItemsFromLogLine(quickPickEntries[1]);
-    const secondaryTerminals = secondaryItems.filter(
-      (i) => typeof i.label === 'string' && (i.label as string).includes('rl-tp-009-'),
-    );
+    const secondaryTerminals = secondaryItems.filter((i) => typeof i.label === 'string' && (i.label as string).includes('rl-tp-009-'));
     assert.strictEqual(secondaryTerminals.length, TERMINAL_OVERFLOW_COUNT);
 
     const activeSecondary = secondaryTerminals.find((i) => i.isActive === true);
@@ -465,16 +450,12 @@ standardSuite('Terminal Picker', (ss) => {
     const logCapture = getLogCapture();
     logCapture.mark('before-tp-010');
 
-    await waitForHuman(
-      'terminal-picker-010',
-      'Cmd+R Cmd+D → "More terminals..." → Escape → Escape again',
-      [
-        '1. Press Cmd+R Cmd+D',
-        '2. Click "More terminals..."',
-        '3. Escape the secondary picker (parent should reopen)',
-        '4. Escape the parent picker',
-      ],
-    );
+    await waitForHuman('terminal-picker-010', 'Cmd+R Cmd+D → "More terminals..." → Escape → Escape again', [
+      '1. Press Cmd+R Cmd+D',
+      '2. Click "More terminals..."',
+      '3. Escape the secondary picker (parent should reopen)',
+      '4. Escape the parent picker',
+    ]);
 
     const lines = logCapture.getLinesSince('before-tp-010');
     const quickPickEntries = getQuickPickLines(lines);
@@ -573,9 +554,7 @@ standardSuite('Terminal Picker', (ss) => {
     const items = extractQuickPickItemsLogged(lines);
     assert.ok(items, 'Expected showQuickPick log entry');
 
-    const terminalSeparator = items!.find(
-      (i) => i.kind === SEPARATOR_KIND && i.label === 'Terminals',
-    );
+    const terminalSeparator = items!.find((i) => i.kind === SEPARATOR_KIND && i.label === 'Terminals');
     assert.ok(terminalSeparator, 'Expected "Terminals" separator in R-M menu');
 
     const termItems = findTerminalItems(items!);
@@ -734,9 +713,7 @@ standardSuite('Terminal Picker', (ss) => {
       },
     );
 
-    const moreFiles = items!.find(
-      (i) => typeof i.label === 'string' && (i.label as string).includes('More files...'),
-    );
+    const moreFiles = items!.find((i) => typeof i.label === 'string' && (i.label as string).includes('More files...'));
     assert.ok(moreFiles, 'Expected "More files..." overflow item');
     assert.deepStrictEqual(
       {
@@ -786,11 +763,7 @@ standardSuite('Terminal Picker', (ss) => {
     assert.deepStrictEqual(termItems, [], 'Expected no terminal items when only a pty exists');
 
     const moreTerminals = items!.find((i) => i.label === 'More terminals...');
-    assert.strictEqual(
-      moreTerminals,
-      undefined,
-      'Expected no "More terminals..." overflow when there are no bindable terminals',
-    );
+    assert.strictEqual(moreTerminals, undefined, 'Expected no "More terminals..." overflow when there are no bindable terminals');
 
     ss.log('✓ Terminal section absent from R-D picker when only pty terminal is open');
   });
@@ -806,9 +779,7 @@ standardSuite('Terminal Picker', (ss) => {
     const ptyTerminal = await ss.createTerminal('rl-tp-015-pty', { pty });
     await ss.settle();
 
-    ss.expectToastMessages([
-      { level: 'error', message: 'Cannot bind to "rl-tp-015-pty": this terminal is not bindable.' },
-    ]);
+    ss.expectToastMessages([{ level: 'error', message: 'Cannot bind to "rl-tp-015-pty": this terminal is not bindable.' }]);
 
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL, ptyTerminal);
     await ss.settle();
@@ -828,10 +799,7 @@ standardSuite('Terminal Picker', (ss) => {
     t.dispose();
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-aut-001")',
-      'RangeLink: Unbound from Terminal ("rl-aut-001") — terminal closed',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-aut-001")', 'RangeLink: Unbound from Terminal ("rl-aut-001") — terminal closed']);
     ss.log('✓ Terminal close triggered status bar auto-unbind message');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/textEditorDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/textEditorDestination.test.ts
@@ -1,8 +1,4 @@
-import {
-  CMD_BIND_TO_TEXT_EDITOR_HERE,
-  CMD_COPY_LINK_RELATIVE,
-  CMD_PASTE_TO_DESTINATION,
-} from '../../constants/commandIds';
+import { CMD_BIND_TO_TEXT_EDITOR_HERE, CMD_COPY_LINK_RELATIVE, CMD_PASTE_TO_DESTINATION } from '../../constants/commandIds';
 import {
   assertClipboardEqualsGeneratedLink,
   closeAllEditors,
@@ -28,15 +24,11 @@ standardSuite('Text Editor Destination', (ss) => {
     await ss.settle();
 
     const destBasename = path.basename(fileUri.fsPath);
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Text Editor ("${destBasename}")`,
-      '✓ RangeLink: RangeLink copied to clipboard',
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Text Editor ("${destBasename}")`, '✓ RangeLink: RangeLink copied to clipboard']);
     ss.expectToastMessages([
       {
         level: 'info',
-        message:
-          'Cannot auto-paste to same file. Link copied to clipboard. Tip: Use R-C for clipboard-only links.',
+        message: 'Cannot auto-paste to same file. Link copied to clipboard. Tip: Use R-C for clipboard-only links.',
       },
     ]);
     ss.expectContextKeys({ 'rangelink.isBound': true });
@@ -64,14 +56,11 @@ standardSuite('Text Editor Destination', (ss) => {
     const sourceUri = ss.createWorkspaceFile('ted-002-source', 'source content\n');
     const destBasename = path.basename(destUri.fsPath);
 
-    const destEditor = await vscode.window.showTextDocument(
-      await vscode.workspace.openTextDocument(destUri),
-      { viewColumn: vscode.ViewColumn.Two, preview: false },
-    );
-    destEditor.selection = new vscode.Selection(
-      new vscode.Position(1, 0),
-      new vscode.Position(1, 0),
-    );
+    const destEditor = await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(destUri), {
+      viewColumn: vscode.ViewColumn.Two,
+      preview: false,
+    });
+    destEditor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 0));
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
     await ss.settle();
 
@@ -79,10 +68,7 @@ standardSuite('Text Editor Destination', (ss) => {
     await openSourceWithSelection(sourceUri, vscode.ViewColumn.Three);
     await ss.settle();
 
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Text Editor ("${destBasename}")`,
-      `✓ RangeLink: RangeLink sent to Text Editor ("${destBasename}")`,
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Text Editor ("${destBasename}")`, `✓ RangeLink: RangeLink sent to Text Editor ("${destBasename}")`]);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
     const logCapture = getLogCapture();
@@ -93,10 +79,7 @@ standardSuite('Text Editor Destination', (ss) => {
     const link = getGeneratedLink('before-ted-002', { smartPad: 'both' });
 
     const destDoc = await vscode.workspace.openTextDocument(destUri);
-    assert.ok(
-      destDoc.getText().includes(link),
-      `Expected dest to contain generated link "${link}", got: "${destDoc.getText()}"`,
-    );
+    assert.ok(destDoc.getText().includes(link), `Expected dest to contain generated link "${link}", got: "${destDoc.getText()}"`);
     ss.log('✓ R-L different view column: allowed, link pasted in destination column');
   });
 
@@ -107,31 +90,22 @@ standardSuite('Text Editor Destination', (ss) => {
     const destUri = ss.createWorkspaceFile('htl-001-dest', `${ANCHOR_START}\n${ANCHOR_END}\n`);
     const sourceUri = ss.createWorkspaceFile('htl-001-source', `${SOURCE_CONTENT}\n`);
     const destBasename = path.basename(destUri.fsPath);
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Text Editor ("${destBasename}")`,
-      `✓ RangeLink: RangeLink sent to Text Editor ("${destBasename}")`,
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Text Editor ("${destBasename}")`, `✓ RangeLink: RangeLink sent to Text Editor ("${destBasename}")`]);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
-    const destEditor = await vscode.window.showTextDocument(
-      await vscode.workspace.openTextDocument(destUri),
-      { viewColumn: vscode.ViewColumn.One, preview: false },
-    );
-    destEditor.selection = new vscode.Selection(
-      new vscode.Position(1, 0),
-      new vscode.Position(1, 0),
-    );
+    const destEditor = await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(destUri), {
+      viewColumn: vscode.ViewColumn.One,
+      preview: false,
+    });
+    destEditor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 0));
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
     await ss.settle();
 
-    const sourceEditor = await vscode.window.showTextDocument(
-      await vscode.workspace.openTextDocument(sourceUri),
-      { viewColumn: vscode.ViewColumn.One, preview: false },
-    );
-    sourceEditor.selection = new vscode.Selection(
-      new vscode.Position(0, 0),
-      new vscode.Position(0, SOURCE_CONTENT.length),
-    );
+    const sourceEditor = await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(sourceUri), {
+      viewColumn: vscode.ViewColumn.One,
+      preview: false,
+    });
+    sourceEditor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, SOURCE_CONTENT.length));
     await ss.settle();
 
     const logCapture = getLogCapture();
@@ -150,18 +124,12 @@ standardSuite('Text Editor Destination', (ss) => {
         ctx?.editorUri === destUri.toString()
       );
     });
-    assert.ok(
-      hiddenTabLog,
-      'Expected hidden-tab log but none found — paste may not have triggered the hidden-tab path',
-    );
+    assert.ok(hiddenTabLog, 'Expected hidden-tab log but none found — paste may not have triggered the hidden-tab path');
 
     const link = getGeneratedLink('before-htl-001', { smartPad: 'both' });
 
     const destContent = (await vscode.workspace.openTextDocument(destUri)).getText();
-    assert.ok(
-      destContent.includes(link),
-      `Expected dest to include generated link "${link}", got: "${destContent}"`,
-    );
+    assert.ok(destContent.includes(link), `Expected dest to include generated link "${link}", got: "${destContent}"`);
 
     ss.log('✓ Bound editor brought to foreground and received RangeLink');
   });
@@ -173,31 +141,22 @@ standardSuite('Text Editor Destination', (ss) => {
     const destUri = ss.createWorkspaceFile('htl-002-dest', `${ANCHOR_START}\n${ANCHOR_END}\n`);
     const sourceUri = ss.createWorkspaceFile('htl-002-source', `${SELECTED_TEXT}\n`);
     const destBasename = path.basename(destUri.fsPath);
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Text Editor ("${destBasename}")`,
-      `✓ RangeLink: Selected text sent to Text Editor ("${destBasename}")`,
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Text Editor ("${destBasename}")`, `✓ RangeLink: Selected text sent to Text Editor ("${destBasename}")`]);
     ss.expectContextKeys({ 'rangelink.isBound': true });
 
-    const destEditor = await vscode.window.showTextDocument(
-      await vscode.workspace.openTextDocument(destUri),
-      { viewColumn: vscode.ViewColumn.One, preview: false },
-    );
-    destEditor.selection = new vscode.Selection(
-      new vscode.Position(1, 0),
-      new vscode.Position(1, 0),
-    );
+    const destEditor = await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(destUri), {
+      viewColumn: vscode.ViewColumn.One,
+      preview: false,
+    });
+    destEditor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 0));
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
     await ss.settle();
 
-    const sourceEditor = await vscode.window.showTextDocument(
-      await vscode.workspace.openTextDocument(sourceUri),
-      { viewColumn: vscode.ViewColumn.One, preview: false },
-    );
-    sourceEditor.selection = new vscode.Selection(
-      new vscode.Position(0, 0),
-      new vscode.Position(0, SELECTED_TEXT.length),
-    );
+    const sourceEditor = await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(sourceUri), {
+      viewColumn: vscode.ViewColumn.One,
+      preview: false,
+    });
+    sourceEditor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, SELECTED_TEXT.length));
     await ss.settle();
 
     const logCapture = getLogCapture();
@@ -216,10 +175,7 @@ standardSuite('Text Editor Destination', (ss) => {
         ctx?.editorUri === destUri.toString()
       );
     });
-    assert.ok(
-      hiddenTabLog,
-      'Expected hidden-tab log but none found — paste may not have triggered the hidden-tab path',
-    );
+    assert.ok(hiddenTabLog, 'Expected hidden-tab log but none found — paste may not have triggered the hidden-tab path');
 
     const destContent = (await vscode.workspace.openTextDocument(destUri)).getText();
     assert.ok(
@@ -230,8 +186,7 @@ standardSuite('Text Editor Destination', (ss) => {
     ss.log('✓ Bound editor brought to foreground and received selected text');
   });
 
-  const WARN_DUPLICATE_TAB_GROUPS =
-    'Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed.';
+  const WARN_DUPLICATE_TAB_GROUPS = 'Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed.';
 
   test('duplicate-tab-group-001: warning toast fires when bound file is opened in a second editor group', async () => {
     const destUri = ss.createWorkspaceFile('dtg-001-dest', 'destination file\n');
@@ -320,8 +275,7 @@ standardSuite('Text Editor Destination', (ss) => {
       { level: 'warning', message: WARN_DUPLICATE_TAB_GROUPS },
       {
         level: 'error',
-        message:
-          'Bound editor is open in multiple tab groups. Close the duplicate tab and try again.',
+        message: 'Bound editor is open in multiple tab groups. Close the duplicate tab and try again.',
       },
       {
         level: 'warning',
@@ -451,10 +405,7 @@ standardSuite('Text Editor Destination', (ss) => {
     const sourceUri = ss.createWorkspaceFile('svc-001-source', `${SOURCE_TEXT}\n`);
     const dummyUri = ss.createWorkspaceFile('svc-001-dummy', '');
 
-    ss.expectStatusBarMessages([
-      `✓ RangeLink: Bound to Text Editor ("${destBasename}")`,
-      `✓ RangeLink: RangeLink sent to Text Editor ("${destBasename}")`,
-    ]);
+    ss.expectStatusBarMessages([`✓ RangeLink: Bound to Text Editor ("${destBasename}")`, `✓ RangeLink: RangeLink sent to Text Editor ("${destBasename}")`]);
     ss.expectContextKeys({ 'rangelink.isBound': true });
     ss.expectToastMessages([{ level: 'warning', message: WARN_DUPLICATE_TAB_GROUPS }]);
 
@@ -465,10 +416,7 @@ standardSuite('Text Editor Destination', (ss) => {
       viewColumn: vscode.ViewColumn.Two,
       preview: false,
     });
-    destEditor.selection = new vscode.Selection(
-      new vscode.Position(1, 0),
-      new vscode.Position(1, 0),
-    );
+    destEditor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 0));
     await vscode.commands.executeCommand(CMD_BIND_TO_TEXT_EDITOR_HERE);
     await ss.settle();
 
@@ -512,10 +460,7 @@ standardSuite('Text Editor Destination', (ss) => {
 
     const destContent = (await vscode.workspace.openTextDocument(destUri)).getText();
     const relativeSourcePath = vscode.workspace.asRelativePath(sourceUri);
-    assert.ok(
-      destContent.includes(relativeSourcePath),
-      `Expected RangeLink referencing "${relativeSourcePath}" in dest, got: "${destContent}"`,
-    );
+    assert.ok(destContent.includes(relativeSourcePath), `Expected RangeLink referencing "${relativeSourcePath}" in dest, got: "${destContent}"`);
 
     ss.log('✓ Paste followed bound editor to new view column');
   });

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/unbind.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/unbind.test.ts
@@ -1,15 +1,5 @@
-import {
-  CMD_BIND_TO_TERMINAL_HERE,
-  CMD_COPY_LINK_ONLY_RELATIVE,
-  CMD_UNBIND_DESTINATION,
-} from '../../constants/commandIds';
-import {
-  assertClipboardEqualsGeneratedLink,
-  getLogCapture,
-  standardSuite,
-  waitForHuman,
-  waitForHumanVerdict,
-} from '../helpers';
+import { CMD_BIND_TO_TERMINAL_HERE, CMD_COPY_LINK_ONLY_RELATIVE, CMD_UNBIND_DESTINATION } from '../../constants/commandIds';
+import { assertClipboardEqualsGeneratedLink, getLogCapture, standardSuite, waitForHuman, waitForHumanVerdict } from '../helpers';
 
 import assert from 'node:assert';
 import * as vscode from 'vscode';
@@ -50,10 +40,7 @@ standardSuite('Unbind Destination', (ss) => {
   });
 
   test('unbind-004: RangeLink: Unbind Destination available in Command Palette', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-unbind-004-test")',
-      '✓ RangeLink: Unbound from Terminal ("rl-unbind-004-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-unbind-004-test")', '✓ RangeLink: Unbound from Terminal ("rl-unbind-004-test")']);
     ss.expectContextKeys({ 'rangelink.isActiveTerminalBindable': true });
 
     await ss.createTerminal('rl-unbind-004-test');
@@ -67,15 +54,11 @@ standardSuite('Unbind Destination', (ss) => {
   });
 
   test('[assisted] unbind-005: "RangeLink: Unbind" hidden in command palette when no destination is bound', async () => {
-    const verdict = await waitForHumanVerdict(
-      'unbind-005',
-      'Open Command Palette (Cmd+Shift+P), type "RangeLink: Unbind" — is "RangeLink: Unbind" ABSENT?',
-      [
-        '1. Open the Command Palette (Cmd+Shift+P / Ctrl+Shift+P)',
-        '2. Type "RangeLink: Unbind"',
-        'Verdict:',
-      ],
-    );
+    const verdict = await waitForHumanVerdict('unbind-005', 'Open Command Palette (Cmd+Shift+P), type "RangeLink: Unbind" — is "RangeLink: Unbind" ABSENT?', [
+      '1. Open the Command Palette (Cmd+Shift+P / Ctrl+Shift+P)',
+      '2. Type "RangeLink: Unbind"',
+      'Verdict:',
+    ]);
 
     assert.strictEqual(
       verdict,
@@ -85,10 +68,7 @@ standardSuite('Unbind Destination', (ss) => {
   });
 
   test('[assisted] unbind-006: "RangeLink: Unbind" visible in command palette when a destination is bound', async () => {
-    ss.expectStatusBarMessages([
-      '✓ RangeLink: Bound to Terminal ("rl-unbind-006-test")',
-      '✓ RangeLink: Unbound from Terminal ("rl-unbind-006-test")',
-    ]);
+    ss.expectStatusBarMessages(['✓ RangeLink: Bound to Terminal ("rl-unbind-006-test")', '✓ RangeLink: Unbound from Terminal ("rl-unbind-006-test")']);
     ss.expectContextKeys({ 'rangelink.isActiveTerminalBindable': true });
 
     await ss.createTerminal('rl-unbind-006-test');
@@ -98,24 +78,17 @@ standardSuite('Unbind Destination', (ss) => {
 
     await vscode.commands.executeCommand(CMD_BIND_TO_TERMINAL_HERE);
 
-    await waitForHuman(
-      'unbind-006',
-      'Open Command Palette (Cmd+Shift+P), type "RangeLink: Unbind", and execute it.',
-      [
-        '1. Open the Command Palette (Cmd+Shift+P / Ctrl+Shift+P)',
-        '2. Type "RangeLink: Unbind"',
-        '3. Execute "RangeLink: Unbind" to unbind the destination',
-      ],
-    );
+    await waitForHuman('unbind-006', 'Open Command Palette (Cmd+Shift+P), type "RangeLink: Unbind", and execute it.', [
+      '1. Open the Command Palette (Cmd+Shift+P / Ctrl+Shift+P)',
+      '2. Type "RangeLink: Unbind"',
+      '3. Execute "RangeLink: Unbind" to unbind the destination',
+    ]);
 
     ss.log('✓ Unbind executed from palette; isBound context set to false');
   });
 
   test('unbind-003: unbindDestination is a safe no-op when no destination is bound', async () => {
-    ss.expectStatusBarMessages([
-      'RangeLink: No destination bound',
-      'RangeLink: No destination bound',
-    ]);
+    ss.expectStatusBarMessages(['RangeLink: No destination bound', 'RangeLink: No destination bound']);
 
     await vscode.commands.executeCommand(CMD_UNBIND_DESTINATION);
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/untitledNavigation.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/untitledNavigation.test.ts
@@ -13,11 +13,7 @@ import * as vscode from 'vscode';
  * by untitled URI scheme instead of filename suffix, since untitled documents
  * don't have filesystem paths.
  */
-const navigateToUntitledLink = (
-  linkText: string,
-  parsed: ParsedLink,
-  targetUri: vscode.Uri,
-): Promise<{ sel: vscode.Selection; doc: vscode.TextDocument }> => {
+const navigateToUntitledLink = (linkText: string, parsed: ParsedLink, targetUri: vscode.Uri): Promise<{ sel: vscode.Selection; doc: vscode.TextDocument }> => {
   const STABLE_MS = 300;
   const TIMEOUT_MS = 10000;
 
@@ -31,11 +27,7 @@ const navigateToUntitledLink = (
       if (lastResult) {
         resolve(lastResult);
       } else {
-        reject(
-          new Error(
-            `No selection change event received within ${TIMEOUT_MS}ms for ${targetUri.toString()}`,
-          ),
-        );
+        reject(new Error(`No selection change event received within ${TIMEOUT_MS}ms for ${targetUri.toString()}`));
       }
     }, TIMEOUT_MS);
 
@@ -51,9 +43,7 @@ const navigateToUntitledLink = (
       }
     });
 
-    Promise.resolve(
-      vscode.commands.executeCommand(CMD_HANDLE_DOCUMENT_LINK_CLICK, { linkText, parsed }),
-    ).catch((error: unknown) => {
+    Promise.resolve(vscode.commands.executeCommand(CMD_HANDLE_DOCUMENT_LINK_CLICK, { linkText, parsed })).catch((error: unknown) => {
       clearTimeout(overallTimeout);
       if (stableTimer) clearTimeout(stableTimer);
       disposable.dispose();
@@ -62,10 +52,7 @@ const navigateToUntitledLink = (
   });
 };
 
-const UNTITLED_CONTENT = Array.from(
-  { length: 15 },
-  (_, i) => `untitled line ${i + 1} content here`,
-).join('\n');
+const UNTITLED_CONTENT = Array.from({ length: 15 }, (_, i) => `untitled line ${i + 1} content here`).join('\n');
 
 standardSuite('Untitled File Navigation', (ss) => {
   let untitledDoc: vscode.TextDocument;
@@ -109,9 +96,7 @@ standardSuite('Untitled File Navigation', (ss) => {
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
     assert.ok(parseResult.success, `Expected parseLink to succeed for: ${linkText}`);
 
-    ss.expectToastMessages([
-      { level: 'info', message: `Navigated to ${untitledDisplayName} @ 3-7` },
-    ]);
+    ss.expectToastMessages([{ level: 'info', message: `Navigated to ${untitledDisplayName} @ 3-7` }]);
 
     await clearEditorSelection();
     const { sel, doc } = await navigateToUntitledLink(linkText, parseResult.value, untitledDoc.uri);
@@ -154,9 +139,7 @@ standardSuite('Untitled File Navigation', (ss) => {
     const parseResult = parseLink(linkText, DEFAULT_DELIMITERS);
     assert.ok(parseResult.success, `Expected parseLink to succeed for: ${linkText}`);
 
-    ss.expectToastMessages([
-      { level: 'info', message: `Navigated to ${untitledDisplayName} @ 5:10-5:20` },
-    ]);
+    ss.expectToastMessages([{ level: 'info', message: `Navigated to ${untitledDisplayName} @ 5:10-5:20` }]);
 
     await clearEditorSelection();
     const { sel, doc } = await navigateToUntitledLink(linkText, parseResult.value, untitledDoc.uri);

--- a/packages/rangelink-vscode-extension/src/__tests__/LogCapture.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/LogCapture.test.ts
@@ -49,10 +49,7 @@ describe('LogCapture', () => {
       capture.appendLine('after marker 1');
       capture.appendLine('after marker 2');
 
-      expect(capture.getLinesSince('test-start')).toStrictEqual([
-        'after marker 1',
-        'after marker 2',
-      ]);
+      expect(capture.getLinesSince('test-start')).toStrictEqual(['after marker 1', 'after marker 2']);
     });
 
     it('returns all lines when marker does not exist', () => {
@@ -130,8 +127,7 @@ describe('LogCapture', () => {
       const capture = new LogCapture(mockChannel as any);
 
       expect(() => capture.mark('test')).toThrowDetailedError('LOG_CAPTURE_DISABLED', {
-        message:
-          'LogCapture.mark() called without RANGELINK_CAPTURE_LOGS=true — this method is for integration tests only',
+        message: 'LogCapture.mark() called without RANGELINK_CAPTURE_LOGS=true — this method is for integration tests only',
         functionName: 'LogCapture.mark',
       });
     });
@@ -141,8 +137,7 @@ describe('LogCapture', () => {
       const capture = new LogCapture(mockChannel as any);
 
       expect(() => capture.getLinesSince('test')).toThrowDetailedError('LOG_CAPTURE_DISABLED', {
-        message:
-          'LogCapture.getLinesSince() called without RANGELINK_CAPTURE_LOGS=true — this method is for integration tests only',
+        message: 'LogCapture.getLinesSince() called without RANGELINK_CAPTURE_LOGS=true — this method is for integration tests only',
         functionName: 'LogCapture.getLinesSince',
       });
     });
@@ -152,8 +147,7 @@ describe('LogCapture', () => {
       const capture = new LogCapture(mockChannel as any);
 
       expect(() => capture.getAllLines()).toThrowDetailedError('LOG_CAPTURE_DISABLED', {
-        message:
-          'LogCapture.getAllLines() called without RANGELINK_CAPTURE_LOGS=true — this method is for integration tests only',
+        message: 'LogCapture.getAllLines() called without RANGELINK_CAPTURE_LOGS=true — this method is for integration tests only',
         functionName: 'LogCapture.getAllLines',
       });
     });
@@ -163,8 +157,7 @@ describe('LogCapture', () => {
       const capture = new LogCapture(mockChannel as any);
 
       expect(() => capture.clear()).toThrowDetailedError('LOG_CAPTURE_DISABLED', {
-        message:
-          'LogCapture.clear() called without RANGELINK_CAPTURE_LOGS=true — this method is for integration tests only',
+        message: 'LogCapture.clear() called without RANGELINK_CAPTURE_LOGS=true — this method is for integration tests only',
         functionName: 'LogCapture.clear',
       });
     });

--- a/packages/rangelink-vscode-extension/src/__tests__/__mocks__/vscode.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/__mocks__/vscode.ts
@@ -20,8 +20,7 @@ function createMockEvent<T>(): vscode.Event<T> & { fire(data: T): void } {
 export class MockExtensionContext implements vscode.ExtensionContext {
   subscriptions: Array<{ dispose(): void }> = [];
   workspaceState = new MockMemento();
-  globalState: MockMemento & { setKeysForSync(keys: readonly string[]): void } =
-    new MockMemento() as any;
+  globalState: MockMemento & { setKeysForSync(keys: readonly string[]): void } = new MockMemento() as any;
   secrets = {} as any;
   extensionUri = vscode.Uri.parse('file:///mock');
   extension = {} as any;
@@ -125,11 +124,7 @@ const mockLanguages = {
 class MockEventEmitter<T> implements vscode.EventEmitter<T> {
   private handlers: Array<(e: T) => void> = [];
 
-  readonly event: vscode.Event<T> = (
-    listener: (e: T) => any,
-    _thisArgs?: any,
-    _disposables?: any,
-  ) => {
+  readonly event: vscode.Event<T> = (listener: (e: T) => any, _thisArgs?: any, _disposables?: any) => {
     this.handlers.push(listener);
     return {
       dispose: () => {

--- a/packages/rangelink-vscode-extension/src/__tests__/clipboard/ClipboardService.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/clipboard/ClipboardService.test.ts
@@ -34,10 +34,7 @@ describe('ClipboardService', () => {
         { fn: 'ClipboardService::stage::read', priorLength: PRIOR.length },
         'Clipboard current value read and saved',
       );
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'ClipboardService::stage::write', textLength: NEW_TEXT.length },
-        'Clipboard write succeeded',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ClipboardService::stage::write', textLength: NEW_TEXT.length }, 'Clipboard write succeeded');
     });
 
     it('bails out on clipboard read failure', async () => {
@@ -55,10 +52,7 @@ describe('ClipboardService', () => {
         cause: readError,
       });
       expect(fn).not.toHaveBeenCalled();
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        { fn: 'ClipboardService::stage::read', error: readError },
-        'Clipboard read failed',
-      );
+      expect(mockLogger.error).toHaveBeenCalledWith({ fn: 'ClipboardService::stage::read', error: readError }, 'Clipboard read failed');
     });
 
     it('bails out on clipboard write failure', async () => {
@@ -77,10 +71,7 @@ describe('ClipboardService', () => {
         cause: writeError,
       });
       expect(fn).not.toHaveBeenCalled();
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        { fn: 'ClipboardService::stage::write', error: writeError },
-        'Clipboard write failed',
-      );
+      expect(mockLogger.error).toHaveBeenCalledWith({ fn: 'ClipboardService::stage::write', error: writeError }, 'Clipboard write failed');
     });
 
     it('restores clipboard and returns error when fn throws', async () => {
@@ -99,10 +90,7 @@ describe('ClipboardService', () => {
         cause: fnError,
       });
       expect(writeSpy).toHaveBeenCalledWith(PRIOR);
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        { fn: 'ClipboardService::stage', error: fnError },
-        'Callback threw',
-      );
+      expect(mockLogger.error).toHaveBeenCalledWith({ fn: 'ClipboardService::stage', error: fnError }, 'Callback threw');
     });
 
     it('returns fn result even when restore fails', async () => {
@@ -142,10 +130,7 @@ describe('ClipboardService', () => {
       const result = await service.route(fn);
 
       expect(result).toBeSuccess(TEST_RESULT);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'ClipboardService::route', mode: 'never' },
-        'Clipboard preservation disabled; executing directly',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ClipboardService::route', mode: 'never' }, 'Clipboard preservation disabled; executing directly');
     });
 
     it("returns error when fn throws in 'never' mode", async () => {
@@ -164,10 +149,7 @@ describe('ClipboardService', () => {
         functionName: 'ClipboardService::route',
         cause: fnError,
       });
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        { fn: 'ClipboardService::route', mode: 'never', error: fnError },
-        'Callback threw',
-      );
+      expect(mockLogger.error).toHaveBeenCalledWith({ fn: 'ClipboardService::route', mode: 'never', error: fnError }, 'Callback threw');
     });
 
     it('saves clipboard, runs fn, then restores on success', async () => {
@@ -210,10 +192,7 @@ describe('ClipboardService', () => {
       expect(result).toBeSuccess(TEST_RESULT);
       expect(shouldRestore).toHaveBeenCalled();
       expect(writeSpy).not.toHaveBeenCalled();
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'ClipboardService::route', mode: 'always' },
-        'Clipboard restoration skipped',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ClipboardService::route', mode: 'always' }, 'Clipboard restoration skipped');
     });
 
     it('bails out on clipboard read failure', async () => {
@@ -234,10 +213,7 @@ describe('ClipboardService', () => {
         cause: readError,
       });
       expect(fn).not.toHaveBeenCalled();
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        { fn: 'ClipboardService::route::read', mode: 'always', error: readError },
-        'Clipboard read failed',
-      );
+      expect(mockLogger.error).toHaveBeenCalledWith({ fn: 'ClipboardService::route::read', mode: 'always', error: readError }, 'Clipboard read failed');
     });
 
     it('restores clipboard and returns error when fn throws', async () => {
@@ -259,10 +235,7 @@ describe('ClipboardService', () => {
         cause: fnError,
       });
       expect(writeSpy).toHaveBeenCalledWith(PRIOR);
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        { fn: 'ClipboardService::route', mode: 'always', error: fnError },
-        'Callback threw',
-      );
+      expect(mockLogger.error).toHaveBeenCalledWith({ fn: 'ClipboardService::route', mode: 'always', error: fnError }, 'Callback threw');
     });
 
     it('returns fn result even when restore fails', async () => {
@@ -304,10 +277,7 @@ describe('ClipboardService', () => {
       expect(result).toBeSuccess({ clipboard: CAPTURED_TEXT, produced: undefined });
       expect(producer).toHaveBeenCalledTimes(1);
       expect(writeSpy).toHaveBeenCalledWith(PRIOR);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'test::capture::read', priorLength: PRIOR.length },
-        'Clipboard current value read and saved',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'test::capture::read', priorLength: PRIOR.length }, 'Clipboard current value read and saved');
     });
 
     it('returns error when initial clipboard read fails', async () => {
@@ -325,10 +295,7 @@ describe('ClipboardService', () => {
         cause: readError,
       });
       expect(producer).not.toHaveBeenCalled();
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        { fn: 'test::capture::read', error: readError },
-        'Clipboard read failed',
-      );
+      expect(mockLogger.error).toHaveBeenCalledWith({ fn: 'test::capture::read', error: readError }, 'Clipboard read failed');
     });
 
     it('restores clipboard and returns error when producer throws', async () => {
@@ -347,10 +314,7 @@ describe('ClipboardService', () => {
         cause: producerError,
       });
       expect(writeSpy).toHaveBeenCalledWith(PRIOR);
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        { fn: 'test::capture', error: producerError },
-        'Producer callback threw during capture',
-      );
+      expect(mockLogger.error).toHaveBeenCalledWith({ fn: 'test::capture', error: producerError }, 'Producer callback threw during capture');
     });
 
     it('restores clipboard and returns error when read after producer fails', async () => {
@@ -370,10 +334,7 @@ describe('ClipboardService', () => {
         cause: readError,
       });
       expect(writeSpy).toHaveBeenCalledWith(PRIOR);
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        { fn: 'test::capture::read', error: readError },
-        'Clipboard read failed',
-      );
+      expect(mockLogger.error).toHaveBeenCalledWith({ fn: 'test::capture::read', error: readError }, 'Clipboard read failed');
     });
 
     it('returns captured text even when restore fails', async () => {

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/AddBookmarkCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/AddBookmarkCommand.test.ts
@@ -27,10 +27,7 @@ describe('AddBookmarkCommand', () => {
 
       new AddBookmarkCommand(GET_DELIMITERS, mockAdapter, mockBookmarkService, mockLogger);
 
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'AddBookmarkCommand.constructor' },
-        'AddBookmarkCommand initialized',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'AddBookmarkCommand.constructor' }, 'AddBookmarkCommand initialized');
     });
   });
 
@@ -44,21 +41,13 @@ describe('AddBookmarkCommand', () => {
             showErrorMessage: mockShowErrorMessage,
           },
         });
-        command = new AddBookmarkCommand(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockBookmarkService,
-          mockLogger,
-        );
+        command = new AddBookmarkCommand(GET_DELIMITERS, mockAdapter, mockBookmarkService, mockLogger);
 
         await command.execute();
 
         expect(mockShowErrorMessage).toHaveBeenCalledWith('Cannot add bookmark - no active editor');
         expect(mockBookmarkService.addBookmark).not.toHaveBeenCalled();
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'AddBookmarkCommand.execute' },
-          'No active editor',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'AddBookmarkCommand.execute' }, 'No active editor');
       });
     });
 
@@ -75,12 +64,7 @@ describe('AddBookmarkCommand', () => {
             showInputBox: jest.fn().mockResolvedValue('My Bookmark'),
           },
         });
-        command = new AddBookmarkCommand(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockBookmarkService,
-          mockLogger,
-        );
+        command = new AddBookmarkCommand(GET_DELIMITERS, mockAdapter, mockBookmarkService, mockLogger);
 
         await command.execute();
 
@@ -89,10 +73,7 @@ describe('AddBookmarkCommand', () => {
           link: TEST_LINK,
           scope: 'global',
         });
-        expect(mockLogger.info).toHaveBeenCalledWith(
-          { fn: 'AddBookmarkCommand.execute', source: 'existing-link', link: TEST_LINK },
-          'Using existing link',
-        );
+        expect(mockLogger.info).toHaveBeenCalledWith({ fn: 'AddBookmarkCommand.execute', source: 'existing-link', link: TEST_LINK }, 'Using existing link');
       });
 
       it('uses existing link even when selection is in untitled file', async () => {
@@ -108,12 +89,7 @@ describe('AddBookmarkCommand', () => {
             showInputBox: jest.fn().mockResolvedValue('Bookmark from Scratchpad'),
           },
         });
-        command = new AddBookmarkCommand(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockBookmarkService,
-          mockLogger,
-        );
+        command = new AddBookmarkCommand(GET_DELIMITERS, mockAdapter, mockBookmarkService, mockLogger);
 
         await command.execute();
 
@@ -138,12 +114,7 @@ describe('AddBookmarkCommand', () => {
             showInputBox: jest.fn().mockResolvedValue('Multi-line Bookmark'),
           },
         });
-        command = new AddBookmarkCommand(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockBookmarkService,
-          mockLogger,
-        );
+        command = new AddBookmarkCommand(GET_DELIMITERS, mockAdapter, mockBookmarkService, mockLogger);
 
         await command.execute();
 
@@ -169,12 +140,7 @@ describe('AddBookmarkCommand', () => {
             showInputBox: jest.fn().mockResolvedValue('Generated Bookmark'),
           },
         });
-        command = new AddBookmarkCommand(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockBookmarkService,
-          mockLogger,
-        );
+        command = new AddBookmarkCommand(GET_DELIMITERS, mockAdapter, mockBookmarkService, mockLogger);
 
         await command.execute();
 
@@ -239,12 +205,7 @@ describe('AddBookmarkCommand', () => {
             showInputBox: jest.fn().mockResolvedValue('Rectangular Selection'),
           },
         });
-        command = new AddBookmarkCommand(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockBookmarkService,
-          mockLogger,
-        );
+        command = new AddBookmarkCommand(GET_DELIMITERS, mockAdapter, mockBookmarkService, mockLogger);
 
         await command.execute();
 
@@ -277,23 +238,13 @@ describe('AddBookmarkCommand', () => {
             showErrorMessage: mockShowErrorMessage,
           },
         });
-        command = new AddBookmarkCommand(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockBookmarkService,
-          mockLogger,
-        );
+        command = new AddBookmarkCommand(GET_DELIMITERS, mockAdapter, mockBookmarkService, mockLogger);
 
         await command.execute();
 
-        expect(mockShowErrorMessage).toHaveBeenCalledWith(
-          'Cannot bookmark unsaved file. Save the file first, or select an existing RangeLink to bookmark.',
-        );
+        expect(mockShowErrorMessage).toHaveBeenCalledWith('Cannot bookmark unsaved file. Save the file first, or select an existing RangeLink to bookmark.');
         expect(mockBookmarkService.addBookmark).not.toHaveBeenCalled();
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'AddBookmarkCommand.execute', reason: 'untitled-file' },
-          'Cannot bookmark unsaved file',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'AddBookmarkCommand.execute', reason: 'untitled-file' }, 'Cannot bookmark unsaved file');
       });
     });
 
@@ -313,18 +264,11 @@ describe('AddBookmarkCommand', () => {
             showErrorMessage: mockShowErrorMessage,
           },
         });
-        command = new AddBookmarkCommand(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockBookmarkService,
-          mockLogger,
-        );
+        command = new AddBookmarkCommand(GET_DELIMITERS, mockAdapter, mockBookmarkService, mockLogger);
 
         await command.execute();
 
-        expect(mockShowErrorMessage).toHaveBeenCalledWith(
-          'Cannot add bookmark - failed to generate link from selection',
-        );
+        expect(mockShowErrorMessage).toHaveBeenCalledWith('Cannot add bookmark - failed to generate link from selection');
         expect(mockBookmarkService.addBookmark).not.toHaveBeenCalled();
       });
     });
@@ -338,20 +282,12 @@ describe('AddBookmarkCommand', () => {
             showInputBox: jest.fn().mockResolvedValue(undefined),
           },
         });
-        command = new AddBookmarkCommand(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockBookmarkService,
-          mockLogger,
-        );
+        command = new AddBookmarkCommand(GET_DELIMITERS, mockAdapter, mockBookmarkService, mockLogger);
 
         await command.execute();
 
         expect(mockBookmarkService.addBookmark).not.toHaveBeenCalled();
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'AddBookmarkCommand.execute', link: TEST_LINK },
-          'User cancelled bookmark creation',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'AddBookmarkCommand.execute', link: TEST_LINK }, 'User cancelled bookmark creation');
       });
     });
 
@@ -366,21 +302,13 @@ describe('AddBookmarkCommand', () => {
             showErrorMessage: mockShowErrorMessage,
           },
         });
-        command = new AddBookmarkCommand(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockBookmarkService,
-          mockLogger,
-        );
+        command = new AddBookmarkCommand(GET_DELIMITERS, mockAdapter, mockBookmarkService, mockLogger);
 
         await command.execute();
 
         expect(mockShowErrorMessage).toHaveBeenCalledWith('Bookmark label cannot be empty');
         expect(mockBookmarkService.addBookmark).not.toHaveBeenCalled();
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'AddBookmarkCommand.execute' },
-          'Empty label provided',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'AddBookmarkCommand.execute' }, 'Empty label provided');
       });
     });
 
@@ -401,20 +329,12 @@ describe('AddBookmarkCommand', () => {
           },
         });
         mockBookmarkService.addBookmark.mockResolvedValue(ExtensionResult.err(storageError));
-        command = new AddBookmarkCommand(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockBookmarkService,
-          mockLogger,
-        );
+        command = new AddBookmarkCommand(GET_DELIMITERS, mockAdapter, mockBookmarkService, mockLogger);
 
         await command.execute();
 
         expect(mockShowErrorMessage).toHaveBeenCalledWith('Failed to save bookmark');
-        expect(mockLogger.error).toHaveBeenCalledWith(
-          { fn: 'AddBookmarkCommand.execute', error: storageError },
-          'Failed to save bookmark',
-        );
+        expect(mockLogger.error).toHaveBeenCalledWith({ fn: 'AddBookmarkCommand.execute', error: storageError }, 'Failed to save bookmark');
       });
     });
 
@@ -429,23 +349,12 @@ describe('AddBookmarkCommand', () => {
             setStatusBarMessage: mockSetStatusBarMessage,
           },
         });
-        command = new AddBookmarkCommand(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockBookmarkService,
-          mockLogger,
-        );
+        command = new AddBookmarkCommand(GET_DELIMITERS, mockAdapter, mockBookmarkService, mockLogger);
 
         await command.execute();
 
-        expect(mockSetStatusBarMessage).toHaveBeenCalledWith(
-          '✓ RangeLink: Bookmark saved: Success Bookmark',
-          2000,
-        );
-        expect(mockLogger.info).toHaveBeenCalledWith(
-          { fn: 'AddBookmarkCommand.execute', label: 'Success Bookmark', link: TEST_LINK },
-          'Bookmark saved',
-        );
+        expect(mockSetStatusBarMessage).toHaveBeenCalledWith('✓ RangeLink: Bookmark saved: Success Bookmark', 2000);
+        expect(mockLogger.info).toHaveBeenCalledWith({ fn: 'AddBookmarkCommand.execute', label: 'Success Bookmark', link: TEST_LINK }, 'Bookmark saved');
       });
 
       it('trims whitespace from label', async () => {
@@ -456,12 +365,7 @@ describe('AddBookmarkCommand', () => {
             showInputBox: jest.fn().mockResolvedValue('  Trimmed Label  '),
           },
         });
-        command = new AddBookmarkCommand(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockBookmarkService,
-          mockLogger,
-        );
+        command = new AddBookmarkCommand(GET_DELIMITERS, mockAdapter, mockBookmarkService, mockLogger);
 
         await command.execute();
 
@@ -479,20 +383,13 @@ describe('AddBookmarkCommand', () => {
         mockAdapter = createMockVscodeAdapter({
           windowOptions: {
             activeTextEditor: editor,
-            showInputBox: jest.fn(
-              (opts: { value?: string; prompt?: string; placeHolder?: string }) => {
-                capturedOptions.push(opts);
-                return Promise.resolve('Final Label');
-              },
-            ),
+            showInputBox: jest.fn((opts: { value?: string; prompt?: string; placeHolder?: string }) => {
+              capturedOptions.push(opts);
+              return Promise.resolve('Final Label');
+            }),
           },
         });
-        command = new AddBookmarkCommand(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockBookmarkService,
-          mockLogger,
-        );
+        command = new AddBookmarkCommand(GET_DELIMITERS, mockAdapter, mockBookmarkService, mockLogger);
 
         await command.execute();
 
@@ -511,12 +408,7 @@ describe('AddBookmarkCommand', () => {
             showInputBox: jest.fn().mockResolvedValue('Label'),
           },
         });
-        command = new AddBookmarkCommand(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockBookmarkService,
-          mockLogger,
-        );
+        command = new AddBookmarkCommand(GET_DELIMITERS, mockAdapter, mockBookmarkService, mockLogger);
 
         await command.execute();
 

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/BindToDestinationCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/BindToDestinationCommand.test.ts
@@ -16,15 +16,11 @@ import { createMockLogger } from '@couimet/logger-contract-testing';
 
 describe('BindToDestinationCommand message contracts', () => {
   it('placeholder message identifies RangeLink and describes the action', () => {
-    expect(messagesEn['INFO_BIND_QUICK_PICK_PLACEHOLDER']).toBe(
-      'RangeLink: Choose a destination to bind to',
-    );
+    expect(messagesEn['INFO_BIND_QUICK_PICK_PLACEHOLDER']).toBe('RangeLink: Choose a destination to bind to');
   });
 
   it('no-destinations message explains how to resolve the situation', () => {
-    expect(messagesEn['INFO_BIND_NO_DESTINATIONS_AVAILABLE']).toBe(
-      'No destinations available. Open a terminal, a file, or install an AI assistant extension.',
-    );
+    expect(messagesEn['INFO_BIND_NO_DESTINATIONS_AVAILABLE']).toBe('No destinations available. Open a terminal, a file, or install an AI assistant extension.');
   });
 });
 
@@ -40,19 +36,11 @@ describe('BindToDestinationCommand', () => {
     mockDestinationPicker = createMockDestinationPicker();
     mockSession = createMockBoundSession();
     mockLogger = createMockLogger();
-    command = new BindToDestinationCommand(
-      mockDestinationManager,
-      mockDestinationPicker,
-      mockSession,
-      mockLogger,
-    );
+    command = new BindToDestinationCommand(mockDestinationManager, mockDestinationPicker, mockSession, mockLogger);
   });
 
   it('logs initialization in constructor', () => {
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'BindToDestinationCommand.constructor' },
-      'BindToDestinationCommand initialized',
-    );
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToDestinationCommand.constructor' }, 'BindToDestinationCommand initialized');
   });
 
   it('shows picker with bind-specific message codes and returns bound on successful selection', async () => {
@@ -65,12 +53,7 @@ describe('BindToDestinationCommand', () => {
       pick: jest.fn().mockResolvedValue({ outcome: 'selected', bindOptions }),
     });
     mockDestinationManager = createMockDestinationManager({ bindResult });
-    command = new BindToDestinationCommand(
-      mockDestinationManager,
-      mockDestinationPicker,
-      mockSession,
-      mockLogger,
-    );
+    command = new BindToDestinationCommand(mockDestinationManager, mockDestinationPicker, mockSession, mockLogger);
 
     const result = await command.execute();
 
@@ -83,26 +66,15 @@ describe('BindToDestinationCommand', () => {
       placeholderMessageCode: 'INFO_BIND_QUICK_PICK_PLACEHOLDER',
     });
     expect(mockDestinationManager.bind).toHaveBeenCalledWith(bindOptions);
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'BindToDestinationCommand.execute' },
-      'Showing destination picker for binding',
-    );
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'BindToDestinationCommand.execute' },
-      'Binding selected destination',
-    );
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToDestinationCommand.execute' }, 'Showing destination picker for binding');
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToDestinationCommand.execute' }, 'Binding selected destination');
   });
 
   it('returns no-resource when picker reports no destinations available', async () => {
     mockDestinationPicker = createMockDestinationPicker({
       pick: jest.fn().mockResolvedValue({ outcome: 'no-resource' }),
     });
-    command = new BindToDestinationCommand(
-      mockDestinationManager,
-      mockDestinationPicker,
-      mockSession,
-      mockLogger,
-    );
+    command = new BindToDestinationCommand(mockDestinationManager, mockDestinationPicker, mockSession, mockLogger);
 
     const result = await command.execute();
 
@@ -112,26 +84,15 @@ describe('BindToDestinationCommand', () => {
       placeholderMessageCode: 'INFO_BIND_QUICK_PICK_PLACEHOLDER',
     });
     expect(mockDestinationManager.bind).not.toHaveBeenCalled();
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'BindToDestinationCommand.execute' },
-      'Showing destination picker for binding',
-    );
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'BindToDestinationCommand.execute' },
-      'No destinations available',
-    );
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToDestinationCommand.execute' }, 'Showing destination picker for binding');
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToDestinationCommand.execute' }, 'No destinations available');
   });
 
   it('returns cancelled when user cancels picker', async () => {
     mockDestinationPicker = createMockDestinationPicker({
       pick: jest.fn().mockResolvedValue({ outcome: 'cancelled' }),
     });
-    command = new BindToDestinationCommand(
-      mockDestinationManager,
-      mockDestinationPicker,
-      mockSession,
-      mockLogger,
-    );
+    command = new BindToDestinationCommand(mockDestinationManager, mockDestinationPicker, mockSession, mockLogger);
 
     const result = await command.execute();
 
@@ -141,10 +102,7 @@ describe('BindToDestinationCommand', () => {
       placeholderMessageCode: 'INFO_BIND_QUICK_PICK_PLACEHOLDER',
     });
     expect(mockDestinationManager.bind).not.toHaveBeenCalled();
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'BindToDestinationCommand.execute' },
-      'User cancelled picker',
-    );
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToDestinationCommand.execute' }, 'User cancelled picker');
   });
 
   it('returns bind-failed when bind fails after picker selection', async () => {
@@ -160,12 +118,7 @@ describe('BindToDestinationCommand', () => {
     mockDestinationManager = createMockDestinationManager({
       bindResult: ExtensionResult.err<BindSuccessInfo>(bindError),
     });
-    command = new BindToDestinationCommand(
-      mockDestinationManager,
-      mockDestinationPicker,
-      mockSession,
-      mockLogger,
-    );
+    command = new BindToDestinationCommand(mockDestinationManager, mockDestinationPicker, mockSession, mockLogger);
 
     const result = await command.execute();
 
@@ -175,10 +128,7 @@ describe('BindToDestinationCommand', () => {
       placeholderMessageCode: 'INFO_BIND_QUICK_PICK_PLACEHOLDER',
     });
     expect(mockDestinationManager.bind).toHaveBeenCalledWith(bindOptions);
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'BindToDestinationCommand.execute' },
-      'Bind failed',
-    );
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToDestinationCommand.execute' }, 'Bind failed');
   });
 
   it('passes bound editor uri and viewColumn to pick() when an editor is currently bound', async () => {
@@ -193,12 +143,7 @@ describe('BindToDestinationCommand', () => {
     mockDestinationPicker = createMockDestinationPicker({
       pick: jest.fn().mockResolvedValue({ outcome: 'cancelled' }),
     });
-    command = new BindToDestinationCommand(
-      mockDestinationManager,
-      mockDestinationPicker,
-      mockSession,
-      mockLogger,
-    );
+    command = new BindToDestinationCommand(mockDestinationManager, mockDestinationPicker, mockSession, mockLogger);
 
     await command.execute();
 
@@ -208,14 +153,8 @@ describe('BindToDestinationCommand', () => {
       boundFileUriString: 'file:///workspace/src/main.ts',
       boundFileViewColumn: 2,
     });
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'BindToDestinationCommand.execute' },
-      'Showing destination picker for binding',
-    );
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'BindToDestinationCommand.execute' },
-      'User cancelled picker',
-    );
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToDestinationCommand.execute' }, 'Showing destination picker for binding');
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToDestinationCommand.execute' }, 'User cancelled picker');
   });
 
   it('passes bound terminal processId to pick() when a terminal is currently bound', async () => {
@@ -226,12 +165,7 @@ describe('BindToDestinationCommand', () => {
     mockDestinationPicker = createMockDestinationPicker({
       pick: jest.fn().mockResolvedValue({ outcome: 'cancelled' }),
     });
-    command = new BindToDestinationCommand(
-      mockDestinationManager,
-      mockDestinationPicker,
-      mockSession,
-      mockLogger,
-    );
+    command = new BindToDestinationCommand(mockDestinationManager, mockDestinationPicker, mockSession, mockLogger);
 
     await command.execute();
 
@@ -240,13 +174,7 @@ describe('BindToDestinationCommand', () => {
       placeholderMessageCode: 'INFO_BIND_QUICK_PICK_PLACEHOLDER',
       boundTerminalProcessId: 99,
     });
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'BindToDestinationCommand.execute' },
-      'Showing destination picker for binding',
-    );
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'BindToDestinationCommand.execute' },
-      'User cancelled picker',
-    );
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToDestinationCommand.execute' }, 'Showing destination picker for binding');
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToDestinationCommand.execute' }, 'User cancelled picker');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/BindToTerminalCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/BindToTerminalCommand.test.ts
@@ -36,18 +36,9 @@ describe('BindToTerminalCommand', () => {
   describe('constructor', () => {
     it('logs initialization', () => {
       mockAdapter = createMockVscodeAdapter();
-      new BindToTerminalCommand(
-        mockAdapter,
-        mockAvailabilityService,
-        mockDestinationManager,
-        mockSession,
-        mockLogger,
-      );
+      new BindToTerminalCommand(mockAdapter, mockAvailabilityService, mockDestinationManager, mockSession, mockLogger);
 
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'BindToTerminalCommand.constructor' },
-        'BindToTerminalCommand initialized',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToTerminalCommand.constructor' }, 'BindToTerminalCommand initialized');
     });
   });
 
@@ -55,29 +46,15 @@ describe('BindToTerminalCommand', () => {
     describe('0 terminals', () => {
       it('returns no-resource outcome when no terminals exist', async () => {
         mockAdapter = createMockVscodeAdapter();
-        command = new BindToTerminalCommand(
-          mockAdapter,
-          mockAvailabilityService,
-          mockDestinationManager,
-          mockSession,
-          mockLogger,
-        );
+        command = new BindToTerminalCommand(mockAdapter, mockAvailabilityService, mockDestinationManager, mockSession, mockLogger);
 
         const result = await command.execute();
 
         expect(result).toStrictEqual({ outcome: 'no-resource' });
         expect(mockAvailabilityService.getTerminalItems).toHaveBeenCalledWith(Infinity, undefined);
-        expect(mockAdapter.__getVscodeInstance().window.showErrorMessage).toHaveBeenCalledWith(
-          'No bindable terminal. Open a new terminal and try again.',
-        );
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'BindToTerminalCommand.execute', terminalCount: 0 },
-          'Starting bind to terminal command',
-        );
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'BindToTerminalCommand.execute' },
-          'No terminals available',
-        );
+        expect(mockAdapter.__getVscodeInstance().window.showErrorMessage).toHaveBeenCalledWith('No bindable terminal. Open a new terminal and try again.');
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToTerminalCommand.execute', terminalCount: 0 }, 'Starting bind to terminal command');
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToTerminalCommand.execute' }, 'No terminals available');
         expect(showTerminalPickerSpy).not.toHaveBeenCalled();
       });
     });
@@ -86,19 +63,9 @@ describe('BindToTerminalCommand', () => {
       it('auto-binds to single terminal without showing picker', async () => {
         const terminal = createMockTerminal({ name: 'My Terminal' });
         mockAdapter = createMockVscodeAdapter();
-        mockAvailabilityService.getTerminalItems.mockResolvedValue([
-          createMockTerminalQuickPickItem(terminal),
-        ]);
-        (mockDestinationManager.bind as jest.Mock).mockResolvedValue(
-          ExtensionResult.ok({ destinationName: 'My Terminal', destinationKind: 'terminal' }),
-        );
-        command = new BindToTerminalCommand(
-          mockAdapter,
-          mockAvailabilityService,
-          mockDestinationManager,
-          mockSession,
-          mockLogger,
-        );
+        mockAvailabilityService.getTerminalItems.mockResolvedValue([createMockTerminalQuickPickItem(terminal)]);
+        (mockDestinationManager.bind as jest.Mock).mockResolvedValue(ExtensionResult.ok({ destinationName: 'My Terminal', destinationKind: 'terminal' }));
+        command = new BindToTerminalCommand(mockAdapter, mockAvailabilityService, mockDestinationManager, mockSession, mockLogger);
 
         const result = await command.execute();
 
@@ -111,33 +78,20 @@ describe('BindToTerminalCommand', () => {
           kind: 'terminal',
           terminal,
         });
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'BindToTerminalCommand.execute', terminalName: 'My Terminal' },
-          'Single terminal, auto-binding',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToTerminalCommand.execute', terminalName: 'My Terminal' }, 'Single terminal, auto-binding');
       });
 
       it('returns bind-failed when bind fails', async () => {
         const terminal = createMockTerminal({ name: 'My Terminal' });
         mockAdapter = createMockVscodeAdapter();
-        mockAvailabilityService.getTerminalItems.mockResolvedValue([
-          createMockTerminalQuickPickItem(terminal),
-        ]);
+        mockAvailabilityService.getTerminalItems.mockResolvedValue([createMockTerminalQuickPickItem(terminal)]);
         const bindError = new RangeLinkExtensionError({
           code: RangeLinkExtensionErrorCodes.DESTINATION_BIND_FAILED,
           message: 'Terminal bind failed',
           functionName: 'PasteDestinationManager.bind',
         });
-        (mockDestinationManager.bind as jest.Mock).mockResolvedValue(
-          ExtensionResult.err(bindError),
-        );
-        command = new BindToTerminalCommand(
-          mockAdapter,
-          mockAvailabilityService,
-          mockDestinationManager,
-          mockSession,
-          mockLogger,
-        );
+        (mockDestinationManager.bind as jest.Mock).mockResolvedValue(ExtensionResult.err(bindError));
+        command = new BindToTerminalCommand(mockAdapter, mockAvailabilityService, mockDestinationManager, mockSession, mockLogger);
 
         const result = await command.execute();
 
@@ -145,10 +99,7 @@ describe('BindToTerminalCommand', () => {
           outcome: 'bind-failed',
           error: bindError,
         });
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'BindToTerminalCommand.execute', terminalName: 'My Terminal' },
-          'Single terminal, auto-binding',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToTerminalCommand.execute', terminalName: 'My Terminal' }, 'Single terminal, auto-binding');
       });
     });
 
@@ -173,18 +124,10 @@ describe('BindToTerminalCommand', () => {
             handlers: TerminalPickerHandlers<ExtensionResult<BindSuccessInfo>>,
             _logger: unknown,
           ) => {
-            return handlers.onSelected(
-              createMockEligibleTerminal({ terminal: terminal2, name: 'Terminal 2' }),
-            );
+            return handlers.onSelected(createMockEligibleTerminal({ terminal: terminal2, name: 'Terminal 2' }));
           },
         );
-        command = new BindToTerminalCommand(
-          mockAdapter,
-          mockAvailabilityService,
-          mockDestinationManager,
-          mockSession,
-          mockLogger,
-        );
+        command = new BindToTerminalCommand(mockAdapter, mockAvailabilityService, mockDestinationManager, mockSession, mockLogger);
 
         const result = await command.execute();
 
@@ -203,26 +146,14 @@ describe('BindToTerminalCommand', () => {
         const terminal1 = createMockTerminal({ name: 'Terminal 1' });
         const terminal2 = createMockTerminal({ name: 'Terminal 2' });
         mockAdapter = createMockVscodeAdapter();
-        mockAvailabilityService.getTerminalItems.mockResolvedValue([
-          createMockTerminalQuickPickItem(terminal1),
-          createMockTerminalQuickPickItem(terminal2),
-        ]);
+        mockAvailabilityService.getTerminalItems.mockResolvedValue([createMockTerminalQuickPickItem(terminal1), createMockTerminalQuickPickItem(terminal2)]);
         showTerminalPickerSpy.mockResolvedValue(undefined);
-        command = new BindToTerminalCommand(
-          mockAdapter,
-          mockAvailabilityService,
-          mockDestinationManager,
-          mockSession,
-          mockLogger,
-        );
+        command = new BindToTerminalCommand(mockAdapter, mockAvailabilityService, mockDestinationManager, mockSession, mockLogger);
 
         const result = await command.execute();
 
         expect(result).toStrictEqual({ outcome: 'cancelled' });
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'BindToTerminalCommand.execute' },
-          'User cancelled terminal picker',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToTerminalCommand.execute' }, 'User cancelled terminal picker');
         expect(mockDestinationManager.bind).not.toHaveBeenCalled();
       });
 
@@ -230,18 +161,13 @@ describe('BindToTerminalCommand', () => {
         const terminal1 = createMockTerminal({ name: 'Terminal 1' });
         const terminal2 = createMockTerminal({ name: 'Terminal 2' });
         mockAdapter = createMockVscodeAdapter();
-        mockAvailabilityService.getTerminalItems.mockResolvedValue([
-          createMockTerminalQuickPickItem(terminal1),
-          createMockTerminalQuickPickItem(terminal2),
-        ]);
+        mockAvailabilityService.getTerminalItems.mockResolvedValue([createMockTerminalQuickPickItem(terminal1), createMockTerminalQuickPickItem(terminal2)]);
         const bindError = new RangeLinkExtensionError({
           code: RangeLinkExtensionErrorCodes.DESTINATION_BIND_FAILED,
           message: 'Terminal bind failed',
           functionName: 'PasteDestinationManager.bind',
         });
-        (mockDestinationManager.bind as jest.Mock).mockResolvedValue(
-          ExtensionResult.err(bindError),
-        );
+        (mockDestinationManager.bind as jest.Mock).mockResolvedValue(ExtensionResult.err(bindError));
         showTerminalPickerSpy.mockImplementation(
           (
             _terminals: readonly TerminalBindableQuickPickItem[],
@@ -249,18 +175,10 @@ describe('BindToTerminalCommand', () => {
             handlers: TerminalPickerHandlers<ExtensionResult<BindSuccessInfo>>,
             _logger: unknown,
           ) => {
-            return handlers.onSelected(
-              createMockEligibleTerminal({ terminal: terminal2, name: 'Terminal 2' }),
-            );
+            return handlers.onSelected(createMockEligibleTerminal({ terminal: terminal2, name: 'Terminal 2' }));
           },
         );
-        command = new BindToTerminalCommand(
-          mockAdapter,
-          mockAvailabilityService,
-          mockDestinationManager,
-          mockSession,
-          mockLogger,
-        );
+        command = new BindToTerminalCommand(mockAdapter, mockAvailabilityService, mockDestinationManager, mockSession, mockLogger);
 
         const result = await command.execute();
 
@@ -279,21 +197,12 @@ describe('BindToTerminalCommand', () => {
           createMockTerminalQuickPickItem(terminal2),
         ]);
         showTerminalPickerSpy.mockResolvedValue(undefined);
-        command = new BindToTerminalCommand(
-          mockAdapter,
-          mockAvailabilityService,
-          mockDestinationManager,
-          mockSession,
-          mockLogger,
-        );
+        command = new BindToTerminalCommand(mockAdapter, mockAvailabilityService, mockDestinationManager, mockSession, mockLogger);
 
         await command.execute();
 
         expect(showTerminalPickerSpy).toHaveBeenCalledWith(
-          [
-            createMockTerminalQuickPickItem(terminal1, true),
-            createMockTerminalQuickPickItem(terminal2),
-          ],
+          [createMockTerminalQuickPickItem(terminal1, true), createMockTerminalQuickPickItem(terminal2)],
           mockAdapter,
           {
             getPlaceholder: expect.any(Function),
@@ -314,13 +223,7 @@ describe('BindToTerminalCommand', () => {
             destinationKind: 'terminal',
           }),
         );
-        command = new BindToTerminalCommand(
-          mockAdapter,
-          mockAvailabilityService,
-          mockDestinationManager,
-          mockSession,
-          mockLogger,
-        );
+        command = new BindToTerminalCommand(mockAdapter, mockAvailabilityService, mockDestinationManager, mockSession, mockLogger);
 
         const result = await command.execute(terminal);
 
@@ -355,16 +258,8 @@ describe('BindToTerminalCommand', () => {
           functionName: 'PasteDestinationManager.bind',
         });
         mockAdapter = createMockVscodeAdapter();
-        (mockDestinationManager.bind as jest.Mock).mockResolvedValue(
-          ExtensionResult.err(bindError) as ExtensionResult<BindSuccessInfo>,
-        );
-        command = new BindToTerminalCommand(
-          mockAdapter,
-          mockAvailabilityService,
-          mockDestinationManager,
-          mockSession,
-          mockLogger,
-        );
+        (mockDestinationManager.bind as jest.Mock).mockResolvedValue(ExtensionResult.err(bindError) as ExtensionResult<BindSuccessInfo>);
+        command = new BindToTerminalCommand(mockAdapter, mockAvailabilityService, mockDestinationManager, mockSession, mockLogger);
 
         const result = await command.execute(terminal);
 
@@ -376,27 +271,14 @@ describe('BindToTerminalCommand', () => {
       it('falls through to picker-flow logic when preferredTerminal is omitted', async () => {
         const terminal = createMockTerminal({ name: 'Only Terminal' });
         mockAdapter = createMockVscodeAdapter();
-        mockAvailabilityService.getTerminalItems.mockResolvedValue([
-          createMockTerminalQuickPickItem(terminal),
-        ]);
-        (mockDestinationManager.bind as jest.Mock).mockResolvedValue(
-          ExtensionResult.ok({ destinationName: 'Only Terminal', destinationKind: 'terminal' }),
-        );
-        command = new BindToTerminalCommand(
-          mockAdapter,
-          mockAvailabilityService,
-          mockDestinationManager,
-          mockSession,
-          mockLogger,
-        );
+        mockAvailabilityService.getTerminalItems.mockResolvedValue([createMockTerminalQuickPickItem(terminal)]);
+        (mockDestinationManager.bind as jest.Mock).mockResolvedValue(ExtensionResult.ok({ destinationName: 'Only Terminal', destinationKind: 'terminal' }));
+        command = new BindToTerminalCommand(mockAdapter, mockAvailabilityService, mockDestinationManager, mockSession, mockLogger);
 
         await command.execute();
 
         expect(mockAvailabilityService.getTerminalItems).toHaveBeenCalledWith(Infinity, undefined);
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'BindToTerminalCommand.execute', terminalName: 'Only Terminal' },
-          'Single terminal, auto-binding',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToTerminalCommand.execute', terminalName: 'Only Terminal' }, 'Single terminal, auto-binding');
       });
 
       it('rejects context-menu bind on an extension-managed pty terminal', async () => {
@@ -409,13 +291,7 @@ describe('BindToTerminalCommand', () => {
           },
         });
         mockAdapter = createMockVscodeAdapter();
-        command = new BindToTerminalCommand(
-          mockAdapter,
-          mockAvailabilityService,
-          mockDestinationManager,
-          mockSession,
-          mockLogger,
-        );
+        command = new BindToTerminalCommand(mockAdapter, mockAvailabilityService, mockDestinationManager, mockSession, mockLogger);
 
         const result = await command.execute(ptyTerminal);
 
@@ -442,21 +318,13 @@ describe('BindToTerminalCommand', () => {
           exitStatus: { code: 0, reason: 1 },
         });
         mockAdapter = createMockVscodeAdapter();
-        command = new BindToTerminalCommand(
-          mockAdapter,
-          mockAvailabilityService,
-          mockDestinationManager,
-          mockSession,
-          mockLogger,
-        );
+        command = new BindToTerminalCommand(mockAdapter, mockAvailabilityService, mockDestinationManager, mockSession, mockLogger);
 
         const result = await command.execute(exitedTerminal);
 
         expect(result).toStrictEqual({ outcome: 'cancelled' });
         expect(mockDestinationManager.bind).not.toHaveBeenCalled();
-        expect(mockAdapter.__getVscodeInstance().window.showErrorMessage).toHaveBeenCalledWith(
-          'Cannot bind to "dead-shell": this terminal is not bindable.',
-        );
+        expect(mockAdapter.__getVscodeInstance().window.showErrorMessage).toHaveBeenCalledWith('Cannot bind to "dead-shell": this terminal is not bindable.');
         expect(mockLogger.debug).toHaveBeenCalledWith(
           {
             fn: 'BindToTerminalCommand.execute',

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/BindToTextEditorCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/BindToTextEditorCommand.test.ts
@@ -37,48 +37,31 @@ describe('BindToTextEditorCommand', () => {
     mockSession = createMockBoundSession();
     mockLogger = createMockLogger();
     showFilePickerSpy = spyOnShowFilePicker();
-    command = new BindToTextEditorCommand(
-      mockAdapter,
-      mockAvailabilityService,
-      mockDestinationManager,
-      mockSession,
-      mockLogger,
-    );
+    command = new BindToTextEditorCommand(mockAdapter, mockAvailabilityService, mockDestinationManager, mockSession, mockLogger);
   });
 
   it('logs initialization in constructor', () => {
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'BindToTextEditorCommand.constructor' },
-      'BindToTextEditorCommand initialized',
-    );
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToTextEditorCommand.constructor' }, 'BindToTextEditorCommand initialized');
   });
 
   describe('executeWithPicker (no URI)', () => {
     it('shows error and returns no-resource when no files are available', async () => {
       mockAvailabilityService.getAllFileItems.mockReturnValue([]);
-      const showErrorMessageMock = mockAdapter.__getVscodeInstance().window
-        .showErrorMessage as jest.Mock;
+      const showErrorMessageMock = mockAdapter.__getVscodeInstance().window.showErrorMessage as jest.Mock;
 
       const result = await command.execute();
 
       expect(result).toStrictEqual({ outcome: 'no-resource' });
-      expect(showErrorMessageMock).toHaveBeenCalledWith(
-        'No bindable text editor. Open a file and try again.',
-      );
+      expect(showErrorMessageMock).toHaveBeenCalledWith('No bindable text editor. Open a file and try again.');
       expect(showFilePickerSpy).not.toHaveBeenCalled();
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'BindToTextEditorCommand.executeWithPicker' },
-        'No files available',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToTextEditorCommand.executeWithPicker' }, 'No files available');
     });
 
     it('auto-binds without showing a picker when only 1 file is available', async () => {
       const eligibleFile = createMockEligibleFile({ filename: 'app.ts', viewColumn: 1 });
       const fileItem = createMockTextEditorQuickPickItem(eligibleFile);
       mockAvailabilityService.getAllFileItems.mockReturnValue([fileItem]);
-      mockDestinationManager.bind.mockResolvedValue(
-        ExtensionResult.ok({ destinationName: 'app.ts', destinationKind: 'text-editor' }),
-      );
+      mockDestinationManager.bind.mockResolvedValue(ExtensionResult.ok({ destinationName: 'app.ts', destinationKind: 'text-editor' }));
 
       const result = await command.execute();
 
@@ -88,10 +71,7 @@ describe('BindToTextEditorCommand', () => {
         bindInfo: { destinationName: 'app.ts', destinationKind: 'text-editor' },
       });
       expect(mockDestinationManager.bind).toHaveBeenCalledWith(eligibleFile.bindOptions);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'BindToTextEditorCommand.executeWithPicker', filename: 'app.ts' },
-        'Single file, auto-binding',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToTextEditorCommand.executeWithPicker', filename: 'app.ts' }, 'Single file, auto-binding');
     });
 
     it('returns cancelled when user dismisses the file picker', async () => {
@@ -116,16 +96,10 @@ describe('BindToTextEditorCommand', () => {
         createMockTextEditorQuickPickItem(eligibleFile1),
         createMockTextEditorQuickPickItem(eligibleFile2),
       ]);
-      mockDestinationManager.bind.mockResolvedValue(
-        ExtensionResult.ok({ destinationName: 'utils.ts', destinationKind: 'text-editor' }),
-      );
+      mockDestinationManager.bind.mockResolvedValue(ExtensionResult.ok({ destinationName: 'utils.ts', destinationKind: 'text-editor' }));
       showFilePickerSpy.mockImplementation(
-        (
-          _files: readonly FileBindableQuickPickItem[],
-          _provider: unknown,
-          handlers: FilePickerHandlers<unknown>,
-          _logger: unknown,
-        ) => handlers.onSelected(eligibleFile2),
+        (_files: readonly FileBindableQuickPickItem[], _provider: unknown, handlers: FilePickerHandlers<unknown>, _logger: unknown) =>
+          handlers.onSelected(eligibleFile2),
       );
 
       const result = await command.execute();
@@ -135,10 +109,7 @@ describe('BindToTextEditorCommand', () => {
         bindInfo: { destinationName: 'utils.ts', destinationKind: 'text-editor' },
       });
       expect(mockDestinationManager.bind).toHaveBeenCalledWith(eligibleFile2.bindOptions);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'BindToTextEditorCommand.executeWithPicker', fileCount: 2 },
-        'Starting bind to text editor command',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToTextEditorCommand.executeWithPicker', fileCount: 2 }, 'Starting bind to text editor command');
     });
 
     it('returns bind-failed when bind fails after selection from the picker', async () => {
@@ -155,12 +126,8 @@ describe('BindToTextEditorCommand', () => {
       });
       mockDestinationManager.bind.mockResolvedValue(ExtensionResult.err(bindError));
       showFilePickerSpy.mockImplementation(
-        (
-          _files: readonly FileBindableQuickPickItem[],
-          _provider: unknown,
-          handlers: FilePickerHandlers<unknown>,
-          _logger: unknown,
-        ) => handlers.onSelected(eligibleFile1),
+        (_files: readonly FileBindableQuickPickItem[], _provider: unknown, handlers: FilePickerHandlers<unknown>, _logger: unknown) =>
+          handlers.onSelected(eligibleFile1),
       );
 
       const result = await command.execute();
@@ -178,28 +145,13 @@ describe('BindToTextEditorCommand', () => {
       mockSession.isSet.mockReturnValue(true);
       mockSession.get.mockReturnValue(boundEditorDest);
       mockAvailabilityService.getAllFileItems.mockReturnValue([]);
-      command = new BindToTextEditorCommand(
-        mockAdapter,
-        mockAvailabilityService,
-        mockDestinationManager,
-        mockSession,
-        mockLogger,
-      );
+      command = new BindToTextEditorCommand(mockAdapter, mockAvailabilityService, mockDestinationManager, mockSession, mockLogger);
 
       await command.execute();
 
-      expect(mockAvailabilityService.getAllFileItems).toHaveBeenCalledWith(
-        'file:///workspace/src/bound.ts',
-        3,
-      );
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'BindToTextEditorCommand.executeWithPicker', fileCount: 0 },
-        'Starting bind to text editor command',
-      );
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'BindToTextEditorCommand.executeWithPicker' },
-        'No files available',
-      );
+      expect(mockAvailabilityService.getAllFileItems).toHaveBeenCalledWith('file:///workspace/src/bound.ts', 3);
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToTextEditorCommand.executeWithPicker', fileCount: 0 }, 'Starting bind to text editor command');
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToTextEditorCommand.executeWithPicker' }, 'No files available');
     });
 
     it('passes no bound state to getAllFileItems when nothing is bound', async () => {
@@ -208,14 +160,8 @@ describe('BindToTextEditorCommand', () => {
       await command.execute();
 
       expect(mockAvailabilityService.getAllFileItems).toHaveBeenCalledWith(undefined, undefined);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'BindToTextEditorCommand.executeWithPicker', fileCount: 0 },
-        'Starting bind to text editor command',
-      );
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'BindToTextEditorCommand.executeWithPicker' },
-        'No files available',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToTextEditorCommand.executeWithPicker', fileCount: 0 }, 'Starting bind to text editor command');
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToTextEditorCommand.executeWithPicker' }, 'No files available');
     });
 
     it('invokes getPlaceholder callback when multiple files trigger the picker', async () => {
@@ -225,17 +171,11 @@ describe('BindToTextEditorCommand', () => {
         createMockTextEditorQuickPickItem(eligibleFile1),
         createMockTextEditorQuickPickItem(eligibleFile2),
       ]);
-      showFilePickerSpy.mockImplementation(
-        (
-          _files: readonly FileBindableQuickPickItem[],
-          _provider: unknown,
-          handlers: FilePickerHandlers<unknown>,
-        ) => {
-          const placeholder = handlers.getPlaceholder();
-          expect(placeholder).toBe('Select file to bind to');
-          return undefined;
-        },
-      );
+      showFilePickerSpy.mockImplementation((_files: readonly FileBindableQuickPickItem[], _provider: unknown, handlers: FilePickerHandlers<unknown>) => {
+        const placeholder = handlers.getPlaceholder();
+        expect(placeholder).toBe('Select file to bind to');
+        return undefined;
+      });
 
       await command.execute();
 
@@ -247,14 +187,10 @@ describe('BindToTextEditorCommand', () => {
     it('opens file and binds when file is not in any tab group', async () => {
       const uri = createMockUri('/workspace/src/new-file.ts');
       const mockEditor = createMockEditor({ viewColumn: 1 });
-      const showTextDocSpy = jest
-        .spyOn(mockAdapter, 'showTextDocument')
-        .mockResolvedValue(mockEditor);
+      const showTextDocSpy = jest.spyOn(mockAdapter, 'showTextDocument').mockResolvedValue(mockEditor);
       const vscodeInstance = mockAdapter.__getVscodeInstance();
       vscodeInstance.window.tabGroups = createMockTabGroups({ all: [] });
-      mockDestinationManager.bind.mockResolvedValue(
-        ExtensionResult.ok({ destinationName: 'new-file.ts', destinationKind: 'text-editor' }),
-      );
+      mockDestinationManager.bind.mockResolvedValue(ExtensionResult.ok({ destinationName: 'new-file.ts', destinationKind: 'text-editor' }));
 
       const result = await command.execute(uri);
 
@@ -263,10 +199,7 @@ describe('BindToTextEditorCommand', () => {
         bindInfo: { destinationName: 'new-file.ts', destinationKind: 'text-editor' },
       });
       expect(showTextDocSpy).toHaveBeenCalledWith(uri, undefined);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'BindToTextEditorCommand.executeWithUri', matchCount: 0 },
-        'Found tab groups containing URI',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToTextEditorCommand.executeWithUri', matchCount: 0 }, 'Found tab groups containing URI');
     });
 
     it('focuses existing tab group when file is in exactly one group', async () => {
@@ -274,14 +207,10 @@ describe('BindToTextEditorCommand', () => {
       const tab = createMockTab(uri);
       const group = createMockTabGroup([tab], { viewColumn: 2 });
       const mockEditor = createMockEditor({ viewColumn: 2 });
-      const showTextDocSpy = jest
-        .spyOn(mockAdapter, 'showTextDocument')
-        .mockResolvedValue(mockEditor);
+      const showTextDocSpy = jest.spyOn(mockAdapter, 'showTextDocument').mockResolvedValue(mockEditor);
       const vscodeInstance = mockAdapter.__getVscodeInstance();
       vscodeInstance.window.tabGroups = createMockTabGroups({ all: [group] });
-      mockDestinationManager.bind.mockResolvedValue(
-        ExtensionResult.ok({ destinationName: 'existing.ts', destinationKind: 'text-editor' }),
-      );
+      mockDestinationManager.bind.mockResolvedValue(ExtensionResult.ok({ destinationName: 'existing.ts', destinationKind: 'text-editor' }));
 
       const result = await command.execute(uri);
 
@@ -304,9 +233,7 @@ describe('BindToTextEditorCommand', () => {
         label: 'Group 3',
         viewColumn: 3,
       } as any);
-      mockDestinationManager.bind.mockResolvedValue(
-        ExtensionResult.ok({ destinationName: 'shared.ts', destinationKind: 'text-editor' }),
-      );
+      mockDestinationManager.bind.mockResolvedValue(ExtensionResult.ok({ destinationName: 'shared.ts', destinationKind: 'text-editor' }));
 
       const result = await command.execute(uri);
 
@@ -336,10 +263,7 @@ describe('BindToTextEditorCommand', () => {
 
       expect(result).toStrictEqual({ outcome: 'cancelled' });
       expect(mockDestinationManager.bind).not.toHaveBeenCalled();
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'BindToTextEditorCommand.executeWithUri' },
-        'User cancelled tab group picker',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BindToTextEditorCommand.executeWithUri' }, 'User cancelled tab group picker');
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/GoToRangeLinkCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/GoToRangeLinkCommand.test.ts
@@ -3,13 +3,7 @@ import { createMockNavigationHandler, createMockVscodeAdapter } from '../helpers
 
 import { DetailedResult } from '@couimet/detailed-result';
 import { createMockLogger } from '@couimet/logger-contract-testing';
-import {
-  LinkType,
-  ParsedLink,
-  RangeLinkError,
-  RangeLinkErrorCodes,
-  SelectionType,
-} from 'rangelink-core-ts';
+import { LinkType, ParsedLink, RangeLinkError, RangeLinkErrorCodes, SelectionType } from 'rangelink-core-ts';
 
 describe('GoToRangeLinkCommand', () => {
   let mockLogger: ReturnType<typeof createMockLogger>;
@@ -26,10 +20,7 @@ describe('GoToRangeLinkCommand', () => {
 
       new GoToRangeLinkCommand(mockAdapter, mockNavigationHandler, mockLogger);
 
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'GoToRangeLinkCommand.constructor' },
-        'GoToRangeLinkCommand initialized',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'GoToRangeLinkCommand.constructor' }, 'GoToRangeLinkCommand initialized');
     });
   });
 
@@ -52,10 +43,7 @@ describe('GoToRangeLinkCommand', () => {
         });
         expect(mockNavigationHandler.parseLink).not.toHaveBeenCalled();
         expect(mockNavigationHandler.navigateToLink).not.toHaveBeenCalled();
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'GoToRangeLinkCommand.execute' },
-          'User cancelled input',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'GoToRangeLinkCommand.execute' }, 'User cancelled input');
       });
     });
 
@@ -76,10 +64,7 @@ describe('GoToRangeLinkCommand', () => {
         expect(mockShowErrorMessage).toHaveBeenCalledWith('Please enter a link to navigate');
         expect(mockNavigationHandler.parseLink).not.toHaveBeenCalled();
         expect(mockNavigationHandler.navigateToLink).not.toHaveBeenCalled();
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'GoToRangeLinkCommand.execute' },
-          'Empty input provided',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'GoToRangeLinkCommand.execute' }, 'Empty input provided');
       });
 
       it('shows error message when input is whitespace only', async () => {
@@ -98,10 +83,7 @@ describe('GoToRangeLinkCommand', () => {
         expect(mockShowErrorMessage).toHaveBeenCalledWith('Please enter a link to navigate');
         expect(mockNavigationHandler.parseLink).not.toHaveBeenCalled();
         expect(mockNavigationHandler.navigateToLink).not.toHaveBeenCalled();
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'GoToRangeLinkCommand.execute' },
-          'Empty input provided',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'GoToRangeLinkCommand.execute' }, 'Empty input provided');
       });
     });
 
@@ -128,9 +110,7 @@ describe('GoToRangeLinkCommand', () => {
         await command.execute();
 
         expect(mockNavigationHandler.parseLink).toHaveBeenCalledWith(invalidInput);
-        expect(mockShowErrorMessage).toHaveBeenCalledWith(
-          "Invalid link format: 'not-a-valid-link'",
-        );
+        expect(mockShowErrorMessage).toHaveBeenCalledWith("Invalid link format: 'not-a-valid-link'");
         expect(mockNavigationHandler.navigateToLink).not.toHaveBeenCalled();
         expect(mockLogger.debug).toHaveBeenCalledWith(
           {
@@ -197,22 +177,10 @@ describe('GoToRangeLinkCommand', () => {
         await command.execute();
 
         expect(mockNavigationHandler.parseLink).toHaveBeenCalledWith(validLink);
-        expect(mockNavigationHandler.navigateToLink).toHaveBeenCalledWith(
-          mockParsedLink,
-          validLink,
-        );
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'GoToRangeLinkCommand.execute' },
-          'Showing input box for RangeLink',
-        );
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'GoToRangeLinkCommand.execute', input: validLink },
-          'Parsing RangeLink',
-        );
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'GoToRangeLinkCommand.execute', parsed: mockParsedLink },
-          'Navigating to link',
-        );
+        expect(mockNavigationHandler.navigateToLink).toHaveBeenCalledWith(mockParsedLink, validLink);
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'GoToRangeLinkCommand.execute' }, 'Showing input box for RangeLink');
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'GoToRangeLinkCommand.execute', input: validLink }, 'Parsing RangeLink');
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'GoToRangeLinkCommand.execute', parsed: mockParsedLink }, 'Navigating to link');
       });
 
       it('trims whitespace from input before parsing', async () => {
@@ -230,18 +198,9 @@ describe('GoToRangeLinkCommand', () => {
         await command.execute();
 
         expect(mockNavigationHandler.parseLink).toHaveBeenCalledWith(trimmedLink);
-        expect(mockNavigationHandler.navigateToLink).toHaveBeenCalledWith(
-          mockParsedLink,
-          trimmedLink,
-        );
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'GoToRangeLinkCommand.execute', input: trimmedLink },
-          'Parsing RangeLink',
-        );
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'GoToRangeLinkCommand.execute', parsed: mockParsedLink },
-          'Navigating to link',
-        );
+        expect(mockNavigationHandler.navigateToLink).toHaveBeenCalledWith(mockParsedLink, trimmedLink);
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'GoToRangeLinkCommand.execute', input: trimmedLink }, 'Parsing RangeLink');
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'GoToRangeLinkCommand.execute', parsed: mockParsedLink }, 'Navigating to link');
       });
     });
   });

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/JumpToDestinationCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/JumpToDestinationCommand.test.ts
@@ -1,32 +1,19 @@
 import { JumpToDestinationCommand } from '../../commands';
-import type {
-  BoundSession,
-  DestinationPicker,
-  FocusSuccessInfo,
-  PasteDestinationManager,
-} from '../../destinations';
+import type { BoundSession, DestinationPicker, FocusSuccessInfo, PasteDestinationManager } from '../../destinations';
 import { RangeLinkExtensionError, RangeLinkExtensionErrorCodes } from '../../errors';
 import { messagesEn } from '../../i18n';
 import { BindOptions, DestinationPickerResult, ExtensionResult } from '../../types';
-import {
-  createMockBoundSession,
-  createMockDestinationManager,
-  createMockDestinationPicker,
-} from '../helpers';
+import { createMockBoundSession, createMockDestinationManager, createMockDestinationPicker } from '../helpers';
 
 import { createMockLogger } from '@couimet/logger-contract-testing';
 
 describe('JumpToDestinationCommand message contracts', () => {
   it('placeholder message identifies RangeLink and describes the action', () => {
-    expect(messagesEn['INFO_JUMP_QUICK_PICK_PLACEHOLDER']).toBe(
-      'RangeLink: No destination bound. Choose destination to jump to',
-    );
+    expect(messagesEn['INFO_JUMP_QUICK_PICK_PLACEHOLDER']).toBe('RangeLink: No destination bound. Choose destination to jump to');
   });
 
   it('no-destinations message explains how to resolve the situation', () => {
-    expect(messagesEn['INFO_JUMP_NO_DESTINATIONS_AVAILABLE']).toBe(
-      'No destinations available. Open a terminal, a file, or install an AI assistant extension.',
-    );
+    expect(messagesEn['INFO_JUMP_NO_DESTINATIONS_AVAILABLE']).toBe('No destinations available. Open a terminal, a file, or install an AI assistant extension.');
   });
 });
 
@@ -42,19 +29,11 @@ describe('JumpToDestinationCommand', () => {
     mockSession = createMockBoundSession();
     mockPickerCommand = createMockDestinationPicker();
     mockLogger = createMockLogger();
-    command = new JumpToDestinationCommand(
-      mockDestinationManager,
-      mockSession,
-      mockPickerCommand,
-      mockLogger,
-    );
+    command = new JumpToDestinationCommand(mockDestinationManager, mockSession, mockPickerCommand, mockLogger);
   });
 
   it('logs initialization in constructor', () => {
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'JumpToDestinationCommand.constructor' },
-      'JumpToDestinationCommand initialized',
-    );
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'JumpToDestinationCommand.constructor' }, 'JumpToDestinationCommand initialized');
   });
 
   describe('when destination is already bound', () => {
@@ -77,10 +56,7 @@ describe('JumpToDestinationCommand', () => {
         destinationName: 'Terminal ("bash")',
       });
       expect(mockPickerCommand.pick).not.toHaveBeenCalled();
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'JumpToDestinationCommand.execute' },
-        'Destination already bound, focusing',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'JumpToDestinationCommand.execute' }, 'Destination already bound, focusing');
     });
 
     it('returns focus-failed when focus fails', async () => {
@@ -89,9 +65,7 @@ describe('JumpToDestinationCommand', () => {
         message: 'Failed to focus destination: Terminal ("bash")',
         functionName: 'PasteDestinationManager.focusBoundDestination',
       });
-      mockDestinationManager.focusBoundDestination.mockResolvedValue(
-        ExtensionResult.err(focusError),
-      );
+      mockDestinationManager.focusBoundDestination.mockResolvedValue(ExtensionResult.err(focusError));
 
       const result = await command.execute();
 
@@ -129,14 +103,8 @@ describe('JumpToDestinationCommand', () => {
         placeholderMessageCode: 'INFO_JUMP_QUICK_PICK_PLACEHOLDER',
       });
       expect(mockDestinationManager.bindAndFocus).toHaveBeenCalledWith(bindOptions);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'JumpToDestinationCommand.execute' },
-        'No destination bound, showing picker',
-      );
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'JumpToDestinationCommand.execute' },
-        'Binding selected destination and focusing',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'JumpToDestinationCommand.execute' }, 'No destination bound, showing picker');
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'JumpToDestinationCommand.execute' }, 'Binding selected destination and focusing');
     });
 
     it('returns no-resource when picker reports no destinations available', async () => {
@@ -152,14 +120,8 @@ describe('JumpToDestinationCommand', () => {
         placeholderMessageCode: 'INFO_JUMP_QUICK_PICK_PLACEHOLDER',
       });
       expect(mockDestinationManager.bindAndFocus).not.toHaveBeenCalled();
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'JumpToDestinationCommand.execute' },
-        'No destination bound, showing picker',
-      );
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'JumpToDestinationCommand.execute' },
-        'No destinations available',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'JumpToDestinationCommand.execute' }, 'No destination bound, showing picker');
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'JumpToDestinationCommand.execute' }, 'No destinations available');
     });
 
     it('returns cancelled when user cancels picker', async () => {
@@ -175,10 +137,7 @@ describe('JumpToDestinationCommand', () => {
         placeholderMessageCode: 'INFO_JUMP_QUICK_PICK_PLACEHOLDER',
       });
       expect(mockDestinationManager.bindAndFocus).not.toHaveBeenCalled();
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'JumpToDestinationCommand.execute' },
-        'User cancelled picker',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'JumpToDestinationCommand.execute' }, 'User cancelled picker');
     });
 
     it('returns focus-failed when bindAndFocus fails after picker selection', async () => {
@@ -192,9 +151,7 @@ describe('JumpToDestinationCommand', () => {
         outcome: 'selected',
         bindOptions,
       });
-      mockDestinationManager.bindAndFocus.mockResolvedValue(
-        ExtensionResult.err<FocusSuccessInfo>(bindError),
-      );
+      mockDestinationManager.bindAndFocus.mockResolvedValue(ExtensionResult.err<FocusSuccessInfo>(bindError));
 
       const result = await command.execute();
 
@@ -203,10 +160,7 @@ describe('JumpToDestinationCommand', () => {
         noDestinationsMessageCode: 'INFO_JUMP_NO_DESTINATIONS_AVAILABLE',
         placeholderMessageCode: 'INFO_JUMP_QUICK_PICK_PLACEHOLDER',
       });
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'JumpToDestinationCommand.execute' },
-        'Bind and focus failed',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'JumpToDestinationCommand.execute' }, 'Bind and focus failed');
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/ListBookmarksCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/ListBookmarksCommand.test.ts
@@ -40,10 +40,7 @@ describe('ListBookmarksCommand', () => {
 
       new ListBookmarksCommand(mockAdapter, mockBookmarkService, mockLogger);
 
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'ListBookmarksCommand.constructor' },
-        'ListBookmarksCommand initialized',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ListBookmarksCommand.constructor' }, 'ListBookmarksCommand initialized');
     });
   });
 
@@ -52,9 +49,7 @@ describe('ListBookmarksCommand', () => {
       it('shows empty state when no bookmarks exist', async () => {
         mockBookmarkService.getAllBookmarks.mockReturnValue([]);
         mockAdapter = createMockVscodeAdapter();
-        const showQuickPickSpy = jest
-          .spyOn(mockAdapter, 'showQuickPick')
-          .mockResolvedValue(undefined);
+        const showQuickPickSpy = jest.spyOn(mockAdapter, 'showQuickPick').mockResolvedValue(undefined);
         command = new ListBookmarksCommand(mockAdapter, mockBookmarkService, mockLogger);
 
         await command.execute();
@@ -102,9 +97,7 @@ describe('ListBookmarksCommand', () => {
       it('displays bookmarks with label and detail (full link)', async () => {
         mockBookmarkService.getAllBookmarks.mockReturnValue([TEST_BOOKMARK, TEST_BOOKMARK_2]);
         mockAdapter = createMockVscodeAdapter();
-        const showQuickPickSpy = jest
-          .spyOn(mockAdapter, 'showQuickPick')
-          .mockResolvedValue(undefined);
+        const showQuickPickSpy = jest.spyOn(mockAdapter, 'showQuickPick').mockResolvedValue(undefined);
         command = new ListBookmarksCommand(mockAdapter, mockBookmarkService, mockLogger);
 
         await command.execute();
@@ -153,10 +146,7 @@ describe('ListBookmarksCommand', () => {
 
         await command.execute();
 
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'ListBookmarksCommand.execute' },
-          'User dismissed bookmark list',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ListBookmarksCommand.execute' }, 'User dismissed bookmark list');
         expect(mockBookmarkService.sendBookmark).not.toHaveBeenCalled();
       });
     });
@@ -177,10 +167,7 @@ describe('ListBookmarksCommand', () => {
         await command.execute();
 
         expect(mockBookmarkService.sendBookmark).toHaveBeenCalledWith('bookmark-1');
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'ListBookmarksCommand.handleSelection', bookmarkId: 'bookmark-1' },
-          'Bookmark selected and sent',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ListBookmarksCommand.handleSelection', bookmarkId: 'bookmark-1' }, 'Bookmark selected and sent');
       });
     });
 
@@ -191,9 +178,7 @@ describe('ListBookmarksCommand', () => {
         mockAdapter = createMockVscodeAdapter({
           windowOptions: { showQuickPick: jest.fn().mockResolvedValue(emptyStateItem) },
         });
-        const executeCommandSpy = jest
-          .spyOn(mockAdapter, 'executeCommand')
-          .mockResolvedValue(undefined);
+        const executeCommandSpy = jest.spyOn(mockAdapter, 'executeCommand').mockResolvedValue(undefined);
         command = new ListBookmarksCommand(mockAdapter, mockBookmarkService, mockLogger);
 
         await command.execute();

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/ManageBookmarksCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/ManageBookmarksCommand.test.ts
@@ -2,11 +2,7 @@ import type { Bookmark } from '../../bookmarks';
 import { ManageBookmarksCommand } from '../../commands/ManageBookmarksCommand';
 import { RangeLinkExtensionError, RangeLinkExtensionErrorCodes } from '../../errors';
 import { ExtensionResult } from '../../types';
-import {
-  createMockBookmarkService,
-  createMockQuickPick,
-  createMockVscodeAdapter,
-} from '../helpers';
+import { createMockBookmarkService, createMockQuickPick, createMockVscodeAdapter } from '../helpers';
 
 import { createMockLogger } from '@couimet/logger-contract-testing';
 import * as vscode from 'vscode';
@@ -45,10 +41,7 @@ describe('ManageBookmarksCommand', () => {
     it('logs initialization', () => {
       new ManageBookmarksCommand(mockAdapter, mockBookmarkService, mockLogger);
 
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'ManageBookmarksCommand.constructor' },
-        'ManageBookmarksCommand initialized',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ManageBookmarksCommand.constructor' }, 'ManageBookmarksCommand initialized');
     });
   });
 
@@ -61,10 +54,7 @@ describe('ManageBookmarksCommand', () => {
         await command.execute();
 
         expect(showInfoSpy).toHaveBeenCalledWith('No bookmarks to manage');
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'ManageBookmarksCommand.execute' },
-          'No bookmarks to manage',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ManageBookmarksCommand.execute' }, 'No bookmarks to manage');
       });
     });
 
@@ -98,10 +88,7 @@ describe('ManageBookmarksCommand', () => {
           },
         ]);
         expect(mockQuickPick.show).toHaveBeenCalled();
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'ManageBookmarksCommand.execute', bookmarkCount: 2 },
-          'Showing manage QuickPick',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ManageBookmarksCommand.execute', bookmarkCount: 2 }, 'Showing manage QuickPick');
       });
 
       it('disposes QuickPick on hide', async () => {
@@ -116,10 +103,7 @@ describe('ManageBookmarksCommand', () => {
         mockQuickPick.__triggerHide();
 
         expect(mockQuickPick.dispose).toHaveBeenCalled();
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'ManageBookmarksCommand.showManageQuickPick' },
-          'QuickPick disposed',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ManageBookmarksCommand.showManageQuickPick' }, 'QuickPick disposed');
       });
 
       it('hides QuickPick on accept without action', async () => {
@@ -134,10 +118,7 @@ describe('ManageBookmarksCommand', () => {
         mockQuickPick.__triggerAccept();
 
         expect(mockQuickPick.hide).toHaveBeenCalled();
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'ManageBookmarksCommand.showManageQuickPick' },
-          'User selected item without action',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ManageBookmarksCommand.showManageQuickPick' }, 'User selected item without action');
       });
     });
 
@@ -161,11 +142,7 @@ describe('ManageBookmarksCommand', () => {
           button: deleteButton,
         });
 
-        expect(mockShowWarningMessage).toHaveBeenCalledWith(
-          'Delete bookmark "Test Bookmark"?',
-          'Delete',
-          'Cancel',
-        );
+        expect(mockShowWarningMessage).toHaveBeenCalledWith('Delete bookmark "Test Bookmark"?', 'Delete', 'Cancel');
       });
 
       it('cancels deletion when user selects Cancel', async () => {
@@ -187,10 +164,7 @@ describe('ManageBookmarksCommand', () => {
         });
 
         expect(mockBookmarkService.removeBookmark).not.toHaveBeenCalled();
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'ManageBookmarksCommand.confirmAndDelete', bookmark: TEST_BOOKMARK },
-          'Delete cancelled by user',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ManageBookmarksCommand.confirmAndDelete', bookmark: TEST_BOOKMARK }, 'Delete cancelled by user');
       });
 
       it('cancels deletion when user dismisses dialog', async () => {
@@ -212,16 +186,11 @@ describe('ManageBookmarksCommand', () => {
         });
 
         expect(mockBookmarkService.removeBookmark).not.toHaveBeenCalled();
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'ManageBookmarksCommand.confirmAndDelete', bookmark: TEST_BOOKMARK },
-          'Delete cancelled by user',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ManageBookmarksCommand.confirmAndDelete', bookmark: TEST_BOOKMARK }, 'Delete cancelled by user');
       });
 
       it('deletes bookmark when user confirms', async () => {
-        mockBookmarkService.getAllBookmarks
-          .mockReturnValueOnce([TEST_BOOKMARK])
-          .mockReturnValueOnce([]);
+        mockBookmarkService.getAllBookmarks.mockReturnValueOnce([TEST_BOOKMARK]).mockReturnValueOnce([]);
         const mockQuickPick = createMockQuickPick();
         const mockShowInformationMessage = jest.fn();
         mockAdapter = createMockVscodeAdapter({
@@ -241,9 +210,7 @@ describe('ManageBookmarksCommand', () => {
         });
 
         expect(mockBookmarkService.removeBookmark).toHaveBeenCalledWith('bookmark-1');
-        expect(mockShowInformationMessage).toHaveBeenCalledWith(
-          '✓ Bookmark deleted: Test Bookmark',
-        );
+        expect(mockShowInformationMessage).toHaveBeenCalledWith('✓ Bookmark deleted: Test Bookmark');
         expect(mockLogger.debug).toHaveBeenCalledWith(
           { fn: 'ManageBookmarksCommand.confirmAndDelete', bookmark: TEST_BOOKMARK },
           'Bookmark deleted successfully',
@@ -251,9 +218,7 @@ describe('ManageBookmarksCommand', () => {
       });
 
       it('hides QuickPick when last bookmark deleted', async () => {
-        mockBookmarkService.getAllBookmarks
-          .mockReturnValueOnce([TEST_BOOKMARK])
-          .mockReturnValueOnce([]);
+        mockBookmarkService.getAllBookmarks.mockReturnValueOnce([TEST_BOOKMARK]).mockReturnValueOnce([]);
         const mockQuickPick = createMockQuickPick();
         mockAdapter = createMockVscodeAdapter({
           windowOptions: {
@@ -274,9 +239,7 @@ describe('ManageBookmarksCommand', () => {
       });
 
       it('refreshes items when deleting one of multiple bookmarks', async () => {
-        mockBookmarkService.getAllBookmarks
-          .mockReturnValueOnce([TEST_BOOKMARK, TEST_BOOKMARK_2])
-          .mockReturnValueOnce([TEST_BOOKMARK_2]);
+        mockBookmarkService.getAllBookmarks.mockReturnValueOnce([TEST_BOOKMARK, TEST_BOOKMARK_2]).mockReturnValueOnce([TEST_BOOKMARK_2]);
         const mockQuickPick = createMockQuickPick();
         mockAdapter = createMockVscodeAdapter({
           windowOptions: {

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/ShowVersionCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/ShowVersionCommand.test.ts
@@ -31,10 +31,7 @@ describe('ShowVersionCommand', () => {
 
       new ShowVersionCommand(mockAdapter, mockLogger, CLEAN_VERSION_INFO);
 
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'ShowVersionCommand.constructor' },
-        'ShowVersionCommand initialized',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ShowVersionCommand.constructor' }, 'ShowVersionCommand initialized');
     });
   });
 
@@ -52,10 +49,7 @@ describe('ShowVersionCommand', () => {
         await command.execute();
 
         expect(mockShowErrorMessage).toHaveBeenCalledWith('Version information not available');
-        expect(mockLogger.error).toHaveBeenCalledWith(
-          { fn: 'ShowVersionCommand.execute' },
-          'Failed to load version info',
-        );
+        expect(mockLogger.error).toHaveBeenCalledWith({ fn: 'ShowVersionCommand.execute' }, 'Failed to load version info');
       });
     });
 
@@ -71,10 +65,7 @@ describe('ShowVersionCommand', () => {
 
         await command.execute();
 
-        expect(mockShowInformationMessage).toHaveBeenCalledWith(
-          'RangeLink v1.0.0\nCommit: abc123\nBranch: main\nBuild: 2025-01-16',
-          'Copy Commit Hash',
-        );
+        expect(mockShowInformationMessage).toHaveBeenCalledWith('RangeLink v1.0.0\nCommit: abc123\nBranch: main\nBuild: 2025-01-16', 'Copy Commit Hash');
         expect(mockLogger.info).toHaveBeenCalledWith(
           {
             fn: 'ShowVersionCommand.execute',
@@ -117,10 +108,7 @@ describe('ShowVersionCommand', () => {
 
     describe('when user clicks copy button', () => {
       it('copies full commit hash to clipboard and shows confirmation', async () => {
-        const mockShowInformationMessage = jest
-          .fn()
-          .mockResolvedValueOnce('Copy Commit Hash')
-          .mockResolvedValueOnce(undefined);
+        const mockShowInformationMessage = jest.fn().mockResolvedValueOnce('Copy Commit Hash').mockResolvedValueOnce(undefined);
         const mockClipboard = createMockClipboard();
         const mockAdapter = createMockVscodeAdapter({
           windowOptions: {

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/createBindAIAssistantCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/createBindAIAssistantCommand.test.ts
@@ -1,84 +1,52 @@
 import { createBindAIAssistantCommand } from '../../commands/createBindAIAssistantCommand';
 import { AI_ASSISTANT_KINDS, type AIAssistantDestinationKind } from '../../types';
-import {
-  createMockDestinationAvailabilityService,
-  createMockDestinationManager,
-  createMockVscodeAdapter,
-  spyOnFormatMessage,
-} from '../helpers';
+import { createMockDestinationAvailabilityService, createMockDestinationManager, createMockVscodeAdapter, spyOnFormatMessage } from '../helpers';
 
 import { createMockLogger } from '@couimet/logger-contract-testing';
 
 describe('createBindAIAssistantCommand', () => {
   const mockLogger = createMockLogger();
 
-  it.each(AI_ASSISTANT_KINDS)(
-    'binds to %s when available',
-    async (kind: AIAssistantDestinationKind) => {
-      const mockAvailability = createMockDestinationAvailabilityService();
-      const mockManager = createMockDestinationManager();
-      const mockAdapter = createMockVscodeAdapter();
-      const showInfoSpy = jest.spyOn(mockAdapter, 'showInformationMessage');
+  it.each(AI_ASSISTANT_KINDS)('binds to %s when available', async (kind: AIAssistantDestinationKind) => {
+    const mockAvailability = createMockDestinationAvailabilityService();
+    const mockManager = createMockDestinationManager();
+    const mockAdapter = createMockVscodeAdapter();
+    const showInfoSpy = jest.spyOn(mockAdapter, 'showInformationMessage');
 
-      (mockAvailability.isAIAssistantAvailable as jest.Mock).mockResolvedValue(true);
+    (mockAvailability.isAIAssistantAvailable as jest.Mock).mockResolvedValue(true);
 
-      const handler = createBindAIAssistantCommand(
-        kind,
-        mockAvailability,
-        mockManager,
-        mockAdapter,
-        mockLogger,
-      );
-      await handler();
+    const handler = createBindAIAssistantCommand(kind, mockAvailability, mockManager, mockAdapter, mockLogger);
+    await handler();
 
-      expect(mockAvailability.isAIAssistantAvailable).toHaveBeenCalledWith(kind);
-      expect(mockManager.bind).toHaveBeenCalledWith({ kind });
-      expect(showInfoSpy).not.toHaveBeenCalled();
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: `createBindAIAssistantCommand[${kind}]`, kind },
-        `Executing bind command for ${kind}`,
-      );
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: `createBindAIAssistantCommand[${kind}]`, kind },
-        `Bind command completed for ${kind}`,
-      );
-    },
-  );
+    expect(mockAvailability.isAIAssistantAvailable).toHaveBeenCalledWith(kind);
+    expect(mockManager.bind).toHaveBeenCalledWith({ kind });
+    expect(showInfoSpy).not.toHaveBeenCalled();
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: `createBindAIAssistantCommand[${kind}]`, kind }, `Executing bind command for ${kind}`);
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: `createBindAIAssistantCommand[${kind}]`, kind }, `Bind command completed for ${kind}`);
+  });
 
-  it.each(AI_ASSISTANT_KINDS)(
-    'shows info message when %s is not available',
-    async (kind: AIAssistantDestinationKind) => {
-      const formatMessageSpy = spyOnFormatMessage();
-      const mockAvailability = createMockDestinationAvailabilityService();
-      const mockManager = createMockDestinationManager();
-      const mockAdapter = createMockVscodeAdapter();
-      const showInfoSpy = jest.spyOn(mockAdapter, 'showInformationMessage');
+  it.each(AI_ASSISTANT_KINDS)('shows info message when %s is not available', async (kind: AIAssistantDestinationKind) => {
+    const formatMessageSpy = spyOnFormatMessage();
+    const mockAvailability = createMockDestinationAvailabilityService();
+    const mockManager = createMockDestinationManager();
+    const mockAdapter = createMockVscodeAdapter();
+    const showInfoSpy = jest.spyOn(mockAdapter, 'showInformationMessage');
 
-      const unavailableCode = 'MOCK_UNAVAILABLE_CODE';
-      const renderedMessage = 'Mocked unavailable message';
-      (mockAvailability.isAIAssistantAvailable as jest.Mock).mockResolvedValue(false);
-      (mockAvailability.getUnavailableMessageCode as jest.Mock).mockReturnValue(unavailableCode);
-      formatMessageSpy.mockReturnValue(renderedMessage);
+    const unavailableCode = 'MOCK_UNAVAILABLE_CODE';
+    const renderedMessage = 'Mocked unavailable message';
+    (mockAvailability.isAIAssistantAvailable as jest.Mock).mockResolvedValue(false);
+    (mockAvailability.getUnavailableMessageCode as jest.Mock).mockReturnValue(unavailableCode);
+    formatMessageSpy.mockReturnValue(renderedMessage);
 
-      const handler = createBindAIAssistantCommand(
-        kind,
-        mockAvailability,
-        mockManager,
-        mockAdapter,
-        mockLogger,
-      );
-      await handler();
+    const handler = createBindAIAssistantCommand(kind, mockAvailability, mockManager, mockAdapter, mockLogger);
+    await handler();
 
-      expect(mockAvailability.isAIAssistantAvailable).toHaveBeenCalledWith(kind);
-      expect(mockAvailability.getUnavailableMessageCode).toHaveBeenCalledWith(kind);
-      expect(formatMessageSpy).toHaveBeenCalledWith(unavailableCode);
-      expect(showInfoSpy).toHaveBeenCalledWith(renderedMessage);
+    expect(mockAvailability.isAIAssistantAvailable).toHaveBeenCalledWith(kind);
+    expect(mockAvailability.getUnavailableMessageCode).toHaveBeenCalledWith(kind);
+    expect(formatMessageSpy).toHaveBeenCalledWith(unavailableCode);
+    expect(showInfoSpy).toHaveBeenCalledWith(renderedMessage);
 
-      expect(mockManager.bind).not.toHaveBeenCalled();
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        { fn: `createBindAIAssistantCommand[${kind}]`, kind },
-        `${kind} not available`,
-      );
-    },
-  );
+    expect(mockManager.bind).not.toHaveBeenCalled();
+    expect(mockLogger.info).toHaveBeenCalledWith({ fn: `createBindAIAssistantCommand[${kind}]`, kind }, `${kind} not available`);
+  });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/commands/createBindToCustomAiByIdCommand.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/commands/createBindToCustomAiByIdCommand.test.ts
@@ -29,10 +29,7 @@ describe('createBindToCustomAiByIdCommand', () => {
     });
 
     expect(mockManager.bind).not.toHaveBeenCalled();
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      { fn: 'createBindToCustomAiByIdCommand' },
-      'Invalid or missing arguments for bindToCustomAiById',
-    );
+    expect(mockLogger.warn).toHaveBeenCalledWith({ fn: 'createBindToCustomAiByIdCommand' }, 'Invalid or missing arguments for bindToCustomAiById');
   });
 
   it('returns error when args is null', async () => {
@@ -82,10 +79,7 @@ describe('createBindToCustomAiByIdCommand', () => {
       functionName: 'createBindToCustomAiByIdCommand',
     });
 
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      { fn: 'createBindToCustomAiByIdCommand', argsType: 'object' },
-      'Missing or invalid extensionId in args',
-    );
+    expect(mockLogger.warn).toHaveBeenCalledWith({ fn: 'createBindToCustomAiByIdCommand', argsType: 'object' }, 'Missing or invalid extensionId in args');
   });
 
   it('returns error when extensionId is an empty string', async () => {
@@ -113,9 +107,7 @@ describe('createBindToCustomAiByIdCommand', () => {
   });
 
   it('returns error when resolveKindByExtensionId returns undefined for unknown extensionId', async () => {
-    const resolveSpy = jest
-      .spyOn(destinationBuilders, 'resolveKindByExtensionId')
-      .mockReturnValue(undefined);
+    const resolveSpy = jest.spyOn(destinationBuilders, 'resolveKindByExtensionId').mockReturnValue(undefined);
     const mockManager = createMockDestinationManager();
 
     const handler = createBindToCustomAiByIdCommand([], mockManager, mockLogger);
@@ -131,9 +123,7 @@ describe('createBindToCustomAiByIdCommand', () => {
   });
 
   it('binds a built-in assistant when resolveKindByExtensionId returns a built-in kind', async () => {
-    const resolveSpy = jest
-      .spyOn(destinationBuilders, 'resolveKindByExtensionId')
-      .mockReturnValue('claude-code');
+    const resolveSpy = jest.spyOn(destinationBuilders, 'resolveKindByExtensionId').mockReturnValue('claude-code');
 
     const bindResult = ExtensionResult.ok<BindSuccessInfo>({
       destinationName: 'Claude Code Chat',
@@ -167,9 +157,7 @@ describe('createBindToCustomAiByIdCommand', () => {
     const kind = `custom-ai:${extensionId}` as const;
     const customAssistants = [createCustomConfig(extensionId)];
 
-    const resolveSpy = jest
-      .spyOn(destinationBuilders, 'resolveKindByExtensionId')
-      .mockReturnValue(kind);
+    const resolveSpy = jest.spyOn(destinationBuilders, 'resolveKindByExtensionId').mockReturnValue(kind);
 
     const bindResult = ExtensionResult.ok<BindSuccessInfo>({
       destinationName: 'Custom my-custom.extension',
@@ -200,9 +188,7 @@ describe('createBindToCustomAiByIdCommand', () => {
   });
 
   it('passes bind error through when destinationManager.bind returns an error', async () => {
-    const resolveSpy = jest
-      .spyOn(destinationBuilders, 'resolveKindByExtensionId')
-      .mockReturnValue('gemini-code-assist');
+    const resolveSpy = jest.spyOn(destinationBuilders, 'resolveKindByExtensionId').mockReturnValue('gemini-code-assist');
 
     const bindError = new RangeLinkExtensionError({
       code: RangeLinkExtensionErrorCodes.DESTINATION_BIND_FAILED,

--- a/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
@@ -45,8 +45,7 @@ describe('package.json contributions', () => {
   describe('commands', () => {
     const commands = packageJson.contributes.commands as CommandContribution[];
 
-    const findCommand = (commandId: string): CommandContribution | undefined =>
-      commands.find((cmd) => cmd.command === commandId);
+    const findCommand = (commandId: string): CommandContribution | undefined => commands.find((cmd) => cmd.command === commandId);
 
     describe('link copy commands', () => {
       it('rangelink.copyLinkWithRelativePath', () => {
@@ -519,18 +518,14 @@ describe('package.json contributions', () => {
   });
 
   describe('configuration', () => {
-    const properties = packageJson.contributes.configuration.properties as Record<
-      string,
-      ConfigurationProperty
-    >;
+    const properties = packageJson.contributes.configuration.properties as Record<string, ConfigurationProperty>;
 
     describe('feature flag settings', () => {
       it('rangelink.features.bookmarks.enabled', () => {
         expect(properties['rangelink.features.bookmarks.enabled']).toStrictEqual({
           type: 'boolean',
           default: false,
-          description:
-            'Enable Bookmarks feature (beta). Save code locations for quick access later.',
+          description: 'Enable Bookmarks feature (beta). Save code locations for quick access later.',
           title: 'Feature: Bookmarks',
         });
       });
@@ -546,8 +541,7 @@ describe('package.json contributions', () => {
             'Save and restore clipboard around operations that use it as transport — your prior clipboard content is preserved (default)',
             'Never restore clipboard — clipboard always contains last RangeLink output',
           ],
-          description:
-            'Controls whether RangeLink restores your clipboard after operations that use it as a transport mechanism',
+          description: 'Controls whether RangeLink restores your clipboard after operations that use it as a transport mechanism',
           title: 'Clipboard Preservation',
         });
       });
@@ -569,8 +563,7 @@ describe('package.json contributions', () => {
             properties: {
               extensionId: {
                 type: 'string',
-                description:
-                  'VS Code extension identifier (publisher.name) used to detect availability',
+                description: 'VS Code extension identifier (publisher.name) used to detect availability',
               },
               extensionName: {
                 type: 'string',
@@ -593,8 +586,7 @@ describe('package.json contributions', () => {
                           description: 'VS Code command ID',
                         },
                         args: {
-                          description:
-                            'Argument template — use ${content} as placeholder for the link text',
+                          description: 'Argument template — use ${content} as placeholder for the link text',
                         },
                       },
                       additionalProperties: false,
@@ -687,14 +679,8 @@ describe('package.json contributions', () => {
           type: 'string',
           enum: ['both', 'before', 'after', 'none'],
           default: 'none',
-          enumDescriptions: [
-            'Add space before and after',
-            'Add space before only',
-            'Add space after only',
-            'No padding (paste text exactly as selected)',
-          ],
-          description:
-            'Smart padding for selected text when using Paste Selected Text to Destination (R-V)',
+          enumDescriptions: ['Add space before and after', 'Add space before only', 'Add space after only', 'No padding (paste text exactly as selected)'],
+          description: 'Smart padding for selected text when using Paste Selected Text to Destination (R-V)',
           title: 'Paste: Content Padding',
         });
       });
@@ -737,8 +723,7 @@ describe('package.json contributions', () => {
         expect(properties['rangelink.navigation.showNavigatedToast']).toStrictEqual({
           type: 'boolean',
           default: true,
-          description:
-            "Show info toast after successful navigation (e.g., 'Navigated to recipes/baking/chickenpie.ts @ 3:14-314:16')",
+          description: "Show info toast after successful navigation (e.g., 'Navigated to recipes/baking/chickenpie.ts @ 3:14-314:16')",
           title: 'Navigation: Show Confirmation Toast',
         });
       });
@@ -770,8 +755,7 @@ describe('package.json contributions', () => {
           type: 'number',
           default: 5,
           minimum: 1,
-          description:
-            "Maximum terminals shown inline in destination picker (extras collapsed into 'More terminals...')",
+          description: "Maximum terminals shown inline in destination picker (extras collapsed into 'More terminals...')",
           title: 'Terminal Picker: Max Inline Items',
         });
       });
@@ -791,17 +775,14 @@ describe('package.json contributions', () => {
       });
 
       it('rangelink.destinations.claudeCode.coldRefocusIntervalMs', () => {
-        expect(properties['rangelink.destinations.claudeCode.coldRefocusIntervalMs']).toStrictEqual(
-          {
-            type: 'number',
-            default: 300,
-            minimum: 100,
-            maximum: 5000,
-            description:
-              'Interval (ms) between successive focus-command re-sends during the Claude Code cold-start window.',
-            title: 'Claude Code Cold Re-focus Interval',
-          },
-        );
+        expect(properties['rangelink.destinations.claudeCode.coldRefocusIntervalMs']).toStrictEqual({
+          type: 'number',
+          default: 300,
+          minimum: 100,
+          maximum: 5000,
+          description: 'Interval (ms) between successive focus-command re-sends during the Claude Code cold-start window.',
+          title: 'Claude Code Cold Re-focus Interval',
+        });
       });
 
       it('rangelink.destinations.gemini.coldStartDelayMs', () => {
@@ -822,8 +803,7 @@ describe('package.json contributions', () => {
           default: 300,
           minimum: 100,
           maximum: 5000,
-          description:
-            'Interval (ms) at which RangeLink re-sends the Gemini focus signal during the cold-start period. Must be less than coldStartDelayMs.',
+          description: 'Interval (ms) at which RangeLink re-sends the Gemini focus signal during the cold-start period. Must be less than coldStartDelayMs.',
           title: 'Gemini Code Assist Cold Re-focus Interval',
         });
       });
@@ -857,8 +837,7 @@ describe('package.json contributions', () => {
   describe('keybindings', () => {
     const keybindings = packageJson.contributes.keybindings as KeybindingContribution[];
 
-    const findKeybinding = (commandId: string): KeybindingContribution | undefined =>
-      keybindings.find((kb) => kb.command === commandId);
+    const findKeybinding = (commandId: string): KeybindingContribution | undefined => keybindings.find((kb) => kb.command === commandId);
 
     it('rangelink.copyLinkWithRelativePath keybinding', () => {
       expect(findKeybinding('rangelink.copyLinkWithRelativePath')).toStrictEqual({
@@ -1034,9 +1013,7 @@ describe('package.json contributions', () => {
 
   describe('menus', () => {
     describe('editor/context', () => {
-      const editorContextMenu = packageJson.contributes.menus[
-        'editor/context'
-      ] as MenuContribution[];
+      const editorContextMenu = packageJson.contributes.menus['editor/context'] as MenuContribution[];
 
       it('has the expected number of editor context menu items', () => {
         expect(editorContextMenu).toHaveLength(10);
@@ -1124,9 +1101,7 @@ describe('package.json contributions', () => {
     });
 
     describe('editor/title/context', () => {
-      const editorTitleContextMenu = packageJson.contributes.menus[
-        'editor/title/context'
-      ] as MenuContribution[];
+      const editorTitleContextMenu = packageJson.contributes.menus['editor/title/context'] as MenuContribution[];
 
       it('has the expected number of editor title context menu items', () => {
         expect(editorTitleContextMenu).toHaveLength(4);
@@ -1166,9 +1141,7 @@ describe('package.json contributions', () => {
     });
 
     describe('explorer/context', () => {
-      const explorerContextMenu = packageJson.contributes.menus[
-        'explorer/context'
-      ] as MenuContribution[];
+      const explorerContextMenu = packageJson.contributes.menus['explorer/context'] as MenuContribution[];
 
       it('has the expected number of explorer context menu items', () => {
         expect(explorerContextMenu).toHaveLength(4);
@@ -1208,8 +1181,7 @@ describe('package.json contributions', () => {
     describe('commandPalette', () => {
       const commandPalette = packageJson.contributes.menus['commandPalette'] as MenuContribution[];
 
-      const findEntry = (commandId: string): MenuContribution | undefined =>
-        commandPalette.find((entry) => entry.command === commandId);
+      const findEntry = (commandId: string): MenuContribution | undefined => commandPalette.find((entry) => entry.command === commandId);
 
       it('has the expected number of commandPalette entries', () => {
         expect(commandPalette).toHaveLength(29);
@@ -1420,9 +1392,7 @@ describe('package.json contributions', () => {
     });
 
     describe('terminal/title/context', () => {
-      const terminalTitleContextMenu = packageJson.contributes.menus[
-        'terminal/title/context'
-      ] as MenuContribution[];
+      const terminalTitleContextMenu = packageJson.contributes.menus['terminal/title/context'] as MenuContribution[];
 
       it('has the expected number of terminal title context menu items', () => {
         expect(terminalTitleContextMenu).toHaveLength(2);
@@ -1446,9 +1416,7 @@ describe('package.json contributions', () => {
     });
 
     describe('terminal/context', () => {
-      const terminalContextMenu = packageJson.contributes.menus[
-        'terminal/context'
-      ] as MenuContribution[];
+      const terminalContextMenu = packageJson.contributes.menus['terminal/context'] as MenuContribution[];
 
       it('has the expected number of terminal context menu items', () => {
         expect(terminalContextMenu).toHaveLength(3);

--- a/packages/rangelink-vscode-extension/src/__tests__/contextKeys/ContextKeyService.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/contextKeys/ContextKeyService.test.ts
@@ -22,8 +22,7 @@ describe('ContextKeyService', () => {
   let logger: ReturnType<typeof createMockLogger>;
   let setContextSpy: jest.SpyInstance;
 
-  const createService = (): ContextKeyService =>
-    new ContextKeyService(adapter, session as any, logger);
+  const createService = (): ContextKeyService => new ContextKeyService(adapter, session as any, logger);
 
   beforeEach(() => {
     adapter = createMockVscodeAdapter();
@@ -40,10 +39,7 @@ describe('ContextKeyService', () => {
     createService();
 
     expect(setContextSpy).toHaveBeenCalledWith('rangelink.isBound', false);
-    expect(logger.debug).toHaveBeenCalledWith(
-      { fn: 'ContextKeyService.updateIsBound', isBound: false },
-      'Evaluating isBound context key',
-    );
+    expect(logger.debug).toHaveBeenCalledWith({ fn: 'ContextKeyService.updateIsBound', isBound: false }, 'Evaluating isBound context key');
   });
 
   it('sets isBound=true on construction when a destination is bound', () => {
@@ -52,10 +48,7 @@ describe('ContextKeyService', () => {
     createService();
 
     expect(setContextSpy).toHaveBeenCalledWith('rangelink.isBound', true);
-    expect(logger.debug).toHaveBeenCalledWith(
-      { fn: 'ContextKeyService.updateIsBound', isBound: true },
-      'Evaluating isBound context key',
-    );
+    expect(logger.debug).toHaveBeenCalledWith({ fn: 'ContextKeyService.updateIsBound', isBound: true }, 'Evaluating isBound context key');
   });
 
   // --- isActiveTerminalBindable ---
@@ -189,10 +182,7 @@ describe('ContextKeyService', () => {
   it('logs initialization on construction', () => {
     createService();
 
-    expect(logger.debug).toHaveBeenCalledWith(
-      { fn: 'ContextKeyService' },
-      'ContextKeyService initializing all context keys',
-    );
+    expect(logger.debug).toHaveBeenCalledWith({ fn: 'ContextKeyService' }, 'ContextKeyService initializing all context keys');
   });
 
   // --- re-evaluation ---
@@ -238,10 +228,7 @@ describe('ContextKeyService', () => {
     session._emitter.fire({ id: 'terminal', displayName: 'Terminal ("zsh")' });
 
     expect(setContextSpy).toHaveBeenCalledWith('rangelink.isBound', true);
-    expect(logger.debug).toHaveBeenCalledWith(
-      { fn: 'ContextKeyService.updateIsBound', isBound: true },
-      'Evaluating isBound context key',
-    );
+    expect(logger.debug).toHaveBeenCalledWith({ fn: 'ContextKeyService.updateIsBound', isBound: true }, 'Evaluating isBound context key');
   });
 
   // --- getLastSetValues ---
@@ -282,9 +269,7 @@ describe('ContextKeyService', () => {
     const boundDisposable = { dispose: jest.fn() };
     (vscodeMock.window.onDidOpenTerminal as jest.Mock).mockReturnValueOnce(openDisposable);
     (vscodeMock.window.onDidCloseTerminal as jest.Mock).mockReturnValueOnce(closeDisposable);
-    (vscodeMock.window.onDidChangeActiveTerminal as jest.Mock).mockReturnValueOnce(
-      changeDisposable,
-    );
+    (vscodeMock.window.onDidChangeActiveTerminal as jest.Mock).mockReturnValueOnce(changeDisposable);
     session.onDidChange.mockReturnValueOnce(boundDisposable);
 
     const service = createService();
@@ -294,9 +279,6 @@ describe('ContextKeyService', () => {
     expect(closeDisposable.dispose).toHaveBeenCalledTimes(1);
     expect(changeDisposable.dispose).toHaveBeenCalledTimes(1);
     expect(boundDisposable.dispose).toHaveBeenCalledTimes(1);
-    expect(logger.debug).toHaveBeenCalledWith(
-      { fn: 'ContextKeyService' },
-      'Disposing ContextKeyService',
-    );
+    expect(logger.debug).toHaveBeenCalledWith({ fn: 'ContextKeyService' }, 'Disposing ContextKeyService');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/ComposablePasteDestination.integration.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/ComposablePasteDestination.integration.test.ts
@@ -37,24 +37,13 @@ describe('ComposablePasteDestination Integration Tests', () => {
         processId: Promise.resolve(12345),
       });
 
-      const terminalPasteService = new TerminalPasteService(
-        mockAdapter,
-        createMockClipboardService(),
-        mockLogger,
-      );
+      const terminalPasteService = new TerminalPasteService(mockAdapter, createMockClipboardService(), mockLogger);
       const insertFactory = new TerminalInsertFactory(terminalPasteService, mockLogger);
-      const focusCapability = new TerminalFocusCapability(
-        mockAdapter,
-        mockTerminal,
-        insertFactory,
-        mockLogger,
-      );
+      const focusCapability = new TerminalFocusCapability(mockAdapter, mockTerminal, insertFactory, mockLogger);
       const eligibilityChecker = new ContentEligibilityChecker(mockLogger);
 
       const showTerminalSpy = jest.spyOn(mockAdapter, 'showTerminal');
-      const pasteTextSpy = jest
-        .spyOn(terminalPasteService, 'pasteIntoTerminal')
-        .mockResolvedValue(ExtensionResult.ok(undefined));
+      const pasteTextSpy = jest.spyOn(terminalPasteService, 'pasteIntoTerminal').mockResolvedValue(ExtensionResult.ok(undefined));
 
       const destination = ComposablePasteDestination.createForTesting({
         id: 'terminal',
@@ -92,18 +81,9 @@ describe('ComposablePasteDestination Integration Tests', () => {
       const mockAdapter = createMockVscodeAdapter();
       const mockTerminal = createMockTerminal({ name: 'Test Terminal' });
 
-      const terminalPasteService = new TerminalPasteService(
-        mockAdapter,
-        createMockClipboardService(),
-        mockLogger,
-      );
+      const terminalPasteService = new TerminalPasteService(mockAdapter, createMockClipboardService(), mockLogger);
       const insertFactory = new TerminalInsertFactory(terminalPasteService, mockLogger);
-      const focusCapability = new TerminalFocusCapability(
-        mockAdapter,
-        mockTerminal,
-        insertFactory,
-        mockLogger,
-      );
+      const focusCapability = new TerminalFocusCapability(mockAdapter, mockTerminal, insertFactory, mockLogger);
       const eligibilityChecker = new ContentEligibilityChecker(mockLogger);
 
       const callOrder: string[] = [];
@@ -151,21 +131,11 @@ describe('ComposablePasteDestination Integration Tests', () => {
       const mockAdapter = createMockVscodeAdapter();
 
       const insertFactory = new AIAssistantInsertFactory(mockAdapter, mockLogger);
-      const focusCapability = new AIAssistantFocusCapability(
-        mockAdapter,
-        ['ai.assistant.focus'],
-        undefined,
-        insertFactory,
-        mockLogger,
-      );
+      const focusCapability = new AIAssistantFocusCapability(mockAdapter, ['ai.assistant.focus'], undefined, insertFactory, mockLogger);
       const eligibilityChecker = new ContentEligibilityChecker(mockLogger);
 
-      const executeCommandSpy = jest
-        .spyOn(mockAdapter, 'executeCommand')
-        .mockResolvedValue(undefined);
-      const pasteClipboardSpy = jest
-        .spyOn(mockAdapter, 'pasteClipboardToAiAssistant')
-        .mockResolvedValue(true);
+      const executeCommandSpy = jest.spyOn(mockAdapter, 'executeCommand').mockResolvedValue(undefined);
+      const pasteClipboardSpy = jest.spyOn(mockAdapter, 'pasteClipboardToAiAssistant').mockResolvedValue(true);
 
       const destination = ComposablePasteDestination.createForTesting({
         id: 'claude-code',
@@ -210,10 +180,7 @@ describe('ComposablePasteDestination Integration Tests', () => {
       );
       const eligibilityChecker = new ContentEligibilityChecker(mockLogger);
 
-      const executeCommandSpy = jest
-        .spyOn(mockAdapter, 'executeCommand')
-        .mockRejectedValueOnce(new Error('First failed'))
-        .mockResolvedValueOnce(undefined);
+      const executeCommandSpy = jest.spyOn(mockAdapter, 'executeCommand').mockRejectedValueOnce(new Error('First failed')).mockResolvedValueOnce(undefined);
       jest.spyOn(mockAdapter, 'pasteClipboardToAiAssistant').mockResolvedValue(true);
 
       const destination = ComposablePasteDestination.createForTesting({
@@ -250,19 +217,10 @@ describe('ComposablePasteDestination Integration Tests', () => {
       const mockAdapter = createMockVscodeAdapter();
 
       const insertFactory = new AIAssistantInsertFactory(mockAdapter, mockLogger);
-      const focusCapability = new AIAssistantFocusCapability(
-        mockAdapter,
-        ['command.first', 'command.second'],
-        undefined,
-        insertFactory,
-        mockLogger,
-      );
+      const focusCapability = new AIAssistantFocusCapability(mockAdapter, ['command.first', 'command.second'], undefined, insertFactory, mockLogger);
       const eligibilityChecker = new ContentEligibilityChecker(mockLogger);
 
-      jest
-        .spyOn(mockAdapter, 'executeCommand')
-        .mockRejectedValueOnce(new Error('First failed'))
-        .mockRejectedValueOnce(new Error('Second failed'));
+      jest.spyOn(mockAdapter, 'executeCommand').mockRejectedValueOnce(new Error('First failed')).mockRejectedValueOnce(new Error('Second failed'));
 
       const destination = ComposablePasteDestination.createForTesting({
         id: 'claude-code',
@@ -306,13 +264,7 @@ describe('ComposablePasteDestination Integration Tests', () => {
       const insertSpy = jest.spyOn(mockAdapter, 'insertTextAtCursor').mockResolvedValue(true);
 
       const insertFactory = new EditorInsertFactory(mockAdapter, mockLogger);
-      const focusCapability = new EditorFocusCapability(
-        mockAdapter,
-        mockUri,
-        1,
-        insertFactory,
-        mockLogger,
-      );
+      const focusCapability = new EditorFocusCapability(mockAdapter, mockUri, 1, insertFactory, mockLogger);
       const eligibilityChecker = new ContentEligibilityChecker(mockLogger);
 
       const destination = ComposablePasteDestination.createForTesting({
@@ -356,13 +308,7 @@ describe('ComposablePasteDestination Integration Tests', () => {
       jest.spyOn(mockAdapter, 'showTextDocument').mockRejectedValue(new Error('Editor not found'));
 
       const insertFactory = new EditorInsertFactory(mockAdapter, mockLogger);
-      const focusCapability = new EditorFocusCapability(
-        mockAdapter,
-        mockUri,
-        1,
-        insertFactory,
-        mockLogger,
-      );
+      const focusCapability = new EditorFocusCapability(mockAdapter, mockUri, 1, insertFactory, mockLogger);
       const eligibilityChecker = new ContentEligibilityChecker(mockLogger);
 
       const destination = ComposablePasteDestination.createForTesting({
@@ -405,13 +351,7 @@ describe('ComposablePasteDestination Integration Tests', () => {
       jest.spyOn(mockAdapter, 'insertTextAtCursor').mockResolvedValue(false);
 
       const insertFactory = new EditorInsertFactory(mockAdapter, mockLogger);
-      const focusCapability = new EditorFocusCapability(
-        mockAdapter,
-        mockUri,
-        1,
-        insertFactory,
-        mockLogger,
-      );
+      const focusCapability = new EditorFocusCapability(mockAdapter, mockUri, 1, insertFactory, mockLogger);
       const eligibilityChecker = new ContentEligibilityChecker(mockLogger);
 
       const destination = ComposablePasteDestination.createForTesting({
@@ -447,18 +387,9 @@ describe('ComposablePasteDestination Integration Tests', () => {
       const mockAdapter = createMockVscodeAdapter();
       const mockTerminal = createMockTerminal({ name: 'Test Terminal' });
 
-      const terminalPasteService = new TerminalPasteService(
-        mockAdapter,
-        createMockClipboardService(),
-        mockLogger,
-      );
+      const terminalPasteService = new TerminalPasteService(mockAdapter, createMockClipboardService(), mockLogger);
       const insertFactory = new TerminalInsertFactory(terminalPasteService, mockLogger);
-      const focusCapability = new TerminalFocusCapability(
-        mockAdapter,
-        mockTerminal,
-        insertFactory,
-        mockLogger,
-      );
+      const focusCapability = new TerminalFocusCapability(mockAdapter, mockTerminal, insertFactory, mockLogger);
       const eligibilityChecker = new ContentEligibilityChecker(mockLogger);
 
       const destination = ComposablePasteDestination.createForTesting({
@@ -492,24 +423,13 @@ describe('ComposablePasteDestination Integration Tests', () => {
       const mockAdapter = createMockVscodeAdapter();
       const mockTerminal = createMockTerminal({ name: 'Test Terminal' });
 
-      const terminalPasteService = new TerminalPasteService(
-        mockAdapter,
-        createMockClipboardService(),
-        mockLogger,
-      );
+      const terminalPasteService = new TerminalPasteService(mockAdapter, createMockClipboardService(), mockLogger);
       const insertFactory = new TerminalInsertFactory(terminalPasteService, mockLogger);
-      const focusCapability = new TerminalFocusCapability(
-        mockAdapter,
-        mockTerminal,
-        insertFactory,
-        mockLogger,
-      );
+      const focusCapability = new TerminalFocusCapability(mockAdapter, mockTerminal, insertFactory, mockLogger);
       const eligibilityChecker = new ContentEligibilityChecker(mockLogger);
 
       jest.spyOn(mockAdapter, 'showTerminal').mockReturnValue(ExtensionResult.ok(undefined));
-      const pasteTextSpy = jest
-        .spyOn(terminalPasteService, 'pasteIntoTerminal')
-        .mockResolvedValue(ExtensionResult.ok(undefined));
+      const pasteTextSpy = jest.spyOn(terminalPasteService, 'pasteIntoTerminal').mockResolvedValue(ExtensionResult.ok(undefined));
 
       const destination = ComposablePasteDestination.createForTesting({
         id: 'terminal',

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/ComposablePasteDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/ComposablePasteDestination.test.ts
@@ -118,9 +118,7 @@ describe('ComposablePasteDestination', () => {
 
     it('should return false when focus fails', async () => {
       const focusCapability = createMockFocusCapability();
-      focusCapability.focus.mockResolvedValue(
-        DetailedResult.failure({ reason: FocusErrorReason.SHOW_DOCUMENT_FAILED }),
-      );
+      focusCapability.focus.mockResolvedValue(DetailedResult.failure({ reason: FocusErrorReason.SHOW_DOCUMENT_FAILED }));
 
       const destination = createMockComposablePasteDestination({
         focusCapability,
@@ -143,10 +141,7 @@ describe('ComposablePasteDestination', () => {
 
       await destination['performPaste']('text', context, PasteContentType.Link);
 
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        context,
-        'Cannot paste link: Mock Destination not available',
-      );
+      expect(mockLogger.info).toHaveBeenCalledWith(context, 'Cannot paste link: Mock Destination not available');
     });
 
     it('should use "content" label for PasteContentType.Text in log messages', async () => {
@@ -159,10 +154,7 @@ describe('ComposablePasteDestination', () => {
 
       await destination['performPaste']('text', context, PasteContentType.Text);
 
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        context,
-        'Cannot paste content: Mock Destination not available',
-      );
+      expect(mockLogger.info).toHaveBeenCalledWith(context, 'Cannot paste content: Mock Destination not available');
     });
   });
 
@@ -286,9 +278,7 @@ describe('ComposablePasteDestination', () => {
 
     it('should return false when focus fails', async () => {
       const focusCapability = createMockFocusCapability();
-      focusCapability.focus.mockResolvedValue(
-        DetailedResult.failure({ reason: FocusErrorReason.TERMINAL_FOCUS_FAILED }),
-      );
+      focusCapability.focus.mockResolvedValue(DetailedResult.failure({ reason: FocusErrorReason.TERMINAL_FOCUS_FAILED }));
 
       const destination = createMockComposablePasteDestination({
         focusCapability,
@@ -349,9 +339,7 @@ describe('ComposablePasteDestination', () => {
     });
 
     describe('AI assistant kind-based equality (createAiAssistant factory)', () => {
-      const createAiAssistantDestination = (
-        id: 'claude-code' | 'cursor-ai' | 'github-copilot-chat',
-      ) =>
+      const createAiAssistantDestination = (id: 'claude-code' | 'cursor-ai' | 'github-copilot-chat') =>
         ComposablePasteDestination.createAiAssistant({
           id,
           displayName: `Mock ${id}`,

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/DestinationAvailabilityService.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/DestinationAvailabilityService.test.ts
@@ -41,12 +41,7 @@ describe('DestinationAvailabilityService', () => {
         tabGroups: createMockTabGroupsWithCount(1),
       },
     });
-    service = new DestinationAvailabilityService(
-      mockRegistry,
-      ideAdapter,
-      mockConfigReader,
-      mockLogger,
-    );
+    service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
   });
 
   describe('isAIAssistantAvailable()', () => {
@@ -115,12 +110,7 @@ describe('DestinationAvailabilityService', () => {
           tabGroups: createMockTabGroupsWithCount(1),
         },
       });
-      service = new DestinationAvailabilityService(
-        mockRegistry,
-        ideAdapter,
-        mockConfigReader,
-        mockLogger,
-      );
+      service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
       const result = await service.getTerminalItems(Infinity);
 
@@ -180,12 +170,7 @@ describe('DestinationAvailabilityService', () => {
             tabGroups: createMockTabGroupsWithCount(1),
           },
         });
-        service = new DestinationAvailabilityService(
-          mockRegistry,
-          ideAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
         const result = await service.getGroupedDestinationItems();
 
@@ -225,12 +210,7 @@ describe('DestinationAvailabilityService', () => {
             tabGroups: createMockTabGroupsWithCount(1),
           },
         });
-        service = new DestinationAvailabilityService(
-          mockRegistry,
-          ideAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
         const result = await service.getGroupedDestinationItems();
 
@@ -270,12 +250,7 @@ describe('DestinationAvailabilityService', () => {
             tabGroups: createMockTabGroupsWithCount(1),
           },
         });
-        service = new DestinationAvailabilityService(
-          mockRegistry,
-          ideAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
         const result = await service.getGroupedDestinationItems();
 
@@ -308,12 +283,7 @@ describe('DestinationAvailabilityService', () => {
             tabGroups: createMockTabGroupsWithCount(1),
           },
         });
-        service = new DestinationAvailabilityService(
-          mockRegistry,
-          ideAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
         const result = await service.getGroupedDestinationItems();
 
@@ -346,12 +316,7 @@ describe('DestinationAvailabilityService', () => {
             tabGroups: createMockTabGroupsWithCount(1),
           },
         });
-        service = new DestinationAvailabilityService(
-          mockRegistry,
-          ideAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
         const result = await service.getGroupedDestinationItems();
 
@@ -386,12 +351,7 @@ describe('DestinationAvailabilityService', () => {
             tabGroups: createMockTabGroupsWithCount(1),
           },
         });
-        service = new DestinationAvailabilityService(
-          mockRegistry,
-          ideAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
         const result = await service.getGroupedDestinationItems();
 
@@ -452,12 +412,7 @@ describe('DestinationAvailabilityService', () => {
             tabGroups: { all: [group] },
           },
         });
-        service = new DestinationAvailabilityService(
-          mockRegistry,
-          ideAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
         const result = await service.getGroupedDestinationItems({
           destinationKinds: ['text-editor'],
@@ -503,12 +458,7 @@ describe('DestinationAvailabilityService', () => {
             tabGroups: { all: [] },
           },
         });
-        service = new DestinationAvailabilityService(
-          mockRegistry,
-          ideAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
         const result = await service.getGroupedDestinationItems({
           destinationKinds: ['text-editor'],
@@ -540,12 +490,7 @@ describe('DestinationAvailabilityService', () => {
             tabGroups: { all: [group] },
           },
         });
-        service = new DestinationAvailabilityService(
-          mockRegistry,
-          ideAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
         const result = await service.getGroupedDestinationItems({
           destinationKinds: ['text-editor'],
@@ -599,12 +544,7 @@ describe('DestinationAvailabilityService', () => {
             tabGroups: { all: [group] },
           },
         });
-        service = new DestinationAvailabilityService(
-          mockRegistry,
-          ideAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
         const result = await service.getGroupedDestinationItems({
           destinationKinds: ['text-editor'],
@@ -661,12 +601,7 @@ describe('DestinationAvailabilityService', () => {
             tabGroups: { all: [group1, group2] },
           },
         });
-        service = new DestinationAvailabilityService(
-          mockRegistry,
-          ideAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
         const result = await service.getGroupedDestinationItems({
           destinationKinds: ['text-editor'],
@@ -736,12 +671,7 @@ describe('DestinationAvailabilityService', () => {
             tabGroups: { all: [group1, group2] },
           },
         });
-        service = new DestinationAvailabilityService(
-          mockRegistry,
-          ideAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
         const result = await service.getGroupedDestinationItems({
           destinationKinds: ['text-editor'],
@@ -807,12 +737,7 @@ describe('DestinationAvailabilityService', () => {
           tabGroups: { all: [] },
         },
       });
-      service = new DestinationAvailabilityService(
-        mockRegistry,
-        ideAdapter,
-        mockConfigReader,
-        mockLogger,
-      );
+      service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
       const result = service.getAllFileItems();
 
@@ -830,12 +755,7 @@ describe('DestinationAvailabilityService', () => {
           tabGroups: { all: [group] },
         },
       });
-      service = new DestinationAvailabilityService(
-        mockRegistry,
-        ideAdapter,
-        mockConfigReader,
-        mockLogger,
-      );
+      service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
       const result = service.getAllFileItems();
 
@@ -873,10 +793,7 @@ describe('DestinationAvailabilityService', () => {
           },
         },
       ]);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'DestinationAvailabilityService.getAllFileItems', fileCount: 2 },
-        'Built all file items',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'DestinationAvailabilityService.getAllFileItems', fileCount: 2 }, 'Built all file items');
     });
 
     it('marks bound file with bound state', () => {
@@ -888,12 +805,7 @@ describe('DestinationAvailabilityService', () => {
           tabGroups: { all: [group] },
         },
       });
-      service = new DestinationAvailabilityService(
-        mockRegistry,
-        ideAdapter,
-        mockConfigReader,
-        mockLogger,
-      );
+      service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
       const result = service.getAllFileItems(uri.toString());
 
@@ -915,10 +827,7 @@ describe('DestinationAvailabilityService', () => {
           },
         },
       ]);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'DestinationAvailabilityService.getAllFileItems', fileCount: 1 },
-        'Built all file items',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'DestinationAvailabilityService.getAllFileItems', fileCount: 1 }, 'Built all file items');
     });
 
     it('marks only the file in the matching viewColumn as bound when same URI appears in two tab groups', () => {
@@ -932,12 +841,7 @@ describe('DestinationAvailabilityService', () => {
           tabGroups: { all: [group1, group2] },
         },
       });
-      service = new DestinationAvailabilityService(
-        mockRegistry,
-        ideAdapter,
-        mockConfigReader,
-        mockLogger,
-      );
+      service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
       const result = service.getAllFileItems(uri.toString(), 1);
 
@@ -975,10 +879,7 @@ describe('DestinationAvailabilityService', () => {
           },
         },
       ]);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'DestinationAvailabilityService.getAllFileItems', fileCount: 2 },
-        'Built all file items',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'DestinationAvailabilityService.getAllFileItems', fileCount: 2 }, 'Built all file items');
     });
 
     it('marks both entries as bound when same URI appears in two tab groups and no viewColumn is given', () => {
@@ -992,12 +893,7 @@ describe('DestinationAvailabilityService', () => {
           tabGroups: { all: [group1, group2] },
         },
       });
-      service = new DestinationAvailabilityService(
-        mockRegistry,
-        ideAdapter,
-        mockConfigReader,
-        mockLogger,
-      );
+      service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
       const result = service.getAllFileItems(uri.toString());
 
@@ -1035,10 +931,7 @@ describe('DestinationAvailabilityService', () => {
           },
         },
       ]);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'DestinationAvailabilityService.getAllFileItems', fileCount: 2 },
-        'Built all file items',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'DestinationAvailabilityService.getAllFileItems', fileCount: 2 }, 'Built all file items');
     });
 
     it('applies disambiguators for duplicate filenames', () => {
@@ -1052,12 +945,7 @@ describe('DestinationAvailabilityService', () => {
           tabGroups: { all: [group] },
         },
       });
-      service = new DestinationAvailabilityService(
-        mockRegistry,
-        ideAdapter,
-        mockConfigReader,
-        mockLogger,
-      );
+      service = new DestinationAvailabilityService(mockRegistry, ideAdapter, mockConfigReader, mockLogger);
 
       const result = service.getAllFileItems();
 
@@ -1095,10 +983,7 @@ describe('DestinationAvailabilityService', () => {
           },
         },
       ]);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'DestinationAvailabilityService.getAllFileItems', fileCount: 2 },
-        'Built all file items',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'DestinationAvailabilityService.getAllFileItems', fileCount: 2 }, 'Built all file items');
     });
   });
 
@@ -1116,12 +1001,7 @@ describe('DestinationAvailabilityService', () => {
       });
       customRegistry.getSupportedKinds.mockReturnValue([customKind]);
 
-      const customService = new DestinationAvailabilityService(
-        customRegistry,
-        ideAdapter,
-        mockConfigReader,
-        mockLogger,
-      );
+      const customService = new DestinationAvailabilityService(customRegistry, ideAdapter, mockConfigReader, mockLogger);
 
       const result = await customService.getGroupedDestinationItems();
 
@@ -1149,12 +1029,7 @@ describe('DestinationAvailabilityService', () => {
       });
       customRegistry.getSupportedKinds.mockReturnValue([customKind]);
 
-      const customService = new DestinationAvailabilityService(
-        customRegistry,
-        ideAdapter,
-        mockConfigReader,
-        mockLogger,
-      );
+      const customService = new DestinationAvailabilityService(customRegistry, ideAdapter, mockConfigReader, mockLogger);
 
       const result = await customService.getGroupedDestinationItems();
 

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/DestinationPicker.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/DestinationPicker.test.ts
@@ -1,13 +1,6 @@
-import {
-  DestinationPicker,
-  type DestinationPickerOptions,
-} from '../../destinations/DestinationPicker';
+import { DestinationPicker, type DestinationPickerOptions } from '../../destinations/DestinationPicker';
 import type { FilePickerHandlers, TerminalPickerHandlers } from '../../destinations/types';
-import {
-  type FileBindableQuickPickItem,
-  MessageCode,
-  type TerminalBindableQuickPickItem,
-} from '../../types';
+import { type FileBindableQuickPickItem, MessageCode, type TerminalBindableQuickPickItem } from '../../types';
 import {
   createMockAIAssistantQuickPickItem,
   createMockDestinationAvailabilityService,
@@ -50,10 +43,7 @@ describe('DestinationPicker', () => {
 
   describe('constructor', () => {
     it('logs initialization', () => {
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'DestinationPicker.constructor' },
-        'DestinationPicker initialized',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'DestinationPicker.constructor' }, 'DestinationPicker initialized');
     });
   });
 
@@ -65,11 +55,8 @@ describe('DestinationPicker', () => {
         const result = await picker.pick(defaultOptions);
 
         expect(result).toStrictEqual({ outcome: 'no-resource' });
-        const showInfoMock = mockAdapter.__getVscodeInstance().window
-          .showInformationMessage as jest.Mock;
-        expect(showInfoMock).toHaveBeenCalledWith(
-          'No destinations available. Open a terminal, a file, or install an AI assistant extension.',
-        );
+        const showInfoMock = mockAdapter.__getVscodeInstance().window.showInformationMessage as jest.Mock;
+        expect(showInfoMock).toHaveBeenCalledWith('No destinations available. Open a terminal, a file, or install an AI assistant extension.');
         expect(showQuickPickMock).not.toHaveBeenCalled();
       });
     });
@@ -85,18 +72,9 @@ describe('DestinationPicker', () => {
         const result = await picker.pick(defaultOptions);
 
         expect(result).toStrictEqual({ outcome: 'cancelled' });
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'DestinationPicker.pick' },
-          'Showing destination picker',
-        );
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'DestinationPicker.pick', availableCount: 2 },
-          'Showing quick pick with 2 items',
-        );
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'DestinationPicker.pick' },
-          'User cancelled quick pick',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'DestinationPicker.pick' }, 'Showing destination picker');
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'DestinationPicker.pick', availableCount: 2 }, 'Showing quick pick with 2 items');
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'DestinationPicker.pick' }, 'User cancelled quick pick');
       });
     });
 
@@ -163,18 +141,11 @@ describe('DestinationPicker', () => {
           'file-more': moreItem,
         });
         showQuickPickMock.mockResolvedValue(moreItem);
-        mockAvailabilityService.getAllFileItems.mockReturnValue([
-          createMockTextEditorQuickPickItem(),
-        ]);
+        mockAvailabilityService.getAllFileItems.mockReturnValue([createMockTextEditorQuickPickItem()]);
 
         let capturedPlaceholder: string | undefined;
         showFilePickerSpy.mockImplementation(
-          <T>(
-            _files: readonly FileBindableQuickPickItem[],
-            _provider: unknown,
-            handlers: FilePickerHandlers<T>,
-            _logger: unknown,
-          ) => {
+          <T>(_files: readonly FileBindableQuickPickItem[], _provider: unknown, handlers: FilePickerHandlers<T>, _logger: unknown) => {
             capturedPlaceholder = handlers.getPlaceholder();
             return handlers.onSelected(fileInfo);
           },
@@ -182,9 +153,7 @@ describe('DestinationPicker', () => {
 
         const result = await picker.pick(defaultOptions);
 
-        expect(capturedPlaceholder).toBe(
-          'RangeLink: No destination bound. Choose destination to jump to',
-        );
+        expect(capturedPlaceholder).toBe('RangeLink: No destination bound. Choose destination to jump to');
         expect(showFilePickerSpy).toHaveBeenCalled();
         expect(result).toStrictEqual({
           outcome: 'selected',
@@ -203,9 +172,7 @@ describe('DestinationPicker', () => {
           'text-editor': [editorItem],
           'file-more': moreItem,
         });
-        mockAvailabilityService.getAllFileItems.mockReturnValue([
-          createMockTextEditorQuickPickItem(),
-        ]);
+        mockAvailabilityService.getAllFileItems.mockReturnValue([createMockTextEditorQuickPickItem()]);
 
         let callCount = 0;
         showQuickPickMock.mockImplementation(() => {
@@ -217,25 +184,14 @@ describe('DestinationPicker', () => {
         });
 
         showFilePickerSpy.mockImplementation(
-          <T>(
-            _files: readonly FileBindableQuickPickItem[],
-            _provider: unknown,
-            handlers: FilePickerHandlers<T>,
-            _logger: unknown,
-          ) => handlers.onDismissed?.(),
+          <T>(_files: readonly FileBindableQuickPickItem[], _provider: unknown, handlers: FilePickerHandlers<T>, _logger: unknown) => handlers.onDismissed?.(),
         );
 
         const result = await picker.pick(defaultOptions);
 
         expect(showQuickPickMock).toHaveBeenCalledTimes(2);
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'DestinationPicker.showSecondaryFilePicker' },
-          'User returned from secondary file picker',
-        );
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'DestinationPicker.pick' },
-          'Returning to main destination picker',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'DestinationPicker.showSecondaryFilePicker' }, 'User returned from secondary file picker');
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'DestinationPicker.pick' }, 'Returning to main destination picker');
         expect(result).toStrictEqual({
           outcome: 'selected',
           bindOptions: editorItem.bindOptions,
@@ -257,14 +213,8 @@ describe('DestinationPicker', () => {
 
         expect(showFilePickerSpy).not.toHaveBeenCalled();
         expect(result).toStrictEqual({ outcome: 'cancelled' });
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'DestinationPicker.showSecondaryFilePicker' },
-          'No files available in secondary picker',
-        );
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'DestinationPicker.pick' },
-          'Returning to main destination picker',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'DestinationPicker.showSecondaryFilePicker' }, 'No files available in secondary picker');
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'DestinationPicker.pick' }, 'Returning to main destination picker');
       });
 
       it('passes boundFileUriString and boundFileViewColumn to getAllFileItems', async () => {
@@ -282,18 +232,12 @@ describe('DestinationPicker', () => {
           boundFileViewColumn: 2,
         });
 
-        expect(mockAvailabilityService.getAllFileItems).toHaveBeenCalledWith(
-          'file:///workspace/app.ts',
-          2,
-        );
+        expect(mockAvailabilityService.getAllFileItems).toHaveBeenCalledWith('file:///workspace/app.ts', 2);
         expect(mockLogger.debug).toHaveBeenCalledWith(
           { fn: 'DestinationPicker.handleQuickPickSelection' },
           'User selected "More files...", showing secondary picker',
         );
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'DestinationPicker.showSecondaryFilePicker' },
-          'No files available in secondary picker',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'DestinationPicker.showSecondaryFilePicker' }, 'No files available in secondary picker');
       });
     });
 
@@ -308,19 +252,11 @@ describe('DestinationPicker', () => {
         });
         showQuickPickMock.mockResolvedValue(moreItem);
 
-        mockAvailabilityService.getTerminalItems.mockResolvedValue([
-          createMockTerminalQuickPickItem(terminal1),
-          createMockTerminalQuickPickItem(terminal2),
-        ]);
+        mockAvailabilityService.getTerminalItems.mockResolvedValue([createMockTerminalQuickPickItem(terminal1), createMockTerminalQuickPickItem(terminal2)]);
 
         let capturedPlaceholder: string | undefined;
         showTerminalPickerSpy.mockImplementation(
-          <T>(
-            _terminals: readonly TerminalBindableQuickPickItem[],
-            _provider: unknown,
-            handlers: TerminalPickerHandlers<T>,
-            _logger: unknown,
-          ) => {
+          <T>(_terminals: readonly TerminalBindableQuickPickItem[], _provider: unknown, handlers: TerminalPickerHandlers<T>, _logger: unknown) => {
             capturedPlaceholder = handlers.getPlaceholder();
             return handlers.onSelected({
               bindOptions: { kind: 'terminal', terminal: terminal2 },
@@ -332,9 +268,7 @@ describe('DestinationPicker', () => {
 
         const result = await picker.pick(defaultOptions);
 
-        expect(capturedPlaceholder).toBe(
-          'RangeLink: No destination bound. Choose destination to jump to',
-        );
+        expect(capturedPlaceholder).toBe('RangeLink: No destination bound. Choose destination to jump to');
         expect(showTerminalPickerSpy).toHaveBeenCalled();
         expect(result).toStrictEqual({
           outcome: 'selected',
@@ -361,25 +295,15 @@ describe('DestinationPicker', () => {
         });
 
         showTerminalPickerSpy.mockImplementation(
-          <T>(
-            _terminals: readonly TerminalBindableQuickPickItem[],
-            _provider: unknown,
-            handlers: TerminalPickerHandlers<T>,
-            _logger: unknown,
-          ) => handlers.onDismissed?.(),
+          <T>(_terminals: readonly TerminalBindableQuickPickItem[], _provider: unknown, handlers: TerminalPickerHandlers<T>, _logger: unknown) =>
+            handlers.onDismissed?.(),
         );
 
         const result = await picker.pick(defaultOptions);
 
         expect(showQuickPickMock).toHaveBeenCalledTimes(2);
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'DestinationPicker.showSecondaryTerminalPicker' },
-          'User returned from secondary terminal picker',
-        );
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'DestinationPicker.pick' },
-          'Returning to main destination picker',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'DestinationPicker.showSecondaryTerminalPicker' }, 'User returned from secondary terminal picker');
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'DestinationPicker.pick' }, 'Returning to main destination picker');
         expect(result).toStrictEqual({
           outcome: 'selected',
           bindOptions: { kind: 'terminal', terminal },

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/DestinationRegistry.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/DestinationRegistry.test.ts
@@ -1,8 +1,4 @@
-import {
-  type DestinationBuilder,
-  type DestinationBuilderContext,
-  DestinationRegistry,
-} from '../../destinations';
+import { type DestinationBuilder, type DestinationBuilderContext, DestinationRegistry } from '../../destinations';
 import type { BindOptions } from '../../types';
 import {
   createBaseMockPasteDestination,
@@ -26,13 +22,7 @@ describe('DestinationRegistry', () => {
   });
 
   const createRegistry = (factories = createMockFactories()) =>
-    new DestinationRegistry(
-      factories.focusCapability,
-      factories.eligibilityChecker,
-      mockAdapter,
-      mockConfigReader,
-      mockLogger,
-    );
+    new DestinationRegistry(factories.focusCapability, factories.eligibilityChecker, mockAdapter, mockConfigReader, mockLogger);
 
   describe('register()', () => {
     it('should store builder in map when registered', () => {
@@ -57,9 +47,7 @@ describe('DestinationRegistry', () => {
     it('should overwrite previous builder when registering same kind', () => {
       const registry = createRegistry();
       const firstBuilder = jest.fn();
-      const secondBuilder = jest
-        .fn()
-        .mockReturnValue(createBaseMockPasteDestination({ id: 'terminal' }));
+      const secondBuilder = jest.fn().mockReturnValue(createBaseMockPasteDestination({ id: 'terminal' }));
 
       registry.register('terminal', firstBuilder);
       registry.register('terminal', secondBuilder);
@@ -174,9 +162,7 @@ describe('DestinationRegistry', () => {
     it('should throw DESTINATION_NOT_IMPLEMENTED for unregistered kind', () => {
       const registry = createRegistry();
 
-      expect(() =>
-        registry.create({ kind: 'terminal', terminal: {} as never }),
-      ).toThrowDetailedError('DESTINATION_NOT_IMPLEMENTED', {
+      expect(() => registry.create({ kind: 'terminal', terminal: {} as never })).toThrowDetailedError('DESTINATION_NOT_IMPLEMENTED', {
         message: 'No builder registered for destination kind: terminal',
         functionName: 'DestinationRegistry.create',
         details: { kind: 'terminal' },
@@ -186,14 +172,11 @@ describe('DestinationRegistry', () => {
     it('should include destination kind in error message', () => {
       const registry = createRegistry();
 
-      expect(() => registry.create({ kind: 'github-copilot-chat' })).toThrowDetailedError(
-        'DESTINATION_NOT_IMPLEMENTED',
-        {
-          message: 'No builder registered for destination kind: github-copilot-chat',
-          functionName: 'DestinationRegistry.create',
-          details: { kind: 'github-copilot-chat' },
-        },
-      );
+      expect(() => registry.create({ kind: 'github-copilot-chat' })).toThrowDetailedError('DESTINATION_NOT_IMPLEMENTED', {
+        message: 'No builder registered for destination kind: github-copilot-chat',
+        functionName: 'DestinationRegistry.create',
+        details: { kind: 'github-copilot-chat' },
+      });
     });
   });
 
@@ -225,35 +208,25 @@ describe('DestinationRegistry', () => {
     it('should allow mocking FocusCapabilityFactory methods in builder', () => {
       const factories = createMockFactories();
       const mockCapability = { focus: jest.fn() };
-      factories.focusCapability.createAIAssistantCapability.mockReturnValue(
-        mockCapability as never,
-      );
+      factories.focusCapability.createAIAssistantCapability.mockReturnValue(mockCapability as never);
       const registry = createRegistry(factories);
 
       let capturedCapability: unknown;
       const builder: DestinationBuilder = (_options, context) => {
-        capturedCapability = context.factories.focusCapability.createAIAssistantCapability(
-          ['focus'],
-          undefined,
-        );
+        capturedCapability = context.factories.focusCapability.createAIAssistantCapability(['focus'], undefined);
         return createBaseMockPasteDestination({ id: 'terminal' });
       };
       registry.register('terminal', builder);
       registry.create({ kind: 'terminal', terminal: {} as never });
 
       expect(capturedCapability).toBe(mockCapability);
-      expect(factories.focusCapability.createAIAssistantCapability).toHaveBeenCalledWith(
-        ['focus'],
-        undefined,
-      );
+      expect(factories.focusCapability.createAIAssistantCapability).toHaveBeenCalledWith(['focus'], undefined);
     });
 
     it('should allow mocking EligibilityCheckerFactory methods in builder', () => {
       const factories = createMockFactories();
       const mockChecker = { isEligible: jest.fn() };
-      factories.eligibilityChecker.createContentEligibilityChecker.mockReturnValue(
-        mockChecker as never,
-      );
+      factories.eligibilityChecker.createContentEligibilityChecker.mockReturnValue(mockChecker as never);
       const registry = createRegistry(factories);
 
       let capturedChecker: unknown;
@@ -314,20 +287,13 @@ describe('DestinationRegistry', () => {
       const mockCapability = { focus: jest.fn() };
       const mockChecker = { isEligible: jest.fn() };
 
-      factories.focusCapability.createAIAssistantCapability.mockReturnValue(
-        mockCapability as never,
-      );
-      factories.eligibilityChecker.createContentEligibilityChecker.mockReturnValue(
-        mockChecker as never,
-      );
+      factories.focusCapability.createAIAssistantCapability.mockReturnValue(mockCapability as never);
+      factories.eligibilityChecker.createContentEligibilityChecker.mockReturnValue(mockChecker as never);
 
       const registry = createRegistry(factories);
 
       const builder: DestinationBuilder = (_options, context) => {
-        const capability = context.factories.focusCapability.createAIAssistantCapability(
-          ['focus.cmd'],
-          undefined,
-        );
+        const capability = context.factories.focusCapability.createAIAssistantCapability(['focus.cmd'], undefined);
         const checker = context.factories.eligibilityChecker.createContentEligibilityChecker();
 
         expect(capability).toBe(mockCapability);
@@ -340,10 +306,7 @@ describe('DestinationRegistry', () => {
       const destination = registry.create({ kind: 'cursor-ai' });
 
       expect(destination).toBeDefined();
-      expect(factories.focusCapability.createAIAssistantCapability).toHaveBeenCalledWith(
-        ['focus.cmd'],
-        undefined,
-      );
+      expect(factories.focusCapability.createAIAssistantCapability).toHaveBeenCalledWith(['focus.cmd'], undefined);
       expect(factories.eligibilityChecker.createContentEligibilityChecker).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/PasteDestinationManager.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/PasteDestinationManager.test.ts
@@ -1,18 +1,7 @@
-import {
-  type BindSuccessInfo,
-  ComposablePasteDestination,
-  type FocusSuccessInfo,
-  type PasteDestination,
-  PasteDestinationManager,
-} from '../../destinations';
+import { type BindSuccessInfo, ComposablePasteDestination, type FocusSuccessInfo, type PasteDestination, PasteDestinationManager } from '../../destinations';
 import { RangeLinkExtensionError } from '../../errors/RangeLinkExtensionError';
 import { RangeLinkExtensionErrorCodes } from '../../errors/RangeLinkExtensionErrorCodes';
-import {
-  AutoPasteResult,
-  type BindOptions,
-  type DestinationKind,
-  ExtensionResult,
-} from '../../types';
+import { AutoPasteResult, type BindOptions, type DestinationKind, ExtensionResult } from '../../types';
 import {
   configureEmptyTabGroups,
   createBaseMockPasteDestination,
@@ -46,10 +35,7 @@ import * as vscode from 'vscode';
  * Helper to assert QuickPick was called with confirmation dialog for smart bind.
  * Validates that items contain expected labels and that placeholder is present.
  */
-const expectQuickPickConfirmation = (
-  showQuickPickMock: jest.Mock,
-  expectedStrings: { currentDestination: string; newDestination: string },
-): void => {
+const expectQuickPickConfirmation = (showQuickPickMock: jest.Mock, expectedStrings: { currentDestination: string; newDestination: string }): void => {
   expect(showQuickPickMock).toHaveBeenCalledWith(
     [
       {
@@ -84,10 +70,7 @@ describe('PasteDestinationManager', () => {
    * Helper to create a manager with optional environment and window overrides.
    * Useful for tests that need to simulate Cursor IDE or configure message mocks.
    */
-  const createManager = (options?: {
-    envOptions?: MockVscodeOptions['envOptions'];
-    windowOptions?: MockVscodeOptions['windowOptions'];
-  }) => {
+  const createManager = (options?: { envOptions?: MockVscodeOptions['envOptions']; windowOptions?: MockVscodeOptions['windowOptions'] }) => {
     const adapter = createMockVscodeAdapter({
       envOptions: options?.envOptions,
       windowOptions: options?.windowOptions,
@@ -149,13 +132,7 @@ describe('PasteDestinationManager', () => {
         return undefined;
       },
     });
-    const mgr = new PasteDestinationManager(
-      registry,
-      adapter,
-      mockSession,
-      mockFeedback,
-      mockLogger,
-    );
+    const mgr = new PasteDestinationManager(registry, adapter, mockSession, mockFeedback, mockLogger);
 
     return { manager: mgr, adapter, registry };
   };
@@ -216,13 +193,7 @@ describe('PasteDestinationManager', () => {
       const controlledFactory = createMockDestinationRegistry({
         createImpl: () => terminalDest,
       });
-      const controlledManager = new PasteDestinationManager(
-        controlledFactory,
-        mockAdapter,
-        mockSession,
-        mockFeedback,
-        mockLogger,
-      );
+      const controlledManager = new PasteDestinationManager(controlledFactory, mockAdapter, mockSession, mockFeedback, mockLogger);
 
       // First bind
       await controlledManager.bind({ kind: 'terminal', terminal: mockTerminal });
@@ -243,10 +214,7 @@ describe('PasteDestinationManager', () => {
     it('should suppress notifyBound when skipMessage is true', async () => {
       mockAdapter.__getVscodeInstance().window.activeTerminal = mockTerminal;
 
-      const result = await manager.bind(
-        { kind: 'terminal', terminal: mockTerminal },
-        { skipMessage: true },
-      );
+      const result = await manager.bind({ kind: 'terminal', terminal: mockTerminal }, { skipMessage: true });
 
       expect(result).toBeSuccess({
         destinationName: 'Terminal ("bash")',
@@ -318,10 +286,7 @@ describe('PasteDestinationManager', () => {
       });
       expect(mockSession.isSet()).toBe(false);
 
-      expect(mockFeedback.notifyBindFailedNotAvailable).toHaveBeenCalledWith(
-        'Cursor AI Assistant',
-        'cursor-ai',
-      );
+      expect(mockFeedback.notifyBindFailedNotAvailable).toHaveBeenCalledWith('Cursor AI Assistant', 'cursor-ai');
 
       expect(mockFeedback.notifyBound).not.toHaveBeenCalled();
     });
@@ -338,10 +303,7 @@ describe('PasteDestinationManager', () => {
         details: { failedBindDetails: 'DESTINATION_NOT_AVAILABLE' },
       });
       expect(mockSession.isSet()).toBe(false);
-      expect(mockFeedback.notifyBindFailedNotAvailable).toHaveBeenCalledWith(
-        'Claude Code Chat',
-        'claude-code',
-      );
+      expect(mockFeedback.notifyBindFailedNotAvailable).toHaveBeenCalledWith('Claude Code Chat', 'claude-code');
 
       expect(mockFeedback.notifyBound).not.toHaveBeenCalled();
     });
@@ -418,10 +380,7 @@ describe('PasteDestinationManager', () => {
         details: { failedBindDetails: 'DESTINATION_NOT_AVAILABLE' },
       });
       expect(mockSession.isSet()).toBe(false);
-      expect(mockFeedback.notifyBindFailedNotAvailable).toHaveBeenCalledWith(
-        'Gemini Code Assist',
-        'gemini-code-assist',
-      );
+      expect(mockFeedback.notifyBindFailedNotAvailable).toHaveBeenCalledWith('Gemini Code Assist', 'gemini-code-assist');
 
       expect(mockFeedback.notifyBound).not.toHaveBeenCalled();
     });
@@ -461,10 +420,7 @@ describe('PasteDestinationManager', () => {
         details: { failedBindDetails: 'DESTINATION_NOT_AVAILABLE' },
       });
       expect(mockSession.isSet()).toBe(false);
-      expect(mockFeedback.notifyBindFailedNotAvailable).toHaveBeenCalledWith(
-        'GitHub Copilot Chat',
-        'github-copilot-chat',
-      );
+      expect(mockFeedback.notifyBindFailedNotAvailable).toHaveBeenCalledWith('GitHub Copilot Chat', 'github-copilot-chat');
 
       expect(mockFeedback.notifyBound).not.toHaveBeenCalled();
     });
@@ -549,10 +505,7 @@ describe('PasteDestinationManager', () => {
         details: { failedBindDetails: 'DESTINATION_NOT_AVAILABLE' },
       });
       expect(mockSession.isSet()).toBe(false);
-      expect(mockFeedback.notifyBindFailedNotAvailable).toHaveBeenCalledWith(
-        DISPLAY_NAME,
-        CUSTOM_AI_KIND,
-      );
+      expect(mockFeedback.notifyBindFailedNotAvailable).toHaveBeenCalledWith(DISPLAY_NAME, CUSTOM_AI_KIND);
       expect(mockFeedback.notifyBound).not.toHaveBeenCalled();
     });
   });
@@ -605,10 +558,7 @@ describe('PasteDestinationManager', () => {
 
       mockAdapter.__getVscodeInstance().window.visibleTextEditors = [mockEditor];
 
-      const result = await manager.bind(
-        { kind: 'text-editor', uri: mockUri, viewColumn: 1 },
-        { skipMessage: true },
-      );
+      const result = await manager.bind({ kind: 'text-editor', uri: mockUri, viewColumn: 1 }, { skipMessage: true });
 
       expect(result).toBeSuccess({
         destinationName: 'Text Editor ("file.ts")',
@@ -624,9 +574,7 @@ describe('PasteDestinationManager', () => {
       configureEmptyTabGroups(mockAdapter.__getVscodeInstance().window, 2);
       const missingUri = createMockUri('/workspace/src/gone.ts');
       const fileNotFoundError = new Error('File not found');
-      mockAdapter
-        .__getVscodeInstance()
-        .workspace.openTextDocument.mockRejectedValueOnce(fileNotFoundError);
+      mockAdapter.__getVscodeInstance().workspace.openTextDocument.mockRejectedValueOnce(fileNotFoundError);
 
       const result = await manager.bind({ kind: 'text-editor', uri: missingUri, viewColumn: 1 });
 
@@ -666,9 +614,7 @@ describe('PasteDestinationManager', () => {
       const backgroundUri = createMockUri('/workspace/src/file.ts');
 
       mockAdapter.__getVscodeInstance().window.showTextDocument.mockImplementationOnce(() => {
-        mockAdapter.__getVscodeInstance().window.visibleTextEditors = [
-          { document: { uri: backgroundUri }, viewColumn: 1 } as unknown as vscode.TextEditor,
-        ];
+        mockAdapter.__getVscodeInstance().window.visibleTextEditors = [{ document: { uri: backgroundUri }, viewColumn: 1 } as unknown as vscode.TextEditor];
         return undefined;
       });
 
@@ -693,9 +639,7 @@ describe('PasteDestinationManager', () => {
         },
         'Editor not visible, bringing background tab to foreground',
       );
-      expect(mockAdapter.__getVscodeInstance().workspace.openTextDocument).toHaveBeenCalledWith(
-        backgroundUri,
-      );
+      expect(mockAdapter.__getVscodeInstance().workspace.openTextDocument).toHaveBeenCalledWith(backgroundUri);
       expect(mockFeedback.notifyBackgroundTabOpened).toHaveBeenCalledWith('file.ts');
       expect(mockFeedback.notifyBound).toHaveBeenCalledTimes(1);
       expect(mockFeedback.notifyBound).toHaveBeenNthCalledWith(1, 'Text Editor ("file.ts")');
@@ -764,10 +708,7 @@ describe('PasteDestinationManager', () => {
         { fn: 'PasteDestinationManager.bindTextEditor', scheme: 'git', fileName: 'file.ts' },
         'Cannot bind: Editor is read-only (scheme: git)',
       );
-      expect(mockFeedback.notifyBindFailedEditor).toHaveBeenCalledWith(
-        'ERROR_TEXT_EDITOR_READ_ONLY',
-        { scheme: 'git' },
-      );
+      expect(mockFeedback.notifyBindFailedEditor).toHaveBeenCalledWith('ERROR_TEXT_EDITOR_READ_ONLY', { scheme: 'git' });
 
       expect(mockFeedback.notifyBound).not.toHaveBeenCalled();
     });
@@ -796,10 +737,7 @@ describe('PasteDestinationManager', () => {
         { fn: 'PasteDestinationManager.bindTextEditor', scheme: 'file', fileName: testFileName },
         'Cannot bind: Editor is a binary file',
       );
-      expect(mockFeedback.notifyBindFailedEditor).toHaveBeenCalledWith(
-        'ERROR_TEXT_EDITOR_BINARY_FILE',
-        { fileName: testFileName },
-      );
+      expect(mockFeedback.notifyBindFailedEditor).toHaveBeenCalledWith('ERROR_TEXT_EDITOR_BINARY_FILE', { fileName: testFileName });
       expect(mockFeedback.notifyBound).not.toHaveBeenCalled();
     });
   });
@@ -989,8 +927,7 @@ describe('PasteDestinationManager', () => {
         destinations: { 'github-copilot-chat': mockCopilotDest as any },
       });
       // Override the registry's create method to return our mock
-      (localManager as unknown as { registry: typeof mockRegistryForCopilot }).registry =
-        mockRegistryForCopilot;
+      (localManager as unknown as { registry: typeof mockRegistryForCopilot }).registry = mockRegistryForCopilot;
 
       // Mock user cancels confirmation
       const showQuickPickMock = localAdapter.__getVscodeInstance().window.showQuickPick;
@@ -1232,13 +1169,7 @@ describe('PasteDestinationManager', () => {
       });
 
       // Recreate manager with mock factory
-      manager = new PasteDestinationManager(
-        mockRegistryForSend,
-        mockAdapter,
-        mockSession,
-        mockFeedback,
-        mockLogger,
-      );
+      manager = new PasteDestinationManager(mockRegistryForSend, mockAdapter, mockSession, mockFeedback, mockLogger);
     });
 
     it('should send to bound terminal successfully', async () => {
@@ -1276,11 +1207,7 @@ describe('PasteDestinationManager', () => {
       await cursorManager.bind({ kind: 'cursor-ai' });
 
       const boundDest = mockSession.get()!;
-      boundDest.getUserInstruction = jest
-        .fn()
-        .mockImplementation((result) =>
-          result === AutoPasteResult.Success ? 'Manual paste instruction' : undefined,
-        );
+      boundDest.getUserInstruction = jest.fn().mockImplementation((result) => (result === AutoPasteResult.Success ? 'Manual paste instruction' : undefined));
 
       const formattedLink = createMockFormattedLink('src/file.ts#L10');
       const result = await cursorManager.sendLinkToDestination(formattedLink);
@@ -1305,9 +1232,7 @@ describe('PasteDestinationManager', () => {
     });
 
     it('should return false when no destination bound', async () => {
-      const result = await manager.sendLinkToDestination(
-        createMockFormattedLink('src/file.ts#L10'),
-      );
+      const result = await manager.sendLinkToDestination(createMockFormattedLink('src/file.ts#L10'));
 
       expect(result).toBe(false);
       expect(mockTerminalDest.pasteLink).not.toHaveBeenCalled();
@@ -1325,9 +1250,7 @@ describe('PasteDestinationManager', () => {
       boundDest.getUserInstruction = jest.fn().mockReturnValue(undefined);
       jest.spyOn(boundDest, 'pasteLink').mockResolvedValueOnce(false);
 
-      const result = await localManager.sendLinkToDestination(
-        createMockFormattedLink('src/file.ts#L10'),
-      );
+      const result = await localManager.sendLinkToDestination(createMockFormattedLink('src/file.ts#L10'));
 
       expect(result).toBe(false);
       expect(boundDest.pasteLink).toHaveBeenCalledTimes(1);
@@ -1341,17 +1264,11 @@ describe('PasteDestinationManager', () => {
       await cursorManager.bind({ kind: 'cursor-ai' });
 
       const boundDest = mockSession.get()!;
-      boundDest.getUserInstruction = jest
-        .fn()
-        .mockImplementation((result) =>
-          result === AutoPasteResult.Failure ? 'Manual paste instruction' : undefined,
-        );
+      boundDest.getUserInstruction = jest.fn().mockImplementation((result) => (result === AutoPasteResult.Failure ? 'Manual paste instruction' : undefined));
 
       (boundDest.pasteLink as jest.Mock).mockResolvedValueOnce(false);
 
-      const result = await cursorManager.sendLinkToDestination(
-        createMockFormattedLink('src/file.ts#L10'),
-      );
+      const result = await cursorManager.sendLinkToDestination(createMockFormattedLink('src/file.ts#L10'));
 
       expect(result).toBe(false);
       expect(boundDest.pasteLink).toHaveBeenCalledTimes(1);
@@ -1391,9 +1308,7 @@ describe('PasteDestinationManager', () => {
       mockSession.isSet.mockReturnValue(true);
       mockSession.get.mockReturnValue(mockTextEditorDest);
 
-      const result = await localManager.sendLinkToDestination(
-        createMockFormattedLink('src/file.ts#L10'),
-      );
+      const result = await localManager.sendLinkToDestination(createMockFormattedLink('src/file.ts#L10'));
 
       expect(result).toBe(false);
       expect(pasteLinkSpy).toHaveBeenCalledTimes(1);
@@ -1434,11 +1349,7 @@ describe('PasteDestinationManager', () => {
     let mockRegistryForSmartBind: ReturnType<typeof createMockDestinationRegistry>;
 
     // Helper to create mock destinations using the existing infrastructure
-    const createMockDestinationForTest = (
-      id: string,
-      displayName: string,
-      isAvailable = true,
-    ): jest.Mocked<PasteDestination> => {
+    const createMockDestinationForTest = (id: string, displayName: string, isAvailable = true): jest.Mocked<PasteDestination> => {
       // Use createBaseMockPasteDestination with custom equals for instance comparison
       const dest = createBaseMockPasteDestination({
         id: id as DestinationKind,
@@ -1446,9 +1357,7 @@ describe('PasteDestinationManager', () => {
         isAvailable: jest.fn().mockResolvedValue(isAvailable),
       });
       // Override equals to compare by instance reference
-      dest.equals = jest
-        .fn()
-        .mockImplementation((other: PasteDestination | undefined) => dest === other);
+      dest.equals = jest.fn().mockImplementation((other: PasteDestination | undefined) => dest === other);
       return dest as jest.Mocked<PasteDestination>;
     };
 
@@ -1457,13 +1366,7 @@ describe('PasteDestinationManager', () => {
       mockRegistryForSmartBind = createMockDestinationRegistry();
 
       // Recreate manager with mock factory
-      manager = new PasteDestinationManager(
-        mockRegistryForSmartBind,
-        mockAdapter,
-        mockSession,
-        mockFeedback,
-        mockLogger,
-      );
+      manager = new PasteDestinationManager(mockRegistryForSmartBind, mockAdapter, mockSession, mockFeedback, mockLogger);
 
       // Setup default 2 tab groups (required for text editor binding in smart bind scenarios)
       configureEmptyTabGroups(mockAdapter.__getVscodeInstance().window, 2);
@@ -1473,10 +1376,7 @@ describe('PasteDestinationManager', () => {
       it('should unbind old destination and bind new one when user confirms', async () => {
         // Setup: Create mock destinations
         const terminalDest = createMockDestinationForTest('terminal', 'Terminal ("TestTerminal")');
-        const textEditorDest = createMockDestinationForTest(
-          'text-editor',
-          'Text Editor ("file.ts")',
-        );
+        const textEditorDest = createMockDestinationForTest('text-editor', 'Text Editor ("file.ts")');
 
         // Mock factory to return destinations
         (mockRegistryForSmartBind.create as jest.Mock).mockImplementation((options) => {
@@ -1537,8 +1437,7 @@ describe('PasteDestinationManager', () => {
             },
           ],
           {
-            placeHolder:
-              'Already bound to Terminal ("TestTerminal"). Replace with Text Editor ("file.ts")?',
+            placeHolder: 'Already bound to Terminal ("TestTerminal"). Replace with Text Editor ("file.ts")?',
           },
         );
 
@@ -1554,10 +1453,7 @@ describe('PasteDestinationManager', () => {
         expect(mockFeedback.notifyBound).toHaveBeenCalledTimes(1);
         expect(mockFeedback.notifyBound).toHaveBeenCalledWith('Terminal ("TestTerminal")');
         expect(mockFeedback.notifyRebound).toHaveBeenCalledTimes(1);
-        expect(mockFeedback.notifyRebound).toHaveBeenCalledWith(
-          'Text Editor ("file.ts")',
-          'Terminal ("TestTerminal")',
-        );
+        expect(mockFeedback.notifyRebound).toHaveBeenCalledWith('Text Editor ("file.ts")', 'Terminal ("TestTerminal")');
       });
     });
 
@@ -1565,10 +1461,7 @@ describe('PasteDestinationManager', () => {
       it('should keep current binding when user cancels confirmation', async () => {
         // Setup: Create mock destinations
         const terminalDest = createMockDestinationForTest('terminal', 'Terminal ("TestTerminal")');
-        const textEditorDest = createMockDestinationForTest(
-          'text-editor',
-          'Text Editor ("file.ts")',
-        );
+        const textEditorDest = createMockDestinationForTest('text-editor', 'Text Editor ("file.ts")');
 
         (mockRegistryForSmartBind.create as jest.Mock).mockImplementation((options) => {
           if (options.kind === 'terminal') return terminalDest;
@@ -1633,11 +1526,9 @@ describe('PasteDestinationManager', () => {
         (mockRegistryForSmartBind.create as jest.Mock).mockImplementation(() => {
           const newDest = createMockDestinationForTest('terminal', 'Terminal ("TestTerminal")');
           // Make all terminal destinations equal to each other
-          (newDest.equals as jest.Mock).mockImplementation(
-            (other: PasteDestination | undefined) => {
-              return other?.id === 'terminal';
-            },
-          );
+          (newDest.equals as jest.Mock).mockImplementation((other: PasteDestination | undefined) => {
+            return other?.id === 'terminal';
+          });
           return newDest;
         });
 
@@ -1707,10 +1598,7 @@ describe('PasteDestinationManager', () => {
       it('should keep current binding when user presses Esc', async () => {
         // Setup: Create mock destinations
         const terminalDest = createMockDestinationForTest('terminal', 'Terminal ("TestTerminal")');
-        const textEditorDest = createMockDestinationForTest(
-          'text-editor',
-          'Text Editor ("file.ts")',
-        );
+        const textEditorDest = createMockDestinationForTest('text-editor', 'Text Editor ("file.ts")');
 
         (mockRegistryForSmartBind.create as jest.Mock).mockImplementation((options) => {
           if (options.kind === 'terminal') return terminalDest;
@@ -1778,13 +1666,7 @@ describe('PasteDestinationManager', () => {
           createImpl: () => mockTerminalDest,
         });
 
-        manager = new PasteDestinationManager(
-          mockRegistryForSend,
-          mockAdapter,
-          mockSession,
-          mockFeedback,
-          mockLogger,
-        );
+        manager = new PasteDestinationManager(mockRegistryForSend, mockAdapter, mockSession, mockFeedback, mockLogger);
 
         mockVscode = mockAdapter.__getVscodeInstance();
       });
@@ -1866,13 +1748,7 @@ describe('PasteDestinationManager', () => {
           createImpl: () => mockTerminalDest,
         });
 
-        manager = new PasteDestinationManager(
-          mockRegistryForDuplicate,
-          mockAdapter,
-          mockSession,
-          mockFeedback,
-          mockLogger,
-        );
+        manager = new PasteDestinationManager(mockRegistryForDuplicate, mockAdapter, mockSession, mockFeedback, mockLogger);
       });
 
       it('should show already-bound info message and preserve state', async () => {
@@ -1919,13 +1795,7 @@ describe('PasteDestinationManager', () => {
         },
       });
 
-      manager = new PasteDestinationManager(
-        mockRegistryForFocus,
-        mockAdapter,
-        mockSession,
-        mockFeedback,
-        mockLogger,
-      );
+      manager = new PasteDestinationManager(mockRegistryForFocus, mockAdapter, mockSession, mockFeedback, mockLogger);
     });
 
     it('returns err with DESTINATION_NOT_BOUND when no destination bound', async () => {
@@ -2048,14 +1918,11 @@ describe('PasteDestinationManager', () => {
     it('throws UNEXPECTED_DESTINATION_KIND for unhandled options kind', async () => {
       const bogusOptions = { kind: 'unknown-kind' } as unknown as BindOptions;
 
-      await expect(() => manager.bind(bogusOptions)).toThrowDetailedErrorAsync(
-        'UNEXPECTED_DESTINATION_KIND',
-        {
-          message: 'Unhandled bind options kind: unknown-kind',
-          functionName: 'PasteDestinationManager.bind',
-          details: { options: bogusOptions },
-        },
-      );
+      await expect(() => manager.bind(bogusOptions)).toThrowDetailedErrorAsync('UNEXPECTED_DESTINATION_KIND', {
+        message: 'Unhandled bind options kind: unknown-kind',
+        functionName: 'PasteDestinationManager.bind',
+        details: { options: bogusOptions },
+      });
       expect(mockFeedback.notifyBound).not.toHaveBeenCalled();
     });
   });

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/AIAssistantFocusCapability.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/AIAssistantFocusCapability.test.ts
@@ -29,17 +29,8 @@ describe('AIAssistantFocusCapability', () => {
     jest.useRealTimers();
   });
 
-  const createCapability = (
-    commands: string[] = FOCUS_COMMANDS,
-    getColdRefocus?: () => ColdRefocusConfig,
-  ): AIAssistantFocusCapability =>
-    new AIAssistantFocusCapability(
-      mockAdapter,
-      commands,
-      getColdRefocus,
-      mockInsertFactory,
-      mockLogger,
-    );
+  const createCapability = (commands: string[] = FOCUS_COMMANDS, getColdRefocus?: () => ColdRefocusConfig): AIAssistantFocusCapability =>
+    new AIAssistantFocusCapability(mockAdapter, commands, getColdRefocus, mockInsertFactory, mockLogger);
 
   it('succeeds on first focus command and returns inserter', async () => {
     jest.spyOn(mockAdapter, 'executeCommand').mockResolvedValue(undefined);
@@ -52,17 +43,11 @@ describe('AIAssistantFocusCapability', () => {
       expect(value.inserter).toBeUndefined();
     });
     expect(mockAdapter.executeCommand).toHaveBeenCalledWith('ai.focus');
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'test', command: 'ai.focus' },
-      'Focus command succeeded',
-    );
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'test', command: 'ai.focus' }, 'Focus command succeeded');
   });
 
   it('falls back through command list until one succeeds', async () => {
-    jest
-      .spyOn(mockAdapter, 'executeCommand')
-      .mockRejectedValueOnce(new Error('first failed'))
-      .mockResolvedValueOnce(undefined);
+    jest.spyOn(mockAdapter, 'executeCommand').mockRejectedValueOnce(new Error('first failed')).mockResolvedValueOnce(undefined);
     const capability = createCapability(['cmd.a', 'cmd.b', 'cmd.c']);
     const focusPromise = capability.focus(CTX);
     await jest.advanceTimersByTimeAsync(200);
@@ -84,10 +69,7 @@ describe('AIAssistantFocusCapability', () => {
     expect(result).toBeFailureWith((error) => {
       expect(error.reason).toBe('COMMAND_FOCUS_FAILED');
     });
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      { fn: 'test', allCommandsFailed: true },
-      'All focus commands failed',
-    );
+    expect(mockLogger.warn).toHaveBeenCalledWith({ fn: 'test', allCommandsFailed: true }, 'All focus commands failed');
   });
 
   it('waits FOCUS_TO_PASTE_DELAY_MS when no coldRefocus configured (warm delay)', async () => {
@@ -164,10 +146,7 @@ describe('AIAssistantFocusCapability', () => {
     await jest.advanceTimersByTimeAsync(900);
     await focusPromise;
 
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'test', totalMs: expect.any(Number) as number, intervalMs: 300 },
-      'Cold refocus loop completed',
-    );
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'test', totalMs: expect.any(Number) as number, intervalMs: 300 }, 'Cold refocus loop completed');
   });
 
   it('falls back to warm delay when intervalMs is 0', async () => {
@@ -182,10 +161,7 @@ describe('AIAssistantFocusCapability', () => {
     expect(result).toBeSuccessWith((value) => {
       expect(value.inserter).toBeUndefined();
     });
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      { fn: 'test', totalMs: 2500, intervalMs: 0 },
-      'Invalid cold refocus config, falling back to warm delay',
-    );
+    expect(mockLogger.warn).toHaveBeenCalledWith({ fn: 'test', totalMs: 2500, intervalMs: 0 }, 'Invalid cold refocus config, falling back to warm delay');
     expect(mockAdapter.executeCommand).toHaveBeenCalledTimes(1);
   });
 
@@ -216,10 +192,7 @@ describe('AIAssistantFocusCapability', () => {
     expect(result).toBeSuccessWith((value) => {
       expect(value.inserter).toBeUndefined();
     });
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      { fn: 'test', totalMs: 300, intervalMs: 300 },
-      'Invalid cold refocus config, falling back to warm delay',
-    );
+    expect(mockLogger.warn).toHaveBeenCalledWith({ fn: 'test', totalMs: 300, intervalMs: 300 }, 'Invalid cold refocus config, falling back to warm delay');
     expect(mockAdapter.executeCommand).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/ContentEligibilityChecker.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/ContentEligibilityChecker.test.ts
@@ -58,10 +58,7 @@ describe('ContentEligibilityChecker', () => {
 
       await checker.isEligible('', testContext);
 
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        { fn: 'test', contentLength: 0 },
-        'Content not eligible for paste',
-      );
+      expect(mockLogger.info).toHaveBeenCalledWith({ fn: 'test', contentLength: 0 }, 'Content not eligible for paste');
     });
 
     it('should include content length in log', async () => {
@@ -71,10 +68,7 @@ describe('ContentEligibilityChecker', () => {
 
       await checker.isEligible('   ', testContext);
 
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        { fn: 'test', contentLength: 3 },
-        'Content not eligible for paste',
-      );
+      expect(mockLogger.info).toHaveBeenCalledWith({ fn: 'test', contentLength: 3 }, 'Content not eligible for paste');
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/EditorFocusCapability.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/EditorFocusCapability.test.ts
@@ -1,11 +1,5 @@
 import { EditorFocusCapability } from '../../../destinations/capabilities/EditorFocusCapability';
-import {
-  createMockDocument,
-  createMockEditor,
-  createMockInsertFactory,
-  createMockUri,
-  createMockVscodeAdapter,
-} from '../../helpers';
+import { createMockDocument, createMockEditor, createMockInsertFactory, createMockUri, createMockVscodeAdapter } from '../../helpers';
 
 import { createMockLogger } from '@couimet/logger-contract-testing';
 
@@ -34,13 +28,7 @@ describe('EditorFocusCapability', () => {
       const mockInsertFactory = createMockInsertFactory();
       mockInsertFactory.forTarget.mockReturnValue(mockInserterFn);
 
-      const capability = new EditorFocusCapability(
-        mockAdapter,
-        DOCUMENT_URI,
-        BOUND_VIEW_COLUMN,
-        mockInsertFactory,
-        mockLogger,
-      );
+      const capability = new EditorFocusCapability(mockAdapter, DOCUMENT_URI, BOUND_VIEW_COLUMN, mockInsertFactory, mockLogger);
 
       const result = await capability.focus(LOGGING_CONTEXT);
 
@@ -81,20 +69,12 @@ describe('EditorFocusCapability', () => {
       const showErrorSpy = jest.spyOn(mockAdapter, 'showErrorMessage');
 
       const mockInsertFactory = createMockInsertFactory();
-      const capability = new EditorFocusCapability(
-        mockAdapter,
-        DOCUMENT_URI,
-        BOUND_VIEW_COLUMN,
-        mockInsertFactory,
-        mockLogger,
-      );
+      const capability = new EditorFocusCapability(mockAdapter, DOCUMENT_URI, BOUND_VIEW_COLUMN, mockInsertFactory, mockLogger);
 
       const result = await capability.focus(LOGGING_CONTEXT);
 
       expect(result).toBeFailure({ reason: 'EDITOR_AMBIGUOUS_COLUMNS' });
-      expect(showErrorSpy).toHaveBeenCalledWith(
-        'Bound editor is open in multiple tab groups. Close the duplicate tab and try again.',
-      );
+      expect(showErrorSpy).toHaveBeenCalledWith('Bound editor is open in multiple tab groups. Close the duplicate tab and try again.');
       expect(mockLogger.warn).toHaveBeenCalledWith(
         {
           fn: 'EditorFocusCapability.resolveViewColumn',
@@ -127,13 +107,7 @@ describe('EditorFocusCapability', () => {
       const mockInsertFactory = createMockInsertFactory();
       mockInsertFactory.forTarget.mockReturnValue(mockInserterFn);
 
-      const capability = new EditorFocusCapability(
-        mockAdapter,
-        DOCUMENT_URI,
-        BOUND_VIEW_COLUMN,
-        mockInsertFactory,
-        mockLogger,
-      );
+      const capability = new EditorFocusCapability(mockAdapter, DOCUMENT_URI, BOUND_VIEW_COLUMN, mockInsertFactory, mockLogger);
 
       const result = await capability.focus(LOGGING_CONTEXT);
 
@@ -169,13 +143,7 @@ describe('EditorFocusCapability', () => {
       const mockInsertFactory = createMockInsertFactory();
       mockInsertFactory.forTarget.mockReturnValue(mockInserterFn);
 
-      const capability = new EditorFocusCapability(
-        mockAdapter,
-        DOCUMENT_URI,
-        BOUND_VIEW_COLUMN,
-        mockInsertFactory,
-        mockLogger,
-      );
+      const capability = new EditorFocusCapability(mockAdapter, DOCUMENT_URI, BOUND_VIEW_COLUMN, mockInsertFactory, mockLogger);
 
       const result = await capability.focus(LOGGING_CONTEXT);
 
@@ -202,20 +170,12 @@ describe('EditorFocusCapability', () => {
       const showErrorSpy = jest.spyOn(mockAdapter, 'showErrorMessage');
 
       const mockInsertFactory = createMockInsertFactory();
-      const capability = new EditorFocusCapability(
-        mockAdapter,
-        DOCUMENT_URI,
-        BOUND_VIEW_COLUMN,
-        mockInsertFactory,
-        mockLogger,
-      );
+      const capability = new EditorFocusCapability(mockAdapter, DOCUMENT_URI, BOUND_VIEW_COLUMN, mockInsertFactory, mockLogger);
 
       const result = await capability.focus(LOGGING_CONTEXT);
 
       expect(result).toBeFailure({ reason: 'EDITOR_NOT_VISIBLE' });
-      expect(showErrorSpy).toHaveBeenCalledWith(
-        'Bound editor is no longer visible. Re-open the file and bind again.',
-      );
+      expect(showErrorSpy).toHaveBeenCalledWith('Bound editor is no longer visible. Re-open the file and bind again.');
       expect(mockLogger.warn).toHaveBeenCalledWith(
         { fn: 'EditorFocusCapability.resolveViewColumn', editorUri: DOCUMENT_URI_STRING },
         'Bound editor not visible (defensive: auto-unbind should prevent this)',
@@ -238,20 +198,12 @@ describe('EditorFocusCapability', () => {
       const showErrorSpy = jest.spyOn(mockAdapter, 'showErrorMessage');
 
       const mockInsertFactory = createMockInsertFactory();
-      const capability = new EditorFocusCapability(
-        mockAdapter,
-        DOCUMENT_URI,
-        BOUND_VIEW_COLUMN,
-        mockInsertFactory,
-        mockLogger,
-      );
+      const capability = new EditorFocusCapability(mockAdapter, DOCUMENT_URI, BOUND_VIEW_COLUMN, mockInsertFactory, mockLogger);
 
       const result = await capability.focus(LOGGING_CONTEXT);
 
       expect(result).toBeFailure({ reason: 'EDITOR_AMBIGUOUS_COLUMNS' });
-      expect(showErrorSpy).toHaveBeenCalledWith(
-        'Bound editor is open in multiple tab groups. Close the duplicate tab and try again.',
-      );
+      expect(showErrorSpy).toHaveBeenCalledWith('Bound editor is open in multiple tab groups. Close the duplicate tab and try again.');
       expect(mockLogger.warn).toHaveBeenCalledWith(
         {
           fn: 'EditorFocusCapability.resolveViewColumn',
@@ -268,9 +220,7 @@ describe('EditorFocusCapability', () => {
       const mockAdapter = createMockVscodeAdapter();
       jest.spyOn(mockAdapter, 'hasVisibleEditorAt').mockReturnValue(false);
       jest.spyOn(mockAdapter, 'findVisibleEditorsByUri').mockReturnValue([]);
-      jest
-        .spyOn(mockAdapter, 'findAllTabGroupsForDocument')
-        .mockReturnValue([{ viewColumn: BOUND_VIEW_COLUMN } as any]);
+      jest.spyOn(mockAdapter, 'findAllTabGroupsForDocument').mockReturnValue([{ viewColumn: BOUND_VIEW_COLUMN } as any]);
 
       const freshEditor = createMockEditor({
         document: createMockDocument({ uri: DOCUMENT_URI }),
@@ -282,13 +232,7 @@ describe('EditorFocusCapability', () => {
       const mockInsertFactory = createMockInsertFactory();
       mockInsertFactory.forTarget.mockReturnValue(mockInserterFn);
 
-      const capability = new EditorFocusCapability(
-        mockAdapter,
-        DOCUMENT_URI,
-        BOUND_VIEW_COLUMN,
-        mockInsertFactory,
-        mockLogger,
-      );
+      const capability = new EditorFocusCapability(mockAdapter, DOCUMENT_URI, BOUND_VIEW_COLUMN, mockInsertFactory, mockLogger);
 
       const result = await capability.focus(LOGGING_CONTEXT);
 
@@ -313,10 +257,7 @@ describe('EditorFocusCapability', () => {
       jest.spyOn(mockAdapter, 'findVisibleEditorsByUri').mockReturnValue([]);
       jest
         .spyOn(mockAdapter, 'findAllTabGroupsForDocument')
-        .mockReturnValue([
-          { viewColumn: DIFFERENT_VIEW_COLUMN } as any,
-          { viewColumn: BOUND_VIEW_COLUMN } as any,
-        ]);
+        .mockReturnValue([{ viewColumn: DIFFERENT_VIEW_COLUMN } as any, { viewColumn: BOUND_VIEW_COLUMN } as any]);
 
       const freshEditor = createMockEditor({
         document: createMockDocument({ uri: DOCUMENT_URI }),
@@ -328,13 +269,7 @@ describe('EditorFocusCapability', () => {
       const mockInsertFactory = createMockInsertFactory();
       mockInsertFactory.forTarget.mockReturnValue(mockInserterFn);
 
-      const capability = new EditorFocusCapability(
-        mockAdapter,
-        DOCUMENT_URI,
-        BOUND_VIEW_COLUMN,
-        mockInsertFactory,
-        mockLogger,
-      );
+      const capability = new EditorFocusCapability(mockAdapter, DOCUMENT_URI, BOUND_VIEW_COLUMN, mockInsertFactory, mockLogger);
 
       const result = await capability.focus(LOGGING_CONTEXT);
 
@@ -357,26 +292,16 @@ describe('EditorFocusCapability', () => {
       const mockAdapter = createMockVscodeAdapter();
       jest.spyOn(mockAdapter, 'hasVisibleEditorAt').mockReturnValue(false);
       jest.spyOn(mockAdapter, 'findVisibleEditorsByUri').mockReturnValue([]);
-      jest
-        .spyOn(mockAdapter, 'findAllTabGroupsForDocument')
-        .mockReturnValue([{ viewColumn: DIFFERENT_VIEW_COLUMN } as any]);
+      jest.spyOn(mockAdapter, 'findAllTabGroupsForDocument').mockReturnValue([{ viewColumn: DIFFERENT_VIEW_COLUMN } as any]);
       const showErrorSpy = jest.spyOn(mockAdapter, 'showErrorMessage');
 
       const mockInsertFactory = createMockInsertFactory();
-      const capability = new EditorFocusCapability(
-        mockAdapter,
-        DOCUMENT_URI,
-        BOUND_VIEW_COLUMN,
-        mockInsertFactory,
-        mockLogger,
-      );
+      const capability = new EditorFocusCapability(mockAdapter, DOCUMENT_URI, BOUND_VIEW_COLUMN, mockInsertFactory, mockLogger);
 
       const result = await capability.focus(LOGGING_CONTEXT);
 
       expect(result).toBeFailure({ reason: 'EDITOR_NOT_VISIBLE' });
-      expect(showErrorSpy).toHaveBeenCalledWith(
-        'Bound editor is no longer visible. Re-open the file and bind again.',
-      );
+      expect(showErrorSpy).toHaveBeenCalledWith('Bound editor is no longer visible. Re-open the file and bind again.');
       expect(mockLogger.warn).toHaveBeenCalledWith(
         { fn: 'EditorFocusCapability.resolveViewColumn', editorUri: DOCUMENT_URI_STRING },
         'Bound editor not visible (defensive: auto-unbind should prevent this)',
@@ -393,13 +318,7 @@ describe('EditorFocusCapability', () => {
       jest.spyOn(mockAdapter, 'showTextDocument').mockRejectedValue(showDocError);
 
       const mockInsertFactory = createMockInsertFactory();
-      const capability = new EditorFocusCapability(
-        mockAdapter,
-        DOCUMENT_URI,
-        BOUND_VIEW_COLUMN,
-        mockInsertFactory,
-        mockLogger,
-      );
+      const capability = new EditorFocusCapability(mockAdapter, DOCUMENT_URI, BOUND_VIEW_COLUMN, mockInsertFactory, mockLogger);
 
       const result = await capability.focus(LOGGING_CONTEXT);
 

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/FocusCapabilityFactory.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/FocusCapabilityFactory.test.ts
@@ -4,12 +4,7 @@ import { EditorFocusCapability } from '../../../destinations/capabilities/Editor
 import { FocusCapabilityFactory } from '../../../destinations/capabilities/FocusCapabilityFactory';
 import { LazyResolvedFocusCapability } from '../../../destinations/capabilities/LazyResolvedFocusCapability';
 import { TerminalFocusCapability } from '../../../destinations/capabilities/TerminalFocusCapability';
-import {
-  createMockTerminal,
-  createMockTerminalPasteService,
-  createMockUri,
-  createMockVscodeAdapter,
-} from '../../helpers';
+import { createMockTerminal, createMockTerminalPasteService, createMockUri, createMockVscodeAdapter } from '../../helpers';
 
 import { createMockLogger } from '@couimet/logger-contract-testing';
 
@@ -38,10 +33,7 @@ describe('FocusCapabilityFactory', () => {
   });
 
   it('creates AIAssistantFocusCapability', () => {
-    const capability = factory.createAIAssistantCapability(
-      ['workbench.action.chat.open'],
-      undefined,
-    );
+    const capability = factory.createAIAssistantCapability(['workbench.action.chat.open'], undefined);
 
     expect(capability).toBeInstanceOf(AIAssistantFocusCapability);
   });

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/LazyResolvedFocusCapability.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/LazyResolvedFocusCapability.test.ts
@@ -21,9 +21,7 @@ describe('LazyResolvedFocusCapability', () => {
 
   it('resolves on first focus() call via getCommands and caches the result', async () => {
     const mockAdapter = createMockVscodeAdapter();
-    const getCommandsSpy = jest
-      .spyOn(mockAdapter, 'getCommands')
-      .mockResolvedValue(['sparkAi.insertText']);
+    const getCommandsSpy = jest.spyOn(mockAdapter, 'getCommands').mockResolvedValue(['sparkAi.insertText']);
 
     const tier: FocusTier = {
       commands: ['sparkAi.insertText'],
@@ -88,13 +86,7 @@ describe('LazyResolvedFocusCapability', () => {
     };
 
     const FALLBACK_INDEX = 1;
-    const capability = new LazyResolvedFocusCapability(
-      mockAdapter,
-      [userTier, fallbackTier],
-      mockLogger,
-      LOG_PREFIX,
-      FALLBACK_INDEX,
-    );
+    const capability = new LazyResolvedFocusCapability(mockAdapter, [userTier, fallbackTier], mockLogger, LOG_PREFIX, FALLBACK_INDEX);
 
     expect(capability.isFallbackResolution).toBe(false);
 
@@ -129,18 +121,13 @@ describe('LazyResolvedFocusCapability', () => {
     await capability.focus(CONTEXT);
 
     expect(capability.isFallbackResolution).toBe(false);
-    expect(mockLogger.info).toHaveBeenCalledWith(
-      { ...CONTEXT, tier: 'insertCommands', logPrefix: LOG_PREFIX },
-      'TestAssistant: resolved to insertCommands',
-    );
+    expect(mockLogger.info).toHaveBeenCalledWith({ ...CONTEXT, tier: 'insertCommands', logPrefix: LOG_PREFIX }, 'TestAssistant: resolved to insertCommands');
   });
 
   it('delegates to ResolvedFocusCapability for execute probeMode after resolution', async () => {
     const mockAdapter = createMockVscodeAdapter();
     jest.spyOn(mockAdapter, 'getCommands').mockResolvedValue(['sparkAi.focus']);
-    const executeCommandSpy = jest
-      .spyOn(mockAdapter, 'executeCommand')
-      .mockResolvedValue(undefined);
+    const executeCommandSpy = jest.spyOn(mockAdapter, 'executeCommand').mockResolvedValue(undefined);
 
     const tier: FocusTier = {
       commands: ['sparkAi.focus'],

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/ResolvedFocusCapability.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/ResolvedFocusCapability.test.ts
@@ -37,10 +37,7 @@ describe('ResolvedFocusCapability', () => {
     expect(factory.forTarget).toHaveBeenCalled();
     expect(executeCommandSpy).not.toHaveBeenCalled();
     expect(capability.resolvedTierLabel).toBe('insertCommands');
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { ...CONTEXT, tier: 'insertCommands' },
-      'Resolved tier insertCommands — returning inserter directly',
-    );
+    expect(mockLogger.debug).toHaveBeenCalledWith({ ...CONTEXT, tier: 'insertCommands' }, 'Resolved tier insertCommands — returning inserter directly');
   });
 
   it('executes focus command for probeMode execute and returns inserter', async () => {
@@ -65,10 +62,7 @@ describe('ResolvedFocusCapability', () => {
 
   it('tries multiple commands within the resolved tier', async () => {
     const mockAdapter = createMockVscodeAdapter();
-    const executeCommandSpy = jest
-      .spyOn(mockAdapter, 'executeCommand')
-      .mockRejectedValueOnce(new Error('First cmd failed'))
-      .mockResolvedValueOnce(undefined);
+    const executeCommandSpy = jest.spyOn(mockAdapter, 'executeCommand').mockRejectedValueOnce(new Error('First cmd failed')).mockResolvedValueOnce(undefined);
 
     const factory = createMockInsertFactory();
     const tier: FocusTier = {

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/TerminalFocusCapability.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/TerminalFocusCapability.test.ts
@@ -2,11 +2,7 @@ import { TerminalFocusCapability } from '../../../destinations/capabilities/Term
 import { RangeLinkExtensionError } from '../../../errors/RangeLinkExtensionError';
 import { RangeLinkExtensionErrorCodes } from '../../../errors/RangeLinkExtensionErrorCodes';
 import { ExtensionResult } from '../../../types';
-import {
-  createMockInsertFactory,
-  createMockTerminal,
-  createMockVscodeAdapter,
-} from '../../helpers';
+import { createMockInsertFactory, createMockTerminal, createMockVscodeAdapter } from '../../helpers';
 
 import { createMockLogger } from '@couimet/logger-contract-testing';
 import type * as vscode from 'vscode';
@@ -23,20 +19,12 @@ describe('TerminalFocusCapability', () => {
     const mockInsertFactory = createMockInsertFactory<vscode.Terminal>();
     mockInsertFactory.forTarget.mockReturnValue(mockInserterFn);
 
-    const capability = new TerminalFocusCapability(
-      mockAdapter,
-      terminal,
-      mockInsertFactory,
-      mockLogger,
-    );
+    const capability = new TerminalFocusCapability(mockAdapter, terminal, mockInsertFactory, mockLogger);
 
     const result = await capability.focus(LOGGING_CONTEXT);
 
     expect(result).toBeSuccess(expect.objectContaining({ inserter: mockInserterFn }));
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'test::focus', terminalName: 'zsh' },
-      'Terminal focused via showTerminal()',
-    );
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'test::focus', terminalName: 'zsh' }, 'Terminal focused via showTerminal()');
   });
 
   it('returns TERMINAL_FOCUS_FAILED error when showTerminal fails', async () => {
@@ -49,12 +37,7 @@ describe('TerminalFocusCapability', () => {
     const terminal = createMockTerminal({ name: 'bash' });
     const mockInsertFactory = createMockInsertFactory<vscode.Terminal>();
 
-    const capability = new TerminalFocusCapability(
-      mockAdapter,
-      terminal,
-      mockInsertFactory,
-      mockLogger,
-    );
+    const capability = new TerminalFocusCapability(mockAdapter, terminal, mockInsertFactory, mockLogger);
 
     const result = await capability.focus(LOGGING_CONTEXT);
 
@@ -62,9 +45,6 @@ describe('TerminalFocusCapability', () => {
       reason: 'TERMINAL_FOCUS_FAILED',
       cause: focusError,
     });
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      { fn: 'test::focus', terminalName: 'bash', error: focusError },
-      'Failed to focus terminal',
-    );
+    expect(mockLogger.warn).toHaveBeenCalledWith({ fn: 'test::focus', terminalName: 'bash', error: focusError }, 'Failed to focus terminal');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/insertFactories/aiAssistantInsertFactory.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/insertFactories/aiAssistantInsertFactory.test.ts
@@ -37,10 +37,7 @@ describe('AIAssistantInsertFactory', () => {
     const result = await insertFn('content');
 
     expect(result).toBe(false);
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      { fn: 'AIAssistantInsertFactory.insert', allCommandsFailed: true },
-      'Clipboard paste command failed',
-    );
+    expect(mockLogger.warn).toHaveBeenCalledWith({ fn: 'AIAssistantInsertFactory.insert', allCommandsFailed: true }, 'Clipboard paste command failed');
     expect(mockAdapter.writeTextToClipboard).not.toHaveBeenCalled();
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/insertFactories/directInsertFactory.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/insertFactories/directInsertFactory.test.ts
@@ -1,7 +1,4 @@
-import {
-  DirectInsertFactory,
-  InsertCommandEntry,
-} from '../../../../destinations/capabilities/insertFactories/directInsertFactory';
+import { DirectInsertFactory, InsertCommandEntry } from '../../../../destinations/capabilities/insertFactories/directInsertFactory';
 import { createMockVscodeAdapter } from '../../../helpers';
 
 import { createMockLogger } from '@couimet/logger-contract-testing';
@@ -17,9 +14,7 @@ describe('DirectInsertFactory', () => {
 
   it('calls executeCommand with text as first positional arg when no args template', async () => {
     const mockAdapter = createMockVscodeAdapter();
-    const executeCommandSpy = jest
-      .spyOn(mockAdapter, 'executeCommand')
-      .mockResolvedValue(undefined);
+    const executeCommandSpy = jest.spyOn(mockAdapter, 'executeCommand').mockResolvedValue(undefined);
 
     const entries: InsertCommandEntry[] = [{ command: 'sparkAi.insertText' }];
     const factory = new DirectInsertFactory(mockAdapter, entries, mockLogger);
@@ -29,21 +24,14 @@ describe('DirectInsertFactory', () => {
 
     expect(result).toBe(true);
     expect(executeCommandSpy).toHaveBeenCalledWith('sparkAi.insertText', 'src/app.ts#L10-L20');
-    expect(mockLogger.info).toHaveBeenCalledWith(
-      { fn: 'DirectInsertFactory.insert', command: 'sparkAi.insertText' },
-      'Direct insert succeeded',
-    );
+    expect(mockLogger.info).toHaveBeenCalledWith({ fn: 'DirectInsertFactory.insert', command: 'sparkAi.insertText' }, 'Direct insert succeeded');
   });
 
   it('interpolates ${content} in args template and spreads as arguments', async () => {
     const mockAdapter = createMockVscodeAdapter();
-    const executeCommandSpy = jest
-      .spyOn(mockAdapter, 'executeCommand')
-      .mockResolvedValue(undefined);
+    const executeCommandSpy = jest.spyOn(mockAdapter, 'executeCommand').mockResolvedValue(undefined);
 
-    const entries: InsertCommandEntry[] = [
-      { command: 'fancy.cmd', args: [{ text: '${content}', format: 'markdown' }] },
-    ];
+    const entries: InsertCommandEntry[] = [{ command: 'fancy.cmd', args: [{ text: '${content}', format: 'markdown' }] }];
     const factory = new DirectInsertFactory(mockAdapter, entries, mockLogger);
     const insertFn = factory.forTarget();
 
@@ -58,9 +46,7 @@ describe('DirectInsertFactory', () => {
 
   it('wraps non-array interpolated args as a single argument', async () => {
     const mockAdapter = createMockVscodeAdapter();
-    const executeCommandSpy = jest
-      .spyOn(mockAdapter, 'executeCommand')
-      .mockResolvedValue(undefined);
+    const executeCommandSpy = jest.spyOn(mockAdapter, 'executeCommand').mockResolvedValue(undefined);
 
     const entries: InsertCommandEntry[] = [{ command: 'cmd', args: { content: '${content}' } }];
     const factory = new DirectInsertFactory(mockAdapter, entries, mockLogger);
@@ -74,13 +60,9 @@ describe('DirectInsertFactory', () => {
 
   it('spreads multiple elements from an array args template as separate arguments', async () => {
     const mockAdapter = createMockVscodeAdapter();
-    const executeCommandSpy = jest
-      .spyOn(mockAdapter, 'executeCommand')
-      .mockResolvedValue(undefined);
+    const executeCommandSpy = jest.spyOn(mockAdapter, 'executeCommand').mockResolvedValue(undefined);
 
-    const entries: InsertCommandEntry[] = [
-      { command: 'multi.cmd', args: ['${content}', { source: 'rangelink' }] },
-    ];
+    const entries: InsertCommandEntry[] = [{ command: 'multi.cmd', args: ['${content}', { source: 'rangelink' }] }];
     const factory = new DirectInsertFactory(mockAdapter, entries, mockLogger);
     const insertFn = factory.forTarget();
 
@@ -90,19 +72,13 @@ describe('DirectInsertFactory', () => {
     expect(executeCommandSpy).toHaveBeenCalledWith('multi.cmd', 'src/app.ts#L10-L20', {
       source: 'rangelink',
     });
-    expect(mockLogger.info).toHaveBeenCalledWith(
-      { fn: 'DirectInsertFactory.insert', command: 'multi.cmd' },
-      'Direct insert succeeded',
-    );
+    expect(mockLogger.info).toHaveBeenCalledWith({ fn: 'DirectInsertFactory.insert', command: 'multi.cmd' }, 'Direct insert succeeded');
   });
 
   it('falls through to next command when first fails', async () => {
     const mockAdapter = createMockVscodeAdapter();
     const primaryError = new Error('Not found');
-    const executeCommandSpy = jest
-      .spyOn(mockAdapter, 'executeCommand')
-      .mockRejectedValueOnce(primaryError)
-      .mockResolvedValueOnce(undefined);
+    const executeCommandSpy = jest.spyOn(mockAdapter, 'executeCommand').mockRejectedValueOnce(primaryError).mockResolvedValueOnce(undefined);
 
     const entries: InsertCommandEntry[] = [{ command: 'cmd.primary' }, { command: 'cmd.fallback' }];
     const factory = new DirectInsertFactory(mockAdapter, entries, mockLogger);
@@ -122,10 +98,7 @@ describe('DirectInsertFactory', () => {
 
   it('returns false when all commands fail', async () => {
     const mockAdapter = createMockVscodeAdapter();
-    jest
-      .spyOn(mockAdapter, 'executeCommand')
-      .mockRejectedValueOnce(new Error('First failed'))
-      .mockRejectedValueOnce(new Error('Second failed'));
+    jest.spyOn(mockAdapter, 'executeCommand').mockRejectedValueOnce(new Error('First failed')).mockRejectedValueOnce(new Error('Second failed'));
 
     const entries: InsertCommandEntry[] = [{ command: 'cmd.first' }, { command: 'cmd.second' }];
     const factory = new DirectInsertFactory(mockAdapter, entries, mockLogger);
@@ -134,9 +107,6 @@ describe('DirectInsertFactory', () => {
     const result = await insertFn(LINK_TEXT);
 
     expect(result).toBe(false);
-    expect(mockLogger.info).toHaveBeenCalledWith(
-      { fn: 'DirectInsertFactory.insert', allCommandsFailed: true },
-      'All direct insert commands failed',
-    );
+    expect(mockLogger.info).toHaveBeenCalledWith({ fn: 'DirectInsertFactory.insert', allCommandsFailed: true }, 'All direct insert commands failed');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/insertFactories/editorInsertFactory.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/insertFactories/editorInsertFactory.test.ts
@@ -1,10 +1,5 @@
 import { EditorInsertFactory } from '../../../../destinations/capabilities/insertFactories/editorInsertFactory';
-import {
-  createMockDocument,
-  createMockEditor,
-  createMockUri,
-  createMockVscodeAdapter,
-} from '../../../helpers';
+import { createMockDocument, createMockEditor, createMockUri, createMockVscodeAdapter } from '../../../helpers';
 
 import { createMockLogger } from '@couimet/logger-contract-testing';
 
@@ -31,10 +26,7 @@ describe('EditorInsertFactory', () => {
     expect(result).toBe(true);
     expect(insertSpy).toHaveBeenCalledTimes(1);
     expect(insertSpy).toHaveBeenCalledWith(mockEditor, 'test content');
-    expect(mockLogger.info).toHaveBeenCalledWith(
-      { fn: 'EditorInsertFactory.insert', editorUri: 'file:///path/to/file.ts' },
-      'Editor insert succeeded',
-    );
+    expect(mockLogger.info).toHaveBeenCalledWith({ fn: 'EditorInsertFactory.insert', editorUri: 'file:///path/to/file.ts' }, 'Editor insert succeeded');
   });
 
   it('returns false when insertTextAtCursor returns false', async () => {
@@ -48,10 +40,7 @@ describe('EditorInsertFactory', () => {
     const result = await insertFn('content');
 
     expect(result).toBe(false);
-    expect(mockLogger.info).toHaveBeenCalledWith(
-      { fn: 'EditorInsertFactory.insert', editorUri: 'file:///path/to/file.ts' },
-      'Editor insert failed',
-    );
+    expect(mockLogger.info).toHaveBeenCalledWith({ fn: 'EditorInsertFactory.insert', editorUri: 'file:///path/to/file.ts' }, 'Editor insert failed');
   });
 
   it('returns false when insertTextAtCursor throws an error', async () => {

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/insertFactories/manualPasteInsertFactory.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/insertFactories/manualPasteInsertFactory.test.ts
@@ -19,9 +19,6 @@ describe('ManualPasteInsertFactory', () => {
     const result = await insertFn(LINK_TEXT);
 
     expect(result).toBe(true);
-    expect(mockLogger.info).toHaveBeenCalledWith(
-      { fn: 'ManualPasteInsertFactory.insert', textLength: LINK_TEXT_LENGTH },
-      'Link ready for manual paste',
-    );
+    expect(mockLogger.info).toHaveBeenCalledWith({ fn: 'ManualPasteInsertFactory.insert', textLength: LINK_TEXT_LENGTH }, 'Link ready for manual paste');
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/insertFactories/terminalInsertFactory.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/insertFactories/terminalInsertFactory.test.ts
@@ -23,10 +23,7 @@ describe('TerminalInsertFactory', () => {
 
     expect(result).toBe(true);
     expect(mockPasteService.pasteIntoTerminal).toHaveBeenCalledWith('test content', mockTerminal);
-    expect(mockLogger.info).toHaveBeenCalledWith(
-      { fn: 'TerminalInsertFactory.insert', terminalName: 'My Terminal' },
-      'Terminal paste succeeded',
-    );
+    expect(mockLogger.info).toHaveBeenCalledWith({ fn: 'TerminalInsertFactory.insert', terminalName: 'My Terminal' }, 'Terminal paste succeeded');
   });
 
   it('returns false when pasteIntoTerminal returns error', async () => {
@@ -69,28 +66,12 @@ describe('TerminalInsertFactory', () => {
     await insertFn2('content for terminal 2');
 
     expect(mockPasteService.pasteIntoTerminal).toHaveBeenCalledTimes(2);
-    expect(mockPasteService.pasteIntoTerminal).toHaveBeenNthCalledWith(
-      1,
-      'content for terminal 1',
-      terminal1,
-    );
-    expect(mockPasteService.pasteIntoTerminal).toHaveBeenNthCalledWith(
-      2,
-      'content for terminal 2',
-      terminal2,
-    );
+    expect(mockPasteService.pasteIntoTerminal).toHaveBeenNthCalledWith(1, 'content for terminal 1', terminal1);
+    expect(mockPasteService.pasteIntoTerminal).toHaveBeenNthCalledWith(2, 'content for terminal 2', terminal2);
 
     expect(mockLogger.info).toHaveBeenCalledTimes(2);
-    expect(mockLogger.info).toHaveBeenNthCalledWith(
-      1,
-      { fn: 'TerminalInsertFactory.insert', terminalName: 'Terminal 1' },
-      'Terminal paste succeeded',
-    );
-    expect(mockLogger.info).toHaveBeenNthCalledWith(
-      2,
-      { fn: 'TerminalInsertFactory.insert', terminalName: 'Terminal 2' },
-      'Terminal paste succeeded',
-    );
+    expect(mockLogger.info).toHaveBeenNthCalledWith(1, { fn: 'TerminalInsertFactory.insert', terminalName: 'Terminal 1' }, 'Terminal paste succeeded');
+    expect(mockLogger.info).toHaveBeenNthCalledWith(2, { fn: 'TerminalInsertFactory.insert', terminalName: 'Terminal 2' }, 'Terminal paste succeeded');
 
     expect(mockLogger.error).not.toHaveBeenCalled();
   });

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/resolveFocusTier.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/capabilities/resolveFocusTier.test.ts
@@ -31,12 +31,7 @@ describe('resolveFocusTier', () => {
       probeMode: 'execute',
     };
 
-    const result = resolveFocusTier(
-      [tier1, tier2],
-      ['sparkAi.insertText', 'sparkAi.focus'],
-      mockLogger,
-      LOG_PREFIX,
-    );
+    const result = resolveFocusTier([tier1, tier2], ['sparkAi.insertText', 'sparkAi.focus'], mockLogger, LOG_PREFIX);
 
     expect(result).toBeDefined();
     expect(result!.resolvedTier.label).toBe('insertCommands');
@@ -146,13 +141,7 @@ describe('resolveFocusTier', () => {
 
     const FALLBACK_INDEX = 1;
 
-    const result = resolveFocusTier(
-      [userTier, fallbackTier],
-      ['builtin.focus'],
-      mockLogger,
-      LOG_PREFIX,
-      FALLBACK_INDEX,
-    );
+    const result = resolveFocusTier([userTier, fallbackTier], ['builtin.focus'], mockLogger, LOG_PREFIX, FALLBACK_INDEX);
 
     expect(result).toBeDefined();
     expect(result!.resolvedTier.label).toBe('builtinFallback');
@@ -175,13 +164,7 @@ describe('resolveFocusTier', () => {
 
     const FALLBACK_INDEX = 1;
 
-    const result = resolveFocusTier(
-      [userTier, fallbackTier],
-      ['custom.insert', 'builtin.focus'],
-      mockLogger,
-      LOG_PREFIX,
-      FALLBACK_INDEX,
-    );
+    const result = resolveFocusTier([userTier, fallbackTier], ['custom.insert', 'builtin.focus'], mockLogger, LOG_PREFIX, FALLBACK_INDEX);
 
     expect(result).toBeDefined();
     expect(result!.resolvedTier.label).toBe('insertCommands');

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/destinationBuilders.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/destinationBuilders.test.ts
@@ -30,9 +30,7 @@ import type * as vscode from 'vscode';
 describe('destinationBuilders', () => {
   const mockLogger = createMockLogger();
 
-  const createMockContext = (
-    adapterOverrides?: Parameters<typeof createMockVscodeAdapter>[0],
-  ): DestinationBuilderContext => ({
+  const createMockContext = (adapterOverrides?: Parameters<typeof createMockVscodeAdapter>[0]): DestinationBuilderContext => ({
     factories: {
       focusCapability: createMockFocusCapabilityFactory(),
       eligibilityChecker: createMockEligibilityCheckerFactory(),
@@ -76,10 +74,7 @@ describe('destinationBuilders', () => {
       const destination = buildTerminalDestination({ kind: 'terminal', terminal }, context);
 
       const otherTerminal = createMockTerminal({ name: 'bash', processId: Promise.resolve(5678) });
-      const otherDestination = buildTerminalDestination(
-        { kind: 'terminal', terminal: otherTerminal },
-        context,
-      );
+      const otherDestination = buildTerminalDestination({ kind: 'terminal', terminal: otherTerminal }, context);
 
       expect(await destination.equals(otherDestination)).toBe(false);
       expect(await destination.equals(destination)).toBe(true);
@@ -88,24 +83,20 @@ describe('destinationBuilders', () => {
     it('throws RangeLinkExtensionError when called with wrong kind', () => {
       const context = createMockContext();
 
-      expect(() =>
-        buildTerminalDestination(
-          { kind: 'text-editor', uri: createMockUri('/test.ts'), viewColumn: 1 },
-          context,
-        ),
-      ).toThrowDetailedError('UNEXPECTED_DESTINATION_KIND', {
-        message: 'buildTerminalDestination called with wrong kind: text-editor',
-        functionName: 'buildTerminalDestination',
-        details: { actualKind: 'text-editor', expectedKind: 'terminal' },
-      });
+      expect(() => buildTerminalDestination({ kind: 'text-editor', uri: createMockUri('/test.ts'), viewColumn: 1 }, context)).toThrowDetailedError(
+        'UNEXPECTED_DESTINATION_KIND',
+        {
+          message: 'buildTerminalDestination called with wrong kind: text-editor',
+          functionName: 'buildTerminalDestination',
+          details: { actualKind: 'text-editor', expectedKind: 'terminal' },
+        },
+      );
     });
 
     it('throws when getTerminalName returns an error', () => {
       const context = createMockContext();
 
-      expect(() =>
-        buildTerminalDestination({ kind: 'terminal', terminal: undefined as any }, context),
-      ).toThrowDetailedError('TERMINAL_NOT_DEFINED', {
+      expect(() => buildTerminalDestination({ kind: 'terminal', terminal: undefined as any }, context)).toThrowDetailedError('TERMINAL_NOT_DEFINED', {
         message: 'Terminal reference is not defined',
         functionName: 'validateTerminalDefined',
       });
@@ -123,10 +114,7 @@ describe('destinationBuilders', () => {
       context.ideAdapter.getWorkspaceFolder = jest.fn().mockReturnValue({ uri: mockUri });
       context.ideAdapter.asRelativePath = jest.fn().mockReturnValue('src/auth.ts');
 
-      const destination = buildTextEditorDestination(
-        { kind: 'text-editor', uri: mockUri, viewColumn: 1 },
-        context,
-      );
+      const destination = buildTextEditorDestination({ kind: 'text-editor', uri: mockUri, viewColumn: 1 }, context);
 
       expect({ id: destination.id, displayName: destination.displayName }).toStrictEqual({
         id: 'text-editor',
@@ -143,10 +131,7 @@ describe('destinationBuilders', () => {
       const context = createMockContext({ windowOptions: { visibleTextEditors: [editor] } });
       context.ideAdapter.getWorkspaceFolder = jest.fn().mockReturnValue(undefined);
 
-      const destination = buildTextEditorDestination(
-        { kind: 'text-editor', uri: mockUri, viewColumn: 1 },
-        context,
-      );
+      const destination = buildTextEditorDestination({ kind: 'text-editor', uri: mockUri, viewColumn: 1 }, context);
 
       expect({ id: destination.id, displayName: destination.displayName }).toStrictEqual({
         id: 'text-editor',
@@ -165,10 +150,7 @@ describe('destinationBuilders', () => {
       });
       const context = createMockContext({ windowOptions: { visibleTextEditors: [editor] } });
 
-      const destination = buildTextEditorDestination(
-        { kind: 'text-editor', uri: mockUri, viewColumn: 1 },
-        context,
-      );
+      const destination = buildTextEditorDestination({ kind: 'text-editor', uri: mockUri, viewColumn: 1 }, context);
 
       expect({ id: destination.id, displayName: destination.displayName }).toStrictEqual({
         id: 'text-editor',
@@ -186,10 +168,7 @@ describe('destinationBuilders', () => {
       context.ideAdapter.getWorkspaceFolder = jest.fn().mockReturnValue({ uri: mockUri });
       context.ideAdapter.asRelativePath = jest.fn().mockReturnValue('src/auth.ts');
 
-      const destination = buildTextEditorDestination(
-        { kind: 'text-editor', uri: mockUri, viewColumn: 1 },
-        context,
-      );
+      const destination = buildTextEditorDestination({ kind: 'text-editor', uri: mockUri, viewColumn: 1 }, context);
 
       const differentUri = createMockUri('/workspace/src/other.ts');
       const otherEditor = createMockEditor({
@@ -202,10 +181,7 @@ describe('destinationBuilders', () => {
       otherContext.ideAdapter.getWorkspaceFolder = jest.fn().mockReturnValue({ uri: differentUri });
       otherContext.ideAdapter.asRelativePath = jest.fn().mockReturnValue('src/other.ts');
 
-      const otherDestination = buildTextEditorDestination(
-        { kind: 'text-editor', uri: differentUri, viewColumn: 2 },
-        otherContext,
-      );
+      const otherDestination = buildTextEditorDestination({ kind: 'text-editor', uri: differentUri, viewColumn: 2 }, otherContext);
 
       expect(await destination.equals(otherDestination)).toBe(false);
       expect(await destination.equals(destination)).toBe(true);
@@ -214,13 +190,14 @@ describe('destinationBuilders', () => {
     it('throws RangeLinkExtensionError when called with wrong kind', () => {
       const context = createMockContext();
 
-      expect(() =>
-        buildTextEditorDestination({ kind: 'terminal', terminal: {} as vscode.Terminal }, context),
-      ).toThrowDetailedError('UNEXPECTED_DESTINATION_KIND', {
-        message: 'buildTextEditorDestination called with wrong kind: terminal',
-        functionName: 'buildTextEditorDestination',
-        details: { actualKind: 'terminal', expectedKind: 'text-editor' },
-      });
+      expect(() => buildTextEditorDestination({ kind: 'terminal', terminal: {} as vscode.Terminal }, context)).toThrowDetailedError(
+        'UNEXPECTED_DESTINATION_KIND',
+        {
+          message: 'buildTextEditorDestination called with wrong kind: terminal',
+          functionName: 'buildTextEditorDestination',
+          details: { actualKind: 'terminal', expectedKind: 'text-editor' },
+        },
+      );
     });
   });
 
@@ -260,9 +237,7 @@ describe('destinationBuilders', () => {
       const context = createMockContext();
       const destination = builder({ kind: 'cursor-ai' }, context);
 
-      expect(destination.getUserInstruction(AutoPasteResult.Failure)).toBe(
-        'Paste (Cmd/Ctrl+V) in Cursor chat to use.',
-      );
+      expect(destination.getUserInstruction(AutoPasteResult.Failure)).toBe('Paste (Cmd/Ctrl+V) in Cursor chat to use.');
     });
 
     it('creates claude-code destination with correct id and displayName', () => {
@@ -300,9 +275,7 @@ describe('destinationBuilders', () => {
       const context = createMockContext();
       const destination = builder({ kind: 'claude-code' }, context);
 
-      expect(destination.getUserInstruction(AutoPasteResult.Failure)).toBe(
-        'Paste (Cmd/Ctrl+V) in Claude Code chat to use.',
-      );
+      expect(destination.getUserInstruction(AutoPasteResult.Failure)).toBe('Paste (Cmd/Ctrl+V) in Claude Code chat to use.');
     });
 
     it('creates gemini-code-assist destination with correct id and displayName', () => {
@@ -340,9 +313,7 @@ describe('destinationBuilders', () => {
       const context = createMockContext();
       const destination = builder({ kind: 'gemini-code-assist' }, context);
 
-      expect(destination.getUserInstruction(AutoPasteResult.Failure)).toBe(
-        'Paste (Cmd/Ctrl+V) in Gemini Code Assist to use.',
-      );
+      expect(destination.getUserInstruction(AutoPasteResult.Failure)).toBe('Paste (Cmd/Ctrl+V) in Gemini Code Assist to use.');
     });
 
     it('creates github-copilot-chat destination with correct id and displayName', () => {
@@ -380,9 +351,7 @@ describe('destinationBuilders', () => {
       const context = createMockContext();
       const destination = builder({ kind: 'github-copilot-chat' }, context);
 
-      expect(destination.getUserInstruction(AutoPasteResult.Failure)).toBe(
-        'Paste (Cmd/Ctrl+V) in GitHub Copilot chat to use.',
-      );
+      expect(destination.getUserInstruction(AutoPasteResult.Failure)).toBe('Paste (Cmd/Ctrl+V) in GitHub Copilot chat to use.');
     });
   });
 
@@ -433,9 +402,7 @@ describe('destinationBuilders', () => {
     it('isAvailable falls back to command check when extension not found', async () => {
       const context = createMockContext();
       jest.spyOn(context.ideAdapter, 'getExtension').mockReturnValue(undefined);
-      jest
-        .spyOn(context.ideAdapter, 'getCommands')
-        .mockResolvedValue(['sparkAi.focus', 'other.cmd']);
+      jest.spyOn(context.ideAdapter, 'getCommands').mockResolvedValue(['sparkAi.focus', 'other.cmd']);
 
       const builder = createCustomAiAssistantBuilder(customConfig);
       const destination = builder({ kind: customConfig.kind }, context);
@@ -491,9 +458,7 @@ describe('destinationBuilders', () => {
       const builder = createCustomAiAssistantBuilder(customConfig);
       const destination = builder({ kind: customConfig.kind }, context);
 
-      expect(destination.getUserInstruction(AutoPasteResult.Failure)).toBe(
-        'Paste (Cmd/Ctrl+V) in Spark AI to use.',
-      );
+      expect(destination.getUserInstruction(AutoPasteResult.Failure)).toBe('Paste (Cmd/Ctrl+V) in Spark AI to use.');
     });
 
     it('jumpSuccessMessage uses i18n with extensionName', () => {
@@ -564,9 +529,7 @@ describe('destinationBuilders', () => {
       const builder = createCustomAiAssistantBuilder(customConfig);
       const destination = builder({ kind: customConfig.kind }, context);
 
-      expect(destination.getUserInstruction(AutoPasteResult.Success)).toBe(
-        'Paste (Cmd/Ctrl+V) in Spark AI to use.',
-      );
+      expect(destination.getUserInstruction(AutoPasteResult.Success)).toBe('Paste (Cmd/Ctrl+V) in Spark AI to use.');
     });
   });
 
@@ -580,10 +543,7 @@ describe('destinationBuilders', () => {
 
     const buildOverriddenDestination = (context: DestinationBuilderContext) => {
       const builders = new Map<DestinationKind, DestinationBuilder>();
-      registerAllDestinationBuilders(
-        { register: (k: DestinationKind, b: DestinationBuilder) => builders.set(k, b) },
-        [overrideConfig],
-      );
+      registerAllDestinationBuilders({ register: (k: DestinationKind, b: DestinationBuilder) => builders.set(k, b) }, [overrideConfig]);
       const builder = builders.get('claude-code')!;
       return builder({ kind: 'claude-code' }, context);
     };
@@ -612,9 +572,7 @@ describe('destinationBuilders', () => {
       const context = createMockContext();
       buildOverriddenDestination(context);
 
-      expect(context.factories.focusCapability.buildCustomAIAssistantTiers).toHaveBeenCalledWith(
-        overrideConfig,
-      );
+      expect(context.factories.focusCapability.buildCustomAIAssistantTiers).toHaveBeenCalledWith(overrideConfig);
     });
 
     it('calls buildBuiltinFallbackTier with built-in focus commands', () => {
@@ -628,16 +586,11 @@ describe('destinationBuilders', () => {
       const context = createMockContext();
       buildOverriddenDestination(context);
 
-      const buildFallbackSpy = context.factories.focusCapability
-        .buildBuiltinFallbackTier as jest.Mock;
+      const buildFallbackSpy = context.factories.focusCapability.buildBuiltinFallbackTier as jest.Mock;
       const mockFallbackTier = buildFallbackSpy.mock.results[0].value;
       const FALLBACK_TIER_INDEX = 0;
 
-      expect(context.factories.focusCapability.createLazyResolvedCapability).toHaveBeenCalledWith(
-        [mockFallbackTier],
-        'Claude Code Chat',
-        FALLBACK_TIER_INDEX,
-      );
+      expect(context.factories.focusCapability.createLazyResolvedCapability).toHaveBeenCalledWith([mockFallbackTier], 'Claude Code Chat', FALLBACK_TIER_INDEX);
     });
 
     it('isAvailable delegates to built-in availability check', async () => {
@@ -666,9 +619,7 @@ describe('destinationBuilders', () => {
 
       const destination = buildOverriddenDestination(context);
 
-      expect(destination.getUserInstruction(AutoPasteResult.Success)).toBe(
-        'Paste (Cmd/Ctrl+V) in Claude Code chat to use.',
-      );
+      expect(destination.getUserInstruction(AutoPasteResult.Success)).toBe('Paste (Cmd/Ctrl+V) in Claude Code chat to use.');
     });
 
     it('getUserInstruction returns undefined on success when tier is not focusCommands', () => {
@@ -685,9 +636,7 @@ describe('destinationBuilders', () => {
       const context = createMockContext();
       const destination = buildOverriddenDestination(context);
 
-      expect(destination.getUserInstruction(AutoPasteResult.Failure)).toBe(
-        'Paste (Cmd/Ctrl+V) in Claude Code chat to use.',
-      );
+      expect(destination.getUserInstruction(AutoPasteResult.Failure)).toBe('Paste (Cmd/Ctrl+V) in Claude Code chat to use.');
     });
   });
 
@@ -702,14 +651,7 @@ describe('destinationBuilders', () => {
 
       registerAllDestinationBuilders(mockRegistry);
 
-      expect(registeredKinds).toStrictEqual([
-        'terminal',
-        'text-editor',
-        'cursor-ai',
-        'claude-code',
-        'gemini-code-assist',
-        'github-copilot-chat',
-      ]);
+      expect(registeredKinds).toStrictEqual(['terminal', 'text-editor', 'cursor-ai', 'claude-code', 'gemini-code-assist', 'github-copilot-chat']);
     });
 
     it('registers custom AI assistants when provided', () => {
@@ -757,14 +699,7 @@ describe('destinationBuilders', () => {
         },
       ]);
 
-      expect(registeredKinds).toStrictEqual([
-        'terminal',
-        'text-editor',
-        'claude-code',
-        'cursor-ai',
-        'gemini-code-assist',
-        'github-copilot-chat',
-      ]);
+      expect(registeredKinds).toStrictEqual(['terminal', 'text-editor', 'claude-code', 'cursor-ai', 'gemini-code-assist', 'github-copilot-chat']);
     });
 
     it('overridden built-in uses built-in kind, not custom-ai prefix', () => {
@@ -795,16 +730,13 @@ describe('destinationBuilders', () => {
       const context = createMockContext();
       builder({ kind: 'claude-code' }, context);
 
-      const createCapabilityMock = context.factories.focusCapability
-        .createAIAssistantCapability as jest.Mock;
+      const createCapabilityMock = context.factories.focusCapability.createAIAssistantCapability as jest.Mock;
       expect(createCapabilityMock).toHaveBeenCalledWith(
         ['claude-vscode.focus', 'claude-vscode.sidebar.open', 'claude-vscode.editor.open'],
         expect.any(Function),
       );
 
-      const getColdRefocusArg = createCapabilityMock.mock.calls[0][1] as (
-        ...args: unknown[]
-      ) => unknown;
+      const getColdRefocusArg = createCapabilityMock.mock.calls[0][1] as (...args: unknown[]) => unknown;
       expect(typeof getColdRefocusArg).toBe('function');
 
       const result = getColdRefocusArg();
@@ -819,8 +751,7 @@ describe('destinationBuilders', () => {
       const context = createMockContext();
       builder({ kind: 'cursor-ai' }, context);
 
-      const createCapabilityMock = context.factories.focusCapability
-        .createAIAssistantCapability as jest.Mock;
+      const createCapabilityMock = context.factories.focusCapability.createAIAssistantCapability as jest.Mock;
       expect(createCapabilityMock).toHaveBeenCalledWith(expect.any(Array), undefined);
     });
 
@@ -834,8 +765,7 @@ describe('destinationBuilders', () => {
       });
 
       builder({ kind: 'claude-code' }, context);
-      const createCapabilityMock = context.factories.focusCapability
-        .createAIAssistantCapability as jest.Mock;
+      const createCapabilityMock = context.factories.focusCapability.createAIAssistantCapability as jest.Mock;
       expect(createCapabilityMock).toHaveBeenCalledTimes(1);
       const [, getColdRefocusFn] = createCapabilityMock.mock.calls[0];
 
@@ -856,8 +786,7 @@ describe('destinationBuilders', () => {
       });
 
       builder({ kind: 'claude-code' }, context);
-      const createCapabilityMock = context.factories.focusCapability
-        .createAIAssistantCapability as jest.Mock;
+      const createCapabilityMock = context.factories.focusCapability.createAIAssistantCapability as jest.Mock;
       expect(createCapabilityMock).toHaveBeenCalledTimes(1);
       const [, getColdRefocusFn] = createCapabilityMock.mock.calls[0];
 
@@ -879,16 +808,10 @@ describe('destinationBuilders', () => {
       const context = createMockContext();
       builder({ kind: 'gemini-code-assist' }, context);
 
-      const createCapabilityMock = context.factories.focusCapability
-        .createAIAssistantCapability as jest.Mock;
-      expect(createCapabilityMock).toHaveBeenCalledWith(
-        ['cloudcode.gemini.chatView.focus'],
-        expect.any(Function),
-      );
+      const createCapabilityMock = context.factories.focusCapability.createAIAssistantCapability as jest.Mock;
+      expect(createCapabilityMock).toHaveBeenCalledWith(['cloudcode.gemini.chatView.focus'], expect.any(Function));
 
-      const getColdRefocusArg = createCapabilityMock.mock.calls[0][1] as (
-        ...args: unknown[]
-      ) => unknown;
+      const getColdRefocusArg = createCapabilityMock.mock.calls[0][1] as (...args: unknown[]) => unknown;
       expect(typeof getColdRefocusArg).toBe('function');
 
       const result = getColdRefocusArg();
@@ -908,8 +831,7 @@ describe('destinationBuilders', () => {
       });
 
       builder({ kind: 'gemini-code-assist' }, context);
-      const createCapabilityMock = context.factories.focusCapability
-        .createAIAssistantCapability as jest.Mock;
+      const createCapabilityMock = context.factories.focusCapability.createAIAssistantCapability as jest.Mock;
       expect(createCapabilityMock).toHaveBeenCalledTimes(1);
       const [, getColdRefocusFn] = createCapabilityMock.mock.calls[0];
 
@@ -930,8 +852,7 @@ describe('destinationBuilders', () => {
       });
 
       builder({ kind: 'gemini-code-assist' }, context);
-      const createCapabilityMock = context.factories.focusCapability
-        .createAIAssistantCapability as jest.Mock;
+      const createCapabilityMock = context.factories.focusCapability.createAIAssistantCapability as jest.Mock;
       expect(createCapabilityMock).toHaveBeenCalledTimes(1);
       const [, getColdRefocusFn] = createCapabilityMock.mock.calls[0];
 
@@ -964,9 +885,7 @@ describe('destinationBuilders', () => {
         },
       ];
 
-      expect(resolveKindByExtensionId('my-extension', customAssistants)).toBe(
-        'custom-ai:my-extension',
-      );
+      expect(resolveKindByExtensionId('my-extension', customAssistants)).toBe('custom-ai:my-extension');
     });
 
     it('prioritises built-in over custom when both match', () => {
@@ -979,9 +898,7 @@ describe('destinationBuilders', () => {
         },
       ];
 
-      expect(resolveKindByExtensionId('anthropic.claude-code', customAssistants)).toBe(
-        'claude-code',
-      );
+      expect(resolveKindByExtensionId('anthropic.claude-code', customAssistants)).toBe('claude-code');
     });
 
     it('returns undefined when extensionId matches neither built-in nor custom', () => {

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/equality/compareEditorsByUri.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/equality/compareEditorsByUri.test.ts
@@ -1,9 +1,5 @@
 import { compareEditorsByUri } from '../../../destinations/equality/compareEditorsByUri';
-import {
-  createMockCursorAIComposableDestination,
-  createMockEditorComposablePasteDestination,
-  createMockUri,
-} from '../../helpers';
+import { createMockCursorAIComposableDestination, createMockEditorComposablePasteDestination, createMockUri } from '../../helpers';
 
 describe('compareEditorsByUri', () => {
   describe('when editors have matching URIs', () => {

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/equality/compareTerminalsByProcessId.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/equality/compareTerminalsByProcessId.test.ts
@@ -1,9 +1,5 @@
 import { compareTerminalsByProcessId } from '../../../destinations/equality/compareTerminalsByProcessId';
-import {
-  createMockCursorAIComposableDestination,
-  createMockTerminal,
-  createMockTerminalComposablePasteDestination,
-} from '../../helpers';
+import { createMockCursorAIComposableDestination, createMockTerminal, createMockTerminalComposablePasteDestination } from '../../helpers';
 
 describe('compareTerminalsByProcessId', () => {
   describe('when terminals have matching process IDs', () => {

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/buildDestinationQuickPickItems.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/buildDestinationQuickPickItems.test.ts
@@ -1,8 +1,4 @@
-import {
-  buildDestinationQuickPickItems,
-  BUILTIN_AI_COUNT,
-  DESTINATION_PICKER_SEQUENCE,
-} from '../../../destinations/utils/buildDestinationQuickPickItems';
+import { buildDestinationQuickPickItems, BUILTIN_AI_COUNT, DESTINATION_PICKER_SEQUENCE } from '../../../destinations/utils/buildDestinationQuickPickItems';
 import { AI_ASSISTANT_KINDS, FileMoreQuickPickItem, GroupedDestinationItems } from '../../../types';
 import { createMockEligibleFile, createMockTextEditorQuickPickItem } from '../../helpers';
 

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/buildFilePickerItems.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/buildFilePickerItems.test.ts
@@ -10,9 +10,7 @@ const separator = (label: string): vscode.QuickPickItem => ({
 
 describe('buildFilePickerItems', () => {
   it('prefixes active files with Active Files separator', () => {
-    const activeFile = createMockTextEditorQuickPickItem(
-      createMockEligibleFile({ filename: 'app.ts', viewColumn: 1, isCurrentInGroup: true }),
-    );
+    const activeFile = createMockTextEditorQuickPickItem(createMockEligibleFile({ filename: 'app.ts', viewColumn: 1, isCurrentInGroup: true }));
 
     const result = buildFilePickerItems([activeFile]);
 
@@ -20,12 +18,8 @@ describe('buildFilePickerItems', () => {
   });
 
   it('prefixes inactive files with Tab Group N separator grouped by viewColumn', () => {
-    const inactive1 = createMockTextEditorQuickPickItem(
-      createMockEligibleFile({ filename: 'a.ts', viewColumn: 1 }),
-    );
-    const inactive2 = createMockTextEditorQuickPickItem(
-      createMockEligibleFile({ filename: 'b.ts', viewColumn: 1 }),
-    );
+    const inactive1 = createMockTextEditorQuickPickItem(createMockEligibleFile({ filename: 'a.ts', viewColumn: 1 }));
+    const inactive2 = createMockTextEditorQuickPickItem(createMockEligibleFile({ filename: 'b.ts', viewColumn: 1 }));
 
     const result = buildFilePickerItems([inactive1, inactive2]);
 
@@ -33,35 +27,18 @@ describe('buildFilePickerItems', () => {
   });
 
   it('produces Active Files section then per-group sections for mixed input', () => {
-    const active = createMockTextEditorQuickPickItem(
-      createMockEligibleFile({ filename: 'app.ts', viewColumn: 1, isCurrentInGroup: true }),
-    );
-    const inactive1 = createMockTextEditorQuickPickItem(
-      createMockEligibleFile({ filename: 'b.ts', viewColumn: 1 }),
-    );
-    const inactive2 = createMockTextEditorQuickPickItem(
-      createMockEligibleFile({ filename: 'c.ts', viewColumn: 2 }),
-    );
+    const active = createMockTextEditorQuickPickItem(createMockEligibleFile({ filename: 'app.ts', viewColumn: 1, isCurrentInGroup: true }));
+    const inactive1 = createMockTextEditorQuickPickItem(createMockEligibleFile({ filename: 'b.ts', viewColumn: 1 }));
+    const inactive2 = createMockTextEditorQuickPickItem(createMockEligibleFile({ filename: 'c.ts', viewColumn: 2 }));
 
     const result = buildFilePickerItems([active, inactive1, inactive2]);
 
-    expect(result).toStrictEqual([
-      separator('Active Files'),
-      active,
-      separator('Tab Group 1'),
-      inactive1,
-      separator('Tab Group 2'),
-      inactive2,
-    ]);
+    expect(result).toStrictEqual([separator('Active Files'), active, separator('Tab Group 1'), inactive1, separator('Tab Group 2'), inactive2]);
   });
 
   it('produces no per-group sections when all files are active', () => {
-    const active1 = createMockTextEditorQuickPickItem(
-      createMockEligibleFile({ filename: 'a.ts', viewColumn: 1, isCurrentInGroup: true }),
-    );
-    const active2 = createMockTextEditorQuickPickItem(
-      createMockEligibleFile({ filename: 'b.ts', viewColumn: 2, isCurrentInGroup: true }),
-    );
+    const active1 = createMockTextEditorQuickPickItem(createMockEligibleFile({ filename: 'a.ts', viewColumn: 1, isCurrentInGroup: true }));
+    const active2 = createMockTextEditorQuickPickItem(createMockEligibleFile({ filename: 'b.ts', viewColumn: 2, isCurrentInGroup: true }));
 
     const result = buildFilePickerItems([active1, active2]);
 
@@ -69,70 +46,33 @@ describe('buildFilePickerItems', () => {
   });
 
   it('produces no Active Files section when no files are current-in-group', () => {
-    const inactive1 = createMockTextEditorQuickPickItem(
-      createMockEligibleFile({ filename: 'a.ts', viewColumn: 1 }),
-    );
-    const inactive2 = createMockTextEditorQuickPickItem(
-      createMockEligibleFile({ filename: 'b.ts', viewColumn: 2 }),
-    );
+    const inactive1 = createMockTextEditorQuickPickItem(createMockEligibleFile({ filename: 'a.ts', viewColumn: 1 }));
+    const inactive2 = createMockTextEditorQuickPickItem(createMockEligibleFile({ filename: 'b.ts', viewColumn: 2 }));
 
     const result = buildFilePickerItems([inactive1, inactive2]);
 
-    expect(result).toStrictEqual([
-      separator('Tab Group 1'),
-      inactive1,
-      separator('Tab Group 2'),
-      inactive2,
-    ]);
+    expect(result).toStrictEqual([separator('Tab Group 1'), inactive1, separator('Tab Group 2'), inactive2]);
   });
 
   it('sorts per-group sections by viewColumn in ascending order', () => {
-    const inactive3 = createMockTextEditorQuickPickItem(
-      createMockEligibleFile({ filename: 'c.ts', viewColumn: 3 }),
-    );
-    const inactive1 = createMockTextEditorQuickPickItem(
-      createMockEligibleFile({ filename: 'a.ts', viewColumn: 1 }),
-    );
-    const inactive2 = createMockTextEditorQuickPickItem(
-      createMockEligibleFile({ filename: 'b.ts', viewColumn: 2 }),
-    );
+    const inactive3 = createMockTextEditorQuickPickItem(createMockEligibleFile({ filename: 'c.ts', viewColumn: 3 }));
+    const inactive1 = createMockTextEditorQuickPickItem(createMockEligibleFile({ filename: 'a.ts', viewColumn: 1 }));
+    const inactive2 = createMockTextEditorQuickPickItem(createMockEligibleFile({ filename: 'b.ts', viewColumn: 2 }));
 
     const result = buildFilePickerItems([inactive3, inactive1, inactive2]);
 
-    expect(result).toStrictEqual([
-      separator('Tab Group 1'),
-      inactive1,
-      separator('Tab Group 2'),
-      inactive2,
-      separator('Tab Group 3'),
-      inactive3,
-    ]);
+    expect(result).toStrictEqual([separator('Tab Group 1'), inactive1, separator('Tab Group 2'), inactive2, separator('Tab Group 3'), inactive3]);
   });
 
   it('preserves input order within each section', () => {
-    const active1 = createMockTextEditorQuickPickItem(
-      createMockEligibleFile({ filename: 'z.ts', viewColumn: 1, isCurrentInGroup: true }),
-    );
-    const active2 = createMockTextEditorQuickPickItem(
-      createMockEligibleFile({ filename: 'a.ts', viewColumn: 1, isCurrentInGroup: true }),
-    );
-    const inactive1 = createMockTextEditorQuickPickItem(
-      createMockEligibleFile({ filename: 'z.ts', viewColumn: 1 }),
-    );
-    const inactive2 = createMockTextEditorQuickPickItem(
-      createMockEligibleFile({ filename: 'a.ts', viewColumn: 1 }),
-    );
+    const active1 = createMockTextEditorQuickPickItem(createMockEligibleFile({ filename: 'z.ts', viewColumn: 1, isCurrentInGroup: true }));
+    const active2 = createMockTextEditorQuickPickItem(createMockEligibleFile({ filename: 'a.ts', viewColumn: 1, isCurrentInGroup: true }));
+    const inactive1 = createMockTextEditorQuickPickItem(createMockEligibleFile({ filename: 'z.ts', viewColumn: 1 }));
+    const inactive2 = createMockTextEditorQuickPickItem(createMockEligibleFile({ filename: 'a.ts', viewColumn: 1 }));
 
     const result = buildFilePickerItems([active1, active2, inactive1, inactive2]);
 
-    expect(result).toStrictEqual([
-      separator('Active Files'),
-      active1,
-      active2,
-      separator('Tab Group 1'),
-      inactive1,
-      inactive2,
-    ]);
+    expect(result).toStrictEqual([separator('Active Files'), active1, active2, separator('Tab Group 1'), inactive1, inactive2]);
   });
 
   it('passes through bound file description unchanged', () => {

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/buildTerminalDescription.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/buildTerminalDescription.test.ts
@@ -3,16 +3,12 @@ import { createMockEligibleTerminal } from '../../helpers';
 
 describe('buildTerminalDescription', () => {
   it('returns "bound · active" when bound AND active', () => {
-    const result = buildTerminalDescription(
-      createMockEligibleTerminal({ boundState: 'bound', isActive: true }),
-    );
+    const result = buildTerminalDescription(createMockEligibleTerminal({ boundState: 'bound', isActive: true }));
     expect(result).toBe('bound \u00b7 active');
   });
 
   it('returns "bound" when bound only', () => {
-    const result = buildTerminalDescription(
-      createMockEligibleTerminal({ boundState: 'bound', isActive: false }),
-    );
+    const result = buildTerminalDescription(createMockEligibleTerminal({ boundState: 'bound', isActive: false }));
     expect(result).toBe('bound');
   });
 
@@ -27,16 +23,12 @@ describe('buildTerminalDescription', () => {
   });
 
   it('returns "active" when boundState is "not-bound" and active', () => {
-    const result = buildTerminalDescription(
-      createMockEligibleTerminal({ boundState: 'not-bound', isActive: true }),
-    );
+    const result = buildTerminalDescription(createMockEligibleTerminal({ boundState: 'not-bound', isActive: true }));
     expect(result).toBe('active');
   });
 
   it('returns undefined when boundState is "not-bound" and not active', () => {
-    const result = buildTerminalDescription(
-      createMockEligibleTerminal({ boundState: 'not-bound', isActive: false }),
-    );
+    const result = buildTerminalDescription(createMockEligibleTerminal({ boundState: 'not-bound', isActive: false }));
     expect(result).toBeUndefined();
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/buildTerminalPickerItems.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/buildTerminalPickerItems.test.ts
@@ -5,9 +5,7 @@ describe('buildTerminalPickerItems', () => {
   const identityLabel = (info: { name: string }): string => info.name;
 
   it('sets description to "bound \u00b7 active" when terminal is bound and active', () => {
-    const items = [
-      createMockTerminalQuickPickItem(createMockTerminal({ name: 'zsh' }), true, 'bound'),
-    ];
+    const items = [createMockTerminalQuickPickItem(createMockTerminal({ name: 'zsh' }), true, 'bound')];
 
     const result = buildTerminalPickerItems(items, identityLabel);
 
@@ -15,9 +13,7 @@ describe('buildTerminalPickerItems', () => {
   });
 
   it('sets description to "bound" when terminal is bound but not active', () => {
-    const items = [
-      createMockTerminalQuickPickItem(createMockTerminal({ name: 'zsh' }), false, 'bound'),
-    ];
+    const items = [createMockTerminalQuickPickItem(createMockTerminal({ name: 'zsh' }), false, 'bound')];
 
     const result = buildTerminalPickerItems(items, identityLabel);
 
@@ -25,9 +21,7 @@ describe('buildTerminalPickerItems', () => {
   });
 
   it('sets description to "active" when terminal is active but not bound', () => {
-    const items = [
-      createMockTerminalQuickPickItem(createMockTerminal({ name: 'zsh' }), true, 'not-bound'),
-    ];
+    const items = [createMockTerminalQuickPickItem(createMockTerminal({ name: 'zsh' }), true, 'not-bound')];
 
     const result = buildTerminalPickerItems(items, identityLabel);
 
@@ -35,9 +29,7 @@ describe('buildTerminalPickerItems', () => {
   });
 
   it('sets description to undefined when terminal is neither bound nor active', () => {
-    const items = [
-      createMockTerminalQuickPickItem(createMockTerminal({ name: 'zsh' }), false, 'not-bound'),
-    ];
+    const items = [createMockTerminalQuickPickItem(createMockTerminal({ name: 'zsh' }), false, 'not-bound')];
 
     const result = buildTerminalPickerItems(items, identityLabel);
 
@@ -61,10 +53,7 @@ describe('buildTerminalPickerItems', () => {
   });
 
   it('applies label builder to each item', () => {
-    const items = [
-      createMockTerminalQuickPickItem(createMockTerminal({ name: 'bash' })),
-      createMockTerminalQuickPickItem(createMockTerminal({ name: 'zsh' })),
-    ];
+    const items = [createMockTerminalQuickPickItem(createMockTerminal({ name: 'bash' })), createMockTerminalQuickPickItem(createMockTerminal({ name: 'zsh' }))];
 
     const result = buildTerminalPickerItems(items, (info) => `prefix-${info.name}`);
 

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/getEligibleFiles.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/getEligibleFiles.test.ts
@@ -1,10 +1,5 @@
 import { getEligibleFiles } from '../../../destinations/utils';
-import {
-  createMockTab,
-  createMockTabGroup,
-  createMockUri,
-  createMockVscodeAdapter,
-} from '../../helpers';
+import { createMockTab, createMockTabGroup, createMockUri, createMockVscodeAdapter } from '../../helpers';
 
 import * as vscode from 'vscode';
 

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/markBoundTerminal.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/markBoundTerminal.test.ts
@@ -19,10 +19,7 @@ describe('markBoundTerminal', () => {
   });
 
   it('marks all as not-bound when boundTerminalProcessId is undefined', () => {
-    const terminals = [
-      createMockEligibleTerminal({ name: 'bash', processId: 100 }),
-      createMockEligibleTerminal({ name: 'zsh', processId: 200 }),
-    ];
+    const terminals = [createMockEligibleTerminal({ name: 'bash', processId: 100 }), createMockEligibleTerminal({ name: 'zsh', processId: 200 })];
 
     const result = markBoundTerminal(terminals, undefined);
 
@@ -33,10 +30,7 @@ describe('markBoundTerminal', () => {
   });
 
   it('marks all as not-bound when no processId matches', () => {
-    const terminals = [
-      createMockEligibleTerminal({ name: 'bash', processId: 100 }),
-      createMockEligibleTerminal({ name: 'zsh', processId: 200 }),
-    ];
+    const terminals = [createMockEligibleTerminal({ name: 'bash', processId: 100 }), createMockEligibleTerminal({ name: 'zsh', processId: 200 })];
 
     const result = markBoundTerminal(terminals, 999);
 
@@ -47,10 +41,7 @@ describe('markBoundTerminal', () => {
   });
 
   it('marks terminal with undefined processId as not-bound even when boundTerminalProcessId is provided', () => {
-    const terminals = [
-      createMockEligibleTerminal({ name: 'bash' }),
-      createMockEligibleTerminal({ name: 'zsh', processId: 200 }),
-    ];
+    const terminals = [createMockEligibleTerminal({ name: 'bash' }), createMockEligibleTerminal({ name: 'zsh', processId: 200 })];
 
     const result = markBoundTerminal(terminals, 200);
 
@@ -62,9 +53,7 @@ describe('markBoundTerminal', () => {
 
   it('preserves all original EligibleTerminal properties', () => {
     const terminal = createMockTerminal({ name: 'bash' });
-    const terminals = [
-      createMockEligibleTerminal({ terminal, name: 'bash', isActive: true, processId: 42 }),
-    ];
+    const terminals = [createMockEligibleTerminal({ terminal, name: 'bash', isActive: true, processId: 42 })];
 
     const result = markBoundTerminal(terminals, 42);
 

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/showFilePicker.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/showFilePicker.test.ts
@@ -11,17 +11,12 @@ const separator = (label: string): vscode.QuickPickItem => ({
   kind: vscode.QuickPickItemKind.Separator,
 });
 
-const withActiveSeparator = (
-  items: FileBindableQuickPickItem[],
-): (FileBindableQuickPickItem | vscode.QuickPickItem)[] => [separator('Active Files'), ...items];
+const withActiveSeparator = (items: FileBindableQuickPickItem[]): (FileBindableQuickPickItem | vscode.QuickPickItem)[] => [separator('Active Files'), ...items];
 
 describe('showFilePicker', () => {
   const identityCallback = (file: EligibleFile): EligibleFile => file;
 
-  const createHandlers = <T>(
-    onSelected: (file: EligibleFile) => T | Promise<T>,
-    overrides: Partial<FilePickerHandlers<T>> = {},
-  ): FilePickerHandlers<T> => ({
+  const createHandlers = <T>(onSelected: (file: EligibleFile) => T | Promise<T>, overrides: Partial<FilePickerHandlers<T>> = {}): FilePickerHandlers<T> => ({
     onSelected,
     getPlaceholder: () => 'Choose a file to bind to',
     ...overrides,
@@ -32,9 +27,7 @@ describe('showFilePicker', () => {
       const quickPickProvider = createMockQuickPickProvider();
       const logger = createMockLogger();
 
-      await expect(() =>
-        showFilePicker([], quickPickProvider, createHandlers(identityCallback), logger),
-      ).toThrowDetailedErrorAsync('FILE_PICKER_EMPTY_ITEMS', {
+      await expect(() => showFilePicker([], quickPickProvider, createHandlers(identityCallback), logger)).toThrowDetailedErrorAsync('FILE_PICKER_EMPTY_ITEMS', {
         message: 'showFilePicker called with no file items',
         functionName: 'showFilePicker',
       });
@@ -49,26 +42,15 @@ describe('showFilePicker', () => {
       quickPickProvider.showQuickPick.mockResolvedValueOnce(items[1]);
       const logger = createMockLogger();
 
-      const result = await showFilePicker(
-        items,
-        quickPickProvider,
-        createHandlers(identityCallback),
-        logger,
-      );
+      const result = await showFilePicker(items, quickPickProvider, createHandlers(identityCallback), logger);
 
       expect(result).toStrictEqual(items[1].fileInfo);
       expect(quickPickProvider.showQuickPick).toHaveBeenCalledWith(withActiveSeparator(items), {
         title: 'RangeLink',
         placeHolder: 'Choose a file to bind to',
       });
-      expect(logger.debug).toHaveBeenCalledWith(
-        { fn: 'showFilePicker', fileCount: 3, itemCount: 4 },
-        'Showing file picker',
-      );
-      expect(logger.debug).toHaveBeenCalledWith(
-        { fn: 'showFilePicker', selected: items[1] },
-        'File selected',
-      );
+      expect(logger.debug).toHaveBeenCalledWith({ fn: 'showFilePicker', fileCount: 3, itemCount: 4 }, 'Showing file picker');
+      expect(logger.debug).toHaveBeenCalledWith({ fn: 'showFilePicker', selected: items[1] }, 'File selected');
     });
 
     it('passes handler return value through as result', async () => {
@@ -85,14 +67,8 @@ describe('showFilePicker', () => {
       );
 
       expect(result).toStrictEqual({ kind: 'text-editor', name: 'file-1.ts' });
-      expect(logger.debug).toHaveBeenCalledWith(
-        { fn: 'showFilePicker', fileCount: 2, itemCount: 3 },
-        'Showing file picker',
-      );
-      expect(logger.debug).toHaveBeenCalledWith(
-        { fn: 'showFilePicker', selected: items[0] },
-        'File selected',
-      );
+      expect(logger.debug).toHaveBeenCalledWith({ fn: 'showFilePicker', fileCount: 2, itemCount: 3 }, 'Showing file picker');
+      expect(logger.debug).toHaveBeenCalledWith({ fn: 'showFilePicker', selected: items[0] }, 'File selected');
     });
 
     it('supports async onSelected handler', async () => {
@@ -109,14 +85,8 @@ describe('showFilePicker', () => {
       );
 
       expect(result).toBe('bound-file-1.ts');
-      expect(logger.debug).toHaveBeenCalledWith(
-        { fn: 'showFilePicker', fileCount: 2, itemCount: 3 },
-        'Showing file picker',
-      );
-      expect(logger.debug).toHaveBeenCalledWith(
-        { fn: 'showFilePicker', selected: items[0] },
-        'File selected',
-      );
+      expect(logger.debug).toHaveBeenCalledWith({ fn: 'showFilePicker', fileCount: 2, itemCount: 3 }, 'Showing file picker');
+      expect(logger.debug).toHaveBeenCalledWith({ fn: 'showFilePicker', selected: items[0] }, 'File selected');
     });
 
     it('uses placeholder from getPlaceholder handler', async () => {
@@ -138,30 +108,17 @@ describe('showFilePicker', () => {
         title: 'RangeLink',
         placeHolder: 'Custom file placeholder',
       });
-      expect(logger.debug).toHaveBeenCalledWith(
-        { fn: 'showFilePicker', fileCount: 2, itemCount: 3 },
-        'Showing file picker',
-      );
-      expect(logger.debug).toHaveBeenCalledWith(
-        { fn: 'showFilePicker', selected: items[0] },
-        'File selected',
-      );
+      expect(logger.debug).toHaveBeenCalledWith({ fn: 'showFilePicker', fileCount: 2, itemCount: 3 }, 'Showing file picker');
+      expect(logger.debug).toHaveBeenCalledWith({ fn: 'showFilePicker', selected: items[0] }, 'File selected');
     });
 
     it('returns undefined when a non-file item is selected', async () => {
       const items = createMockTextEditorQuickPickItems(2);
       const quickPickProvider = createMockQuickPickProvider();
-      quickPickProvider.showQuickPick.mockResolvedValueOnce(
-        separator('Active Files') as unknown as FileBindableQuickPickItem,
-      );
+      quickPickProvider.showQuickPick.mockResolvedValueOnce(separator('Active Files') as unknown as FileBindableQuickPickItem);
       const logger = createMockLogger();
 
-      const result = await showFilePicker(
-        items,
-        quickPickProvider,
-        createHandlers(identityCallback),
-        logger,
-      );
+      const result = await showFilePicker(items, quickPickProvider, createHandlers(identityCallback), logger);
 
       expect(result).toBeUndefined();
     });
@@ -174,18 +131,10 @@ describe('showFilePicker', () => {
       quickPickProvider.showQuickPick.mockResolvedValueOnce(undefined);
       const logger = createMockLogger();
 
-      const result = await showFilePicker(
-        items,
-        quickPickProvider,
-        createHandlers(identityCallback),
-        logger,
-      );
+      const result = await showFilePicker(items, quickPickProvider, createHandlers(identityCallback), logger);
 
       expect(result).toBeUndefined();
-      expect(logger.debug).toHaveBeenCalledWith(
-        { fn: 'showFilePicker', fileCount: 3 },
-        'User cancelled file picker',
-      );
+      expect(logger.debug).toHaveBeenCalledWith({ fn: 'showFilePicker', fileCount: 3 }, 'User cancelled file picker');
     });
 
     it('calls onDismissed handler when provided and user dismisses', async () => {
@@ -204,10 +153,7 @@ describe('showFilePicker', () => {
       );
 
       expect(result).toBe('dismissed-value');
-      expect(logger.debug).not.toHaveBeenCalledWith(
-        { fn: 'showFilePicker', fileCount: 2 },
-        'User cancelled file picker',
-      );
+      expect(logger.debug).not.toHaveBeenCalledWith({ fn: 'showFilePicker', fileCount: 2 }, 'User cancelled file picker');
     });
 
     it('supports async onDismissed handler', async () => {

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/showTerminalPicker.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/showTerminalPicker.test.ts
@@ -1,11 +1,7 @@
 import type { TerminalPickerHandlers } from '../../../destinations/types';
 import { showTerminalPicker } from '../../../destinations/utils';
 import type { EligibleTerminal, TerminalBindableQuickPickItem } from '../../../types';
-import {
-  createMockQuickPickProvider,
-  createMockTerminal,
-  createMockTerminalQuickPickItem,
-} from '../../helpers';
+import { createMockQuickPickProvider, createMockTerminal, createMockTerminalQuickPickItem } from '../../helpers';
 
 import { createMockLogger } from '@couimet/logger-contract-testing';
 
@@ -41,12 +37,13 @@ describe('showTerminalPicker', () => {
       const quickPickProvider = createMockQuickPickProvider();
       const logger = createMockLogger();
 
-      await expect(() =>
-        showTerminalPicker([], quickPickProvider, createHandlers(identityCallback), logger),
-      ).toThrowDetailedErrorAsync('TERMINAL_PICKER_EMPTY_ITEMS', {
-        message: 'showTerminalPicker called with no terminal items',
-        functionName: 'showTerminalPicker',
-      });
+      await expect(() => showTerminalPicker([], quickPickProvider, createHandlers(identityCallback), logger)).toThrowDetailedErrorAsync(
+        'TERMINAL_PICKER_EMPTY_ITEMS',
+        {
+          message: 'showTerminalPicker called with no terminal items',
+          functionName: 'showTerminalPicker',
+        },
+      );
       expect(quickPickProvider.showQuickPick).not.toHaveBeenCalled();
     });
   });
@@ -58,26 +55,15 @@ describe('showTerminalPicker', () => {
       quickPickProvider.showQuickPick.mockResolvedValueOnce(reformattedItem(items[1]));
       const logger = createMockLogger();
 
-      const result = await showTerminalPicker(
-        items,
-        quickPickProvider,
-        createHandlers(identityCallback),
-        logger,
-      );
+      const result = await showTerminalPicker(items, quickPickProvider, createHandlers(identityCallback), logger);
 
       expect(result).toStrictEqual(items[1].terminalInfo);
       expect(quickPickProvider.showQuickPick).toHaveBeenCalledWith(items.map(reformattedItem), {
         title: 'RangeLink',
         placeHolder: 'Choose a terminal to bind to',
       });
-      expect(logger.debug).toHaveBeenCalledWith(
-        { fn: 'showTerminalPicker', terminalCount: 3, itemCount: 3 },
-        'Showing terminal picker',
-      );
-      expect(logger.debug).toHaveBeenCalledWith(
-        { fn: 'showTerminalPicker', selected: reformattedItem(items[1]) },
-        'Terminal selected',
-      );
+      expect(logger.debug).toHaveBeenCalledWith({ fn: 'showTerminalPicker', terminalCount: 3, itemCount: 3 }, 'Showing terminal picker');
+      expect(logger.debug).toHaveBeenCalledWith({ fn: 'showTerminalPicker', selected: reformattedItem(items[1]) }, 'Terminal selected');
     });
 
     it('passes handler return value through as result', async () => {
@@ -161,18 +147,10 @@ describe('showTerminalPicker', () => {
       quickPickProvider.showQuickPick.mockResolvedValueOnce(undefined);
       const logger = createMockLogger();
 
-      const result = await showTerminalPicker(
-        items,
-        quickPickProvider,
-        createHandlers(identityCallback),
-        logger,
-      );
+      const result = await showTerminalPicker(items, quickPickProvider, createHandlers(identityCallback), logger);
 
       expect(result).toBeUndefined();
-      expect(logger.debug).toHaveBeenCalledWith(
-        { fn: 'showTerminalPicker', terminalCount: 3 },
-        'User cancelled terminal picker',
-      );
+      expect(logger.debug).toHaveBeenCalledWith({ fn: 'showTerminalPicker', terminalCount: 3 }, 'User cancelled terminal picker');
     });
 
     it('calls onDismissed handler when provided and user dismisses', async () => {
@@ -191,10 +169,7 @@ describe('showTerminalPicker', () => {
       );
 
       expect(result).toBe('dismissed-value');
-      expect(logger.debug).not.toHaveBeenCalledWith(
-        { fn: 'showTerminalPicker', terminalCount: 2 },
-        'User cancelled terminal picker',
-      );
+      expect(logger.debug).not.toHaveBeenCalledWith({ fn: 'showTerminalPicker', terminalCount: 2 }, 'User cancelled terminal picker');
     });
 
     it('supports async onDismissed handler', async () => {

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/sortEligibleTerminals.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/sortEligibleTerminals.test.ts
@@ -75,10 +75,7 @@ describe('sortEligibleTerminals', () => {
   });
 
   it('does not mutate the input array', () => {
-    const terminals = [
-      createMockEligibleTerminal({ name: 'A', boundState: 'not-bound' }),
-      createMockEligibleTerminal({ name: 'B', boundState: 'bound' }),
-    ];
+    const terminals = [createMockEligibleTerminal({ name: 'A', boundState: 'not-bound' }), createMockEligibleTerminal({ name: 'B', boundState: 'bound' })];
     const original = [...terminals];
 
     sortEligibleTerminals(terminals);

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/testFixtureRegistry.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/testFixtureRegistry.test.ts
@@ -1,7 +1,4 @@
-import {
-  isRangeLinkTestFixture,
-  markRangeLinkTestFixture,
-} from '../../../destinations/utils/testFixtureRegistry';
+import { isRangeLinkTestFixture, markRangeLinkTestFixture } from '../../../destinations/utils/testFixtureRegistry';
 import { createMockTerminal } from '../../helpers';
 
 describe('testFixtureRegistry', () => {
@@ -27,13 +24,10 @@ describe('testFixtureRegistry', () => {
 
     it('markRangeLinkTestFixture throws TEST_FIXTURE_REGISTRY_DISABLED', () => {
       const terminal = createMockTerminal({ name: 'any' });
-      expect(() => markRangeLinkTestFixture(terminal)).toThrowDetailedError(
-        'TEST_FIXTURE_REGISTRY_DISABLED',
-        {
-          message: 'markRangeLinkTestFixture requires RANGELINK_TEST_FIXTURES_ENABLED=true',
-          functionName: 'markRangeLinkTestFixture',
-        },
-      );
+      expect(() => markRangeLinkTestFixture(terminal)).toThrowDetailedError('TEST_FIXTURE_REGISTRY_DISABLED', {
+        message: 'markRangeLinkTestFixture requires RANGELINK_TEST_FIXTURES_ENABLED=true',
+        functionName: 'markRangeLinkTestFixture',
+      });
     });
   });
 

--- a/packages/rangelink-vscode-extension/src/__tests__/extension.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/extension.test.ts
@@ -1,14 +1,7 @@
 import * as extension from '../extension';
 import { VSCodeLogger } from '../VSCodeLogger';
 
-import {
-  createMockCommands,
-  createMockMemento,
-  createMockOutputChannel,
-  createMockStatusBarItem,
-  createMockWindow,
-  createMockWorkspace,
-} from './helpers';
+import { createMockCommands, createMockMemento, createMockOutputChannel, createMockStatusBarItem, createMockWindow, createMockWorkspace } from './helpers';
 
 import { pingLog, setLogger } from '@couimet/logger-contract';
 import * as vscode from 'vscode';
@@ -168,9 +161,7 @@ describe('Configuration loading and validation', () => {
     (vscode.window.createStatusBarItem as jest.Mock).mockReturnValue(mockStatusBarItem);
     (vscode.window.createOutputChannel as jest.Mock).mockReturnValue(mockOutputChannel);
     (vscode.window.showErrorMessage as jest.Mock).mockImplementation(mockWindow.showErrorMessage);
-    (vscode.workspace.getConfiguration as jest.Mock).mockImplementation((...args) =>
-      mockWorkspace.getConfiguration(...args),
-    );
+    (vscode.workspace.getConfiguration as jest.Mock).mockImplementation((...args) => mockWorkspace.getConfiguration(...args));
     (vscode.commands.registerCommand as jest.Mock).mockImplementation(mockCommands.registerCommand);
   });
 
@@ -286,9 +277,7 @@ describe('Configuration loading and validation', () => {
       extension.activate(context as any);
 
       // Verify error was logged about non-unique delimiters
-      expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
-        expect.stringContaining('Delimiters must be unique'),
-      );
+      expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(expect.stringContaining('Delimiters must be unique'));
     });
 
     it('should use defaults when two delimiters are the same', () => {
@@ -321,9 +310,7 @@ describe('Configuration loading and validation', () => {
       extension.activate(context as any);
 
       // Verify error was logged
-      expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
-        expect.stringContaining('Delimiters must be unique'),
-      );
+      expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(expect.stringContaining('Delimiters must be unique'));
     });
   });
 
@@ -365,9 +352,7 @@ describe('Configuration loading and validation', () => {
       extension.activate(context as any);
 
       // Should not log any errors
-      expect(mockOutputChannel.appendLine).not.toHaveBeenCalledWith(
-        expect.stringContaining('[ERROR]'),
-      );
+      expect(mockOutputChannel.appendLine).not.toHaveBeenCalledWith(expect.stringContaining('[ERROR]'));
     });
   });
 
@@ -473,9 +458,7 @@ describe('Extension lifecycle', () => {
     (vscode.window.createStatusBarItem as jest.Mock).mockReturnValue(mockStatusBarItem);
     (vscode.window.createOutputChannel as jest.Mock).mockReturnValue(mockOutputChannel);
     (vscode.window.showErrorMessage as jest.Mock).mockImplementation(mockWindow.showErrorMessage);
-    (vscode.workspace.getConfiguration as jest.Mock).mockImplementation(
-      mockWorkspace.getConfiguration,
-    );
+    (vscode.workspace.getConfiguration as jest.Mock).mockImplementation(mockWorkspace.getConfiguration);
     (vscode.commands.registerCommand as jest.Mock).mockImplementation(mockCommands.registerCommand);
   });
 
@@ -573,8 +556,7 @@ describe('Extension lifecycle', () => {
 
     const INFRASTRUCTURE_COUNT = 4;
     const PROVIDER_COUNT = 4;
-    const EXPECTED_SUBSCRIPTION_COUNT =
-      INFRASTRUCTURE_COUNT + PROVIDER_COUNT + expectedCommands.length;
+    const EXPECTED_SUBSCRIPTION_COUNT = INFRASTRUCTURE_COUNT + PROVIDER_COUNT + expectedCommands.length;
 
     expect(mockContext.subscriptions.length).toBe(EXPECTED_SUBSCRIPTION_COUNT);
   });
@@ -590,14 +572,12 @@ describe('Extension lifecycle', () => {
     (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue(mockConfig);
 
     let capturedBindHandler: ((...args: unknown[]) => Promise<void>) | undefined;
-    (vscode.commands.registerCommand as jest.Mock).mockImplementation(
-      (id: string, handler: (...args: unknown[]) => Promise<void>) => {
-        if (id === 'rangelink.explorer.bind') {
-          capturedBindHandler = handler;
-        }
-        return { dispose: jest.fn() };
-      },
-    );
+    (vscode.commands.registerCommand as jest.Mock).mockImplementation((id: string, handler: (...args: unknown[]) => Promise<void>) => {
+      if (id === 'rangelink.explorer.bind') {
+        capturedBindHandler = handler;
+      }
+      return { dispose: jest.fn() };
+    });
 
     const mockEditor = { viewColumn: 1 } as vscode.TextEditor;
     (vscode.window.showTextDocument as jest.Mock).mockResolvedValue(mockEditor);
@@ -658,9 +638,7 @@ describe('Logger verification and communication channel', () => {
     extension.activate(context as any);
 
     // Verify debug() was called during setLogger with initialization message
-    expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
-      expect.stringMatching(/\[DEBUG\].*setLogger.*Logger initialized/),
-    );
+    expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(expect.stringMatching(/\[DEBUG\].*setLogger.*Logger initialized/));
   });
 
   it('should support pingLog() to exercise all logger levels', () => {
@@ -676,18 +654,10 @@ describe('Logger verification and communication channel', () => {
     pingLog();
 
     // Verify all 4 ping messages were logged
-    expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
-      expect.stringMatching(/\[DEBUG\].*pingLog.*Ping for DEBUG/),
-    );
-    expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
-      expect.stringMatching(/\[INFO\].*pingLog.*Ping for INFO/),
-    );
-    expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
-      expect.stringMatching(/\[WARNING\].*pingLog.*Ping for WARN/),
-    );
-    expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
-      expect.stringMatching(/\[ERROR\].*pingLog.*Ping for ERROR/),
-    );
+    expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(expect.stringMatching(/\[DEBUG\].*pingLog.*Ping for DEBUG/));
+    expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(expect.stringMatching(/\[INFO\].*pingLog.*Ping for INFO/));
+    expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(expect.stringMatching(/\[WARNING\].*pingLog.*Ping for WARN/));
+    expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(expect.stringMatching(/\[ERROR\].*pingLog.*Ping for ERROR/));
   });
 
   it('should verify VSCodeLogger properly formats debug messages', () => {
@@ -697,12 +667,8 @@ describe('Logger verification and communication channel', () => {
     // Manually call debug to test formatting
     logger.debug({ fn: 'testFunction', extraContext: 'value' }, 'Test debug message');
 
-    expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
-      expect.stringMatching(/\[DEBUG\].*testFunction/),
-    );
-    expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
-      expect.stringMatching(/\[DEBUG\].*Test debug message/),
-    );
+    expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(expect.stringMatching(/\[DEBUG\].*testFunction/));
+    expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(expect.stringMatching(/\[DEBUG\].*Test debug message/));
   });
 });
 
@@ -722,10 +688,7 @@ describe('Activation logging', () => {
   const getActivationInfoLine = (): string | undefined => {
     return (mockOutputChannel.appendLine as jest.Mock).mock.calls
       .map((call: string[]) => call[0])
-      .find(
-        (line: string) =>
-          line.startsWith('[INFO]') && line.includes('RangeLink extension activated'),
-      );
+      .find((line: string) => line.startsWith('[INFO]') && line.includes('RangeLink extension activated'));
   };
 
   it('logs version info and logger contract version on successful activation', () => {
@@ -777,9 +740,7 @@ describe('Activation logging', () => {
 
       isolatedExtension.activate(mockContext as any);
 
-      expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
-        expect.stringMatching(/\[WARNING\].*version info unavailable/),
-      );
+      expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(expect.stringMatching(/\[WARNING\].*version info unavailable/));
       expect(getActivationInfoLine()).toBeUndefined();
     });
   });

--- a/packages/rangelink-vscode-extension/src/__tests__/feedback/OperationFeedbackProvider.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/feedback/OperationFeedbackProvider.test.ts
@@ -51,9 +51,7 @@ describe('OperationFeedbackProvider', () => {
       expect(formatMessageSpy).toHaveBeenCalledWith('STATUS_BAR_LINK_COPIED_TO_CLIPBOARD', {
         linkTypeName: 'RangeLink',
       });
-      expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith(
-        'RangeLink copied to clipboard',
-      );
+      expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith('RangeLink copied to clipboard');
     });
   });
 
@@ -67,9 +65,7 @@ describe('OperationFeedbackProvider', () => {
         linkTypeName: 'RangeLink',
         destinationName: 'Terminal ("bash")',
       });
-      expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith(
-        'RangeLink sent to Terminal ("bash")',
-      );
+      expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith('RangeLink sent to Terminal ("bash")');
       expect(mockAdapter.showInformationMessage).not.toHaveBeenCalled();
       expect(mockAdapter.showWarningMessage).not.toHaveBeenCalled();
     });
@@ -80,9 +76,7 @@ describe('OperationFeedbackProvider', () => {
         instruction: 'Press Cmd+V to paste',
       });
 
-      expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith(
-        'RangeLink copied to clipboard',
-      );
+      expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith('RangeLink copied to clipboard');
       expect(mockAdapter.showInformationMessage).toHaveBeenCalledWith('Press Cmd+V to paste');
       expect(mockAdapter.showWarningMessage).not.toHaveBeenCalled();
     });
@@ -93,9 +87,7 @@ describe('OperationFeedbackProvider', () => {
         instruction: 'Manual paste required',
       });
 
-      expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith(
-        'RangeLink copied to clipboard',
-      );
+      expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith('RangeLink copied to clipboard');
       expect(mockAdapter.showWarningMessage).toHaveBeenCalledWith('Manual paste required');
       expect(mockAdapter.showInformationMessage).not.toHaveBeenCalled();
     });
@@ -112,9 +104,7 @@ describe('OperationFeedbackProvider', () => {
         { kind: 'failed-automatic', destinationKind: 'text-editor' },
       );
 
-      expect(mockAdapter.showWarningMessage).toHaveBeenCalledWith(
-        'Could not send to editor. Make sure the bound editor is visible and focused.',
-      );
+      expect(mockAdapter.showWarningMessage).toHaveBeenCalledWith('Could not send to editor. Make sure the bound editor is visible and focused.');
       expect(mockAdapter.setSuccessfulStatusBarMessage).not.toHaveBeenCalled();
     });
 
@@ -123,8 +113,7 @@ describe('OperationFeedbackProvider', () => {
         kind: 'self-paste-blocked',
         destinationKind: 'text-editor',
         clipboardWritten: true,
-        toastMessage:
-          'Cannot auto-paste to same file. Link copied to clipboard. Tip: Use R-C for clipboard-only links.',
+        toastMessage: 'Cannot auto-paste to same file. Link copied to clipboard. Tip: Use R-C for clipboard-only links.',
       });
 
       expect(mockAdapter.showInformationMessage).toHaveBeenCalledWith(
@@ -133,9 +122,7 @@ describe('OperationFeedbackProvider', () => {
       expect(formatMessageSpy).toHaveBeenCalledWith('STATUS_BAR_LINK_COPIED_TO_CLIPBOARD', {
         linkTypeName: 'RangeLink',
       });
-      expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith(
-        'RangeLink copied to clipboard',
-      );
+      expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith('RangeLink copied to clipboard');
       expect(mockAdapter.showWarningMessage).not.toHaveBeenCalled();
     });
 
@@ -147,9 +134,7 @@ describe('OperationFeedbackProvider', () => {
         toastMessage: 'Cannot paste when bound editor has an active selection.',
       });
 
-      expect(mockAdapter.showInformationMessage).toHaveBeenCalledWith(
-        'Cannot paste when bound editor has an active selection.',
-      );
+      expect(mockAdapter.showInformationMessage).toHaveBeenCalledWith('Cannot paste when bound editor has an active selection.');
       expect(mockAdapter.setSuccessfulStatusBarMessage).not.toHaveBeenCalled();
       expect(mockAdapter.showWarningMessage).not.toHaveBeenCalled();
     });
@@ -160,9 +145,7 @@ describe('OperationFeedbackProvider', () => {
       });
 
       expect(formatMessageSpy).toHaveBeenCalledWith('WARN_CLIPBOARD_PRESERVATION_FAILED');
-      expect(mockAdapter.showWarningMessage).toHaveBeenCalledWith(
-        'Clipboard preservation failed. Content was not sent.',
-      );
+      expect(mockAdapter.showWarningMessage).toHaveBeenCalledWith('Clipboard preservation failed. Content was not sent.');
       expect(mockAdapter.setSuccessfulStatusBarMessage).not.toHaveBeenCalled();
       expect(mockAdapter.showInformationMessage).not.toHaveBeenCalled();
     });
@@ -171,19 +154,13 @@ describe('OperationFeedbackProvider', () => {
       const bindContext = { destinationName: 'Terminal ("bash")' };
 
       it('sent-automatic + bindContext uses merged message code', () => {
-        provider.provideSendFeedback(
-          createPasteContext() as any,
-          { kind: 'sent-automatic' },
-          bindContext,
-        );
+        provider.provideSendFeedback(createPasteContext() as any, { kind: 'sent-automatic' }, bindContext);
 
         expect(formatMessageSpy).toHaveBeenCalledWith('STATUS_BAR_DESTINATION_BOUND_AND_SENT', {
           destinationName: 'Terminal ("bash")',
           linkTypeName: 'RangeLink',
         });
-        expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith(
-          'Bound to Terminal ("bash") — RangeLink sent',
-        );
+        expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith('Bound to Terminal ("bash") — RangeLink sent');
         expect(mockAdapter.showInformationMessage).not.toHaveBeenCalled();
         expect(mockAdapter.showWarningMessage).not.toHaveBeenCalled();
       });
@@ -195,9 +172,7 @@ describe('OperationFeedbackProvider', () => {
           linkTypeName: 'RangeLink',
           destinationName: 'Terminal ("bash")',
         });
-        expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith(
-          'RangeLink sent to Terminal ("bash")',
-        );
+        expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith('RangeLink sent to Terminal ("bash")');
       });
 
       it('sent-manual + bindContext prepends bound prefix to clipboard status bar message', () => {
@@ -213,9 +188,7 @@ describe('OperationFeedbackProvider', () => {
         expect(formatMessageSpy).toHaveBeenCalledWith('STATUS_BAR_DESTINATION_BOUND_PREFIX', {
           destinationName: 'Terminal ("bash")',
         });
-        expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith(
-          'Bound to Terminal ("bash") — RangeLink copied to clipboard',
-        );
+        expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith('Bound to Terminal ("bash") — RangeLink copied to clipboard');
         expect(mockAdapter.showInformationMessage).toHaveBeenCalledWith('Press Cmd+V to paste');
       });
 
@@ -229,9 +202,7 @@ describe('OperationFeedbackProvider', () => {
           bindContext,
         );
 
-        expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith(
-          'Bound to Terminal ("bash") — RangeLink copied to clipboard',
-        );
+        expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith('Bound to Terminal ("bash") — RangeLink copied to clipboard');
         expect(mockAdapter.showWarningMessage).toHaveBeenCalledWith('Manual paste required');
       });
 
@@ -265,12 +236,8 @@ describe('OperationFeedbackProvider', () => {
           bindContext,
         );
 
-        expect(mockAdapter.showInformationMessage).toHaveBeenCalledWith(
-          'Cannot auto-paste to same file.',
-        );
-        expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith(
-          'Bound to Terminal ("bash") — RangeLink copied to clipboard',
-        );
+        expect(mockAdapter.showInformationMessage).toHaveBeenCalledWith('Cannot auto-paste to same file.');
+        expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith('Bound to Terminal ("bash") — RangeLink copied to clipboard');
       });
 
       it('self-paste-blocked + bindContext without clipboard written does not show status bar', () => {
@@ -285,9 +252,7 @@ describe('OperationFeedbackProvider', () => {
           bindContext,
         );
 
-        expect(mockAdapter.showInformationMessage).toHaveBeenCalledWith(
-          'Cannot paste when bound editor has an active selection.',
-        );
+        expect(mockAdapter.showInformationMessage).toHaveBeenCalledWith('Cannot paste when bound editor has an active selection.');
         expect(mockAdapter.setSuccessfulStatusBarMessage).not.toHaveBeenCalled();
       });
 
@@ -300,24 +265,20 @@ describe('OperationFeedbackProvider', () => {
           bindContext,
         );
 
-        expect(mockAdapter.showWarningMessage).toHaveBeenCalledWith(
-          'Bound to Terminal ("bash") — Clipboard preservation failed. Content was not sent.',
-        );
+        expect(mockAdapter.showWarningMessage).toHaveBeenCalledWith('Bound to Terminal ("bash") — Clipboard preservation failed. Content was not sent.');
         expect(mockAdapter.setSuccessfulStatusBarMessage).not.toHaveBeenCalled();
       });
     });
 
     it('throws RangeLinkExtensionError on unexpected outcome kind', () => {
-      expect(() =>
-        provider.provideSendFeedback(
-          createPasteContext() as any,
-          { kind: 'unexpected-value' } as any,
-        ),
-      ).toThrowDetailedError('UNEXPECTED_SWITCH_VALUE', {
-        message: 'Unexpected paste send outcome: {"kind":"unexpected-value"}',
-        functionName: 'OperationFeedbackProvider.provideSendFeedback',
-        details: { unexpectedValue: { kind: 'unexpected-value' } },
-      });
+      expect(() => provider.provideSendFeedback(createPasteContext() as any, { kind: 'unexpected-value' } as any)).toThrowDetailedError(
+        'UNEXPECTED_SWITCH_VALUE',
+        {
+          message: 'Unexpected paste send outcome: {"kind":"unexpected-value"}',
+          functionName: 'OperationFeedbackProvider.provideSendFeedback',
+          details: { unexpectedValue: { kind: 'unexpected-value' } },
+        },
+      );
     });
   });
 
@@ -325,25 +286,15 @@ describe('OperationFeedbackProvider', () => {
     it('shows terminal-closed status bar message', () => {
       provider.notifyAutoUnbind('Terminal ("bash")', 'terminal-closed');
 
-      expect(formatMessageSpy).toHaveBeenCalledWith(
-        'STATUS_BAR_DESTINATION_UNBOUND_TERMINAL_CLOSED',
-        { destinationName: 'Terminal ("bash")' },
-      );
-      expect(mockAdapter.setStatusBarMessage).toHaveBeenCalledWith(
-        'Unbound from Terminal ("bash") — terminal closed',
-      );
+      expect(formatMessageSpy).toHaveBeenCalledWith('STATUS_BAR_DESTINATION_UNBOUND_TERMINAL_CLOSED', { destinationName: 'Terminal ("bash")' });
+      expect(mockAdapter.setStatusBarMessage).toHaveBeenCalledWith('Unbound from Terminal ("bash") — terminal closed');
     });
 
     it('shows editor-closed status bar message', () => {
       provider.notifyAutoUnbind('Text Editor ("file.ts")', 'editor-closed');
 
-      expect(formatMessageSpy).toHaveBeenCalledWith(
-        'STATUS_BAR_DESTINATION_UNBOUND_EDITOR_CLOSED',
-        { destinationName: 'Text Editor ("file.ts")' },
-      );
-      expect(mockAdapter.setStatusBarMessage).toHaveBeenCalledWith(
-        'Unbound from Text Editor ("file.ts") — editor closed',
-      );
+      expect(formatMessageSpy).toHaveBeenCalledWith('STATUS_BAR_DESTINATION_UNBOUND_EDITOR_CLOSED', { destinationName: 'Text Editor ("file.ts")' });
+      expect(mockAdapter.setStatusBarMessage).toHaveBeenCalledWith('Unbound from Text Editor ("file.ts") — editor closed');
     });
 
     it('shows file-deleted status bar message and warning toast', () => {
@@ -352,26 +303,19 @@ describe('OperationFeedbackProvider', () => {
       expect(formatMessageSpy).toHaveBeenCalledWith('STATUS_BAR_DESTINATION_UNBOUND_FILE_DELETED', {
         destinationName: 'Text Editor ("server.ts")',
       });
-      expect(mockAdapter.setStatusBarMessage).toHaveBeenCalledWith(
-        'Unbound from Text Editor ("server.ts") — file deleted',
-      );
+      expect(mockAdapter.setStatusBarMessage).toHaveBeenCalledWith('Unbound from Text Editor ("server.ts") — file deleted');
       expect(formatMessageSpy).toHaveBeenCalledWith('WARN_DESTINATION_UNBOUND_FILE_DELETED', {
         destinationName: 'Text Editor ("server.ts")',
       });
-      expect(mockAdapter.showWarningMessage).toHaveBeenCalledWith(
-        'Unbound from Text Editor ("server.ts") — file was deleted from disk',
-      );
+      expect(mockAdapter.showWarningMessage).toHaveBeenCalledWith('Unbound from Text Editor ("server.ts") — file was deleted from disk');
     });
 
     it('throws on unexpected reason', () => {
-      expect(() => provider.notifyAutoUnbind('Test', 'unknown-reason' as any)).toThrowDetailedError(
-        'UNEXPECTED_SWITCH_VALUE',
-        {
-          message: 'Unexpected auto-unbind reason: "unknown-reason"',
-          functionName: 'OperationFeedbackProvider.notifyAutoUnbind',
-          details: { unexpectedValue: 'unknown-reason' },
-        },
-      );
+      expect(() => provider.notifyAutoUnbind('Test', 'unknown-reason' as any)).toThrowDetailedError('UNEXPECTED_SWITCH_VALUE', {
+        message: 'Unexpected auto-unbind reason: "unknown-reason"',
+        functionName: 'OperationFeedbackProvider.notifyAutoUnbind',
+        details: { unexpectedValue: 'unknown-reason' },
+      });
     });
   });
 
@@ -393,53 +337,38 @@ describe('OperationFeedbackProvider', () => {
       const result = (provider as any).buildPasteFailureMessage('text-editor');
 
       expect(formatMessageSpy).toHaveBeenCalledWith('WARN_PASTE_FAILED_EDITOR_HIDDEN');
-      expect(result).toBe(
-        'Could not send to editor. Make sure the bound editor is visible and focused.',
-      );
+      expect(result).toBe('Could not send to editor. Make sure the bound editor is visible and focused.');
     });
 
     it('returns formatted message for terminal destination', () => {
       const result = (provider as any).buildPasteFailureMessage('terminal');
 
       expect(formatMessageSpy).toHaveBeenCalledWith('WARN_PASTE_FAILED_TERMINAL');
-      expect(result).toBe(
-        'Could not send to terminal. Terminal may be closed or not accepting input.',
-      );
+      expect(result).toBe('Could not send to terminal. Terminal may be closed or not accepting input.');
     });
 
     it('throws for claude-code chat assistant destination', () => {
-      expect(() => (provider as any).buildPasteFailureMessage('claude-code')).toThrowDetailedError(
-        'UNEXPECTED_SWITCH_VALUE',
-        {
-          message:
-            "Chat assistant destination 'claude-code' should provide getUserInstruction() and never reach buildPasteFailureMessage()",
-          functionName: 'OperationFeedbackProvider.buildPasteFailureMessage',
-          details: { unexpectedValue: 'claude-code' },
-        },
-      );
+      expect(() => (provider as any).buildPasteFailureMessage('claude-code')).toThrowDetailedError('UNEXPECTED_SWITCH_VALUE', {
+        message: "Chat assistant destination 'claude-code' should provide getUserInstruction() and never reach buildPasteFailureMessage()",
+        functionName: 'OperationFeedbackProvider.buildPasteFailureMessage',
+        details: { unexpectedValue: 'claude-code' },
+      });
     });
 
     it('throws for custom AI assistant destination', () => {
-      expect(() =>
-        (provider as any).buildPasteFailureMessage('custom-ai:my-extension'),
-      ).toThrowDetailedError('UNEXPECTED_SWITCH_VALUE', {
-        message:
-          "AI assistant destination 'custom-ai:my-extension' should provide getUserInstruction() and never reach buildPasteFailureMessage()",
+      expect(() => (provider as any).buildPasteFailureMessage('custom-ai:my-extension')).toThrowDetailedError('UNEXPECTED_SWITCH_VALUE', {
+        message: "AI assistant destination 'custom-ai:my-extension' should provide getUserInstruction() and never reach buildPasteFailureMessage()",
         functionName: 'OperationFeedbackProvider.buildPasteFailureMessage',
         details: { unexpectedValue: 'custom-ai:my-extension' },
       });
     });
 
     it('throws DESTINATION_NOT_IMPLEMENTED for unknown destination kind', () => {
-      expect(() => (provider as any).buildPasteFailureMessage('unknown-kind')).toThrowDetailedError(
-        'DESTINATION_NOT_IMPLEMENTED',
-        {
-          message:
-            "Unknown destination kind 'unknown-kind' - missing case in buildPasteFailureMessage()",
-          functionName: 'OperationFeedbackProvider.buildPasteFailureMessage',
-          details: { destinationKind: 'unknown-kind' },
-        },
-      );
+      expect(() => (provider as any).buildPasteFailureMessage('unknown-kind')).toThrowDetailedError('DESTINATION_NOT_IMPLEMENTED', {
+        message: "Unknown destination kind 'unknown-kind' - missing case in buildPasteFailureMessage()",
+        functionName: 'OperationFeedbackProvider.buildPasteFailureMessage',
+        details: { destinationKind: 'unknown-kind' },
+      });
     });
   });
 
@@ -450,9 +379,7 @@ describe('OperationFeedbackProvider', () => {
       expect(formatMessageSpy).toHaveBeenCalledWith('STATUS_BAR_DESTINATION_BOUND', {
         destinationName: 'Terminal ("bash")',
       });
-      expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith(
-        'Bound to Terminal ("bash")',
-      );
+      expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith('Bound to Terminal ("bash")');
       expect(mockAdapter.showInformationMessage).not.toHaveBeenCalled();
     });
   });
@@ -465,9 +392,7 @@ describe('OperationFeedbackProvider', () => {
         previousDestination: 'Terminal ("bash")',
         newDestination: 'Text Editor ("file.ts")',
       });
-      expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith(
-        'Unbound Terminal ("bash"), now bound to Text Editor ("file.ts")',
-      );
+      expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith('Unbound Terminal ("bash"), now bound to Text Editor ("file.ts")');
       expect(mockAdapter.showInformationMessage).not.toHaveBeenCalled();
     });
   });
@@ -479,9 +404,7 @@ describe('OperationFeedbackProvider', () => {
       expect(formatMessageSpy).toHaveBeenCalledWith('ALREADY_BOUND_TO_DESTINATION', {
         destinationName: 'Terminal ("bash")',
       });
-      expect(mockAdapter.showInformationMessage).toHaveBeenCalledWith(
-        'Already bound to Terminal ("bash")',
-      );
+      expect(mockAdapter.showInformationMessage).toHaveBeenCalledWith('Already bound to Terminal ("bash")');
       expect(mockAdapter.setSuccessfulStatusBarMessage).not.toHaveBeenCalled();
     });
   });
@@ -495,9 +418,7 @@ describe('OperationFeedbackProvider', () => {
       expect(formatMessageSpy).toHaveBeenCalledWith('ERROR_TEXT_EDITOR_READ_ONLY', {
         scheme: 'output',
       });
-      expect(mockAdapter.showErrorMessage).toHaveBeenCalledWith(
-        'Cannot bind to read-only editor (output)',
-      );
+      expect(mockAdapter.showErrorMessage).toHaveBeenCalledWith('Cannot bind to read-only editor (output)');
       expect(mockAdapter.setSuccessfulStatusBarMessage).not.toHaveBeenCalled();
     });
   });
@@ -507,9 +428,7 @@ describe('OperationFeedbackProvider', () => {
       provider.notifyBindFailedNotAvailable('Claude Code', 'claude-code');
 
       expect(formatMessageSpy).toHaveBeenCalledWith('ERROR_CLAUDE_CODE_NOT_AVAILABLE');
-      expect(mockAdapter.showErrorMessage).toHaveBeenCalledWith(
-        'Cannot bind Claude Code - extension not installed or not active',
-      );
+      expect(mockAdapter.showErrorMessage).toHaveBeenCalledWith('Cannot bind Claude Code - extension not installed or not active');
       expect(mockAdapter.setSuccessfulStatusBarMessage).not.toHaveBeenCalled();
     });
 
@@ -519,9 +438,7 @@ describe('OperationFeedbackProvider', () => {
       expect(formatMessageSpy).toHaveBeenCalledWith('ERROR_CUSTOM_AI_NOT_AVAILABLE', {
         extensionName: 'My Extension',
       });
-      expect(mockAdapter.showErrorMessage).toHaveBeenCalledWith(
-        'Cannot bind My Extension - extension not installed or not active',
-      );
+      expect(mockAdapter.showErrorMessage).toHaveBeenCalledWith('Cannot bind My Extension - extension not installed or not active');
       expect(mockAdapter.setSuccessfulStatusBarMessage).not.toHaveBeenCalled();
     });
   });
@@ -533,9 +450,7 @@ describe('OperationFeedbackProvider', () => {
       expect(formatMessageSpy).toHaveBeenCalledWith('INFO_BACKGROUND_TAB_OPENED', {
         fileName: 'file.ts',
       });
-      expect(mockAdapter.showInformationMessage).toHaveBeenCalledWith(
-        '"file.ts" opened at last cursor position. Adjust cursor before pasting.',
-      );
+      expect(mockAdapter.showInformationMessage).toHaveBeenCalledWith('"file.ts" opened at last cursor position. Adjust cursor before pasting.');
       expect(mockAdapter.setSuccessfulStatusBarMessage).not.toHaveBeenCalled();
     });
   });
@@ -547,9 +462,7 @@ describe('OperationFeedbackProvider', () => {
       expect(formatMessageSpy).toHaveBeenCalledWith('STATUS_BAR_DESTINATION_UNBOUND', {
         destinationName: 'Terminal ("bash")',
       });
-      expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith(
-        'Unbound from Terminal ("bash")',
-      );
+      expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith('Unbound from Terminal ("bash")');
       expect(mockAdapter.showInformationMessage).not.toHaveBeenCalled();
     });
   });
@@ -568,9 +481,7 @@ describe('OperationFeedbackProvider', () => {
     it('shows provided message as successful status bar message', () => {
       provider.notifyJumpFocused('Focused Terminal ("bash")');
 
-      expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith(
-        'Focused Terminal ("bash")',
-      );
+      expect(mockAdapter.setSuccessfulStatusBarMessage).toHaveBeenCalledWith('Focused Terminal ("bash")');
       expect(mockAdapter.showInformationMessage).not.toHaveBeenCalled();
     });
   });
@@ -582,9 +493,7 @@ describe('OperationFeedbackProvider', () => {
       expect(formatMessageSpy).toHaveBeenCalledWith('INFO_JUMP_FOCUS_FAILED', {
         destinationName: 'Terminal ("bash")',
       });
-      expect(mockAdapter.showInformationMessage).toHaveBeenCalledWith(
-        'Failed to focus Terminal ("bash")',
-      );
+      expect(mockAdapter.showInformationMessage).toHaveBeenCalledWith('Failed to focus Terminal ("bash")');
       expect(mockAdapter.setSuccessfulStatusBarMessage).not.toHaveBeenCalled();
     });
   });

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/configureEmptyTabGroups.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/configureEmptyTabGroups.ts
@@ -18,8 +18,6 @@ import { createMockTabGroups } from './createMockTabGroups';
  * @param count - Number of empty tab groups to create (default: 2)
  */
 export const configureEmptyTabGroups = (mockWindow: any, count = 2): void => {
-  const emptyGroups = Array.from({ length: count }, () =>
-    createMockTabGroup([], { activeTab: undefined }),
-  );
+  const emptyGroups = Array.from({ length: count }, () => createMockTabGroup([], { activeTab: undefined }));
   mockWindow.tabGroups = createMockTabGroups({ all: emptyGroups });
 };

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/configureWorkspaceMocks.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/configureWorkspaceMocks.ts
@@ -32,11 +32,7 @@ export const configureWorkspaceMocks = (
     visibleEditors?: vscode.TextEditor[];
   } = {},
 ): void => {
-  const {
-    workspacePath = '/workspace',
-    relativePath = 'src/file.ts',
-    visibleEditors = [],
-  } = options;
+  const { workspacePath = '/workspace', relativePath = 'src/file.ts', visibleEditors = [] } = options;
 
   // Mock workspace folder lookup
   (mockVscode.workspace.getWorkspaceFolder as jest.Mock) = jest.fn().mockReturnValue({
@@ -47,9 +43,7 @@ export const configureWorkspaceMocks = (
   (mockVscode.workspace.asRelativePath as jest.Mock) = jest.fn().mockReturnValue(relativePath);
 
   // Mock document opening
-  (mockVscode.workspace.openTextDocument as jest.Mock) = jest
-    .fn()
-    .mockImplementation((uri: vscode.Uri) => Promise.resolve({ uri }));
+  (mockVscode.workspace.openTextDocument as jest.Mock) = jest.fn().mockImplementation((uri: vscode.Uri) => Promise.resolve({ uri }));
 
   // Set visible editors
   mockVscode.window.visibleTextEditors = visibleEditors;

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createBaseMockPasteDestination.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createBaseMockPasteDestination.ts
@@ -58,8 +58,7 @@ const processConvenienceOptions = (options?: MockDestinationOptions): Record<str
 
   // Smart isAvailable handling: boolean → wrapped mock, jest.Mock → as-is
   if (isAvailable !== undefined) {
-    processed.isAvailable =
-      typeof isAvailable === 'boolean' ? jest.fn().mockResolvedValue(isAvailable) : isAvailable;
+    processed.isAvailable = typeof isAvailable === 'boolean' ? jest.fn().mockResolvedValue(isAvailable) : isAvailable;
   }
 
   return processed;
@@ -90,9 +89,7 @@ const processConvenienceOptions = (options?: MockDestinationOptions): Record<str
  * @param options - Configuration with REQUIRED `id` and optional overrides
  * @returns Mock destination with jest.fn() implementations
  */
-export const createBaseMockPasteDestination = (
-  options: BaseMockDestinationOptions,
-): jest.Mocked<PasteDestination> => {
+export const createBaseMockPasteDestination = (options: BaseMockDestinationOptions): jest.Mocked<PasteDestination> => {
   const { id, ...overrides } = options;
   const processedOverrides = processConvenienceOptions(overrides);
 

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockBindableQuickPickItem.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockBindableQuickPickItem.ts
@@ -50,10 +50,7 @@ export const createMockTerminalQuickPickItem = (
  * @param displayName - The display name for the item
  * @returns A BindableQuickPickItem for the AI assistant
  */
-export const createMockAIAssistantQuickPickItem = (
-  kind: AIAssistantDestinationKind,
-  displayName: string,
-): BindableQuickPickItem => ({
+export const createMockAIAssistantQuickPickItem = (kind: AIAssistantDestinationKind, displayName: string): BindableQuickPickItem => ({
   label: displayName,
   displayName,
   bindOptions: { kind },
@@ -67,10 +64,7 @@ export const createMockAIAssistantQuickPickItem = (
  * @param description - Optional description for the item
  * @returns A FileBindableQuickPickItem for the text editor
  */
-export const createMockTextEditorQuickPickItem = (
-  fileInfo?: EligibleFile,
-  description?: string,
-): FileBindableQuickPickItem => {
+export const createMockTextEditorQuickPickItem = (fileInfo?: EligibleFile, description?: string): FileBindableQuickPickItem => {
   const resolvedFileInfo = fileInfo ?? createMockEligibleFile();
   return {
     label: resolvedFileInfo.filename,
@@ -92,11 +86,7 @@ export const createMockTextEditorQuickPickItem = (
  * @returns Array of FileBindableQuickPickItem for the text editor
  */
 export const createMockTextEditorQuickPickItems = (count: number): FileBindableQuickPickItem[] =>
-  Array.from({ length: count }, (_, i) =>
-    createMockTextEditorQuickPickItem(
-      createMockEligibleFile({ filename: `file-${i + 1}.ts`, isCurrentInGroup: true }),
-    ),
-  );
+  Array.from({ length: count }, (_, i) => createMockTextEditorQuickPickItem(createMockEligibleFile({ filename: `file-${i + 1}.ts`, isCurrentInGroup: true })));
 
 /**
  * Create a mock FileMoreQuickPickItem.
@@ -117,9 +107,7 @@ export const createMockFileMoreQuickPickItem = (remainingCount: number): FileMor
  * @param remainingCount - Number of remaining terminals not shown
  * @returns A TerminalMoreQuickPickItem
  */
-export const createMockTerminalMoreQuickPickItem = (
-  remainingCount: number,
-): TerminalMoreQuickPickItem => ({
+export const createMockTerminalMoreQuickPickItem = (remainingCount: number): TerminalMoreQuickPickItem => ({
   label: 'More terminals...',
   displayName: 'More terminals...',
   itemKind: 'terminal-more',
@@ -132,8 +120,6 @@ export const createMockTerminalMoreQuickPickItem = (
  * @param items - Array of TerminalBindableQuickPickItem for terminals
  * @returns GroupedDestinationItems with terminal group
  */
-export const createMockGroupedTerminals = (
-  items: TerminalBindableQuickPickItem[],
-): GroupedDestinationItems => ({
+export const createMockGroupedTerminals = (items: TerminalBindableQuickPickItem[]): GroupedDestinationItems => ({
   terminal: items,
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockBookmarkService.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockBookmarkService.ts
@@ -15,9 +15,7 @@ export interface MockBookmarkServiceOptions {
   bookmarks?: Bookmark[];
 }
 
-export const createMockBookmarkService = (
-  options: MockBookmarkServiceOptions = {},
-): jest.Mocked<BookmarkService> => {
+export const createMockBookmarkService = (options: MockBookmarkServiceOptions = {}): jest.Mocked<BookmarkService> => {
   const { bookmarks = [] } = options;
 
   return {

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockBookmarksStore.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockBookmarksStore.ts
@@ -30,9 +30,7 @@ export interface MockBookmarksStoreOptions {
  * @param options - Optional configuration for the mock
  * @returns Mock BookmarksStore with jest functions
  */
-export const createMockBookmarksStore = (
-  options: MockBookmarksStoreOptions = {},
-): jest.Mocked<BookmarksStore> => {
+export const createMockBookmarksStore = (options: MockBookmarksStoreOptions = {}): jest.Mocked<BookmarksStore> => {
   const bookmarks = options.bookmarks ?? [];
 
   return {

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockBoundSession.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockBoundSession.ts
@@ -38,9 +38,7 @@ export const createMockBoundSession = (overrides?: { get?: jest.Mock; isSet?: je
       fn(getMock());
       return emitter.event(fn);
     }),
-    onDidChange: jest.fn((fn: (info: BoundDestinationInfo | undefined) => void) =>
-      emitter.event(fn),
-    ),
+    onDidChange: jest.fn((fn: (info: BoundDestinationInfo | undefined) => void) => emitter.event(fn)),
     _emitter: emitter,
     isClipboardRestorationApplicable: jest.fn().mockReturnValue(true),
     dispose: jest.fn(),

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockClaudeCodeComposableDestination.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockClaudeCodeComposableDestination.ts
@@ -14,9 +14,7 @@ import {
  * @param overrides - Optional config overrides
  * @returns ComposablePasteDestination instance configured as Claude Code
  */
-export const createMockClaudeCodeComposableDestination = (
-  overrides?: Omit<MockSingletonComposablePasteDestinationConfig, 'id'>,
-) =>
+export const createMockClaudeCodeComposableDestination = (overrides?: Omit<MockSingletonComposablePasteDestinationConfig, 'id'>) =>
   createMockSingletonComposablePasteDestination({
     id: 'claude-code',
     displayName: 'Claude Code Chat',

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockClaudeCodeDestination.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockClaudeCodeDestination.ts
@@ -1,7 +1,4 @@
-import {
-  createBaseMockPasteDestination,
-  type MockDestinationOptions,
-} from './createBaseMockPasteDestination';
+import { createBaseMockPasteDestination, type MockDestinationOptions } from './createBaseMockPasteDestination';
 
 /**
  * Create a mock Claude Code destination for testing (Paradigm A).

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockComposablePasteDestination.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockComposablePasteDestination.ts
@@ -29,9 +29,7 @@ export interface MockComposablePasteDestinationConfig extends Partial<Composable
  * @param insertReturns - What inserter() should return (default: true)
  * @returns Mocked FocusCapability with focus() returning DetailedResult.success({ inserter: ... })
  */
-export const createMockFocusCapability = (
-  insertReturns: boolean = true,
-): jest.Mocked<FocusCapability> => {
+export const createMockFocusCapability = (insertReturns: boolean = true): jest.Mocked<FocusCapability> => {
   const mockInsert = jest.fn().mockResolvedValue(insertReturns);
   const focusedDestination: FocusedDestination = { inserter: mockInsert };
 
@@ -64,9 +62,7 @@ export const createMockEligibilityChecker = (): jest.Mocked<EligibilityChecker> 
  * @param overrides - Optional config overrides
  * @returns ComposablePasteDestination instance with mocked capabilities
  */
-export const createMockComposablePasteDestination = (
-  overrides: MockComposablePasteDestinationConfig = {},
-): ComposablePasteDestination => {
+export const createMockComposablePasteDestination = (overrides: MockComposablePasteDestinationConfig = {}): ComposablePasteDestination => {
   const config: ComposablePasteDestinationConfig = {
     id: 'text-editor',
     displayName: 'Mock Destination',

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockConfigGetter.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockConfigGetter.ts
@@ -6,9 +6,7 @@ import type { ConfigGetter, ConfigInspection } from '../../config/types';
  * @param overrides - Key-value pairs to return from get()
  * @returns A ConfigGetter that returns overrides values or undefined
  */
-export const createMockConfigGetter = (
-  overrides: Partial<Record<string, unknown>> = {},
-): ConfigGetter => ({
+export const createMockConfigGetter = (overrides: Partial<Record<string, unknown>> = {}): ConfigGetter => ({
   get: <T>(key: string): T | undefined => {
     if (key in overrides) {
       return overrides[key] as T;

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockConfigReader.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockConfigReader.ts
@@ -9,9 +9,7 @@ export interface MockConfigReaderOverrides {
   inspect?: jest.Mock;
 }
 
-export const createMockConfigReader = (
-  overrides?: MockConfigReaderOverrides,
-): jest.Mocked<ConfigReader> => {
+export const createMockConfigReader = (overrides?: MockConfigReaderOverrides): jest.Mocked<ConfigReader> => {
   const baseConfigReader = {
     getPaddingMode: jest.fn((_key: string, defaultValue: PaddingMode) => defaultValue),
     getWithDefault: jest.fn((_key: string, defaultValue: unknown) => defaultValue),

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockConfigurationProvider.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockConfigurationProvider.ts
@@ -9,8 +9,6 @@ import { createMockConfigGetter } from './createMockConfigGetter';
  * @param configGetter - Optional ConfigGetter to return from getConfiguration. Defaults to empty config.
  * @returns A mocked ConfigurationProvider with jest mock functions
  */
-export const createMockConfigurationProvider = (
-  configGetter: ConfigGetter = createMockConfigGetter(),
-): jest.Mocked<ConfigurationProvider> => ({
+export const createMockConfigurationProvider = (configGetter: ConfigGetter = createMockConfigGetter()): jest.Mocked<ConfigurationProvider> => ({
   getConfiguration: jest.fn().mockReturnValue(configGetter),
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockCursorAIComposableDestination.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockCursorAIComposableDestination.ts
@@ -14,9 +14,7 @@ import {
  * @param overrides - Optional config overrides
  * @returns ComposablePasteDestination instance configured as Cursor AI
  */
-export const createMockCursorAIComposableDestination = (
-  overrides?: Omit<MockSingletonComposablePasteDestinationConfig, 'id'>,
-) =>
+export const createMockCursorAIComposableDestination = (overrides?: Omit<MockSingletonComposablePasteDestinationConfig, 'id'>) =>
   createMockSingletonComposablePasteDestination({
     id: 'cursor-ai',
     displayName: 'Cursor AI Assistant',

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockCursorAIDestination.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockCursorAIDestination.ts
@@ -1,7 +1,4 @@
-import {
-  createBaseMockPasteDestination,
-  type MockDestinationOptions,
-} from './createBaseMockPasteDestination';
+import { createBaseMockPasteDestination, type MockDestinationOptions } from './createBaseMockPasteDestination';
 
 /**
  * Create a mock Cursor AI destination for testing (Paradigm A).

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockDestinationAvailabilityService.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockDestinationAvailabilityService.ts
@@ -5,14 +5,11 @@ import { MessageCode } from '../../types';
  * Create a mock DestinationAvailabilityService for testing.
  * Only mocks the public methods; private properties are omitted via cast.
  */
-export const createMockDestinationAvailabilityService =
-  (): jest.Mocked<DestinationAvailabilityService> =>
-    ({
-      isAIAssistantAvailable: jest.fn().mockResolvedValue(false),
-      getUnavailableMessageCode: jest
-        .fn()
-        .mockReturnValue(MessageCode.INFO_CLAUDE_CODE_NOT_AVAILABLE),
-      getGroupedDestinationItems: jest.fn().mockResolvedValue({}),
-      getTerminalItems: jest.fn().mockResolvedValue([]),
-      getAllFileItems: jest.fn().mockReturnValue([]),
-    }) as unknown as jest.Mocked<DestinationAvailabilityService>;
+export const createMockDestinationAvailabilityService = (): jest.Mocked<DestinationAvailabilityService> =>
+  ({
+    isAIAssistantAvailable: jest.fn().mockResolvedValue(false),
+    getUnavailableMessageCode: jest.fn().mockReturnValue(MessageCode.INFO_CLAUDE_CODE_NOT_AVAILABLE),
+    getGroupedDestinationItems: jest.fn().mockResolvedValue({}),
+    getTerminalItems: jest.fn().mockResolvedValue([]),
+    getAllFileItems: jest.fn().mockReturnValue([]),
+  }) as unknown as jest.Mocked<DestinationAvailabilityService>;

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockDestinationManager.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockDestinationManager.ts
@@ -10,14 +10,8 @@ export interface MockDestinationManagerOptions {
   bindResult?: ExtensionResult<BindSuccessInfo>;
 }
 
-export const createMockDestinationManager = (
-  options: MockDestinationManagerOptions = {},
-): jest.Mocked<PasteDestinationManager> => {
-  const {
-    sendLinkToDestinationResult = false,
-    sendTextToDestinationResult = false,
-    bindResult,
-  } = options;
+export const createMockDestinationManager = (options: MockDestinationManagerOptions = {}): jest.Mocked<PasteDestinationManager> => {
+  const { sendLinkToDestinationResult = false, sendTextToDestinationResult = false, bindResult } = options;
 
   const bindMock = bindResult !== undefined ? jest.fn().mockResolvedValue(bindResult) : jest.fn();
 

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockDestinationPicker.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockDestinationPicker.ts
@@ -1,8 +1,6 @@
 import type { DestinationPicker } from '../../destinations';
 
-export const createMockDestinationPicker = (
-  overrides: Partial<jest.Mocked<DestinationPicker>> = {},
-): jest.Mocked<DestinationPicker> =>
+export const createMockDestinationPicker = (overrides: Partial<jest.Mocked<DestinationPicker>> = {}): jest.Mocked<DestinationPicker> =>
   ({
     pick: jest.fn(),
     ...overrides,

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockDestinationRegistry.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockDestinationRegistry.ts
@@ -32,12 +32,7 @@ export interface MockDestinationRegistryOptions {
    * Custom implementation for create() method.
    * If provided, overrides default destination lookup behavior.
    */
-  createImpl?: (options: {
-    kind: string;
-    terminal?: vscode.Terminal;
-    uri?: vscode.Uri;
-    viewColumn?: number;
-  }) => PasteDestination | undefined;
+  createImpl?: (options: { kind: string; terminal?: vscode.Terminal; uri?: vscode.Uri; viewColumn?: number }) => PasteDestination | undefined;
 }
 
 const DEFAULT_DISPLAY_NAMES: Record<DestinationKind, string> = {
@@ -59,21 +54,14 @@ const DEFAULT_DISPLAY_NAMES: Record<DestinationKind, string> = {
  * @param options - Configuration for mock registry behavior
  * @returns Mock DestinationRegistry with jest.Mocked type
  */
-export const createMockDestinationRegistry = (
-  options?: MockDestinationRegistryOptions,
-): jest.Mocked<DestinationRegistry> => {
+export const createMockDestinationRegistry = (options?: MockDestinationRegistryOptions): jest.Mocked<DestinationRegistry> => {
   const destinations = options?.destinations ?? {
     terminal: createMockTerminalPasteDestination(),
-    'text-editor':
-      createMockEditorComposablePasteDestination() as unknown as jest.Mocked<PasteDestination>,
-    'claude-code':
-      createMockClaudeCodeComposableDestination() as unknown as jest.Mocked<PasteDestination>,
-    'gemini-code-assist':
-      createMockGeminiCodeAssistComposableDestination() as unknown as jest.Mocked<PasteDestination>,
-    'cursor-ai':
-      createMockCursorAIComposableDestination() as unknown as jest.Mocked<PasteDestination>,
-    'github-copilot-chat':
-      createMockGitHubCopilotChatComposableDestination() as unknown as jest.Mocked<PasteDestination>,
+    'text-editor': createMockEditorComposablePasteDestination() as unknown as jest.Mocked<PasteDestination>,
+    'claude-code': createMockClaudeCodeComposableDestination() as unknown as jest.Mocked<PasteDestination>,
+    'gemini-code-assist': createMockGeminiCodeAssistComposableDestination() as unknown as jest.Mocked<PasteDestination>,
+    'cursor-ai': createMockCursorAIComposableDestination() as unknown as jest.Mocked<PasteDestination>,
+    'github-copilot-chat': createMockGitHubCopilotChatComposableDestination() as unknown as jest.Mocked<PasteDestination>,
   };
 
   const defaultCreateImpl = (createOptions: {

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockDocument.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockDocument.ts
@@ -17,9 +17,7 @@ import * as vscode from 'vscode';
  * @param overrides - Document properties (getText, uri, lineCount, etc.)
  * @returns Mock TextDocument with provided properties
  */
-export const createMockDocument = (
-  overrides: Partial<vscode.TextDocument>,
-): vscode.TextDocument => {
+export const createMockDocument = (overrides: Partial<vscode.TextDocument>): vscode.TextDocument => {
   return {
     ...overrides,
   } as vscode.TextDocument;

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockEditor.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockEditor.ts
@@ -23,22 +23,11 @@ export interface MockEditorOptions {
 
 const DEFAULT_FS_PATH = '/test/file.ts';
 
-const STRUCTURED_OPTION_KEYS: (keyof MockEditorOptions)[] = [
-  'text',
-  'isUntitled',
-  'fsPath',
-  'selectionStart',
-  'selectionEnd',
-  'isEmpty',
-];
+const STRUCTURED_OPTION_KEYS: (keyof MockEditorOptions)[] = ['text', 'isUntitled', 'fsPath', 'selectionStart', 'selectionEnd', 'isEmpty'];
 
-const isStructuredOptions = (
-  options: MockEditorOptions | Partial<vscode.TextEditor> | undefined,
-): options is MockEditorOptions => {
+const isStructuredOptions = (options: MockEditorOptions | Partial<vscode.TextEditor> | undefined): options is MockEditorOptions => {
   if (!options) return false;
-  return Object.keys(options).some((key) =>
-    STRUCTURED_OPTION_KEYS.includes(key as keyof MockEditorOptions),
-  );
+  return Object.keys(options).some((key) => STRUCTURED_OPTION_KEYS.includes(key as keyof MockEditorOptions));
 };
 
 const createEditorFromStructuredOptions = (options: MockEditorOptions): vscode.TextEditor => {
@@ -139,9 +128,7 @@ const createEditorFromOverrides = (overrides?: Partial<vscode.TextEditor>): vsco
  */
 export function createMockEditor(options: MockEditorOptions): vscode.TextEditor;
 export function createMockEditor(overrides?: Partial<vscode.TextEditor>): vscode.TextEditor;
-export function createMockEditor(
-  options?: MockEditorOptions | Partial<vscode.TextEditor>,
-): vscode.TextEditor {
+export function createMockEditor(options?: MockEditorOptions | Partial<vscode.TextEditor>): vscode.TextEditor {
   if (isStructuredOptions(options)) {
     return createEditorFromStructuredOptions(options);
   }

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockEditorComposablePasteDestination.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockEditorComposablePasteDestination.ts
@@ -1,7 +1,4 @@
-import {
-  createMockComposablePasteDestination,
-  type MockComposablePasteDestinationConfig,
-} from './createMockComposablePasteDestination';
+import { createMockComposablePasteDestination, type MockComposablePasteDestinationConfig } from './createMockComposablePasteDestination';
 import { createMockUri } from './createMockUri';
 
 import type * as vscode from 'vscode';
@@ -11,10 +8,7 @@ import type * as vscode from 'vscode';
  *
  * Extends base config with editor-specific options.
  */
-export interface MockEditorComposablePasteDestinationConfig extends Omit<
-  MockComposablePasteDestinationConfig,
-  'resource'
-> {
+export interface MockEditorComposablePasteDestinationConfig extends Omit<MockComposablePasteDestinationConfig, 'resource'> {
   /** URI to use. If not provided, creates a mock URI. */
   uri?: vscode.Uri;
   /** View column to use. Defaults to 1. */

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockEditorWithSelection.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockEditorWithSelection.ts
@@ -32,21 +32,19 @@ export const createMockEditorWithSelection = (options: {
   });
 
   // Convert selection tuples to mock Selection objects
-  const selections = options.selections.map(
-    ([startLine, startCharacter, endLine, endCharacter]) => {
-      const anchor = createMockPosition({ line: startLine, character: startCharacter });
-      const active = createMockPosition({ line: endLine, character: endCharacter });
-      const isEmpty = startLine === endLine && startCharacter === endCharacter;
-      return createMockSelection({
-        anchor,
-        active,
-        start: anchor,
-        end: active,
-        isReversed: false,
-        isEmpty,
-      });
-    },
-  );
+  const selections = options.selections.map(([startLine, startCharacter, endLine, endCharacter]) => {
+    const anchor = createMockPosition({ line: startLine, character: startCharacter });
+    const active = createMockPosition({ line: endLine, character: endCharacter });
+    const isEmpty = startLine === endLine && startCharacter === endCharacter;
+    return createMockSelection({
+      anchor,
+      active,
+      start: anchor,
+      end: active,
+      isReversed: false,
+      isEmpty,
+    });
+  });
 
   const mockEditor = createMockEditor({
     document: mockDocument,

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockEligibleFile.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockEligibleFile.ts
@@ -15,15 +15,7 @@ export interface MockEligibleFileOptions {
 }
 
 export const createMockEligibleFile = (options: MockEligibleFileOptions = {}): EligibleFile => {
-  const {
-    filename = 'file.ts',
-    displayPath,
-    viewColumn = 1,
-    isCurrentInGroup = false,
-    isActiveEditor = false,
-    boundState,
-    uri,
-  } = options;
+  const { filename = 'file.ts', displayPath, viewColumn = 1, isCurrentInGroup = false, isActiveEditor = false, boundState, uri } = options;
   const resolvedUri = uri ?? createMockUri(`/workspace/${filename}`);
   return {
     bindOptions: { kind: 'text-editor', uri: resolvedUri, viewColumn },

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockEligibleTerminal.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockEligibleTerminal.ts
@@ -12,9 +12,7 @@ export interface MockEligibleTerminalOptions {
   readonly terminal?: vscode.Terminal;
 }
 
-export const createMockEligibleTerminal = (
-  options: MockEligibleTerminalOptions = {},
-): EligibleTerminal => {
+export const createMockEligibleTerminal = (options: MockEligibleTerminalOptions = {}): EligibleTerminal => {
   const { name = 'bash', isActive = false, processId, boundState, terminal } = options;
   const resolvedTerminal = terminal ?? createMockTerminal({ name });
   return {

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockExtension.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockExtension.ts
@@ -34,9 +34,7 @@ export interface MockExtensionOptions {
  * @param options - Optional configuration for the mock extension
  * @returns Mock vscode.Extension<unknown> object
  */
-export const createMockExtension = (
-  options: MockExtensionOptions = {},
-): vscode.Extension<unknown> => {
+export const createMockExtension = (options: MockExtensionOptions = {}): vscode.Extension<unknown> => {
   const id = options.id ?? 'test.extension';
   const defaultPath = `/mock/path/${id}`;
 

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockExtensions.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockExtensions.ts
@@ -31,9 +31,7 @@ const normalizeExtensionConfig = (config: MockExtensionConfig): vscode.Extension
  * @param extensions - Array of extension configs (string IDs or detailed objects)
  * @returns Mock extensions object
  */
-export const createMockExtensions = (
-  extensions: MockExtensionConfig[] = [],
-): typeof vscode.extensions => {
+export const createMockExtensions = (extensions: MockExtensionConfig[] = []): typeof vscode.extensions => {
   const mockExtensions = extensions.map(normalizeExtensionConfig);
 
   return {

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockFilePathNavigationHandler.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockFilePathNavigationHandler.ts
@@ -9,9 +9,7 @@ import type { FilePathNavigationHandler } from '../../navigation/FilePathNavigat
  * @param options - Optional method overrides
  * @returns Mock navigation handler
  */
-export const createMockFilePathNavigationHandler = (
-  options?: Partial<jest.Mocked<FilePathNavigationHandler>>,
-): jest.Mocked<FilePathNavigationHandler> =>
+export const createMockFilePathNavigationHandler = (options?: Partial<jest.Mocked<FilePathNavigationHandler>>): jest.Mocked<FilePathNavigationHandler> =>
   ({
     navigateToFile: jest.fn().mockResolvedValue(undefined),
     ...options,

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockFocusCapabilityFactory.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockFocusCapabilityFactory.ts
@@ -1,7 +1,4 @@
-import type {
-  FocusCapabilityFactory,
-  LazyResolvedFocusCapability,
-} from '../../destinations/capabilities';
+import type { FocusCapabilityFactory, LazyResolvedFocusCapability } from '../../destinations/capabilities';
 
 /**
  * Create a mock LazyResolvedFocusCapability for testing.
@@ -32,7 +29,5 @@ export const createMockFocusCapabilityFactory = (): jest.Mocked<FocusCapabilityF
       label: 'builtinFallback',
       probeMode: 'execute',
     }),
-    createLazyResolvedCapability: jest
-      .fn()
-      .mockReturnValue(createMockLazyResolvedFocusCapability()),
+    createLazyResolvedCapability: jest.fn().mockReturnValue(createMockLazyResolvedFocusCapability()),
   }) as unknown as jest.Mocked<FocusCapabilityFactory>;

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockFormattedLink.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockFormattedLink.ts
@@ -2,14 +2,7 @@
  * Create a mock FormattedLink for testing
  */
 
-import {
-  ComputedSelection,
-  DelimiterConfig,
-  FormattedLink,
-  LinkType,
-  RangeFormat,
-  SelectionType,
-} from 'rangelink-core-ts';
+import { ComputedSelection, DelimiterConfig, FormattedLink, LinkType, RangeFormat, SelectionType } from 'rangelink-core-ts';
 
 /**
  * Create a mock FormattedLink for testing
@@ -21,10 +14,7 @@ import {
  * @param overrides - Optional partial FormattedLink to override defaults
  * @returns Mock FormattedLink with all required properties
  */
-export const createMockFormattedLink = (
-  link = 'test-link',
-  overrides: Partial<FormattedLink> = {},
-): FormattedLink => {
+export const createMockFormattedLink = (link = 'test-link', overrides: Partial<FormattedLink> = {}): FormattedLink => {
   const defaultDelimiters: DelimiterConfig = {
     line: 'L',
     position: 'C',

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockGeminiCodeAssistComposableDestination.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockGeminiCodeAssistComposableDestination.ts
@@ -14,9 +14,7 @@ import {
  * @param overrides - Optional config overrides
  * @returns ComposablePasteDestination instance configured as Gemini Code Assist
  */
-export const createMockGeminiCodeAssistComposableDestination = (
-  overrides?: Omit<MockSingletonComposablePasteDestinationConfig, 'id'>,
-) =>
+export const createMockGeminiCodeAssistComposableDestination = (overrides?: Omit<MockSingletonComposablePasteDestinationConfig, 'id'>) =>
   createMockSingletonComposablePasteDestination({
     id: 'gemini-code-assist',
     displayName: 'Gemini Code Assist',

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockGeminiCodeAssistDestination.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockGeminiCodeAssistDestination.ts
@@ -1,7 +1,4 @@
-import {
-  createBaseMockPasteDestination,
-  type MockDestinationOptions,
-} from './createBaseMockPasteDestination';
+import { createBaseMockPasteDestination, type MockDestinationOptions } from './createBaseMockPasteDestination';
 
 /**
  * Create a mock Gemini Code Assist destination for testing (Paradigm A).
@@ -12,9 +9,7 @@ import {
  * @param overrides - Optional overrides for mock behavior
  * @returns Mock PasteDestination configured as Gemini Code Assist
  */
-export const createMockGeminiCodeAssistDestination = (
-  overrides?: Omit<MockDestinationOptions, 'id'>,
-) =>
+export const createMockGeminiCodeAssistDestination = (overrides?: Omit<MockDestinationOptions, 'id'>) =>
   createBaseMockPasteDestination({
     id: 'gemini-code-assist',
     displayName: 'Gemini Code Assist',

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockGitHubCopilotChatComposableDestination.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockGitHubCopilotChatComposableDestination.ts
@@ -14,9 +14,7 @@ import {
  * @param overrides - Optional config overrides
  * @returns ComposablePasteDestination instance configured as GitHub Copilot Chat
  */
-export const createMockGitHubCopilotChatComposableDestination = (
-  overrides?: Omit<MockSingletonComposablePasteDestinationConfig, 'id'>,
-) =>
+export const createMockGitHubCopilotChatComposableDestination = (overrides?: Omit<MockSingletonComposablePasteDestinationConfig, 'id'>) =>
   createMockSingletonComposablePasteDestination({
     id: 'github-copilot-chat',
     displayName: 'GitHub Copilot Chat',

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockGitHubCopilotChatDestination.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockGitHubCopilotChatDestination.ts
@@ -1,7 +1,4 @@
-import {
-  createBaseMockPasteDestination,
-  type MockDestinationOptions,
-} from './createBaseMockPasteDestination';
+import { createBaseMockPasteDestination, type MockDestinationOptions } from './createBaseMockPasteDestination';
 
 /**
  * Create a mock GitHub Copilot Chat destination for testing (Paradigm A).
@@ -12,9 +9,7 @@ import {
  * @param overrides - Optional overrides for mock behavior
  * @returns Mock PasteDestination configured as GitHub Copilot Chat
  */
-export const createMockGitHubCopilotChatDestination = (
-  overrides?: Omit<MockDestinationOptions, 'id'>,
-) =>
+export const createMockGitHubCopilotChatDestination = (overrides?: Omit<MockDestinationOptions, 'id'>) =>
   createBaseMockPasteDestination({
     id: 'github-copilot-chat',
     displayName: 'GitHub Copilot Chat',

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockNavigationHandler.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockNavigationHandler.ts
@@ -19,9 +19,7 @@ import type { RangeLinkNavigationHandler } from '../../navigation/RangeLinkNavig
  * @param options - Optional method overrides
  * @returns Mock navigation handler
  */
-export const createMockNavigationHandler = (
-  options?: Partial<jest.Mocked<RangeLinkNavigationHandler>>,
-): jest.Mocked<RangeLinkNavigationHandler> =>
+export const createMockNavigationHandler = (options?: Partial<jest.Mocked<RangeLinkNavigationHandler>>): jest.Mocked<RangeLinkNavigationHandler> =>
   ({
     parseLink: jest.fn(),
     navigateToLink: jest.fn().mockResolvedValue(undefined),

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockOperationFeedbackProvider.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockOperationFeedbackProvider.ts
@@ -2,9 +2,7 @@ import type { BindingFeedback } from '../../feedback/BindingFeedback';
 import type { LifecycleFeedbackProvider } from '../../feedback/LifecycleFeedbackProvider';
 import type { OperationFeedbackProvider } from '../../feedback/OperationFeedbackProvider';
 
-export const createMockOperationFeedbackProvider = (): jest.Mocked<
-  OperationFeedbackProvider & LifecycleFeedbackProvider & BindingFeedback
-> =>
+export const createMockOperationFeedbackProvider = (): jest.Mocked<OperationFeedbackProvider & LifecycleFeedbackProvider & BindingFeedback> =>
   ({
     showError: jest.fn(),
     provideCopyFeedback: jest.fn(),
@@ -21,6 +19,4 @@ export const createMockOperationFeedbackProvider = (): jest.Mocked<
     notifyNothingToUnbind: jest.fn(),
     notifyJumpFocused: jest.fn(),
     notifyJumpFailed: jest.fn(),
-  }) as unknown as jest.Mocked<
-    OperationFeedbackProvider & LifecycleFeedbackProvider & BindingFeedback
-  >;
+  }) as unknown as jest.Mocked<OperationFeedbackProvider & LifecycleFeedbackProvider & BindingFeedback>;

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockPasteDestinationForSendRouter.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockPasteDestinationForSendRouter.ts
@@ -1,8 +1,6 @@
 import type { PasteDestination } from '../../destinations';
 
-export const createMockPasteDestinationForSendRouter = (
-  overrides: Partial<PasteDestination> = {},
-): jest.Mocked<PasteDestination> =>
+export const createMockPasteDestinationForSendRouter = (overrides: Partial<PasteDestination> = {}): jest.Mocked<PasteDestination> =>
   ({
     id: 'terminal',
     displayName: 'Terminal ("bash")',

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockPosition.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockPosition.ts
@@ -27,5 +27,4 @@ export const createMockPosition = (overrides: Partial<vscode.Position>): vscode.
  * @param character - Character offset
  * @returns Mock Position with line and character set
  */
-export const createMockPos = (line: number, character: number): vscode.Position =>
-  createMockPosition({ line, character });
+export const createMockPos = (line: number, character: number): vscode.Position => createMockPosition({ line, character });

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockQuickPick.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockQuickPick.ts
@@ -24,12 +24,10 @@ export const createMockQuickPick = () => {
     show: jest.fn(),
     hide: jest.fn(),
     dispose: jest.fn(),
-    onDidTriggerItemButton: jest.fn(
-      (handler: (event: vscode.QuickPickItemButtonEvent<MockQuickPickItem>) => any) => {
-        handlers.onDidTriggerItemButton = handler;
-        return { dispose: jest.fn() };
-      },
-    ),
+    onDidTriggerItemButton: jest.fn((handler: (event: vscode.QuickPickItemButtonEvent<MockQuickPickItem>) => any) => {
+      handlers.onDidTriggerItemButton = handler;
+      return { dispose: jest.fn() };
+    }),
 
     onDidAccept: jest.fn((handler: () => any) => {
       handlers.onDidAccept = handler;
@@ -40,8 +38,7 @@ export const createMockQuickPick = () => {
       handlers.onDidHide = handler;
       return { dispose: jest.fn() };
     }),
-    __triggerItemButton: (event: vscode.QuickPickItemButtonEvent<MockQuickPickItem>) =>
-      handlers.onDidTriggerItemButton?.(event),
+    __triggerItemButton: (event: vscode.QuickPickItemButtonEvent<MockQuickPickItem>) => handlers.onDidTriggerItemButton?.(event),
     __triggerAccept: () => handlers.onDidAccept?.(),
     __triggerHide: () => handlers.onDidHide?.(),
   };

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockSingletonComposablePasteDestination.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockSingletonComposablePasteDestination.ts
@@ -1,9 +1,6 @@
 import type { DestinationKind } from '../../types';
 
-import {
-  createMockComposablePasteDestination,
-  type MockComposablePasteDestinationConfig,
-} from './createMockComposablePasteDestination';
+import { createMockComposablePasteDestination, type MockComposablePasteDestinationConfig } from './createMockComposablePasteDestination';
 
 /**
  * Configuration for creating a mock singleton ComposablePasteDestination.
@@ -11,10 +8,7 @@ import {
  * Extends base config, excluding resource (always singleton).
  * Requires explicit `id` for consistency with other mock helpers.
  */
-export interface MockSingletonComposablePasteDestinationConfig extends Omit<
-  MockComposablePasteDestinationConfig,
-  'resource' | 'id'
-> {
+export interface MockSingletonComposablePasteDestinationConfig extends Omit<MockComposablePasteDestinationConfig, 'resource' | 'id'> {
   /** Required: The destination kind being mocked */
   id: DestinationKind;
 }

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockTabGroup.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockTabGroup.ts
@@ -14,10 +14,7 @@ import * as vscode from 'vscode';
  * @param overrides - Optional property overrides (e.g., activeTab)
  * @returns Mock TabGroup instance
  */
-export const createMockTabGroup = (
-  tabs: vscode.Tab[] = [],
-  overrides?: Partial<vscode.TabGroup>,
-): vscode.TabGroup => {
+export const createMockTabGroup = (tabs: vscode.Tab[] = [], overrides?: Partial<vscode.TabGroup>): vscode.TabGroup => {
   return {
     tabs,
     activeTab: tabs[0],

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockTabGroups.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockTabGroups.ts
@@ -13,9 +13,7 @@ import * as vscode from 'vscode';
  * @param overrides - Optional overrides for TabGroups structure
  * @returns Mock TabGroups object
  */
-export const createMockTabGroups = (
-  overrides: Partial<vscode.TabGroups> = {},
-): vscode.TabGroups => {
+export const createMockTabGroups = (overrides: Partial<vscode.TabGroups> = {}): vscode.TabGroups => {
   return {
     all: [],
     activeTabGroup: undefined,
@@ -35,5 +33,4 @@ export const createMockTabGroups = (
  * @param count - Number of tab groups to create
  * @returns Mock TabGroups with the specified count of empty groups
  */
-export const createMockTabGroupsWithCount = (count: number): vscode.TabGroups =>
-  createMockTabGroups({ all: Array(count).fill({ tabs: [] }) });
+export const createMockTabGroupsWithCount = (count: number): vscode.TabGroups => createMockTabGroups({ all: Array(count).fill({ tabs: [] }) });

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockTerminal.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockTerminal.ts
@@ -32,9 +32,7 @@ export interface MockTerminalOptions {
  * @param terminalOrOptions - Optional property overrides or pre-built terminal object
  * @returns Mock Terminal object with Jest functions
  */
-export const createMockTerminal = (
-  terminalOrOptions?: Partial<vscode.Terminal> | MockTerminalOptions,
-): vscode.Terminal => {
+export const createMockTerminal = (terminalOrOptions?: Partial<vscode.Terminal> | MockTerminalOptions): vscode.Terminal => {
   // Simple check: if it has sendText, treat it as a pre-built terminal object
   if (terminalOrOptions && 'sendText' in terminalOrOptions) {
     return terminalOrOptions as vscode.Terminal;

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockTerminalComposablePasteDestination.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockTerminalComposablePasteDestination.ts
@@ -1,7 +1,4 @@
-import {
-  createMockComposablePasteDestination,
-  type MockComposablePasteDestinationConfig,
-} from './createMockComposablePasteDestination';
+import { createMockComposablePasteDestination, type MockComposablePasteDestinationConfig } from './createMockComposablePasteDestination';
 import { createMockTerminal } from './createMockTerminal';
 
 import type * as vscode from 'vscode';
@@ -11,10 +8,7 @@ import type * as vscode from 'vscode';
  *
  * Extends base config with terminal-specific options.
  */
-export interface MockTerminalComposablePasteDestinationConfig extends Omit<
-  MockComposablePasteDestinationConfig,
-  'resource'
-> {
+export interface MockTerminalComposablePasteDestinationConfig extends Omit<MockComposablePasteDestinationConfig, 'resource'> {
   /** Terminal to use. If not provided, creates a mock terminal. */
   terminal?: vscode.Terminal;
   /** Process ID for the terminal. Defaults to 12345. */

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockTerminalPasteDestination.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockTerminalPasteDestination.ts
@@ -6,10 +6,7 @@
  * use createMockTerminalComposablePasteDestination.
  */
 
-import {
-  createBaseMockPasteDestination,
-  type MockDestinationOptions,
-} from './createBaseMockPasteDestination';
+import { createBaseMockPasteDestination, type MockDestinationOptions } from './createBaseMockPasteDestination';
 
 /**
  * Create a mock terminal PasteDestination for testing.
@@ -26,9 +23,7 @@ import {
  * @param overrides - Optional partial object to override default properties/methods
  * @returns Mock terminal destination with jest.fn() implementations
  */
-export const createMockTerminalPasteDestination = (
-  overrides?: Omit<MockDestinationOptions, 'id'>,
-) => {
+export const createMockTerminalPasteDestination = (overrides?: Omit<MockDestinationOptions, 'id'>) => {
   return createBaseMockPasteDestination({
     id: 'terminal',
     displayName: 'Terminal',

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockVscode.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockVscode.ts
@@ -19,11 +19,7 @@
  * ============================================================================
  */
 
-import {
-  createMockCommands,
-  type MockCommands,
-  type MockCommandsOverrides,
-} from './createMockCommands';
+import { createMockCommands, type MockCommands, type MockCommandsOverrides } from './createMockCommands';
 import { createMockDocumentLink } from './createMockDocumentLink';
 import { createMockEnv, type MockEnvOptions } from './createMockEnv';
 import { createMockExtensions, type MockExtensionConfig } from './createMockExtensions';
@@ -79,10 +75,7 @@ export interface MockVscodeOptions {
  * @param overrides - Optional VSCode API property overrides (spread last for flexibility)
  * @returns Mock vscode module compatible with VscodeAdapter constructor
  */
-export const createMockVscode = (
-  options?: MockVscodeOptions,
-  overrides?: Partial<typeof vscode>,
-): any => {
+export const createMockVscode = (options?: MockVscodeOptions, overrides?: Partial<typeof vscode>): any => {
   return {
     window: createMockWindow(options?.windowOptions),
     workspace: createMockWorkspace(options?.workspaceOptions),

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockVscodeAdapter.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockVscodeAdapter.ts
@@ -49,9 +49,7 @@ export interface VscodeAdapterWithTestHooks extends VscodeAdapter {
  * @param options - Optional configuration for environment and VSCode API overrides
  * @returns Real VscodeAdapter instance with test hooks for accessing underlying mock
  */
-export const createMockVscodeAdapter = (
-  options?: MockVscodeAdapterOptions,
-): VscodeAdapterWithTestHooks => {
+export const createMockVscodeAdapter = (options?: MockVscodeAdapterOptions): VscodeAdapterWithTestHooks => {
   const vscodeInstance = createMockVscode(options);
   const logger = options?.logger ?? createMockLogger();
   const adapter = new VscodeAdapter(vscodeInstance, logger) as VscodeAdapterWithTestHooks;

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockWindow.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockWindow.ts
@@ -28,9 +28,7 @@ import * as vscode from 'vscode';
  * @param options - Optional property overrides
  * @returns Mock window object
  */
-export const createMockWindow = (
-  options?: Record<string, unknown> | Partial<typeof vscode.window>,
-) => {
+export const createMockWindow = (options?: Record<string, unknown> | Partial<typeof vscode.window>) => {
   return {
     activeTerminal: undefined as vscode.Terminal | undefined,
     activeTextEditor: undefined as vscode.TextEditor | undefined,

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockWorkspace.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockWorkspace.ts
@@ -21,17 +21,11 @@ import * as vscode from 'vscode';
  * @param options - Optional workspace properties to override defaults
  * @returns Mock workspace with file operations and document handling
  */
-export const createMockWorkspace = (
-  options?: Record<string, unknown> | Partial<typeof vscode.workspace>,
-) => {
+export const createMockWorkspace = (options?: Record<string, unknown> | Partial<typeof vscode.workspace>) => {
   const defaultWorkspaceFolders = ['/workspace'];
-  const workspaceFoldersInput =
-    (options?.workspaceFolders as Array<string | vscode.WorkspaceFolder> | undefined) ??
-    defaultWorkspaceFolders;
+  const workspaceFoldersInput = (options?.workspaceFolders as Array<string | vscode.WorkspaceFolder> | undefined) ?? defaultWorkspaceFolders;
 
-  const folders = workspaceFoldersInput?.map((folder) =>
-    typeof folder === 'string' ? createMockWorkspaceFolder(folder) : folder,
-  );
+  const folders = workspaceFoldersInput?.map((folder) => (typeof folder === 'string' ? createMockWorkspaceFolder(folder) : folder));
 
   return {
     workspaceFolders: folders,

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockWorkspaceFolder.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/createMockWorkspaceFolder.ts
@@ -16,10 +16,7 @@ import * as vscode from 'vscode';
  * @param overrides - Optional property overrides (name, index, etc.)
  * @returns Mock workspace folder
  */
-export const createMockWorkspaceFolder = (
-  fsPath: string,
-  overrides?: Partial<vscode.WorkspaceFolder>,
-): vscode.WorkspaceFolder => {
+export const createMockWorkspaceFolder = (fsPath: string, overrides?: Partial<vscode.WorkspaceFolder>): vscode.WorkspaceFolder => {
   const uri = createMockUri(fsPath);
   return {
     uri,

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/destinationTestHelpers.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/destinationTestHelpers.ts
@@ -50,11 +50,7 @@ export const testDestinationLogging = (
  * @param successScenario - Function that sets up successful paste
  * @param failureScenario - Function that sets up failed paste
  */
-export const testPasteReturnValues = (
-  destination: PasteDestination,
-  successScenario: () => Promise<void>,
-  failureScenario: () => Promise<void>,
-): void => {
+export const testPasteReturnValues = (destination: PasteDestination, successScenario: () => Promise<void>, failureScenario: () => Promise<void>): void => {
   describe('pasteLink() return values', () => {
     it('should return true on successful paste', async () => {
       await successScenario();

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnFindLinksInText.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnFindLinksInText.ts
@@ -1,4 +1,3 @@
 import * as rangelinkCoreModule from 'rangelink-core-ts';
 
-export const spyOnFindLinksInText = (): jest.SpyInstance =>
-  jest.spyOn(rangelinkCoreModule, 'findLinksInText');
+export const spyOnFindLinksInText = (): jest.SpyInstance => jest.spyOn(rangelinkCoreModule, 'findLinksInText');

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnFormatLink.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnFormatLink.ts
@@ -1,4 +1,3 @@
 import * as rangelinkCoreModule from 'rangelink-core-ts';
 
-export const spyOnFormatLink = (): jest.SpyInstance =>
-  jest.spyOn(rangelinkCoreModule, 'formatLink');
+export const spyOnFormatLink = (): jest.SpyInstance => jest.spyOn(rangelinkCoreModule, 'formatLink');

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnFormatLinkTooltip.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnFormatLinkTooltip.ts
@@ -1,4 +1,3 @@
 import * as formatLinkTooltipModule from '../../utils/formatLinkTooltip';
 
-export const spyOnFormatLinkTooltip = (): jest.SpyInstance =>
-  jest.spyOn(formatLinkTooltipModule, 'formatLinkTooltip');
+export const spyOnFormatLinkTooltip = (): jest.SpyInstance => jest.spyOn(formatLinkTooltipModule, 'formatLinkTooltip');

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnFormatMessage.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnFormatMessage.ts
@@ -1,4 +1,3 @@
 import * as formatMessageModule from '../../utils/formatMessage';
 
-export const spyOnFormatMessage = (): jest.SpyInstance =>
-  jest.spyOn(formatMessageModule, 'formatMessage');
+export const spyOnFormatMessage = (): jest.SpyInstance => jest.spyOn(formatMessageModule, 'formatMessage');

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnGenerateLinkFromSelections.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnGenerateLinkFromSelections.ts
@@ -1,4 +1,3 @@
 import * as generateLinkModule from '../../utils/generateLinkFromSelections';
 
-export const spyOnGenerateLinkFromSelections = (): jest.SpyInstance =>
-  jest.spyOn(generateLinkModule, 'generateLinkFromSelections');
+export const spyOnGenerateLinkFromSelections = (): jest.SpyInstance => jest.spyOn(generateLinkModule, 'generateLinkFromSelections');

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnIsClaudeCodeAvailable.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnIsClaudeCodeAvailable.ts
@@ -1,4 +1,3 @@
 import * as isClaudeCodeAvailableModule from '../../utils/aiAssistants/isClaudeCodeAvailable';
 
-export const spyOnIsClaudeCodeAvailable = (): jest.SpyInstance =>
-  jest.spyOn(isClaudeCodeAvailableModule, 'isClaudeCodeAvailable');
+export const spyOnIsClaudeCodeAvailable = (): jest.SpyInstance => jest.spyOn(isClaudeCodeAvailableModule, 'isClaudeCodeAvailable');

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnIsCursorIDEDetected.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnIsCursorIDEDetected.ts
@@ -1,4 +1,3 @@
 import * as isCursorIDEDetectedModule from '../../utils/aiAssistants/isCursorIDEDetected';
 
-export const spyOnIsCursorIDEDetected = (): jest.SpyInstance =>
-  jest.spyOn(isCursorIDEDetectedModule, 'isCursorIDEDetected');
+export const spyOnIsCursorIDEDetected = (): jest.SpyInstance => jest.spyOn(isCursorIDEDetectedModule, 'isCursorIDEDetected');

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnIsGeminiCodeAssistAvailable.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnIsGeminiCodeAssistAvailable.ts
@@ -3,7 +3,5 @@ import * as isGeminiCodeAssistAvailableModule from '../../utils/aiAssistants/isG
 
 import type { Logger } from '@couimet/logger-contract';
 
-export const spyOnIsGeminiCodeAssistAvailable = (): jest.SpyInstance<
-  boolean,
-  [VscodeAdapter, Logger]
-> => jest.spyOn(isGeminiCodeAssistAvailableModule, 'isGeminiCodeAssistAvailable');
+export const spyOnIsGeminiCodeAssistAvailable = (): jest.SpyInstance<boolean, [VscodeAdapter, Logger]> =>
+  jest.spyOn(isGeminiCodeAssistAvailableModule, 'isGeminiCodeAssistAvailable');

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnIsGitHubCopilotChatAvailable.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnIsGitHubCopilotChatAvailable.ts
@@ -3,7 +3,5 @@ import * as isGitHubCopilotChatAvailableModule from '../../utils/aiAssistants/is
 
 import type { Logger } from '@couimet/logger-contract';
 
-export const spyOnIsGitHubCopilotChatAvailable = (): jest.SpyInstance<
-  Promise<boolean>,
-  [VscodeAdapter, Logger]
-> => jest.spyOn(isGitHubCopilotChatAvailableModule, 'isGitHubCopilotChatAvailable');
+export const spyOnIsGitHubCopilotChatAvailable = (): jest.SpyInstance<Promise<boolean>, [VscodeAdapter, Logger]> =>
+  jest.spyOn(isGitHubCopilotChatAvailableModule, 'isGitHubCopilotChatAvailable');

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnResolveWorkspacePath.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnResolveWorkspacePath.ts
@@ -1,4 +1,3 @@
 import * as resolveWorkspacePathModule from '../../utils/resolveWorkspacePath';
 
-export const spyOnResolveWorkspacePath = (): jest.SpyInstance =>
-  jest.spyOn(resolveWorkspacePathModule, 'resolveWorkspacePath');
+export const spyOnResolveWorkspacePath = (): jest.SpyInstance => jest.spyOn(resolveWorkspacePathModule, 'resolveWorkspacePath');

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnShowFilePicker.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnShowFilePicker.ts
@@ -1,4 +1,3 @@
 import * as showFilePickerModule from '../../destinations/utils/showFilePicker';
 
-export const spyOnShowFilePicker = (): jest.SpyInstance =>
-  jest.spyOn(showFilePickerModule, 'showFilePicker');
+export const spyOnShowFilePicker = (): jest.SpyInstance => jest.spyOn(showFilePickerModule, 'showFilePicker');

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnShowTerminalPicker.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnShowTerminalPicker.ts
@@ -1,4 +1,3 @@
 import * as showTerminalPickerModule from '../../destinations/utils/showTerminalPicker';
 
-export const spyOnShowTerminalPicker = (): jest.SpyInstance =>
-  jest.spyOn(showTerminalPickerModule, 'showTerminalPicker');
+export const spyOnShowTerminalPicker = (): jest.SpyInstance => jest.spyOn(showTerminalPickerModule, 'showTerminalPicker');

--- a/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnToInputSelection.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/helpers/spyOnToInputSelection.ts
@@ -1,4 +1,3 @@
 import * as toInputSelectionModule from '../../utils/toInputSelection';
 
-export const spyOnToInputSelection = (): jest.SpyInstance =>
-  jest.spyOn(toInputSelectionModule, 'toInputSelection');
+export const spyOnToInputSelection = (): jest.SpyInstance => jest.spyOn(toInputSelectionModule, 'toInputSelection');

--- a/packages/rangelink-vscode-extension/src/__tests__/ide/vscode/VscodeAdapter.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/ide/vscode/VscodeAdapter.test.ts
@@ -111,10 +111,7 @@ describe('VscodeAdapter', () => {
 
       const result = adapter.setStatusBarMessage(message);
 
-      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith(
-        'RangeLink: test message',
-        2000,
-      );
+      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith('RangeLink: test message', 2000);
       expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       const rawDisposable = mockVSCode.window.setStatusBarMessage.mock.results[0].value;
       expect(result).toBe(rawDisposable);
@@ -134,10 +131,7 @@ describe('VscodeAdapter', () => {
 
       const result = adapter.setStatusBarMessage(message, customTimeout);
 
-      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith(
-        'RangeLink: test message',
-        customTimeout,
-      );
+      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith('RangeLink: test message', customTimeout);
       expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       const rawDisposable = mockVSCode.window.setStatusBarMessage.mock.results[0].value;
       expect(result).toBe(rawDisposable);
@@ -156,10 +150,7 @@ describe('VscodeAdapter', () => {
 
       adapter.setStatusBarMessage(message, 0);
 
-      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith(
-        'RangeLink: test message',
-        0,
-      );
+      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith('RangeLink: test message', 0);
     });
 
     it('should return disposable that can be disposed', () => {
@@ -179,10 +170,7 @@ describe('VscodeAdapter', () => {
 
       const result = adapter.setSuccessfulStatusBarMessage(message);
 
-      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith(
-        '✓ RangeLink: success message',
-        2000,
-      );
+      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith('✓ RangeLink: success message', 2000);
       expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       const rawDisposable = mockVSCode.window.setStatusBarMessage.mock.results[0].value;
       expect(result).toBe(rawDisposable);
@@ -202,10 +190,7 @@ describe('VscodeAdapter', () => {
 
       const result = adapter.setSuccessfulStatusBarMessage(message, customTimeout);
 
-      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith(
-        '✓ RangeLink: success message',
-        customTimeout,
-      );
+      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith('✓ RangeLink: success message', customTimeout);
       expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledTimes(1);
       const rawDisposable = mockVSCode.window.setStatusBarMessage.mock.results[0].value;
       expect(result).toBe(rawDisposable);
@@ -224,10 +209,7 @@ describe('VscodeAdapter', () => {
 
       adapter.setSuccessfulStatusBarMessage(message, 0);
 
-      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith(
-        '✓ RangeLink: success message',
-        0,
-      );
+      expect(mockVSCode.window.setStatusBarMessage).toHaveBeenCalledWith('✓ RangeLink: success message', 0);
     });
 
     it('should return disposable that can be disposed', () => {
@@ -249,10 +231,7 @@ describe('VscodeAdapter', () => {
 
       expect(mockVSCode.window.showWarningMessage).toHaveBeenCalledWith(message);
       expect(mockVSCode.window.showWarningMessage).toHaveBeenCalledTimes(1);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'VscodeAdapter.showWarningMessage', message, items: [] },
-        'Showing warning message',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'VscodeAdapter.showWarningMessage', message, items: [] }, 'Showing warning message');
     });
 
     it('should return undefined when no button is selected', async () => {
@@ -283,11 +262,7 @@ describe('VscodeAdapter', () => {
 
       const result = await adapter.showWarningMessage('Delete this?', 'Yes', 'No');
 
-      expect(mockVSCode.window.showWarningMessage).toHaveBeenCalledWith(
-        'Delete this?',
-        'Yes',
-        'No',
-      );
+      expect(mockVSCode.window.showWarningMessage).toHaveBeenCalledWith('Delete this?', 'Yes', 'No');
       expect(result).toBe('Yes');
     });
   });
@@ -300,10 +275,7 @@ describe('VscodeAdapter', () => {
 
       expect(mockVSCode.window.showErrorMessage).toHaveBeenCalledWith(message);
       expect(mockVSCode.window.showErrorMessage).toHaveBeenCalledTimes(1);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'VscodeAdapter.showErrorMessage', message },
-        'Showing error message',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'VscodeAdapter.showErrorMessage', message }, 'Showing error message');
     });
 
     it('should return undefined when no button is selected', async () => {
@@ -324,8 +296,7 @@ describe('VscodeAdapter', () => {
     });
 
     it('should handle error message with details', async () => {
-      const detailedError =
-        'Invalid delimiter configuration. Using defaults. Check Output → RangeLink for details.';
+      const detailedError = 'Invalid delimiter configuration. Using defaults. Check Output → RangeLink for details.';
 
       await adapter.showErrorMessage(detailedError);
 
@@ -354,10 +325,7 @@ describe('VscodeAdapter', () => {
 
       expect(mockVSCode.window.showInputBox).toHaveBeenCalledWith(options);
       expect(mockVSCode.window.showInputBox).toHaveBeenCalledTimes(1);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'VscodeAdapter.showInputBox', options },
-        'Showing input box',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'VscodeAdapter.showInputBox', options }, 'Showing input box');
       expect(result).toBe('user input');
     });
 
@@ -567,8 +535,7 @@ describe('VscodeAdapter', () => {
       process.env.RANGELINK_CAPTURE_LOGS = 'true';
       try {
         jest.resetModules();
-        const { VscodeAdapter: CapturingAdapter } =
-          await import('../../../ide/vscode/VscodeAdapter');
+        const { VscodeAdapter: CapturingAdapter } = await import('../../../ide/vscode/VscodeAdapter');
         const capturingAdapter = new CapturingAdapter(mockVSCode, mockLogger);
 
         const items = [
@@ -643,11 +610,7 @@ describe('VscodeAdapter', () => {
           fn: 'VscodeAdapter.showQuickPick',
           itemCount: 3,
           options: undefined,
-          items: [
-            { label: 'Plain item' },
-            { label: 'With displayName only', displayName: 'raw name' },
-            { label: 'With itemKind only', itemKind: 'info' },
-          ],
+          items: [{ label: 'Plain item' }, { label: 'With displayName only', displayName: 'raw name' }, { label: 'With itemKind only', itemKind: 'info' }],
         },
         'Showing quick pick',
       );
@@ -956,11 +919,7 @@ describe('VscodeAdapter', () => {
       const result = await adapter.pasteClipboardToAiAssistant();
 
       expect(result).toBe(true);
-      expect(callOrder).toStrictEqual([
-        'delay-200',
-        'cmd-editor.action.clipboardPasteAction',
-        'delay-200',
-      ]);
+      expect(callOrder).toStrictEqual(['delay-200', 'cmd-editor.action.clipboardPasteAction', 'delay-200']);
       expect(mockLogger.debug).toHaveBeenCalledWith(
         {
           fn: 'VscodeAdapter.pasteClipboardToAiAssistant',
@@ -982,18 +941,13 @@ describe('VscodeAdapter', () => {
 
     it('should fall back to the next command when the first dispatch throws', async () => {
       const firstError = new Error('editor command not available');
-      mockVSCode.commands.executeCommand
-        .mockRejectedValueOnce(firstError)
-        .mockResolvedValueOnce(undefined);
+      mockVSCode.commands.executeCommand.mockRejectedValueOnce(firstError).mockResolvedValueOnce(undefined);
       jest.spyOn(adapter as any, 'delay').mockResolvedValue(undefined);
 
       const result = await adapter.pasteClipboardToAiAssistant();
 
       expect(result).toBe(true);
-      expect(mockVSCode.commands.executeCommand).toHaveBeenNthCalledWith(
-        1,
-        'editor.action.clipboardPasteAction',
-      );
+      expect(mockVSCode.commands.executeCommand).toHaveBeenNthCalledWith(1, 'editor.action.clipboardPasteAction');
       expect(mockVSCode.commands.executeCommand).toHaveBeenNthCalledWith(2, 'execPaste');
       expect(mockLogger.debug).toHaveBeenCalledWith(
         {
@@ -1020,19 +974,13 @@ describe('VscodeAdapter', () => {
       const errorEditor = new Error('editor command not available');
       const errorExec = new Error('execPaste not available');
       const errorPaste = new Error('paste not available');
-      mockVSCode.commands.executeCommand
-        .mockRejectedValueOnce(errorEditor)
-        .mockRejectedValueOnce(errorExec)
-        .mockRejectedValueOnce(errorPaste);
+      mockVSCode.commands.executeCommand.mockRejectedValueOnce(errorEditor).mockRejectedValueOnce(errorExec).mockRejectedValueOnce(errorPaste);
       const delaySpy = jest.spyOn(adapter as any, 'delay').mockResolvedValue(undefined);
 
       const result = await adapter.pasteClipboardToAiAssistant();
 
       expect(result).toBe(false);
-      expect(mockVSCode.commands.executeCommand).toHaveBeenNthCalledWith(
-        1,
-        'editor.action.clipboardPasteAction',
-      );
+      expect(mockVSCode.commands.executeCommand).toHaveBeenNthCalledWith(1, 'editor.action.clipboardPasteAction');
       expect(mockVSCode.commands.executeCommand).toHaveBeenNthCalledWith(2, 'execPaste');
       expect(mockVSCode.commands.executeCommand).toHaveBeenNthCalledWith(3, 'paste');
       expect(delaySpy).toHaveBeenCalledTimes(1);
@@ -1336,9 +1284,7 @@ describe('VscodeAdapter', () => {
       it('should handle different channel names', () => {
         const mockChannel1 = { appendLine: jest.fn() };
         const mockChannel2 = { appendLine: jest.fn() };
-        mockVSCode.window.createOutputChannel
-          .mockReturnValueOnce(mockChannel1)
-          .mockReturnValueOnce(mockChannel2);
+        mockVSCode.window.createOutputChannel.mockReturnValueOnce(mockChannel1).mockReturnValueOnce(mockChannel2);
 
         const result1 = adapter.createOutputChannel('Channel1');
         const result2 = adapter.createOutputChannel('Channel2');
@@ -1415,9 +1361,7 @@ describe('VscodeAdapter', () => {
       it('should handle different configuration sections', () => {
         const mockConfig1 = { get: jest.fn() };
         const mockConfig2 = { get: jest.fn() };
-        mockVSCode.workspace.getConfiguration
-          .mockReturnValueOnce(mockConfig1)
-          .mockReturnValueOnce(mockConfig2);
+        mockVSCode.workspace.getConfiguration.mockReturnValueOnce(mockConfig1).mockReturnValueOnce(mockConfig2);
 
         const result1 = adapter.getConfiguration('editor');
         const result2 = adapter.getConfiguration('workbench');
@@ -1470,9 +1414,7 @@ describe('VscodeAdapter', () => {
         const mockProvider2 = { provideTerminalLinks: jest.fn() };
         const mockDisposable1 = { dispose: jest.fn() };
         const mockDisposable2 = { dispose: jest.fn() };
-        mockVSCode.window.registerTerminalLinkProvider
-          .mockReturnValueOnce(mockDisposable1)
-          .mockReturnValueOnce(mockDisposable2);
+        mockVSCode.window.registerTerminalLinkProvider.mockReturnValueOnce(mockDisposable1).mockReturnValueOnce(mockDisposable2);
 
         const result1 = adapter.registerTerminalLinkProvider(mockProvider1 as any);
         const result2 = adapter.registerTerminalLinkProvider(mockProvider2 as any);
@@ -1490,15 +1432,9 @@ describe('VscodeAdapter', () => {
         const mockDisposable = { dispose: jest.fn() };
         mockVSCode.languages.registerDocumentLinkProvider.mockReturnValue(mockDisposable);
 
-        const result = adapter.registerDocumentLinkProvider(
-          mockSelector as any,
-          mockProvider as any,
-        );
+        const result = adapter.registerDocumentLinkProvider(mockSelector as any, mockProvider as any);
 
-        expect(mockVSCode.languages.registerDocumentLinkProvider).toHaveBeenCalledWith(
-          mockSelector,
-          mockProvider,
-        );
+        expect(mockVSCode.languages.registerDocumentLinkProvider).toHaveBeenCalledWith(mockSelector, mockProvider);
         expect(mockVSCode.languages.registerDocumentLinkProvider).toHaveBeenCalledTimes(1);
         expect(result).toBe(mockDisposable);
       });
@@ -1509,15 +1445,9 @@ describe('VscodeAdapter', () => {
         const mockDisposable = { dispose: jest.fn() };
         mockVSCode.languages.registerDocumentLinkProvider.mockReturnValue(mockDisposable);
 
-        const result = adapter.registerDocumentLinkProvider(
-          mockSelectors as any,
-          mockProvider as any,
-        );
+        const result = adapter.registerDocumentLinkProvider(mockSelectors as any, mockProvider as any);
 
-        expect(mockVSCode.languages.registerDocumentLinkProvider).toHaveBeenCalledWith(
-          mockSelectors,
-          mockProvider,
-        );
+        expect(mockVSCode.languages.registerDocumentLinkProvider).toHaveBeenCalledWith(mockSelectors, mockProvider);
         expect(result).toBe(mockDisposable);
       });
 
@@ -1527,10 +1457,7 @@ describe('VscodeAdapter', () => {
         const mockDisposable = { dispose: jest.fn() };
         mockVSCode.languages.registerDocumentLinkProvider.mockReturnValue(mockDisposable);
 
-        const result = adapter.registerDocumentLinkProvider(
-          mockSelector as any,
-          mockProvider as any,
-        );
+        const result = adapter.registerDocumentLinkProvider(mockSelector as any, mockProvider as any);
 
         result.dispose();
         expect(mockDisposable.dispose).toHaveBeenCalledTimes(1);
@@ -1556,23 +1483,15 @@ describe('VscodeAdapter', () => {
         const callback2 = jest.fn();
         const mockDisposable1 = { dispose: jest.fn() };
         const mockDisposable2 = { dispose: jest.fn() };
-        mockVSCode.commands.registerCommand
-          .mockReturnValueOnce(mockDisposable1)
-          .mockReturnValueOnce(mockDisposable2);
+        mockVSCode.commands.registerCommand.mockReturnValueOnce(mockDisposable1).mockReturnValueOnce(mockDisposable2);
 
         const result1 = adapter.registerCommand('rangelink.command1', callback1);
         const result2 = adapter.registerCommand('rangelink.command2', callback2);
 
         expect(result1).toBe(mockDisposable1);
         expect(result2).toBe(mockDisposable2);
-        expect(mockVSCode.commands.registerCommand).toHaveBeenCalledWith(
-          'rangelink.command1',
-          callback1,
-        );
-        expect(mockVSCode.commands.registerCommand).toHaveBeenCalledWith(
-          'rangelink.command2',
-          callback2,
-        );
+        expect(mockVSCode.commands.registerCommand).toHaveBeenCalledWith('rangelink.command1', callback1);
+        expect(mockVSCode.commands.registerCommand).toHaveBeenCalledWith('rangelink.command2', callback2);
       });
 
       it('should return disposable that can be disposed', () => {
@@ -1608,10 +1527,7 @@ describe('VscodeAdapter', () => {
 
       expect(mockVSCode.window.showInformationMessage).toHaveBeenCalledWith(message);
       expect(mockVSCode.window.showInformationMessage).toHaveBeenCalledTimes(1);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'VscodeAdapter.showInformationMessage', message, items: [] },
-        'Showing info message',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'VscodeAdapter.showInformationMessage', message, items: [] }, 'Showing info message');
     });
 
     it('should show information message with single button', async () => {
@@ -1630,11 +1546,7 @@ describe('VscodeAdapter', () => {
 
       await adapter.showInformationMessage(message, button1, button2);
 
-      expect(mockVSCode.window.showInformationMessage).toHaveBeenCalledWith(
-        message,
-        button1,
-        button2,
-      );
+      expect(mockVSCode.window.showInformationMessage).toHaveBeenCalledWith(message, button1, button2);
     });
 
     it('should return button text when button is clicked', async () => {
@@ -2006,12 +1918,8 @@ describe('VscodeAdapter', () => {
       const mockDocument = createMockDocument({ uri: mockUri });
       const mockEditor = createMockEditor({ document: mockDocument });
 
-      const openDocSpy = jest
-        .spyOn(mockVSCode.workspace, 'openTextDocument')
-        .mockResolvedValue(mockDocument);
-      const showDocSpy = jest
-        .spyOn(mockVSCode.window, 'showTextDocument')
-        .mockResolvedValue(mockEditor);
+      const openDocSpy = jest.spyOn(mockVSCode.workspace, 'openTextDocument').mockResolvedValue(mockDocument);
+      const showDocSpy = jest.spyOn(mockVSCode.window, 'showTextDocument').mockResolvedValue(mockEditor);
 
       await adapter.showTextDocument(mockUri);
 
@@ -2049,10 +1957,7 @@ describe('VscodeAdapter', () => {
       expect(mockVSCode.commands.executeCommand).toHaveBeenCalledWith(commandId);
       expect(mockVSCode.commands.executeCommand).toHaveBeenCalledTimes(1);
       expect(result).toBeUndefined();
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'VscodeAdapter.executeCommand', command: commandId, args: [] },
-        'Executing command',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'VscodeAdapter.executeCommand', command: commandId, args: [] }, 'Executing command');
     });
 
     it('should execute command with single argument', async () => {
@@ -2177,11 +2082,7 @@ describe('VscodeAdapter', () => {
     it('should set context key to true via executeCommand', () => {
       adapter.setContext('myExt.someFlag', true);
 
-      expect(mockVSCode.commands.executeCommand).toHaveBeenCalledWith(
-        'setContext',
-        'myExt.someFlag',
-        true,
-      );
+      expect(mockVSCode.commands.executeCommand).toHaveBeenCalledWith('setContext', 'myExt.someFlag', true);
       expect(mockLogger.debug).toHaveBeenCalledWith(
         { fn: 'VscodeAdapter.setContext', key: 'myExt.someFlag', value: true },
         'Setting context key: myExt.someFlag = true',
@@ -2191,11 +2092,7 @@ describe('VscodeAdapter', () => {
     it('should set context key to false via executeCommand', () => {
       adapter.setContext('myExt.someFlag', false);
 
-      expect(mockVSCode.commands.executeCommand).toHaveBeenCalledWith(
-        'setContext',
-        'myExt.someFlag',
-        false,
-      );
+      expect(mockVSCode.commands.executeCommand).toHaveBeenCalledWith('setContext', 'myExt.someFlag', false);
       expect(mockLogger.debug).toHaveBeenCalledWith(
         { fn: 'VscodeAdapter.setContext', key: 'myExt.someFlag', value: false },
         'Setting context key: myExt.someFlag = false',
@@ -2205,11 +2102,7 @@ describe('VscodeAdapter', () => {
     it('should set context key to string value', () => {
       adapter.setContext('myExt.otherFlag', 'someValue');
 
-      expect(mockVSCode.commands.executeCommand).toHaveBeenCalledWith(
-        'setContext',
-        'myExt.otherFlag',
-        'someValue',
-      );
+      expect(mockVSCode.commands.executeCommand).toHaveBeenCalledWith('setContext', 'myExt.otherFlag', 'someValue');
       expect(mockLogger.debug).toHaveBeenCalledWith(
         {
           fn: 'VscodeAdapter.setContext',
@@ -2223,11 +2116,7 @@ describe('VscodeAdapter', () => {
     it('should set context key to undefined', () => {
       adapter.setContext('myExt.someFlag', undefined);
 
-      expect(mockVSCode.commands.executeCommand).toHaveBeenCalledWith(
-        'setContext',
-        'myExt.someFlag',
-        undefined,
-      );
+      expect(mockVSCode.commands.executeCommand).toHaveBeenCalledWith('setContext', 'myExt.someFlag', undefined);
       expect(mockLogger.debug).toHaveBeenCalledWith(
         { fn: 'VscodeAdapter.setContext', key: 'myExt.someFlag', value: undefined },
         'Setting context key: myExt.someFlag = undefined',
@@ -2277,10 +2166,7 @@ describe('VscodeAdapter', () => {
       expect(mockVSCode.Uri.parse).toHaveBeenCalledWith('https://example.com', true);
       expect(mockOpenExternal).toHaveBeenCalledWith(mockUri);
       expect(result).toBe(true);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'VscodeAdapter.openExternal', uri: 'https://example.com' },
-        'Opening external URI',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'VscodeAdapter.openExternal', uri: 'https://example.com' }, 'Opening external URI');
     });
 
     it('returns false when env.openExternal returns false', async () => {
@@ -2294,10 +2180,7 @@ describe('VscodeAdapter', () => {
       expect(mockVSCode.Uri.parse).toHaveBeenCalledWith('https://example.com', true);
       expect(mockOpenExternal).toHaveBeenCalledWith(mockUri);
       expect(result).toBe(false);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'VscodeAdapter.openExternal', uri: 'https://example.com' },
-        'Opening external URI',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'VscodeAdapter.openExternal', uri: 'https://example.com' }, 'Opening external URI');
     });
   });
 
@@ -2668,10 +2551,7 @@ describe('VscodeAdapter', () => {
         const result = adapter.getActiveTextEditorUri();
 
         expect(result).toBe(mockUri);
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'VscodeAdapter.getActiveTextEditorUri' },
-          'Getting active text editor URI',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'VscodeAdapter.getActiveTextEditorUri' }, 'Getting active text editor URI');
       });
 
       it('should return undefined when no editor is active', () => {
@@ -2680,10 +2560,7 @@ describe('VscodeAdapter', () => {
         const result = adapter.getActiveTextEditorUri();
 
         expect(result).toBeUndefined();
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'VscodeAdapter.getActiveTextEditorUri' },
-          'Getting active text editor URI',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'VscodeAdapter.getActiveTextEditorUri' }, 'Getting active text editor URI');
       });
     });
 
@@ -2726,10 +2603,7 @@ describe('VscodeAdapter', () => {
         const result = adapter.getActiveTabUri();
 
         expect(result).toBe(mockUri);
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'VscodeAdapter.getActiveTabUri', inputKind: 'MockTabInputText' },
-          'Resolving active tab URI',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'VscodeAdapter.getActiveTabUri', inputKind: 'MockTabInputText' }, 'Resolving active tab URI');
       });
 
       it('returns .modified when the tab input has no .uri but has .modified', () => {
@@ -2742,10 +2616,7 @@ describe('VscodeAdapter', () => {
         const result = adapter.getActiveTabUri();
 
         expect(result).toBe(modifiedUri);
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'VscodeAdapter.getActiveTabUri', inputKind: 'Object' },
-          'Resolving active tab URI',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'VscodeAdapter.getActiveTabUri', inputKind: 'Object' }, 'Resolving active tab URI');
       });
 
       it('falls back to unknown when the tab input has no constructor name', () => {
@@ -2757,10 +2628,7 @@ describe('VscodeAdapter', () => {
         const result = adapter.getActiveTabUri();
 
         expect(result).toBe(mockUri);
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'VscodeAdapter.getActiveTabUri', inputKind: 'unknown' },
-          'Resolving active tab URI',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'VscodeAdapter.getActiveTabUri', inputKind: 'unknown' }, 'Resolving active tab URI');
       });
 
       it('returns undefined and logs unsupported when the tab input has no file URI', () => {
@@ -2770,10 +2638,7 @@ describe('VscodeAdapter', () => {
         const result = adapter.getActiveTabUri();
 
         expect(result).toBeUndefined();
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'VscodeAdapter.getActiveTabUri', inputKind: 'unsupported' },
-          'No file URI on active tab input',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'VscodeAdapter.getActiveTabUri', inputKind: 'unsupported' }, 'No file URI on active tab input');
       });
 
       it('returns undefined and logs none when there is no active tab group', () => {
@@ -2785,10 +2650,7 @@ describe('VscodeAdapter', () => {
         const result = adapter.getActiveTabUri();
 
         expect(result).toBeUndefined();
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'VscodeAdapter.getActiveTabUri', inputKind: 'none' },
-          'Resolving active tab URI',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'VscodeAdapter.getActiveTabUri', inputKind: 'none' }, 'Resolving active tab URI');
       });
 
       it('returns undefined when the active tab group has no active tab', () => {
@@ -2801,10 +2663,7 @@ describe('VscodeAdapter', () => {
         const result = adapter.getActiveTabUri();
 
         expect(result).toBeUndefined();
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'VscodeAdapter.getActiveTabUri', inputKind: 'none' },
-          'Resolving active tab URI',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'VscodeAdapter.getActiveTabUri', inputKind: 'none' }, 'Resolving active tab URI');
       });
     });
 
@@ -3324,12 +3183,10 @@ describe('VscodeAdapter', () => {
         const mockDocument = createMockDocument({ uri: createMockUri('/workspace/file.ts') });
         let registeredListener: ((document: any) => void) | undefined;
 
-        mockVSCode.workspace.onDidCloseTextDocument.mockImplementation(
-          (cb: (document: any) => void) => {
-            registeredListener = cb;
-            return { dispose: jest.fn() };
-          },
-        );
+        mockVSCode.workspace.onDidCloseTextDocument.mockImplementation((cb: (document: any) => void) => {
+          registeredListener = cb;
+          return { dispose: jest.fn() };
+        });
 
         adapter.onDidCloseTextDocument(listener);
 
@@ -3371,12 +3228,10 @@ describe('VscodeAdapter', () => {
         const mockEvent = { opened: [], closed: [], changed: [] };
         let registeredListener: ((event: any) => void) | undefined;
 
-        (mockVSCode.window.tabGroups.onDidChangeTabs as jest.Mock).mockImplementation(
-          (cb: (event: any) => void) => {
-            registeredListener = cb;
-            return { dispose: jest.fn() };
-          },
-        );
+        (mockVSCode.window.tabGroups.onDidChangeTabs as jest.Mock).mockImplementation((cb: (event: any) => void) => {
+          registeredListener = cb;
+          return { dispose: jest.fn() };
+        });
 
         adapter.onDidChangeTabs(listener);
         registeredListener!(mockEvent);
@@ -3401,9 +3256,7 @@ describe('VscodeAdapter', () => {
       it('should register listener and return Disposable', () => {
         const listener = jest.fn();
         const mockDisposable = { dispose: jest.fn() };
-        (mockVSCode.workspace.onDidChangeConfiguration as jest.Mock).mockReturnValue(
-          mockDisposable,
-        );
+        (mockVSCode.workspace.onDidChangeConfiguration as jest.Mock).mockReturnValue(mockDisposable);
 
         const result = adapter.onDidChangeConfiguration(listener);
 
@@ -3429,12 +3282,7 @@ describe('VscodeAdapter', () => {
 
         const result = adapter.createFileSystemWatcherForFile(fileUri, true, true, false);
 
-        expect(mockVSCode.workspace.createFileSystemWatcher).toHaveBeenCalledWith(
-          { base: fileUri, pattern: '*' },
-          true,
-          true,
-          false,
-        );
+        expect(mockVSCode.workspace.createFileSystemWatcher).toHaveBeenCalledWith({ base: fileUri, pattern: '*' }, true, true, false);
         expect(result).toBe(mockWatcher);
       });
     });
@@ -3483,14 +3331,11 @@ describe('VscodeAdapter', () => {
     const TEST_URI = { toString: () => 'file:///test.ts' };
     const OTHER_URI = { toString: () => 'file:///other.ts' };
 
-    const editorWithSelection = (viewColumn: number) =>
-      ({ document: { uri: TEST_URI }, viewColumn, selection: { isEmpty: false } }) as any;
+    const editorWithSelection = (viewColumn: number) => ({ document: { uri: TEST_URI }, viewColumn, selection: { isEmpty: false } }) as any;
 
-    const editorWithoutSelection = (viewColumn: number) =>
-      ({ document: { uri: TEST_URI }, viewColumn, selection: { isEmpty: true } }) as any;
+    const editorWithoutSelection = (viewColumn: number) => ({ document: { uri: TEST_URI }, viewColumn, selection: { isEmpty: true } }) as any;
 
-    const editorWithOtherUri = (viewColumn: number) =>
-      ({ document: { uri: OTHER_URI }, viewColumn, selection: { isEmpty: false } }) as any;
+    const editorWithOtherUri = (viewColumn: number) => ({ document: { uri: OTHER_URI }, viewColumn, selection: { isEmpty: false } }) as any;
 
     it('returns true when matching editor has non-empty selection', () => {
       Object.defineProperty(adapter, 'visibleTextEditors', {

--- a/packages/rangelink-vscode-extension/src/__tests__/integration-helpers/logBasedUiAssertions.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/integration-helpers/logBasedUiAssertions.test.ts
@@ -14,19 +14,13 @@ describe('logBasedUiAssertions', () => {
     });
 
     it('throws when fn does not match', () => {
-      const lines = [
-        '[DEBUG] {"fn":"RangeLinkNavigationHandler.navigateToLink","suppressedMessage":"msg"} Suppressed',
-      ];
+      const lines = ['[DEBUG] {"fn":"RangeLinkNavigationHandler.navigateToLink","suppressedMessage":"msg"} Suppressed'];
 
-      expect(() =>
-        assertSuppressionLogged(lines, { fn: 'WrongHandler.method', suppressedMessage: 'msg' }),
-      ).toThrow('but it was not found');
+      expect(() => assertSuppressionLogged(lines, { fn: 'WrongHandler.method', suppressedMessage: 'msg' })).toThrow('but it was not found');
     });
 
     it('throws when suppressedMessage does not match', () => {
-      const lines = [
-        '[DEBUG] {"fn":"RangeLinkNavigationHandler.navigateToLink","suppressedMessage":"actual msg"} Suppressed',
-      ];
+      const lines = ['[DEBUG] {"fn":"RangeLinkNavigationHandler.navigateToLink","suppressedMessage":"actual msg"} Suppressed'];
 
       expect(() =>
         assertSuppressionLogged(lines, {

--- a/packages/rangelink-vscode-extension/src/__tests__/isRectangularSelection.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/isRectangularSelection.test.ts
@@ -4,12 +4,7 @@ import { isRectangularSelection } from '../isRectangularSelection';
  * Helper to create a mock vscode.Selection
  * We create plain objects that match the vscode.Selection interface
  */
-function createSelection(
-  startLine: number,
-  startCharacter: number,
-  endLine: number,
-  endCharacter: number,
-): any {
+function createSelection(startLine: number, startCharacter: number, endLine: number, endCharacter: number): any {
   return {
     start: { line: startLine, character: startCharacter },
     end: { line: endLine, character: endCharacter },
@@ -106,11 +101,7 @@ describe('isRectangularSelection', () => {
     });
 
     it('should return true for 3 consecutive lines with same character range', () => {
-      const selections = [
-        createSelection(10, 5, 10, 15),
-        createSelection(11, 5, 11, 15),
-        createSelection(12, 5, 12, 15),
-      ];
+      const selections = [createSelection(10, 5, 10, 15), createSelection(11, 5, 11, 15), createSelection(12, 5, 12, 15)];
       expect(isRectangularSelection(selections)).toBe(true);
     });
 
@@ -121,21 +112,12 @@ describe('isRectangularSelection', () => {
 
     it('should return true when selections are provided in reverse order', () => {
       // The function sorts lines, so order shouldn't matter
-      const selections = [
-        createSelection(12, 5, 12, 15),
-        createSelection(11, 5, 11, 15),
-        createSelection(10, 5, 10, 15),
-      ];
+      const selections = [createSelection(12, 5, 12, 15), createSelection(11, 5, 11, 15), createSelection(10, 5, 10, 15)];
       expect(isRectangularSelection(selections)).toBe(true);
     });
 
     it('should return true when selections are in random order', () => {
-      const selections = [
-        createSelection(7, 10, 7, 20),
-        createSelection(5, 10, 5, 20),
-        createSelection(6, 10, 6, 20),
-        createSelection(8, 10, 8, 20),
-      ];
+      const selections = [createSelection(7, 10, 7, 20), createSelection(5, 10, 5, 20), createSelection(6, 10, 6, 20), createSelection(8, 10, 8, 20)];
       expect(isRectangularSelection(selections)).toBe(true);
     });
 
@@ -145,11 +127,7 @@ describe('isRectangularSelection', () => {
     });
 
     it('should return true for zero-width rectangular selection (same start/end column)', () => {
-      const selections = [
-        createSelection(5, 10, 5, 10),
-        createSelection(6, 10, 6, 10),
-        createSelection(7, 10, 7, 10),
-      ];
+      const selections = [createSelection(5, 10, 5, 10), createSelection(6, 10, 6, 10), createSelection(7, 10, 7, 10)];
       expect(isRectangularSelection(selections)).toBe(true);
     });
 
@@ -161,11 +139,7 @@ describe('isRectangularSelection', () => {
 
   describe('Edge cases', () => {
     it('should handle selections starting at line 0', () => {
-      const selections = [
-        createSelection(0, 5, 0, 10),
-        createSelection(1, 5, 1, 10),
-        createSelection(2, 5, 2, 10),
-      ];
+      const selections = [createSelection(0, 5, 0, 10), createSelection(1, 5, 1, 10), createSelection(2, 5, 2, 10)];
       expect(isRectangularSelection(selections)).toBe(true);
     });
 

--- a/packages/rangelink-vscode-extension/src/__tests__/navigation/FilePathDocumentProvider.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/navigation/FilePathDocumentProvider.test.ts
@@ -34,10 +34,7 @@ describe('FilePathDocumentProvider', () => {
 
   describe('constructor', () => {
     it('should log initialization', () => {
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'FilePathDocumentProvider.constructor' },
-        'FilePathDocumentProvider initialized',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'FilePathDocumentProvider.constructor' }, 'FilePathDocumentProvider initialized');
     });
   });
 
@@ -73,9 +70,7 @@ describe('FilePathDocumentProvider', () => {
       const links = provider.provideDocumentLinks(document) as vscode.DocumentLink[];
 
       const expectedArgs = encodeURIComponent(JSON.stringify([{ filePath: '/path/to/file.ts' }]));
-      expect(links[0].target!.toString()).toBe(
-        `command:rangelink.handleFilePathClick?${expectedArgs}`,
-      );
+      expect(links[0].target!.toString()).toBe(`command:rangelink.handleFilePathClick?${expectedArgs}`);
     });
 
     it('should strip quotes from double-quoted path in command URI', () => {
@@ -89,12 +84,8 @@ describe('FilePathDocumentProvider', () => {
 
       expect(links).toHaveLength(1);
       expect(links[0].tooltip).toBe('Open /path/with spaces/file.ts \u2022 RangeLink');
-      const expectedArgs = encodeURIComponent(
-        JSON.stringify([{ filePath: '/path/with spaces/file.ts' }]),
-      );
-      expect(links[0].target!.toString()).toBe(
-        `command:rangelink.handleFilePathClick?${expectedArgs}`,
-      );
+      const expectedArgs = encodeURIComponent(JSON.stringify([{ filePath: '/path/with spaces/file.ts' }]));
+      expect(links[0].target!.toString()).toBe(`command:rangelink.handleFilePathClick?${expectedArgs}`);
     });
 
     it('should detect multiple paths in document', () => {
@@ -123,9 +114,7 @@ describe('FilePathDocumentProvider', () => {
       expect(links).toHaveLength(1);
       expect(links[0].tooltip).toBe('Open /src/file.ts \u2022 RangeLink');
       const expectedArgs = encodeURIComponent(JSON.stringify([{ filePath: '../src/file.ts' }]));
-      expect(links[0].target!.toString()).toBe(
-        `command:rangelink.handleFilePathClick?${expectedArgs}`,
-      );
+      expect(links[0].target!.toString()).toBe(`command:rangelink.handleFilePathClick?${expectedArgs}`);
     });
 
     it('should return empty array when no paths found', () => {
@@ -164,9 +153,7 @@ describe('FilePathDocumentProvider', () => {
       expect(links).toHaveLength(1);
       expect(links[0].tooltip).toBe('Open /path/to/file.ts \u2022 RangeLink');
       const expectedArgs = encodeURIComponent(JSON.stringify([{ filePath: '/path/to/file.ts' }]));
-      expect(links[0].target!.toString()).toBe(
-        `command:rangelink.handleFilePathClick?${expectedArgs}`,
-      );
+      expect(links[0].target!.toString()).toBe(`command:rangelink.handleFilePathClick?${expectedArgs}`);
     });
 
     it('should detect tilde path', () => {
@@ -182,12 +169,8 @@ describe('FilePathDocumentProvider', () => {
 
       expect(links).toHaveLength(1);
       expect(links[0].tooltip).toBe('Open /home/user/projects/app/main.ts \u2022 RangeLink');
-      const expectedArgs = encodeURIComponent(
-        JSON.stringify([{ filePath: '~/projects/app/main.ts' }]),
-      );
-      expect(links[0].target!.toString()).toBe(
-        `command:rangelink.handleFilePathClick?${expectedArgs}`,
-      );
+      const expectedArgs = encodeURIComponent(JSON.stringify([{ filePath: '~/projects/app/main.ts' }]));
+      expect(links[0].target!.toString()).toBe(`command:rangelink.handleFilePathClick?${expectedArgs}`);
     });
 
     it('should NOT detect file path when path is a RangeLink (coexistence with RangeLinkDocumentProvider)', () => {
@@ -237,9 +220,7 @@ describe('FilePathDocumentProvider', () => {
     it('should not re-throw handler errors', async () => {
       mockHandler.navigateToFile.mockRejectedValue(new Error('Failed'));
 
-      await expect(
-        provider.handleLinkClick({ filePath: '/path/to/file.ts' }),
-      ).resolves.toBeUndefined();
+      await expect(provider.handleLinkClick({ filePath: '/path/to/file.ts' })).resolves.toBeUndefined();
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/navigation/FilePathNavigationHandler.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/navigation/FilePathNavigationHandler.test.ts
@@ -1,11 +1,7 @@
 import { FilePathNavigationHandler } from '../../navigation/FilePathNavigationHandler';
 import { PathFormat } from '../../types/PathFormat';
 import { FILENAME_AMBIGUOUS } from '../../types/ResolvedPath';
-import {
-  createMockUri,
-  createMockVscodeAdapter,
-  type VscodeAdapterWithTestHooks,
-} from '../helpers';
+import { createMockUri, createMockVscodeAdapter, type VscodeAdapterWithTestHooks } from '../helpers';
 
 import type { Logger } from '@couimet/logger-contract';
 import { createMockLogger } from '@couimet/logger-contract-testing';
@@ -25,10 +21,7 @@ describe('FilePathNavigationHandler', () => {
 
   describe('constructor', () => {
     it('should log initialization', () => {
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'FilePathNavigationHandler.constructor' },
-        'FilePathNavigationHandler initialized',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'FilePathNavigationHandler.constructor' }, 'FilePathNavigationHandler initialized');
     });
   });
 
@@ -45,35 +38,25 @@ describe('FilePathNavigationHandler', () => {
 
     describe('quoted paths', () => {
       it('should match double-quoted path', () => {
-        expect(matchesPattern('Check "/path/to/file.ts" for details')).toStrictEqual([
-          '/path/to/file.ts',
-        ]);
+        expect(matchesPattern('Check "/path/to/file.ts" for details')).toStrictEqual(['/path/to/file.ts']);
       });
 
       it('should match single-quoted path', () => {
-        expect(matchesPattern("Check '/path/to/file.ts' for details")).toStrictEqual([
-          '/path/to/file.ts',
-        ]);
+        expect(matchesPattern("Check '/path/to/file.ts' for details")).toStrictEqual(['/path/to/file.ts']);
       });
 
       it('should match double-quoted path with spaces', () => {
-        expect(matchesPattern('Open "/path/with spaces/file.ts" now')).toStrictEqual([
-          '/path/with spaces/file.ts',
-        ]);
+        expect(matchesPattern('Open "/path/with spaces/file.ts" now')).toStrictEqual(['/path/with spaces/file.ts']);
       });
     });
 
     describe('absolute paths', () => {
       it('should match absolute path', () => {
-        expect(matchesPattern('See /path/to/file.ts for details')).toStrictEqual([
-          '/path/to/file.ts',
-        ]);
+        expect(matchesPattern('See /path/to/file.ts for details')).toStrictEqual(['/path/to/file.ts']);
       });
 
       it('should match absolute path with hyphens and dots', () => {
-        expect(matchesPattern('/path/to/my-file.test.ts')).toStrictEqual([
-          '/path/to/my-file.test.ts',
-        ]);
+        expect(matchesPattern('/path/to/my-file.test.ts')).toStrictEqual(['/path/to/my-file.test.ts']);
       });
 
       it('should NOT match absolute path inside a URL', () => {
@@ -93,9 +76,7 @@ describe('FilePathNavigationHandler', () => {
 
     describe('tilde paths', () => {
       it('should match ~/path', () => {
-        expect(matchesPattern('Open ~/projects/app/main.ts now')).toStrictEqual([
-          '~/projects/app/main.ts',
-        ]);
+        expect(matchesPattern('Open ~/projects/app/main.ts now')).toStrictEqual(['~/projects/app/main.ts']);
       });
     });
 
@@ -115,10 +96,7 @@ describe('FilePathNavigationHandler', () => {
 
     describe('multiple matches', () => {
       it('should match multiple paths in one line', () => {
-        expect(matchesPattern('From ./src/a.ts to ./src/b.ts')).toStrictEqual([
-          './src/a.ts',
-          './src/b.ts',
-        ]);
+        expect(matchesPattern('From ./src/a.ts to ./src/b.ts')).toStrictEqual(['./src/a.ts', './src/b.ts']);
       });
     });
   });
@@ -129,9 +107,7 @@ describe('FilePathNavigationHandler', () => {
       const resolveWorkspacePathSpy = jest
         .spyOn(mockAdapter, 'resolveWorkspacePath')
         .mockResolvedValue({ uri: fileUri, resolvedVia: PathFormat.WorkspaceRelative });
-      const showTextDocumentSpy = jest
-        .spyOn(mockAdapter, 'showTextDocument')
-        .mockResolvedValue(undefined as any);
+      const showTextDocumentSpy = jest.spyOn(mockAdapter, 'showTextDocument').mockResolvedValue(undefined as any);
 
       await handler.navigateToFile('/resolved/file.ts');
 
@@ -145,15 +121,11 @@ describe('FilePathNavigationHandler', () => {
 
     it('should show warning when file cannot be resolved', async () => {
       jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue(undefined);
-      const showWarningMessageSpy = jest
-        .spyOn(mockAdapter, 'showWarningMessage')
-        .mockResolvedValue(undefined);
+      const showWarningMessageSpy = jest.spyOn(mockAdapter, 'showWarningMessage').mockResolvedValue(undefined);
 
       await handler.navigateToFile('/nonexistent/file.ts');
 
-      expect(showWarningMessageSpy).toHaveBeenCalledWith(
-        'File does not exist at: /nonexistent/file.ts',
-      );
+      expect(showWarningMessageSpy).toHaveBeenCalledWith('File does not exist at: /nonexistent/file.ts');
       expect(mockLogger.warn).toHaveBeenCalledWith(
         {
           fn: 'FilePathNavigationHandler.navigateToFile',
@@ -166,9 +138,7 @@ describe('FilePathNavigationHandler', () => {
 
     it('should show ambiguity warning when resolveWorkspacePath returns FILENAME_AMBIGUOUS', async () => {
       jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue(FILENAME_AMBIGUOUS);
-      const showWarningMessageSpy = jest
-        .spyOn(mockAdapter, 'showWarningMessage')
-        .mockResolvedValue(undefined);
+      const showWarningMessageSpy = jest.spyOn(mockAdapter, 'showWarningMessage').mockResolvedValue(undefined);
 
       await handler.navigateToFile('index.ts');
 
@@ -186,9 +156,7 @@ describe('FilePathNavigationHandler', () => {
     it('should expand tilde and resolve expanded path', async () => {
       const homeDir = os.homedir();
       const fileUri = createMockUri(`${homeDir}/projects/file.ts`);
-      const resolveWorkspacePathSpy = jest
-        .spyOn(mockAdapter, 'resolveWorkspacePath')
-        .mockResolvedValue({ uri: fileUri, resolvedVia: PathFormat.Absolute });
+      const resolveWorkspacePathSpy = jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue({ uri: fileUri, resolvedVia: PathFormat.Absolute });
       jest.spyOn(mockAdapter, 'showTextDocument').mockResolvedValue(undefined as any);
 
       await handler.navigateToFile('~/projects/file.ts');
@@ -198,20 +166,14 @@ describe('FilePathNavigationHandler', () => {
 
     it('should show error message and rethrow on showTextDocument failure', async () => {
       const fileUri = createMockUri('/path/file.ts');
-      jest
-        .spyOn(mockAdapter, 'resolveWorkspacePath')
-        .mockResolvedValue({ uri: fileUri, resolvedVia: PathFormat.WorkspaceRelative });
+      jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue({ uri: fileUri, resolvedVia: PathFormat.WorkspaceRelative });
       const navigationError = new Error('Failed to open document');
       jest.spyOn(mockAdapter, 'showTextDocument').mockRejectedValue(navigationError);
-      const showErrorMessageSpy = jest
-        .spyOn(mockAdapter, 'showErrorMessage')
-        .mockResolvedValue(undefined);
+      const showErrorMessageSpy = jest.spyOn(mockAdapter, 'showErrorMessage').mockResolvedValue(undefined);
 
       await expect(handler.navigateToFile('/path/file.ts')).rejects.toThrow(navigationError);
 
-      expect(showErrorMessageSpy).toHaveBeenCalledWith(
-        'Failed to open file /path/file.ts: Failed to open document',
-      );
+      expect(showErrorMessageSpy).toHaveBeenCalledWith('Failed to open file /path/file.ts: Failed to open document');
       expect(mockLogger.error).toHaveBeenCalledWith(
         {
           fn: 'FilePathNavigationHandler.navigateToFile',
@@ -224,20 +186,14 @@ describe('FilePathNavigationHandler', () => {
 
     it('should convert non-Error throwables to string for error message', async () => {
       const fileUri = createMockUri('/path/file.ts');
-      jest
-        .spyOn(mockAdapter, 'resolveWorkspacePath')
-        .mockResolvedValue({ uri: fileUri, resolvedVia: PathFormat.WorkspaceRelative });
+      jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue({ uri: fileUri, resolvedVia: PathFormat.WorkspaceRelative });
       const nonErrorThrowable = 'Disk I/O failure';
       jest.spyOn(mockAdapter, 'showTextDocument').mockRejectedValue(nonErrorThrowable);
-      const showErrorMessageSpy = jest
-        .spyOn(mockAdapter, 'showErrorMessage')
-        .mockResolvedValue(undefined);
+      const showErrorMessageSpy = jest.spyOn(mockAdapter, 'showErrorMessage').mockResolvedValue(undefined);
 
       await expect(handler.navigateToFile('/path/file.ts')).rejects.toBe(nonErrorThrowable);
 
-      expect(showErrorMessageSpy).toHaveBeenCalledWith(
-        'Failed to open file /path/file.ts: Disk I/O failure',
-      );
+      expect(showErrorMessageSpy).toHaveBeenCalledWith('Failed to open file /path/file.ts: Disk I/O failure');
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/navigation/FilePathTerminalProvider.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/navigation/FilePathTerminalProvider.test.ts
@@ -10,8 +10,7 @@ import type * as vscode from 'vscode';
 
 const GET_DELIMITERS = () => DEFAULT_DELIMITERS;
 
-const createMockTerminalContext = (line: string): vscode.TerminalLinkContext =>
-  ({ line }) as vscode.TerminalLinkContext;
+const createMockTerminalContext = (line: string): vscode.TerminalLinkContext => ({ line }) as vscode.TerminalLinkContext;
 
 describe('FilePathTerminalProvider', () => {
   let provider: FilePathTerminalProvider;
@@ -26,10 +25,7 @@ describe('FilePathTerminalProvider', () => {
 
   describe('constructor', () => {
     it('should log initialization', () => {
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'FilePathTerminalProvider.constructor' },
-        'FilePathTerminalProvider initialized',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'FilePathTerminalProvider.constructor' }, 'FilePathTerminalProvider initialized');
     });
   });
 

--- a/packages/rangelink-vscode-extension/src/__tests__/navigation/RangeLinkDocumentProvider.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/navigation/RangeLinkDocumentProvider.test.ts
@@ -49,12 +49,7 @@ describe('RangeLinkDocumentProvider', () => {
 
       expect(links).toHaveLength(1);
       expect(links[0].tooltip).toBe('Open src/file.ts:10 \u2022 RangeLink');
-      expect(mockFindLinksInText).toHaveBeenCalledWith(
-        'Check src/file.ts#L10',
-        DEFAULT_DELIMITERS,
-        mockLogger,
-        token,
-      );
+      expect(mockFindLinksInText).toHaveBeenCalledWith('Check src/file.ts#L10', DEFAULT_DELIMITERS, mockLogger, token);
       expect(mockLogger.debug).toHaveBeenCalledWith(
         {
           fn: 'RangeLinkDocumentProvider.provideDocumentLinks',
@@ -77,13 +72,9 @@ describe('RangeLinkDocumentProvider', () => {
       const token = createMockCancellationToken();
       const links = provider.provideDocumentLinks(document, token) as vscode.DocumentLink[];
 
-      const expectedArgs = encodeURIComponent(
-        JSON.stringify({ linkText: detected.linkText, parsed: detected.parsed }),
-      );
+      const expectedArgs = encodeURIComponent(JSON.stringify({ linkText: detected.linkText, parsed: detected.parsed }));
       expect(links[0].target).toBeDefined();
-      expect(links[0].target!.toString()).toBe(
-        `command:rangelink.handleDocumentLinkClick?${expectedArgs}`,
-      );
+      expect(links[0].target!.toString()).toBe(`command:rangelink.handleDocumentLinkClick?${expectedArgs}`);
     });
 
     it('should map multiple detected links', () => {
@@ -157,12 +148,7 @@ describe('RangeLinkDocumentProvider', () => {
       const token = createMockCancellationToken(true);
       provider.provideDocumentLinks(document, token);
 
-      expect(mockFindLinksInText).toHaveBeenCalledWith(
-        'src/a.ts#L1',
-        DEFAULT_DELIMITERS,
-        mockLogger,
-        token,
-      );
+      expect(mockFindLinksInText).toHaveBeenCalledWith('src/a.ts#L1', DEFAULT_DELIMITERS, mockLogger, token);
       expect(mockLogger.debug).toHaveBeenCalledWith(
         {
           fn: 'RangeLinkDocumentProvider.provideDocumentLinks',
@@ -230,9 +216,7 @@ describe('RangeLinkDocumentProvider', () => {
       };
       mockHandler.navigateToLink.mockRejectedValue(new Error('Failed'));
 
-      await expect(
-        provider.handleLinkClick({ linkText: 'src/file.ts#L10', parsed: mockParsed }),
-      ).resolves.toBeUndefined();
+      await expect(provider.handleLinkClick({ linkText: 'src/file.ts#L10', parsed: mockParsed })).resolves.toBeUndefined();
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/navigation/RangeLinkNavigationHandler.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/navigation/RangeLinkNavigationHandler.test.ts
@@ -35,12 +35,7 @@ describe('RangeLinkNavigationHandler', () => {
     mockLogger = createMockLogger();
     mockAdapter = createMockVscodeAdapter();
     mockConfigReader = createMockConfigReader();
-    handler = new RangeLinkNavigationHandler(
-      GET_DELIMITERS,
-      mockAdapter,
-      mockConfigReader,
-      mockLogger,
-    );
+    handler = new RangeLinkNavigationHandler(GET_DELIMITERS, mockAdapter, mockConfigReader, mockLogger);
   });
 
   describe('Single Position Selection Extension', () => {
@@ -61,9 +56,7 @@ describe('RangeLinkNavigationHandler', () => {
       mockAdapter = createMockVscodeAdapter({
         windowOptions: createWindowOptionsForEditor(mockEditor),
         workspaceOptions: {
-          openTextDocument: jest
-            .fn()
-            .mockImplementation((uri: unknown) => Promise.resolve({ uri })),
+          openTextDocument: jest.fn().mockImplementation((uri: unknown) => Promise.resolve({ uri })),
         },
       });
       jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue({
@@ -72,12 +65,7 @@ describe('RangeLinkNavigationHandler', () => {
       });
 
       createSelectionSpy = jest.spyOn(mockAdapter, 'createSelection');
-      handler = new RangeLinkNavigationHandler(
-        GET_DELIMITERS,
-        mockAdapter,
-        mockConfigReader,
-        mockLogger,
-      );
+      handler = new RangeLinkNavigationHandler(GET_DELIMITERS, mockAdapter, mockConfigReader, mockLogger);
     });
 
     it('should extend single-position selection by 1 character (normal case)', async () => {
@@ -108,10 +96,7 @@ describe('RangeLinkNavigationHandler', () => {
       );
 
       // Should call adapter's createSelection with extended positions (31,0) to (31,1) in 0-indexed coords
-      expect(createSelectionSpy).toHaveBeenCalledWith(
-        { line: 31, character: 0 },
-        { line: 31, character: 1 },
-      );
+      expect(createSelectionSpy).toHaveBeenCalledWith({ line: 31, character: 0 }, { line: 31, character: 1 });
     });
 
     it('should NOT extend when at end of line', async () => {
@@ -210,10 +195,7 @@ describe('RangeLinkNavigationHandler', () => {
 
       // Should create selection from start of line to end of line
       // Line content is 'const x = 42; // Sample line content' (36 chars)
-      expect(createSelectionSpy).toHaveBeenCalledWith(
-        { line: 19, character: 0 },
-        { line: 19, character: 36 },
-      );
+      expect(createSelectionSpy).toHaveBeenCalledWith({ line: 19, character: 0 }, { line: 19, character: 36 });
     });
 
     it('should select from start of first line to end of last line for multi-line range', async () => {
@@ -245,16 +227,10 @@ describe('RangeLinkNavigationHandler', () => {
       );
 
       // Should NOT trigger single-position extension
-      expect(mockLogger.debug).not.toHaveBeenCalledWith(
-        expect.any(Object),
-        'Extended single-position selection by 1 character',
-      );
+      expect(mockLogger.debug).not.toHaveBeenCalledWith(expect.any(Object), 'Extended single-position selection by 1 character');
 
       // Should create selection from start of line 10 to END of line 20
-      expect(createSelectionSpy).toHaveBeenCalledWith(
-        { line: 9, character: 0 },
-        { line: 19, character: 36 },
-      );
+      expect(createSelectionSpy).toHaveBeenCalledWith({ line: 9, character: 0 }, { line: 19, character: 36 });
     });
 
     it('should NOT use full-line selection when start has explicit char (#L10C5-L15)', async () => {
@@ -273,16 +249,10 @@ describe('RangeLinkNavigationHandler', () => {
       await handler.navigateToLink(parsed, linkText);
 
       // Assert: Should NOT log full-line selection (start.character is defined)
-      expect(mockLogger.debug).not.toHaveBeenCalledWith(
-        expect.any(Object),
-        'Extended selection to full line(s)',
-      );
+      expect(mockLogger.debug).not.toHaveBeenCalledWith(expect.any(Object), 'Extended selection to full line(s)');
 
       // Should create selection from L10C5 to L15C0 (end defaults to 0)
-      expect(createSelectionSpy).toHaveBeenCalledWith(
-        { line: 9, character: 4 },
-        { line: 14, character: 0 },
-      );
+      expect(createSelectionSpy).toHaveBeenCalledWith({ line: 9, character: 4 }, { line: 14, character: 0 });
     });
 
     it('should NOT use full-line selection when end has explicit char (#L10-L15C10)', async () => {
@@ -301,16 +271,10 @@ describe('RangeLinkNavigationHandler', () => {
       await handler.navigateToLink(parsed, linkText);
 
       // Assert: Should NOT log full-line selection (end.character is defined)
-      expect(mockLogger.debug).not.toHaveBeenCalledWith(
-        expect.any(Object),
-        'Extended selection to full line(s)',
-      );
+      expect(mockLogger.debug).not.toHaveBeenCalledWith(expect.any(Object), 'Extended selection to full line(s)');
 
       // Should create selection from L10C0 to L15C10
-      expect(createSelectionSpy).toHaveBeenCalledWith(
-        { line: 9, character: 0 },
-        { line: 14, character: 9 },
-      );
+      expect(createSelectionSpy).toHaveBeenCalledWith({ line: 9, character: 0 }, { line: 14, character: 9 });
     });
 
     it('should handle full-line selection on empty line', async () => {
@@ -344,10 +308,7 @@ describe('RangeLinkNavigationHandler', () => {
       );
 
       // Selection from 0 to 0 (empty line)
-      expect(createSelectionSpy).toHaveBeenCalledWith(
-        { line: 4, character: 0 },
-        { line: 4, character: 0 },
-      );
+      expect(createSelectionSpy).toHaveBeenCalledWith({ line: 4, character: 0 }, { line: 4, character: 0 });
     });
 
     it('should call revealRange with createRange result and InCenterIfOutsideViewport (value 2)', async () => {
@@ -377,18 +338,12 @@ describe('RangeLinkNavigationHandler', () => {
       });
       const mockRange = createMockRange({ start: mockVsStart, end: mockVsEnd });
 
-      const createPositionSpy = jest
-        .spyOn(mockAdapter, 'createPosition')
-        .mockReturnValueOnce(mockVsStart)
-        .mockReturnValueOnce(mockVsEnd);
+      const createPositionSpy = jest.spyOn(mockAdapter, 'createPosition').mockReturnValueOnce(mockVsStart).mockReturnValueOnce(mockVsEnd);
 
       const createRangeSpy = jest.spyOn(mockAdapter, 'createRange').mockReturnValue(mockRange);
 
       // Act
-      await handler.navigateToLink(
-        parsed,
-        `file.ts#L${startLine}C${startChar}-L${endLine}C${endChar}`,
-      );
+      await handler.navigateToLink(parsed, `file.ts#L${startLine}C${startChar}-L${endLine}C${endChar}`);
 
       expect(createPositionSpy).toHaveBeenCalledTimes(2);
       expect(createPositionSpy).toHaveBeenNthCalledWith(1, startLine - 1, startChar - 1);
@@ -435,12 +390,7 @@ describe('RangeLinkNavigationHandler', () => {
         jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue(undefined);
         jest.spyOn(mockAdapter, 'findOpenUntitledFile').mockReturnValue(untitledUri);
         jest.spyOn(mockAdapter, 'showTextDocument').mockResolvedValue(mockEditor);
-        handler = new RangeLinkNavigationHandler(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        handler = new RangeLinkNavigationHandler(GET_DELIMITERS, mockAdapter, mockConfigReader, mockLogger);
 
         await handler.navigateToLink(parsed, linkText);
 
@@ -484,12 +434,7 @@ describe('RangeLinkNavigationHandler', () => {
         jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue(undefined);
         jest.spyOn(mockAdapter, 'findOpenUntitledFile').mockReturnValue(untitledUri);
         jest.spyOn(mockAdapter, 'showTextDocument').mockResolvedValue(mockEditor);
-        handler = new RangeLinkNavigationHandler(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        handler = new RangeLinkNavigationHandler(GET_DELIMITERS, mockAdapter, mockConfigReader, mockLogger);
 
         await handler.navigateToLink(parsed, 'Untitled-2#L5');
 
@@ -527,12 +472,7 @@ describe('RangeLinkNavigationHandler', () => {
         jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue(undefined);
         jest.spyOn(mockAdapter, 'findOpenUntitledFile').mockReturnValue(untitledUri);
         jest.spyOn(mockAdapter, 'showTextDocument').mockResolvedValue(mockEditor);
-        handler = new RangeLinkNavigationHandler(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        handler = new RangeLinkNavigationHandler(GET_DELIMITERS, mockAdapter, mockConfigReader, mockLogger);
 
         await handler.navigateToLink(parsed, 'Sans titre-1#L3');
 
@@ -571,26 +511,16 @@ describe('RangeLinkNavigationHandler', () => {
           },
           workspaceOptions: { openTextDocument: jest.fn().mockResolvedValue(mockDocument) },
         });
-        jest
-          .spyOn(mockAdapter, 'resolveWorkspacePath')
-          .mockResolvedValue({ uri: mockUri, resolvedVia: PathFormat.WorkspaceRelative });
+        jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue({ uri: mockUri, resolvedVia: PathFormat.WorkspaceRelative });
         jest.spyOn(mockAdapter, 'showTextDocument').mockResolvedValue(mockEditor);
 
         const mockVsStart = createMockPosition({ line: 9, character: 0 });
         const mockVsEnd = createMockPosition({ line: 9, character: 17 });
         const mockRange = createMockRange({ start: mockVsStart, end: mockVsEnd });
-        jest
-          .spyOn(mockAdapter, 'createPosition')
-          .mockReturnValueOnce(mockVsStart)
-          .mockReturnValueOnce(mockVsEnd);
+        jest.spyOn(mockAdapter, 'createPosition').mockReturnValueOnce(mockVsStart).mockReturnValueOnce(mockVsEnd);
         jest.spyOn(mockAdapter, 'createRange').mockReturnValue(mockRange);
 
-        handler = new RangeLinkNavigationHandler(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        handler = new RangeLinkNavigationHandler(GET_DELIMITERS, mockAdapter, mockConfigReader, mockLogger);
 
         await handler.navigateToLink(parsed, linkText);
 
@@ -620,12 +550,7 @@ describe('RangeLinkNavigationHandler', () => {
         });
         jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue(undefined);
         jest.spyOn(mockAdapter, 'findOpenUntitledFile').mockReturnValue(undefined);
-        handler = new RangeLinkNavigationHandler(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        handler = new RangeLinkNavigationHandler(GET_DELIMITERS, mockAdapter, mockConfigReader, mockLogger);
 
         await handler.navigateToLink(parsed, 'src/missing.ts#L10');
 
@@ -651,12 +576,7 @@ describe('RangeLinkNavigationHandler', () => {
         });
         jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue(undefined);
         jest.spyOn(mockAdapter, 'findOpenUntitledFile').mockReturnValue(undefined);
-        handler = new RangeLinkNavigationHandler(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        handler = new RangeLinkNavigationHandler(GET_DELIMITERS, mockAdapter, mockConfigReader, mockLogger);
 
         await handler.navigateToLink(parsed, '/tmp/missing.ts#L1');
 
@@ -680,12 +600,7 @@ describe('RangeLinkNavigationHandler', () => {
         });
         jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue(undefined);
         jest.spyOn(mockAdapter, 'findOpenUntitledFile').mockReturnValue(undefined);
-        handler = new RangeLinkNavigationHandler(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        handler = new RangeLinkNavigationHandler(GET_DELIMITERS, mockAdapter, mockConfigReader, mockLogger);
 
         await handler.navigateToLink(parsed, 'Sans titre-1#L1');
 
@@ -710,12 +625,7 @@ describe('RangeLinkNavigationHandler', () => {
         });
         jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue(undefined);
         jest.spyOn(mockAdapter, 'findOpenUntitledFile').mockReturnValue(undefined);
-        handler = new RangeLinkNavigationHandler(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        handler = new RangeLinkNavigationHandler(GET_DELIMITERS, mockAdapter, mockConfigReader, mockLogger);
 
         await handler.navigateToLink(parsed, 'Untitled-3#L1');
 
@@ -742,12 +652,7 @@ describe('RangeLinkNavigationHandler', () => {
         jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue(FILENAME_AMBIGUOUS);
         const findOpenUntitledFileSpy = jest.spyOn(mockAdapter, 'findOpenUntitledFile');
         const showTextDocumentSpy = jest.spyOn(mockAdapter, 'showTextDocument');
-        handler = new RangeLinkNavigationHandler(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        handler = new RangeLinkNavigationHandler(GET_DELIMITERS, mockAdapter, mockConfigReader, mockLogger);
 
         await handler.navigateToLink(parsed, 'index.ts#L1');
 
@@ -809,16 +714,9 @@ describe('RangeLinkNavigationHandler', () => {
           windowOptions: { showErrorMessage: mockShowErrorMessage },
           workspaceOptions: { openTextDocument: jest.fn().mockResolvedValue(undefined) },
         });
-        jest
-          .spyOn(mockAdapter, 'resolveWorkspacePath')
-          .mockResolvedValue({ uri: mockUri, resolvedVia: PathFormat.WorkspaceRelative });
+        jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue({ uri: mockUri, resolvedVia: PathFormat.WorkspaceRelative });
         jest.spyOn(mockAdapter, 'showTextDocument').mockRejectedValue(showTextDocumentError);
-        handler = new RangeLinkNavigationHandler(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        handler = new RangeLinkNavigationHandler(GET_DELIMITERS, mockAdapter, mockConfigReader, mockLogger);
 
         // Should re-throw the exact same error object (reference equality)
         await expect(handler.navigateToLink(parsed, linkText)).rejects.toBe(showTextDocumentError);
@@ -834,9 +732,7 @@ describe('RangeLinkNavigationHandler', () => {
         );
 
         // Should show error message to user
-        expect(mockShowErrorMessage).toHaveBeenCalledWith(
-          'Failed to navigate to file.ts: Failed to open document',
-        );
+        expect(mockShowErrorMessage).toHaveBeenCalledWith('Failed to navigate to file.ts: Failed to open document');
       });
 
       it('should re-throw non-Error exceptions and show error message', async () => {
@@ -857,24 +753,15 @@ describe('RangeLinkNavigationHandler', () => {
           windowOptions: { showErrorMessage: mockShowErrorMessage },
           workspaceOptions: { openTextDocument: jest.fn().mockResolvedValue(undefined) },
         });
-        jest
-          .spyOn(mockAdapter, 'resolveWorkspacePath')
-          .mockResolvedValue({ uri: mockUri, resolvedVia: PathFormat.WorkspaceRelative });
+        jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue({ uri: mockUri, resolvedVia: PathFormat.WorkspaceRelative });
         jest.spyOn(mockAdapter, 'showTextDocument').mockRejectedValue(nonErrorException);
-        handler = new RangeLinkNavigationHandler(
-          GET_DELIMITERS,
-          mockAdapter,
-          mockConfigReader,
-          mockLogger,
-        );
+        handler = new RangeLinkNavigationHandler(GET_DELIMITERS, mockAdapter, mockConfigReader, mockLogger);
 
         // Should re-throw the exact same exception value (reference equality)
         await expect(handler.navigateToLink(parsed, 'file.ts#L10')).rejects.toBe(nonErrorException);
 
         // Should handle non-Error exception and show error message
-        expect(mockShowErrorMessage).toHaveBeenCalledWith(
-          'Failed to navigate to file.ts: string error',
-        );
+        expect(mockShowErrorMessage).toHaveBeenCalledWith('Failed to navigate to file.ts: string error');
       });
     });
   });
@@ -895,9 +782,7 @@ describe('RangeLinkNavigationHandler', () => {
       mockAdapter = createMockVscodeAdapter({
         windowOptions: createWindowOptionsForEditor(mockEditor),
         workspaceOptions: {
-          openTextDocument: jest
-            .fn()
-            .mockImplementation((uri: unknown) => Promise.resolve({ uri })),
+          openTextDocument: jest.fn().mockImplementation((uri: unknown) => Promise.resolve({ uri })),
         },
       });
       jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue({
@@ -905,12 +790,7 @@ describe('RangeLinkNavigationHandler', () => {
         resolvedVia: PathFormat.WorkspaceRelative,
       });
 
-      handler = new RangeLinkNavigationHandler(
-        GET_DELIMITERS,
-        mockAdapter,
-        mockConfigReader,
-        mockLogger,
-      );
+      handler = new RangeLinkNavigationHandler(GET_DELIMITERS, mockAdapter, mockConfigReader, mockLogger);
     });
 
     it('should log warning and show warning toast when line is clamped', async () => {
@@ -942,9 +822,7 @@ describe('RangeLinkNavigationHandler', () => {
         'Position clamped to document bounds',
       );
 
-      expect(showWarningMessageSpy).toHaveBeenCalledWith(
-        'Navigated to file.ts @ 50 (clamped: line exceeded file length)',
-      );
+      expect(showWarningMessageSpy).toHaveBeenCalledWith('Navigated to file.ts @ 50 (clamped: line exceeded file length)');
       expect(showInformationMessageSpy).not.toHaveBeenCalled();
     });
 
@@ -978,9 +856,7 @@ describe('RangeLinkNavigationHandler', () => {
         'Position clamped to document bounds',
       );
 
-      expect(showWarningMessageSpy).toHaveBeenCalledWith(
-        'Navigated to file.ts @ 1:100 (clamped: column exceeded line length)',
-      );
+      expect(showWarningMessageSpy).toHaveBeenCalledWith('Navigated to file.ts @ 1:100 (clamped: column exceeded line length)');
       expect(showInformationMessageSpy).not.toHaveBeenCalled();
     });
 
@@ -1030,12 +906,7 @@ describe('RangeLinkNavigationHandler', () => {
         resolvedVia: PathFormat.WorkspaceRelative,
       });
 
-      handler = new RangeLinkNavigationHandler(
-        GET_DELIMITERS,
-        mockAdapter,
-        mockConfigReader,
-        mockLogger,
-      );
+      handler = new RangeLinkNavigationHandler(GET_DELIMITERS, mockAdapter, mockConfigReader, mockLogger);
     });
 
     it('should create multi-cursor selections for rectangular mode', async () => {
@@ -1090,16 +961,10 @@ describe('RangeLinkNavigationHandler', () => {
       );
 
       // Line 6 (0-indexed: line 5)
-      expect(createSelectionSpy).toHaveBeenCalledWith(
-        { line: 5, character: 0 },
-        { line: 5, character: 7 },
-      );
+      expect(createSelectionSpy).toHaveBeenCalledWith({ line: 5, character: 0 }, { line: 5, character: 7 });
 
       // Line 7 (0-indexed: line 6)
-      expect(createSelectionSpy).toHaveBeenCalledWith(
-        { line: 6, character: 0 },
-        { line: 6, character: 7 },
-      );
+      expect(createSelectionSpy).toHaveBeenCalledWith({ line: 6, character: 0 }, { line: 6, character: 7 });
     });
   });
 
@@ -1134,20 +999,11 @@ describe('RangeLinkNavigationHandler', () => {
           openTextDocument: jest.fn().mockResolvedValue({ uri: navDoc.uri }),
         },
       });
-      jest
-        .spyOn(mockAdapter, 'resolveWorkspacePath')
-        .mockResolvedValue({ uri: navDoc.uri, resolvedVia: PathFormat.WorkspaceRelative });
+      jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue({ uri: navDoc.uri, resolvedVia: PathFormat.WorkspaceRelative });
       mockConfigReader = createMockConfigReader({
-        getBoolean: jest.fn((key: string, defaultValue: boolean) =>
-          key === 'navigation.showNavigatedToast' ? false : defaultValue,
-        ),
+        getBoolean: jest.fn((key: string, defaultValue: boolean) => (key === 'navigation.showNavigatedToast' ? false : defaultValue)),
       });
-      handler = new RangeLinkNavigationHandler(
-        GET_DELIMITERS,
-        mockAdapter,
-        mockConfigReader,
-        mockLogger,
-      );
+      handler = new RangeLinkNavigationHandler(GET_DELIMITERS, mockAdapter, mockConfigReader, mockLogger);
 
       const parsed: ParsedLink = {
         path: 'recipes/baking/chicken pie.ts',
@@ -1163,10 +1019,7 @@ describe('RangeLinkNavigationHandler', () => {
       await handler.navigateToLink(parsed, "'recipes/baking/chicken pie.ts'#L3C5-L42C10");
 
       expect(showInfoSpy).not.toHaveBeenCalled();
-      expect(mockConfigReader.getBoolean).toHaveBeenCalledWith(
-        'navigation.showNavigatedToast',
-        true,
-      );
+      expect(mockConfigReader.getBoolean).toHaveBeenCalledWith('navigation.showNavigatedToast', true);
       expect(mockLogger.debug).toHaveBeenCalledWith(
         {
           fn: 'RangeLinkNavigationHandler.navigateToLink',
@@ -1192,16 +1045,9 @@ describe('RangeLinkNavigationHandler', () => {
         },
       });
       mockConfigReader = createMockConfigReader({
-        getBoolean: jest.fn((key: string, defaultValue: boolean) =>
-          key === 'navigation.showClampingWarning' ? false : defaultValue,
-        ),
+        getBoolean: jest.fn((key: string, defaultValue: boolean) => (key === 'navigation.showClampingWarning' ? false : defaultValue)),
       });
-      handler = new RangeLinkNavigationHandler(
-        GET_DELIMITERS,
-        mockAdapter,
-        mockConfigReader,
-        mockLogger,
-      );
+      handler = new RangeLinkNavigationHandler(GET_DELIMITERS, mockAdapter, mockConfigReader, mockLogger);
 
       const parsed: ParsedLink = {
         path: 'recipes/baking/chicken pie.ts',
@@ -1217,16 +1063,12 @@ describe('RangeLinkNavigationHandler', () => {
       await handler.navigateToLink(parsed, "'recipes/baking/chicken pie.ts'#L50");
 
       expect(showWarnSpy).not.toHaveBeenCalled();
-      expect(mockConfigReader.getBoolean).toHaveBeenCalledWith(
-        'navigation.showClampingWarning',
-        true,
-      );
+      expect(mockConfigReader.getBoolean).toHaveBeenCalledWith('navigation.showClampingWarning', true);
       expect(mockLogger.debug).toHaveBeenCalledWith(
         {
           fn: 'RangeLinkNavigationHandler.navigateToLink',
           linkText: "'recipes/baking/chicken pie.ts'#L50",
-          suppressedMessage:
-            'Navigated to recipes/baking/chicken pie.ts @ 50 (clamped: line exceeded file length)',
+          suppressedMessage: 'Navigated to recipes/baking/chicken pie.ts @ 50 (clamped: line exceeded file length)',
         },
         'Clamping warning suppressed by setting',
       );
@@ -1246,15 +1088,8 @@ describe('RangeLinkNavigationHandler', () => {
           openTextDocument: jest.fn().mockResolvedValue({ uri: navDoc.uri }),
         },
       });
-      jest
-        .spyOn(mockAdapter, 'resolveWorkspacePath')
-        .mockResolvedValue({ uri: navDoc.uri, resolvedVia: PathFormat.WorkspaceRelative });
-      handler = new RangeLinkNavigationHandler(
-        GET_DELIMITERS,
-        mockAdapter,
-        mockConfigReader,
-        mockLogger,
-      );
+      jest.spyOn(mockAdapter, 'resolveWorkspacePath').mockResolvedValue({ uri: navDoc.uri, resolvedVia: PathFormat.WorkspaceRelative });
+      handler = new RangeLinkNavigationHandler(GET_DELIMITERS, mockAdapter, mockConfigReader, mockLogger);
 
       const parsed: ParsedLink = {
         path: 'recipes/baking/chicken pie.ts',
@@ -1269,13 +1104,8 @@ describe('RangeLinkNavigationHandler', () => {
 
       await handler.navigateToLink(parsed, "'recipes/baking/chicken pie.ts'#L3C5-L42C10");
 
-      expect(showInfoSpy).toHaveBeenCalledWith(
-        'Navigated to recipes/baking/chicken pie.ts @ 3:5-42:10',
-      );
-      expect(mockConfigReader.getBoolean).toHaveBeenCalledWith(
-        'navigation.showNavigatedToast',
-        true,
-      );
+      expect(showInfoSpy).toHaveBeenCalledWith('Navigated to recipes/baking/chicken pie.ts @ 3:5-42:10');
+      expect(mockConfigReader.getBoolean).toHaveBeenCalledWith('navigation.showNavigatedToast', true);
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/navigation/RangeLinkTerminalProvider.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/navigation/RangeLinkTerminalProvider.test.ts
@@ -23,8 +23,7 @@ const GET_DELIMITERS = () => DEFAULT_DELIMITERS;
  * @param line - The terminal line text
  * @returns Mock TerminalLinkContext
  */
-const createMockTerminalContext = (line: string): vscode.TerminalLinkContext =>
-  ({ line }) as vscode.TerminalLinkContext;
+const createMockTerminalContext = (line: string): vscode.TerminalLinkContext => ({ line }) as vscode.TerminalLinkContext;
 
 describe('RangeLinkTerminalProvider', () => {
   let provider: RangeLinkTerminalProvider;
@@ -65,12 +64,7 @@ describe('RangeLinkTerminalProvider', () => {
         data: 'src/file.ts#L10',
         parsed: detected.parsed,
       });
-      expect(mockFindLinksInText).toHaveBeenCalledWith(
-        'Check src/file.ts#L10',
-        DEFAULT_DELIMITERS,
-        mockLogger,
-        token,
-      );
+      expect(mockFindLinksInText).toHaveBeenCalledWith('Check src/file.ts#L10', DEFAULT_DELIMITERS, mockLogger, token);
       expect(mockLogger.debug).toHaveBeenCalledWith(
         {
           fn: 'RangeLinkTerminalProvider.provideTerminalLinks',
@@ -100,9 +94,7 @@ describe('RangeLinkTerminalProvider', () => {
         }),
       ]);
 
-      const context = createMockTerminalContext(
-        'First: src/file.ts#L10 and second: src/b.ts#L2-L3',
-      );
+      const context = createMockTerminalContext('First: src/file.ts#L10 and second: src/b.ts#L2-L3');
       const token = createMockCancellationToken();
       const links = provider.provideTerminalLinks(context, token) as RangeLinkTerminalLink[];
 
@@ -136,12 +128,7 @@ describe('RangeLinkTerminalProvider', () => {
       const token = createMockCancellationToken(true);
       provider.provideTerminalLinks(context, token);
 
-      expect(mockFindLinksInText).toHaveBeenCalledWith(
-        'src/a.ts#L1',
-        DEFAULT_DELIMITERS,
-        mockLogger,
-        token,
-      );
+      expect(mockFindLinksInText).toHaveBeenCalledWith('src/a.ts#L1', DEFAULT_DELIMITERS, mockLogger, token);
     });
   });
 
@@ -166,9 +153,7 @@ describe('RangeLinkTerminalProvider', () => {
         'Terminal link clicked but parse data missing (safety net triggered)',
       );
 
-      expect(mockShowWarningMessage).toHaveBeenCalledWith(
-        'Cannot navigate - invalid link format: file.ts#L0',
-      );
+      expect(mockShowWarningMessage).toHaveBeenCalledWith('Cannot navigate - invalid link format: file.ts#L0');
 
       expect(mockLogger.info).not.toHaveBeenCalled();
     });

--- a/packages/rangelink-vscode-extension/src/__tests__/notification/ReleaseNotifier.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/notification/ReleaseNotifier.test.ts
@@ -38,10 +38,7 @@ describe('ReleaseNotifier', () => {
 
       new ReleaseNotifier(globalState as any, VERSION_INFO_100, adapter, mockLogger);
 
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'ReleaseNotifier.constructor' },
-        'ReleaseNotifier initialized',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ReleaseNotifier.constructor' }, 'ReleaseNotifier initialized');
     });
   });
 
@@ -54,10 +51,7 @@ describe('ReleaseNotifier', () => {
 
         await notifier.maybeNotify();
 
-        expect(mockLogger.warn).toHaveBeenCalledWith(
-          { fn: 'ReleaseNotifier.maybeNotify' },
-          'Version info unavailable — skipping release notification',
-        );
+        expect(mockLogger.warn).toHaveBeenCalledWith({ fn: 'ReleaseNotifier.maybeNotify' }, 'Version info unavailable — skipping release notification');
         expect(globalState.get).not.toHaveBeenCalled();
         expect(globalState.update).not.toHaveBeenCalled();
       });
@@ -70,12 +64,7 @@ describe('ReleaseNotifier', () => {
         const adapter = createMockVscodeAdapter({
           windowOptions: { showInformationMessage: mockShowInformationMessage },
         });
-        const notifier = new ReleaseNotifier(
-          globalState as any,
-          VERSION_INFO_100,
-          adapter,
-          mockLogger,
-        );
+        const notifier = new ReleaseNotifier(globalState as any, VERSION_INFO_100, adapter, mockLogger);
 
         await notifier.maybeNotify();
 
@@ -96,21 +85,13 @@ describe('ReleaseNotifier', () => {
         const adapter = createMockVscodeAdapter({
           windowOptions: { showInformationMessage: mockShowInformationMessage },
         });
-        const notifier = new ReleaseNotifier(
-          globalState as any,
-          VERSION_INFO_100,
-          adapter,
-          mockLogger,
-        );
+        const notifier = new ReleaseNotifier(globalState as any, VERSION_INFO_100, adapter, mockLogger);
 
         await notifier.maybeNotify();
 
         expect(mockShowInformationMessage).not.toHaveBeenCalled();
         expect(globalState.update).not.toHaveBeenCalled();
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'ReleaseNotifier.maybeNotify', version: '1.0.0' },
-          'Same version — skipping release notification',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ReleaseNotifier.maybeNotify', version: '1.0.0' }, 'Same version — skipping release notification');
       });
     });
 
@@ -121,20 +102,11 @@ describe('ReleaseNotifier', () => {
         const adapter = createMockVscodeAdapter({
           windowOptions: { showInformationMessage: mockShowInformationMessage },
         });
-        const notifier = new ReleaseNotifier(
-          globalState as any,
-          VERSION_INFO_110,
-          adapter,
-          mockLogger,
-        );
+        const notifier = new ReleaseNotifier(globalState as any, VERSION_INFO_110, adapter, mockLogger);
 
         await notifier.maybeNotify();
 
-        expect(mockShowInformationMessage).toHaveBeenCalledWith(
-          'RangeLink updated to v1.1.0. See what changed!',
-          "What's New",
-          'Skip for this version',
-        );
+        expect(mockShowInformationMessage).toHaveBeenCalledWith('RangeLink updated to v1.1.0. See what changed!', "What's New", 'Skip for this version');
         expect(globalState.update).not.toHaveBeenCalled();
         expect(mockLogger.info).toHaveBeenCalledWith(
           {
@@ -154,12 +126,7 @@ describe('ReleaseNotifier', () => {
           windowOptions: { showInformationMessage: mockShowInformationMessage },
           envOptions: { openExternal: mockOpenExternal },
         });
-        const notifier = new ReleaseNotifier(
-          globalState as any,
-          VERSION_INFO_110,
-          adapter,
-          mockLogger,
-        );
+        const notifier = new ReleaseNotifier(globalState as any, VERSION_INFO_110, adapter, mockLogger);
 
         await notifier.maybeNotify();
 
@@ -179,21 +146,13 @@ describe('ReleaseNotifier', () => {
           windowOptions: { showInformationMessage: mockShowInformationMessage },
           envOptions: { openExternal: mockOpenExternal },
         });
-        const notifier = new ReleaseNotifier(
-          globalState as any,
-          VERSION_INFO_110,
-          adapter,
-          mockLogger,
-        );
+        const notifier = new ReleaseNotifier(globalState as any, VERSION_INFO_110, adapter, mockLogger);
 
         await notifier.maybeNotify();
 
         expect(globalState.update).toHaveBeenCalledWith('rangelink.lastNotifiedVersion', '1.1.0');
         expect(mockOpenExternal).not.toHaveBeenCalled();
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'ReleaseNotifier.maybeNotify', version: '1.1.0' },
-          'Release notification skipped for this version',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ReleaseNotifier.maybeNotify', version: '1.1.0' }, 'Release notification skipped for this version');
       });
 
       it("stores version and opens release notes URL when user clicks What's New", async () => {
@@ -203,23 +162,13 @@ describe('ReleaseNotifier', () => {
           windowOptions: { showInformationMessage: mockShowInformationMessage },
         });
         const openExternalSpy = jest.spyOn(adapter, 'openExternal').mockResolvedValue(true);
-        const notifier = new ReleaseNotifier(
-          globalState as any,
-          VERSION_INFO_110,
-          adapter,
-          mockLogger,
-        );
+        const notifier = new ReleaseNotifier(globalState as any, VERSION_INFO_110, adapter, mockLogger);
 
         await notifier.maybeNotify();
 
         expect(globalState.update).toHaveBeenCalledWith('rangelink.lastNotifiedVersion', '1.1.0');
-        expect(openExternalSpy).toHaveBeenCalledWith(
-          'https://github.com/couimet/rangeLink/releases/tag/vscode-extension-v1.1.0',
-        );
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          { fn: 'ReleaseNotifier.maybeNotify', version: '1.1.0' },
-          'Opened release notes in browser',
-        );
+        expect(openExternalSpy).toHaveBeenCalledWith('https://github.com/couimet/rangeLink/releases/tag/vscode-extension-v1.1.0');
+        expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ReleaseNotifier.maybeNotify', version: '1.1.0' }, 'Opened release notes in browser');
       });
     });
   });
@@ -228,12 +177,7 @@ describe('ReleaseNotifier', () => {
     it('returns the stored version from globalState', () => {
       const globalState = createMockGlobalState('1.0.0');
       const adapter = createMockVscodeAdapter();
-      const notifier = new ReleaseNotifier(
-        globalState as any,
-        VERSION_INFO_100,
-        adapter,
-        mockLogger,
-      );
+      const notifier = new ReleaseNotifier(globalState as any, VERSION_INFO_100, adapter, mockLogger);
 
       expect(notifier.getLastNotifiedVersion()).toBe('1.0.0');
       expect(globalState.get).toHaveBeenCalledWith('rangelink.lastNotifiedVersion');
@@ -242,12 +186,7 @@ describe('ReleaseNotifier', () => {
     it('returns undefined when no version is stored', () => {
       const globalState = createMockGlobalState(undefined);
       const adapter = createMockVscodeAdapter();
-      const notifier = new ReleaseNotifier(
-        globalState as any,
-        VERSION_INFO_100,
-        adapter,
-        mockLogger,
-      );
+      const notifier = new ReleaseNotifier(globalState as any, VERSION_INFO_100, adapter, mockLogger);
 
       expect(notifier.getLastNotifiedVersion()).toBeUndefined();
     });

--- a/packages/rangelink-vscode-extension/src/__tests__/services/FilePathPaster.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/services/FilePathPaster.test.ts
@@ -23,9 +23,7 @@ describe('getReferencePath', () => {
 
   it('returns workspace-relative path when pathFormat is WorkspaceRelative and file is in workspace', () => {
     const uri = createMockUri('/workspace/src/file.ts');
-    jest
-      .spyOn(mockAdapter, 'getWorkspaceFolder')
-      .mockReturnValue(createMockWorkspaceFolder('/workspace'));
+    jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(createMockWorkspaceFolder('/workspace'));
     jest.spyOn(mockAdapter, 'asRelativePath').mockReturnValue('src/file.ts');
 
     const result = getReferencePath(mockAdapter, uri, PathFormat.WorkspaceRelative);
@@ -36,9 +34,7 @@ describe('getReferencePath', () => {
 
   it('returns absolute fsPath when pathFormat is Absolute', () => {
     const uri = createMockUri('/workspace/src/file.ts');
-    jest
-      .spyOn(mockAdapter, 'getWorkspaceFolder')
-      .mockReturnValue(createMockWorkspaceFolder('/workspace'));
+    jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(createMockWorkspaceFolder('/workspace'));
 
     const result = getReferencePath(mockAdapter, uri, PathFormat.Absolute);
 
@@ -81,13 +77,7 @@ describe('FilePathPaster', () => {
       resolveDestination: jest.fn(),
       sendToDestination: jest.fn(),
     };
-    paster = new FilePathPaster(
-      mockAdapter,
-      mockDestinationManager,
-      mockConfigReader,
-      mockSendRouter as any,
-      mockLogger,
-    );
+    paster = new FilePathPaster(mockAdapter, mockDestinationManager, mockConfigReader, mockSendRouter as any, mockLogger);
     formatMessageSpy = spyOnFormatMessage();
   });
 
@@ -99,10 +89,7 @@ describe('FilePathPaster', () => {
 
       expect(formatMessageSpy).toHaveBeenCalledWith('ERROR_PASTE_FILE_PATH_NO_ACTIVE_FILE');
       expect(mockShowErrorMessage).toHaveBeenCalledTimes(1);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'FilePathPaster.pasteCurrentFilePath', pathFormat: 'absolute' },
-        'No active editor',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'FilePathPaster.pasteCurrentFilePath', pathFormat: 'absolute' }, 'No active editor');
     });
 
     it('delegates to pasteFilePath when active editor exists', async () => {
@@ -121,9 +108,7 @@ describe('FilePathPaster', () => {
       const uri = createMockUri('/workspace/src/file.ts');
       jest.spyOn(mockAdapter, 'findOpenDocument').mockReturnValue(undefined);
       jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(undefined);
-      jest
-        .spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning')
-        .mockResolvedValue(DirtyBufferWarningResult.ContinueAnyway);
+      jest.spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning').mockResolvedValue(DirtyBufferWarningResult.ContinueAnyway);
       mockSendRouter.resolveDestination.mockResolvedValue({ canProceed: false });
 
       await paster.pasteFilePathToDestination(uri, PathFormat.Absolute);
@@ -135,9 +120,7 @@ describe('FilePathPaster', () => {
       const uri = createMockUri('/workspace/src/file.ts');
       jest.spyOn(mockAdapter, 'findOpenDocument').mockReturnValue(undefined);
       jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(undefined);
-      jest
-        .spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning')
-        .mockResolvedValue(DirtyBufferWarningResult.ContinueAnyway);
+      jest.spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning').mockResolvedValue(DirtyBufferWarningResult.ContinueAnyway);
       mockSendRouter.resolveDestination.mockResolvedValue({
         canProceed: true,
         bindPerformed: false,
@@ -183,9 +166,7 @@ describe('FilePathPaster', () => {
       const uri = createMockUri("/workspace/my project/file's.ts");
       jest.spyOn(mockAdapter, 'findOpenDocument').mockReturnValue(undefined);
       jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(undefined);
-      jest
-        .spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning')
-        .mockResolvedValue(DirtyBufferWarningResult.ContinueAnyway);
+      jest.spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning').mockResolvedValue(DirtyBufferWarningResult.ContinueAnyway);
       mockSendRouter.resolveDestination.mockResolvedValue({
         canProceed: true,
         bindPerformed: false,
@@ -235,9 +216,7 @@ describe('FilePathPaster', () => {
       const document = createMockDocument({ uri });
       jest.spyOn(mockAdapter, 'findOpenDocument').mockReturnValue(document);
       jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(undefined);
-      jest
-        .spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning')
-        .mockResolvedValue(DirtyBufferWarningResult.Dismissed);
+      jest.spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning').mockResolvedValue(DirtyBufferWarningResult.Dismissed);
 
       await paster.pasteFilePathToDestination(uri, PathFormat.Absolute);
 
@@ -248,9 +227,7 @@ describe('FilePathPaster', () => {
       const uri = createMockUri('/workspace/src/file.ts');
       jest.spyOn(mockAdapter, 'findOpenDocument').mockReturnValue(createMockDocument({ uri }));
       jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(undefined);
-      jest
-        .spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning')
-        .mockResolvedValue(DirtyBufferWarningResult.SaveFailed);
+      jest.spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning').mockResolvedValue(DirtyBufferWarningResult.SaveFailed);
 
       await paster.pasteFilePathToDestination(uri, PathFormat.Absolute);
 
@@ -261,9 +238,7 @@ describe('FilePathPaster', () => {
       const uri = createMockUri('/workspace/src/file.ts');
       jest.spyOn(mockAdapter, 'findOpenDocument').mockReturnValue(createMockDocument({ uri }));
       jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(undefined);
-      jest
-        .spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning')
-        .mockResolvedValue(DirtyBufferWarningResult.SaveAndContinue);
+      jest.spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning').mockResolvedValue(DirtyBufferWarningResult.SaveAndContinue);
       mockSendRouter.resolveDestination.mockResolvedValue({
         canProceed: true,
         bindPerformed: false,
@@ -300,9 +275,7 @@ describe('FilePathPaster', () => {
       const uri = createMockUri('/workspace/src/file.ts');
       jest.spyOn(mockAdapter, 'findOpenDocument').mockReturnValue(createMockDocument({ uri }));
       jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(undefined);
-      jest
-        .spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning')
-        .mockResolvedValue(DirtyBufferWarningResult.ContinueAnyway);
+      jest.spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning').mockResolvedValue(DirtyBufferWarningResult.ContinueAnyway);
       mockSendRouter.resolveDestination.mockResolvedValue({
         canProceed: true,
         bindPerformed: false,
@@ -340,9 +313,7 @@ describe('FilePathPaster', () => {
       const document = createMockDocument({ uri });
       jest.spyOn(mockAdapter, 'findOpenDocument').mockReturnValue(document);
       jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(undefined);
-      const warningSpy = jest
-        .spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning')
-        .mockResolvedValue(DirtyBufferWarningResult.Dismissed);
+      const warningSpy = jest.spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning').mockResolvedValue(DirtyBufferWarningResult.Dismissed);
 
       await paster.pasteFilePathToDestination(uri, PathFormat.Absolute);
 

--- a/packages/rangelink-vscode-extension/src/__tests__/services/LinkGenerator.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/services/LinkGenerator.test.ts
@@ -163,18 +163,13 @@ describe('LinkGenerator', () => {
       mockSelectionValidator.validateSelectionsAndShowError.mockReturnValue(validated);
       jest.spyOn(mockAdapter, 'getActiveTextEditorUri').mockReturnValue(mockDoc.uri);
       jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(undefined);
-      mockGenLink.mockReturnValue(
-        DetailedResult.success(createMockFormattedLink('src/file.ts#L1')),
-      );
+      mockGenLink.mockReturnValue(DetailedResult.success(createMockFormattedLink('src/file.ts#L1')));
       jest.spyOn(mockAdapter, 'getActiveTextEditorUri').mockReturnValue(undefined);
 
       await generator.createLink();
 
       expect(mockSendRouter.resolveDestination).not.toHaveBeenCalled();
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'LinkGenerator.createLinkCore', linkType: 'regular' },
-        'Active editor URI unavailable, aborting',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'LinkGenerator.createLinkCore', linkType: 'regular' }, 'Active editor URI unavailable, aborting');
     });
 
     it('aborts when picker is cancelled', async () => {
@@ -182,9 +177,7 @@ describe('LinkGenerator', () => {
       mockSelectionValidator.validateSelectionsAndShowError.mockReturnValue(validated);
       jest.spyOn(mockAdapter, 'getActiveTextEditorUri').mockReturnValue(mockDoc.uri);
       jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(undefined);
-      mockGenLink.mockReturnValue(
-        DetailedResult.success(createMockFormattedLink('src/file.ts#L1')),
-      );
+      mockGenLink.mockReturnValue(DetailedResult.success(createMockFormattedLink('src/file.ts#L1')));
       mockSendRouter.resolveDestination.mockResolvedValue({ canProceed: false });
 
       await generator.createLink();
@@ -206,27 +199,19 @@ describe('LinkGenerator', () => {
       mockSelectionValidator.validateSelectionsAndShowError.mockReturnValue(validated);
       jest.spyOn(mockAdapter, 'getActiveTextEditorUri').mockReturnValue(mockDoc.uri);
       jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(undefined);
-      const clipboardSpy = jest
-        .spyOn(mockAdapter, 'writeTextToClipboard')
-        .mockResolvedValue(undefined);
-      mockGenLink.mockReturnValue(
-        DetailedResult.success(createMockFormattedLink('src/file.ts#L1')),
-      );
+      const clipboardSpy = jest.spyOn(mockAdapter, 'writeTextToClipboard').mockResolvedValue(undefined);
+      mockGenLink.mockReturnValue(DetailedResult.success(createMockFormattedLink('src/file.ts#L1')));
 
       await generator.createLinkOnly();
 
       expect(clipboardSpy).toHaveBeenCalledWith('src/file.ts#L1');
-      expect(mockFeedbackProvider.provideCopyFeedback).toHaveBeenCalledWith(
-        'CONTENT_NAME_RANGELINK',
-      );
+      expect(mockFeedbackProvider.provideCopyFeedback).toHaveBeenCalledWith('CONTENT_NAME_RANGELINK');
       expect(mockSendRouter.sendToDestination).not.toHaveBeenCalled();
       expect(mockSendRouter.resolveDestination).not.toHaveBeenCalled();
     });
 
     it('does nothing when no link generated', async () => {
-      const clipboardSpy = jest
-        .spyOn(mockAdapter, 'writeTextToClipboard')
-        .mockResolvedValue(undefined);
+      const clipboardSpy = jest.spyOn(mockAdapter, 'writeTextToClipboard').mockResolvedValue(undefined);
       mockSelectionValidator.validateSelectionsAndShowError.mockReturnValue(undefined);
 
       await generator.createLinkOnly();
@@ -234,10 +219,7 @@ describe('LinkGenerator', () => {
       expect(clipboardSpy).not.toHaveBeenCalled();
       expect(mockFeedbackProvider.provideCopyFeedback).not.toHaveBeenCalled();
       expect(mockSendRouter.sendToDestination).not.toHaveBeenCalled();
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'LinkGenerator.createLinkOnly' },
-        'generateLinkFromSelection returned undefined, aborting',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'LinkGenerator.createLinkOnly' }, 'generateLinkFromSelection returned undefined, aborting');
     });
   });
 
@@ -301,9 +283,7 @@ describe('LinkGenerator', () => {
         editor: { document: mockDoc, selections: [createMockSelection({ isEmpty: false })] },
         selections: [createMockSelection({ isEmpty: false })],
       });
-      const warningSpy = jest
-        .spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning')
-        .mockResolvedValue(DirtyBufferWarningResult.Dismissed);
+      const warningSpy = jest.spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning').mockResolvedValue(DirtyBufferWarningResult.Dismissed);
 
       await generator.createLink();
 
@@ -320,9 +300,7 @@ describe('LinkGenerator', () => {
         editor: { document: mockDoc, selections: [createMockSelection({ isEmpty: false })] },
         selections: [createMockSelection({ isEmpty: false })],
       });
-      const warningSpy = jest
-        .spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning')
-        .mockResolvedValue(DirtyBufferWarningResult.SaveFailed);
+      const warningSpy = jest.spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning').mockResolvedValue(DirtyBufferWarningResult.SaveFailed);
 
       await generator.createLink();
 
@@ -373,10 +351,7 @@ describe('LinkGenerator', () => {
 
       await generator.createLink();
 
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        { fn: 'generateLinkFromSelection', formattedLink: link },
-        `Generated link: ${link.link}`,
-      );
+      expect(mockLogger.info).toHaveBeenCalledWith({ fn: 'generateLinkFromSelection', formattedLink: link }, `Generated link: ${link.link}`);
     });
 
     it('re-validates selections and uses post-save selections when warning returns SaveAndContinue', async () => {
@@ -398,14 +373,10 @@ describe('LinkGenerator', () => {
       mockSelectionValidator.validateSelectionsAndShowError
         .mockReturnValueOnce({ editor: mockEditor, selections: [preSaveSel] })
         .mockReturnValueOnce({ editor: mockEditor, selections: [postSaveSel] });
-      jest
-        .spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning')
-        .mockResolvedValue(DirtyBufferWarningResult.SaveAndContinue);
+      jest.spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning').mockResolvedValue(DirtyBufferWarningResult.SaveAndContinue);
       jest.spyOn(mockAdapter, 'getActiveTextEditorUri').mockReturnValue(mockDoc.uri);
       jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(undefined);
-      mockGenLink.mockReturnValue(
-        DetailedResult.success(createMockFormattedLink('src/file.ts#L4C1-L4C11')),
-      );
+      mockGenLink.mockReturnValue(DetailedResult.success(createMockFormattedLink('src/file.ts#L4C1-L4C11')));
       mockSendRouter.resolveDestination.mockResolvedValue({ canProceed: false });
 
       await generator.createLink();
@@ -422,12 +393,8 @@ describe('LinkGenerator', () => {
       expect(mockLogger.debug).toHaveBeenCalledWith(
         {
           fn: 'generateLinkFromSelection',
-          preSaveSelections: [
-            { index: 0, start: { line: 4, char: 0 }, end: { line: 4, char: 10 }, isEmpty: false },
-          ],
-          postSaveSelections: [
-            { index: 0, start: { line: 3, char: 0 }, end: { line: 3, char: 10 }, isEmpty: false },
-          ],
+          preSaveSelections: [{ index: 0, start: { line: 4, char: 0 }, end: { line: 4, char: 10 }, isEmpty: false }],
+          postSaveSelections: [{ index: 0, start: { line: 3, char: 0 }, end: { line: 3, char: 10 }, isEmpty: false }],
         },
         'Re-read selections after Save & Continue to account for possible format-on-save shifts',
       );
@@ -448,18 +415,13 @@ describe('LinkGenerator', () => {
           selections: [createMockSelection({ isEmpty: false })],
         })
         .mockReturnValueOnce(undefined);
-      jest
-        .spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning')
-        .mockResolvedValue(DirtyBufferWarningResult.SaveAndContinue);
+      jest.spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning').mockResolvedValue(DirtyBufferWarningResult.SaveAndContinue);
 
       await generator.createLink();
 
       expect(mockSelectionValidator.validateSelectionsAndShowError).toHaveBeenCalledTimes(2);
       expect(mockGenLink).not.toHaveBeenCalled();
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'generateLinkFromSelection' },
-        'Post-save re-validation returned no selections, aborting',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'generateLinkFromSelection' }, 'Post-save re-validation returned no selections, aborting');
     });
 
     it('does NOT re-validate selections when warning returns ContinueAnyway', async () => {
@@ -473,14 +435,10 @@ describe('LinkGenerator', () => {
         editor: mockEditor,
         selections: [sel],
       });
-      jest
-        .spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning')
-        .mockResolvedValue(DirtyBufferWarningResult.ContinueAnyway);
+      jest.spyOn(handleDirtyBufferWarningModule, 'handleDirtyBufferWarning').mockResolvedValue(DirtyBufferWarningResult.ContinueAnyway);
       jest.spyOn(mockAdapter, 'getActiveTextEditorUri').mockReturnValue(mockDoc.uri);
       jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(undefined);
-      mockGenLink.mockReturnValue(
-        DetailedResult.success(createMockFormattedLink('src/file.ts#L1')),
-      );
+      mockGenLink.mockReturnValue(DetailedResult.success(createMockFormattedLink('src/file.ts#L1')));
       mockSendRouter.resolveDestination.mockResolvedValue({ canProceed: false });
 
       await generator.createLink();

--- a/packages/rangelink-vscode-extension/src/__tests__/services/SendRouter.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/services/SendRouter.test.ts
@@ -46,13 +46,11 @@ describe('SendRouter', () => {
     mockDestinationManager = createMockDestinationManager();
     mockDestinationPicker = createMockDestinationPicker();
     mockClipboardService = createMockClipboardService();
-    mockClipboardService.route.mockImplementation(
-      async (fn: () => Promise<unknown>, shouldRestore?: () => boolean) => {
-        const result = await fn();
-        shouldRestore?.();
-        return ExtensionResult.ok(result);
-      },
-    );
+    mockClipboardService.route.mockImplementation(async (fn: () => Promise<unknown>, shouldRestore?: () => boolean) => {
+      const result = await fn();
+      shouldRestore?.();
+      return ExtensionResult.ok(result);
+    });
     mockFeedbackProvider = createMockOperationFeedbackProvider();
     mockLogger = createMockLogger();
 
@@ -99,10 +97,7 @@ describe('SendRouter', () => {
         bindPerformed: true,
         destinationName: 'Terminal',
       });
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'test' },
-        'No destination bound, showing quick pick',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'test' }, 'No destination bound, showing quick pick');
     });
 
     it('returns false when picker returns no-resource', async () => {
@@ -112,10 +107,7 @@ describe('SendRouter', () => {
       const result = await router.resolveDestination({ fn: 'test' });
 
       expect(result).toStrictEqual({ canProceed: false });
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'test', outcome: 'no-resource' },
-        'Picker did not bind, aborting',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'test', outcome: 'no-resource' }, 'Picker did not bind, aborting');
     });
 
     it('returns false when user cancels picker', async () => {
@@ -156,10 +148,7 @@ describe('SendRouter', () => {
       await router.sendToDestination(createMockSendOptions() as any);
 
       expect(mockClipboardWriter.writeTextToClipboard).toHaveBeenCalledWith(' src/file.ts#L1 ');
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        { fn: 'testFn' },
-        'No destination bound - copied to clipboard only',
-      );
+      expect(mockLogger.info).toHaveBeenCalledWith({ fn: 'testFn' }, 'No destination bound - copied to clipboard only');
       expect(mockFeedbackProvider.provideSendFeedback).not.toHaveBeenCalled();
     });
 
@@ -186,10 +175,7 @@ describe('SendRouter', () => {
 
       await router.sendToDestination(createMockSendOptions() as any);
 
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        { fn: 'SendRouter.sendToDestination', error: routeError },
-        'Clipboard routing failed',
-      );
+      expect(mockLogger.error).toHaveBeenCalledWith({ fn: 'SendRouter.sendToDestination', error: routeError }, 'Clipboard routing failed');
       expect(mockFeedbackProvider.provideSendFeedback).toHaveBeenCalledWith(
         {
           contentType: 'CONTENT_NAME_RANGELINK',
@@ -313,8 +299,7 @@ describe('SendRouter', () => {
           kind: 'self-paste-blocked',
           destinationKind: 'text-editor',
           clipboardWritten: true,
-          toastMessage:
-            'Cannot auto-paste to same file. Link copied to clipboard. Tip: Use R-C for clipboard-only links.',
+          toastMessage: 'Cannot auto-paste to same file. Link copied to clipboard. Tip: Use R-C for clipboard-only links.',
         },
         undefined,
       );
@@ -412,9 +397,7 @@ describe('SendRouter', () => {
       const dest = createMockPasteDestinationForSendRouter({
         getUserInstruction: jest
           .fn()
-          .mockImplementation((result: AutoPasteResult) =>
-            result === AutoPasteResult.Failure ? 'Manual paste required' : undefined,
-          ),
+          .mockImplementation((result: AutoPasteResult) => (result === AutoPasteResult.Failure ? 'Manual paste required' : undefined)),
       });
       mockDestinationManager = createMockDestinationManager();
       mockSession.isSet.mockReturnValue(true);
@@ -601,8 +584,7 @@ describe('SendRouter', () => {
           kind: 'self-paste-blocked',
           destinationKind: 'text-editor',
           clipboardWritten: true,
-          toastMessage:
-            'Cannot auto-paste to same file. Link copied to clipboard. Tip: Use R-C for clipboard-only links.',
+          toastMessage: 'Cannot auto-paste to same file. Link copied to clipboard. Tip: Use R-C for clipboard-only links.',
         },
         undefined,
       );
@@ -691,16 +673,11 @@ describe('SendRouter', () => {
           kind: 'self-paste-blocked',
           destinationKind: 'text-editor',
           clipboardWritten: true,
-          toastMessage:
-            'Cannot paste when bound editor has an active selection. File path copied to clipboard.',
+          toastMessage: 'Cannot paste when bound editor has an active selection. File path copied to clipboard.',
         },
         undefined,
       );
-      expect(
-        jest
-          .mocked(mockLogger.debug)
-          .mock.calls.filter((c) => c[1] === 'Self-paste policy resolution'),
-      ).toStrictEqual([]);
+      expect(jest.mocked(mockLogger.debug).mock.calls.filter((c) => c[1] === 'Self-paste policy resolution')).toStrictEqual([]);
     });
 
     it('blocks with block-on-editor-selection when selection is active and does NOT write clipboard', async () => {
@@ -750,11 +727,7 @@ describe('SendRouter', () => {
         },
         undefined,
       );
-      expect(
-        jest
-          .mocked(mockLogger.debug)
-          .mock.calls.filter((c) => c[1] === 'Self-paste policy resolution'),
-      ).toStrictEqual([]);
+      expect(jest.mocked(mockLogger.debug).mock.calls.filter((c) => c[1] === 'Self-paste policy resolution')).toStrictEqual([]);
     });
 
     it('allows paste with block-on-editor-selection when destination has no active selection', async () => {
@@ -812,8 +785,7 @@ describe('SendRouter', () => {
   // ── shouldRestoreClipboard ───────────────────────────────────
 
   describe('shouldRestoreClipboard', () => {
-    const createDest = (overrides: Partial<PasteDestination> = {}) =>
-      createMockPasteDestinationForSendRouter(overrides);
+    const createDest = (overrides: Partial<PasteDestination> = {}) => createMockPasteDestinationForSendRouter(overrides);
 
     it('returns false for self-paste-blocked with clipboardWritten: true (regardless of destination)', () => {
       const dest = createDest({ shouldPreserveClipboard: jest.fn().mockReturnValue(true) });
@@ -833,10 +805,7 @@ describe('SendRouter', () => {
     });
 
     it('returns true when no destination is bound', () => {
-      const result = (router as any).shouldRestoreClipboard(
-        { kind: 'failed-automatic', destinationKind: 'terminal' },
-        undefined,
-      );
+      const result = (router as any).shouldRestoreClipboard({ kind: 'failed-automatic', destinationKind: 'terminal' }, undefined);
 
       expect(result).toBe(true);
     });
@@ -860,27 +829,17 @@ describe('SendRouter', () => {
     it('returns true when paste succeeded (sent-manual) and shouldPreserveClipboard returns true', () => {
       const dest = createDest();
 
-      const result = (router as any).shouldRestoreClipboard(
-        { kind: 'sent-manual', instruction: 'Press Cmd+V' },
-        dest,
-      );
+      const result = (router as any).shouldRestoreClipboard({ kind: 'sent-manual', instruction: 'Press Cmd+V' }, dest);
 
       expect(result).toBe(true);
     });
 
     it('returns true when paste failed and destination has no failure instruction', () => {
       const dest = createDest({
-        getUserInstruction: jest
-          .fn()
-          .mockImplementation((result: AutoPasteResult) =>
-            result === AutoPasteResult.Failure ? undefined : 'Press Cmd+V',
-          ),
+        getUserInstruction: jest.fn().mockImplementation((result: AutoPasteResult) => (result === AutoPasteResult.Failure ? undefined : 'Press Cmd+V')),
       });
 
-      const result = (router as any).shouldRestoreClipboard(
-        { kind: 'failed-automatic', destinationKind: 'terminal' },
-        dest,
-      );
+      const result = (router as any).shouldRestoreClipboard({ kind: 'failed-automatic', destinationKind: 'terminal' }, dest);
 
       expect(result).toBe(true);
     });
@@ -890,10 +849,7 @@ describe('SendRouter', () => {
         getUserInstruction: jest.fn().mockReturnValue('Manual paste required'),
       });
 
-      const result = (router as any).shouldRestoreClipboard(
-        { kind: 'failed-manual', instruction: 'Manual paste required' },
-        dest,
-      );
+      const result = (router as any).shouldRestoreClipboard({ kind: 'failed-manual', instruction: 'Manual paste required' }, dest);
 
       expect(result).toBe(false);
     });
@@ -917,10 +873,7 @@ describe('SendRouter', () => {
       const result = await router.resolveDestination({ fn: 'test' });
 
       expect(result).toStrictEqual({ canProceed: false });
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        { fn: 'SendRouter.showPickerAndBind' },
-        'No destinations available - no action taken',
-      );
+      expect(mockLogger.info).toHaveBeenCalledWith({ fn: 'SendRouter.showPickerAndBind' }, 'No destinations available - no action taken');
     });
 
     it('returns cancelled when user dismisses picker', async () => {
@@ -930,10 +883,7 @@ describe('SendRouter', () => {
       const result = await router.resolveDestination({ fn: 'test' });
 
       expect(result).toStrictEqual({ canProceed: false });
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        { fn: 'SendRouter.showPickerAndBind' },
-        'User cancelled quick pick - no action taken',
-      );
+      expect(mockLogger.info).toHaveBeenCalledWith({ fn: 'SendRouter.showPickerAndBind' }, 'User cancelled quick pick - no action taken');
     });
 
     it('returns bound when bind succeeds', async () => {
@@ -956,10 +906,7 @@ describe('SendRouter', () => {
         bindPerformed: true,
         destinationName: 'Terminal',
       });
-      expect(mockDestinationManager.bind).toHaveBeenCalledWith(
-        { kind: 'terminal', terminal: { name: 'bash' } },
-        { skipMessage: true },
-      );
+      expect(mockDestinationManager.bind).toHaveBeenCalledWith({ kind: 'terminal', terminal: { name: 'bash' } }, { skipMessage: true });
     });
 
     it('returns bind-failed when bind returns error', async () => {
@@ -988,9 +935,7 @@ describe('SendRouter', () => {
         outcome: 'unexpected-value',
       } as any);
 
-      await expect(router.resolveDestination({ fn: 'test' })).rejects.toThrow(
-        RangeLinkExtensionError,
-      );
+      await expect(router.resolveDestination({ fn: 'test' })).rejects.toThrow(RangeLinkExtensionError);
     });
 
     it('passes editor destination boundFileUriString and boundFileViewColumn to picker when bound destination is an editor', async () => {

--- a/packages/rangelink-vscode-extension/src/__tests__/services/TerminalPasteService.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/services/TerminalPasteService.test.ts
@@ -2,12 +2,7 @@ import { RangeLinkExtensionError } from '../../errors/RangeLinkExtensionError';
 import { RangeLinkExtensionErrorCodes } from '../../errors/RangeLinkExtensionErrorCodes';
 import { TerminalPasteService } from '../../services';
 import { BehaviourAfterPaste, ExtensionResult } from '../../types';
-import {
-  createMockClipboardService,
-  createMockTerminal,
-  createMockVscodeAdapter,
-  type VscodeAdapterWithTestHooks,
-} from '../helpers';
+import { createMockClipboardService, createMockTerminal, createMockVscodeAdapter, type VscodeAdapterWithTestHooks } from '../helpers';
 
 import { createMockLogger } from '@couimet/logger-contract-testing';
 
@@ -33,10 +28,7 @@ describe('TerminalPasteService', () => {
 
       expect(result.success).toBe(true);
       expect(mockClipboardService.stage).toHaveBeenCalledWith('test content', expect.any(Function));
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        { fn: 'TerminalPasteService.pasteIntoTerminal', terminalName: 'my-terminal' },
-        'Terminal paste succeeded',
-      );
+      expect(mockLogger.info).toHaveBeenCalledWith({ fn: 'TerminalPasteService.pasteIntoTerminal', terminalName: 'my-terminal' }, 'Terminal paste succeeded');
       expect(mockLogger.error).not.toHaveBeenCalled();
     });
 

--- a/packages/rangelink-vscode-extension/src/__tests__/services/TerminalSelectionService.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/services/TerminalSelectionService.test.ts
@@ -46,14 +46,7 @@ describe('TerminalSelectionService', () => {
       resolveDestination: jest.fn(),
       sendToDestination: jest.fn(),
     };
-    service = new TerminalSelectionService(
-      mockAdapter,
-      mockDestinationManager,
-      mockConfigReader,
-      mockClipboardService,
-      mockSendRouter as any,
-      mockLogger,
-    );
+    service = new TerminalSelectionService(mockAdapter, mockDestinationManager, mockConfigReader, mockClipboardService, mockSendRouter as any, mockLogger);
     formatMessageSpy = spyOnFormatMessage();
   });
 
@@ -66,10 +59,7 @@ describe('TerminalSelectionService', () => {
       expect(result).toStrictEqual({ outcome: 'no-active-terminal' });
       expect(formatMessageSpy).toHaveBeenCalledWith('ERROR_NO_ACTIVE_TERMINAL');
       expect(mockShowErrorMessage).toHaveBeenCalledTimes(1);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'TerminalSelectionService.pasteTerminalSelectionToDestination' },
-        'No active terminal',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'TerminalSelectionService.pasteTerminalSelectionToDestination' }, 'No active terminal');
     });
 
     it('returns clipboard-read-failed when clipboard capture fails', async () => {
@@ -127,9 +117,7 @@ describe('TerminalSelectionService', () => {
     it('returns no-text-selected when clipboard roundtrip yields empty string', async () => {
       const terminal = createMockTerminal({ name: 'zsh' });
       Object.defineProperty(mockAdapter, 'activeTerminal', { get: () => terminal });
-      mockClipboardService.capture.mockResolvedValue(
-        ExtensionResult.ok({ clipboard: '', produced: undefined }),
-      );
+      mockClipboardService.capture.mockResolvedValue(ExtensionResult.ok({ clipboard: '', produced: undefined }));
 
       const result = await service.pasteTerminalSelectionToDestination();
 
@@ -144,9 +132,7 @@ describe('TerminalSelectionService', () => {
     it('returns picker-cancelled when resolveDestination returns undefined', async () => {
       const terminal = createMockTerminal({ name: 'zsh' });
       Object.defineProperty(mockAdapter, 'activeTerminal', { get: () => terminal });
-      mockClipboardService.capture.mockResolvedValue(
-        ExtensionResult.ok({ clipboard: 'selected text', produced: undefined }),
-      );
+      mockClipboardService.capture.mockResolvedValue(ExtensionResult.ok({ clipboard: 'selected text', produced: undefined }));
       mockSendRouter.resolveDestination.mockResolvedValue({ canProceed: false });
 
       const result = await service.pasteTerminalSelectionToDestination();
@@ -158,9 +144,7 @@ describe('TerminalSelectionService', () => {
     it('sends content to destination and returns success', async () => {
       const terminal = createMockTerminal({ name: 'zsh' });
       Object.defineProperty(mockAdapter, 'activeTerminal', { get: () => terminal });
-      mockClipboardService.capture.mockResolvedValue(
-        ExtensionResult.ok({ clipboard: 'selected text', produced: undefined }),
-      );
+      mockClipboardService.capture.mockResolvedValue(ExtensionResult.ok({ clipboard: 'selected text', produced: undefined }));
       mockSendRouter.resolveDestination.mockResolvedValue({
         canProceed: true,
         bindPerformed: false,
@@ -204,9 +188,7 @@ describe('TerminalSelectionService', () => {
     it('shows info tip when paste succeeds', async () => {
       const terminal = createMockTerminal({ name: 'zsh' });
       Object.defineProperty(mockAdapter, 'activeTerminal', { get: () => terminal });
-      mockClipboardService.capture.mockResolvedValue(
-        ExtensionResult.ok({ clipboard: 'text', produced: undefined }),
-      );
+      mockClipboardService.capture.mockResolvedValue(ExtensionResult.ok({ clipboard: 'text', produced: undefined }));
       mockSendRouter.resolveDestination.mockResolvedValue({
         canProceed: true,
         bindPerformed: false,
@@ -237,10 +219,7 @@ describe('TerminalSelectionService', () => {
 
       expect(formatMessageSpy).toHaveBeenCalledWith('ERROR_TERMINAL_COPY_LINK_NOT_SUPPORTED');
       expect(mockShowErrorMessage).toHaveBeenCalledTimes(1);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'TerminalSelectionService.terminalCopyLinkGuard' },
-        'R-C pressed in terminal context',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'TerminalSelectionService.terminalCopyLinkGuard' }, 'R-C pressed in terminal context');
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/services/TextSelectionPaster.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/services/TextSelectionPaster.test.ts
@@ -35,13 +35,7 @@ describe('TextSelectionPaster', () => {
     mockSelectionValidator = {
       validateSelectionsAndShowError: jest.fn(),
     };
-    paster = new TextSelectionPaster(
-      mockDestinationManager,
-      mockConfigReader,
-      mockSendRouter as any,
-      mockSelectionValidator as any,
-      mockLogger,
-    );
+    paster = new TextSelectionPaster(mockDestinationManager, mockConfigReader, mockSendRouter as any, mockSelectionValidator as any, mockLogger);
   });
 
   it('returns early when validation fails', async () => {

--- a/packages/rangelink-vscode-extension/src/__tests__/services/handleDirtyBufferWarning.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/services/handleDirtyBufferWarning.test.ts
@@ -1,12 +1,6 @@
 import { handleDirtyBufferWarning } from '../../services/handleDirtyBufferWarning';
 import { FILE_PATH_DIRTY_BUFFER_CODES, LINK_DIRTY_BUFFER_CODES } from '../../services/types';
-import {
-  createMockConfigReader,
-  createMockDocument,
-  createMockUri,
-  createMockVscodeAdapter,
-  spyOnFormatMessage,
-} from '../helpers';
+import { createMockConfigReader, createMockDocument, createMockUri, createMockVscodeAdapter, spyOnFormatMessage } from '../helpers';
 
 import { createMockLogger } from '@couimet/logger-contract-testing';
 
@@ -33,13 +27,7 @@ describe('handleDirtyBufferWarning', () => {
     const configReader = createConfigReader();
     const cleanDoc = createMockDocument({ uri: MOCK_URI, isDirty: false });
 
-    const result = await handleDirtyBufferWarning(
-      cleanDoc,
-      configReader,
-      mockAdapter,
-      mockLogger,
-      LINK_DIRTY_BUFFER_CODES,
-    );
+    const result = await handleDirtyBufferWarning(cleanDoc, configReader, mockAdapter, mockLogger, LINK_DIRTY_BUFFER_CODES);
 
     expect(result).toBe('Clean');
   });
@@ -49,13 +37,7 @@ describe('handleDirtyBufferWarning', () => {
     const showWarnSpy = jest.spyOn(mockAdapter, 'showWarningMessage');
     const configReader = createConfigReader(false);
 
-    const result = await handleDirtyBufferWarning(
-      createDirtyDoc(),
-      configReader,
-      mockAdapter,
-      mockLogger,
-      LINK_DIRTY_BUFFER_CODES,
-    );
+    const result = await handleDirtyBufferWarning(createDirtyDoc(), configReader, mockAdapter, mockLogger, LINK_DIRTY_BUFFER_CODES);
 
     expect(result).toBe('ContinueAnyway');
     expect(showWarnSpy).not.toHaveBeenCalled();
@@ -77,20 +59,11 @@ describe('handleDirtyBufferWarning', () => {
       return `mock:${code}`;
     });
 
-    const result = await handleDirtyBufferWarning(
-      mockDoc,
-      configReader,
-      mockAdapter,
-      mockLogger,
-      LINK_DIRTY_BUFFER_CODES,
-    );
+    const result = await handleDirtyBufferWarning(mockDoc, configReader, mockAdapter, mockLogger, LINK_DIRTY_BUFFER_CODES);
 
     expect(result).toBe('SaveAndContinue');
     expect(mockDoc.save).toHaveBeenCalledTimes(1);
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'handleDirtyBufferWarning' },
-      'Document saved successfully',
-    );
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'handleDirtyBufferWarning' }, 'Document saved successfully');
   });
 
   it('returns SaveFailed and shows warning when save fails', async () => {
@@ -106,20 +79,11 @@ describe('handleDirtyBufferWarning', () => {
       return `mock:${code}`;
     });
 
-    const result = await handleDirtyBufferWarning(
-      mockDoc,
-      configReader,
-      mockAdapter,
-      mockLogger,
-      LINK_DIRTY_BUFFER_CODES,
-    );
+    const result = await handleDirtyBufferWarning(mockDoc, configReader, mockAdapter, mockLogger, LINK_DIRTY_BUFFER_CODES);
 
     expect(result).toBe('SaveFailed');
     expect(mockAdapter.showWarningMessage).toHaveBeenNthCalledWith(2, 'Save failed');
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      { fn: 'handleDirtyBufferWarning' },
-      'Save operation failed or was cancelled',
-    );
+    expect(mockLogger.warn).toHaveBeenCalledWith({ fn: 'handleDirtyBufferWarning' }, 'Save operation failed or was cancelled');
   });
 
   it('returns ContinueAnyway when user chooses to generate without saving', async () => {
@@ -133,19 +97,10 @@ describe('handleDirtyBufferWarning', () => {
       return `mock:${code}`;
     });
 
-    const result = await handleDirtyBufferWarning(
-      createDirtyDoc(),
-      configReader,
-      mockAdapter,
-      mockLogger,
-      LINK_DIRTY_BUFFER_CODES,
-    );
+    const result = await handleDirtyBufferWarning(createDirtyDoc(), configReader, mockAdapter, mockLogger, LINK_DIRTY_BUFFER_CODES);
 
     expect(result).toBe('ContinueAnyway');
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'handleDirtyBufferWarning' },
-      'User chose to continue without saving',
-    );
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'handleDirtyBufferWarning' }, 'User chose to continue without saving');
   });
 
   it('returns Dismissed when user dismisses the dialog', async () => {
@@ -160,20 +115,11 @@ describe('handleDirtyBufferWarning', () => {
       return `mock:${code}`;
     });
 
-    const result = await handleDirtyBufferWarning(
-      createDirtyDoc(),
-      configReader,
-      mockAdapter,
-      mockLogger,
-      LINK_DIRTY_BUFFER_CODES,
-    );
+    const result = await handleDirtyBufferWarning(createDirtyDoc(), configReader, mockAdapter, mockLogger, LINK_DIRTY_BUFFER_CODES);
 
     expect(result).toBe('Dismissed');
     expect(showInfoSpy).toHaveBeenCalledWith('mock:INFO_OPERATION_ABORTED_DIRTY_BUFFER');
-    expect(mockLogger.debug).toHaveBeenCalledWith(
-      { fn: 'handleDirtyBufferWarning' },
-      'User dismissed warning, aborting',
-    );
+    expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'handleDirtyBufferWarning' }, 'User dismissed warning, aborting');
   });
 
   it('uses custom message codes when provided', async () => {
@@ -188,13 +134,7 @@ describe('handleDirtyBufferWarning', () => {
       return `mock:${code}`;
     });
 
-    const result = await handleDirtyBufferWarning(
-      mockDoc,
-      configReader,
-      mockAdapter,
-      mockLogger,
-      FILE_PATH_DIRTY_BUFFER_CODES,
-    );
+    const result = await handleDirtyBufferWarning(mockDoc, configReader, mockAdapter, mockLogger, FILE_PATH_DIRTY_BUFFER_CODES);
 
     expect(result).toBe('SaveAndContinue');
     expect(formatMessageSpy).toHaveBeenCalledWith('WARN_FILE_PATH_DIRTY_BUFFER');

--- a/packages/rangelink-vscode-extension/src/__tests__/statusBar/RangeLinkStatusBar.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/statusBar/RangeLinkStatusBar.test.ts
@@ -11,11 +11,7 @@ import type { BoundSession } from '../../destinations';
 import type { FilePickerHandlers, TerminalPickerHandlers } from '../../destinations/types';
 import { RangeLinkExtensionError, RangeLinkExtensionErrorCodes } from '../../errors';
 import { RangeLinkStatusBar } from '../../statusBar/RangeLinkStatusBar';
-import {
-  ExtensionResult,
-  FileBindableQuickPickItem,
-  TerminalBindableQuickPickItem,
-} from '../../types';
+import { ExtensionResult, FileBindableQuickPickItem, TerminalBindableQuickPickItem } from '../../types';
 import {
   createMockBookmarkService,
   createMockBoundSession,
@@ -104,14 +100,7 @@ describe('RangeLinkStatusBar', () => {
 
   describe('constructor', () => {
     it('creates and configures status bar item', () => {
-      new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       expect(createStatusBarItemMock).toHaveBeenCalledTimes(1);
       expect(createStatusBarItemMock).toHaveBeenCalledWith(vscode.StatusBarAlignment.Right, 100);
@@ -123,10 +112,7 @@ describe('RangeLinkStatusBar', () => {
         { fn: 'RangeLinkStatusBar.updateStatusBarAppearance', isBound: false },
         'Status bar appearance updated for unbound state',
       );
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'RangeLinkStatusBar.constructor' },
-        'Status bar item created',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'RangeLinkStatusBar.constructor' }, 'Status bar item created');
     });
 
     it('uses bound destination tooltip and color when destination is bound at construction', () => {
@@ -137,19 +123,10 @@ describe('RangeLinkStatusBar', () => {
       mockSession.isSet.mockReturnValue(true);
       mockSession.get.mockReturnValue(mockBoundDest);
 
-      new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       expect(mockStatusBarItem.tooltip).toBe('RangeLink — Terminal ("bash")');
-      expect(mockStatusBarItem.color).toStrictEqual(
-        new vscode.ThemeColor('statusBarItem.prominentForeground'),
-      );
+      expect(mockStatusBarItem.color).toStrictEqual(new vscode.ThemeColor('statusBarItem.prominentForeground'));
       expect(mockLogger.debug).toHaveBeenCalledWith(
         {
           fn: 'RangeLinkStatusBar.updateStatusBarAppearance',
@@ -163,14 +140,7 @@ describe('RangeLinkStatusBar', () => {
 
   describe('updateStatusBarAppearance', () => {
     it('updates tooltip and color when bound event fires', () => {
-      new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       (mockSession as any)._emitter.fire({
         id: 'terminal',
@@ -178,20 +148,11 @@ describe('RangeLinkStatusBar', () => {
       });
 
       expect(mockStatusBarItem.tooltip).toBe('RangeLink — Terminal ("zsh")');
-      expect(mockStatusBarItem.color).toStrictEqual(
-        new vscode.ThemeColor('statusBarItem.prominentForeground'),
-      );
+      expect(mockStatusBarItem.color).toStrictEqual(new vscode.ThemeColor('statusBarItem.prominentForeground'));
     });
 
     it('resets tooltip and color when unbound event fires', () => {
-      new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       (mockSession as any)._emitter.fire(undefined);
 
@@ -230,14 +191,7 @@ describe('RangeLinkStatusBar', () => {
           },
         ],
       });
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
@@ -290,14 +244,7 @@ describe('RangeLinkStatusBar', () => {
     });
 
     it('shows "no destinations available" when unbound and no destinations exist', async () => {
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
@@ -334,14 +281,7 @@ describe('RangeLinkStatusBar', () => {
       const boundDestinationManager = createMockDestinationManager();
       mockSession.isSet.mockReturnValue(true);
       mockSession.get.mockReturnValue(mockBoundDestination);
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        boundDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, boundDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
@@ -380,14 +320,7 @@ describe('RangeLinkStatusBar', () => {
       const boundDestinationManager = createMockDestinationManager();
       mockSession.isSet.mockReturnValue(true);
       mockSession.get.mockReturnValue(mockBoundDestination);
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        boundDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, boundDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
@@ -436,14 +369,7 @@ describe('RangeLinkStatusBar', () => {
         ],
       });
       mockBookmarkService.getAllBookmarks.mockReturnValue(MOCK_BOOKMARKS);
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
@@ -508,14 +434,7 @@ describe('RangeLinkStatusBar', () => {
         itemKind: 'command',
         command: 'synthetic.testCommand',
       });
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
@@ -537,23 +456,14 @@ describe('RangeLinkStatusBar', () => {
     it('binds without focusing when bindable item is selected', async () => {
       const mockTerminal = createMockTerminal();
       const bindOptions = { kind: 'terminal' as const, terminal: mockTerminal };
-      mockDestinationManager.bind.mockResolvedValue(
-        ExtensionResult.ok({ destinationName: 'Terminal', destinationKind: 'terminal' }),
-      );
+      mockDestinationManager.bind.mockResolvedValue(ExtensionResult.ok({ destinationName: 'Terminal', destinationKind: 'terminal' }));
       showQuickPickMock.mockResolvedValue({
         label: '    $(arrow-right) Terminal',
         itemKind: 'bindable',
         bindOptions,
         displayName: 'Terminal',
       });
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
@@ -589,14 +499,7 @@ describe('RangeLinkStatusBar', () => {
         displayName: 'Terminal',
       };
       showQuickPickMock.mockResolvedValue(selectedItem);
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
@@ -616,44 +519,24 @@ describe('RangeLinkStatusBar', () => {
     it('logs when info item is selected', async () => {
       const infoItem = { label: 'Synthetic Info Item', itemKind: 'info' as const };
       showQuickPickMock.mockResolvedValue(infoItem);
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
       expect(executeCommandMock).not.toHaveBeenCalled();
       expect(mockDestinationManager.bindAndFocus).not.toHaveBeenCalled();
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'RangeLinkStatusBar.openMenu', selectedItem: infoItem },
-        'Non-actionable item selected',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'RangeLinkStatusBar.openMenu', selectedItem: infoItem }, 'Non-actionable item selected');
     });
 
     it('logs dismissal and takes no action when user dismisses QuickPick', async () => {
       showQuickPickMock.mockResolvedValue(QUICK_PICK_DISMISSED);
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
       expect(executeCommandMock).not.toHaveBeenCalled();
       expect(mockDestinationManager.bindAndFocus).not.toHaveBeenCalled();
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'RangeLinkStatusBar.openMenu' },
-        'User dismissed menu',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'RangeLinkStatusBar.openMenu' }, 'User dismissed menu');
     });
   });
 
@@ -669,12 +552,8 @@ describe('RangeLinkStatusBar', () => {
       const mockTerminal = createMockTerminal({ name: 'bash' });
       const eligibleTerminal = createMockEligibleTerminal({ terminal: mockTerminal });
 
-      mockAvailabilityService.getTerminalItems.mockResolvedValue([
-        createMockTerminalQuickPickItem(mockTerminal),
-      ]);
-      mockDestinationManager.bind.mockResolvedValue(
-        ExtensionResult.ok({ destinationName: 'bash', destinationKind: 'terminal' }),
-      );
+      mockAvailabilityService.getTerminalItems.mockResolvedValue([createMockTerminalQuickPickItem(mockTerminal)]);
+      mockDestinationManager.bind.mockResolvedValue(ExtensionResult.ok({ destinationName: 'bash', destinationKind: 'terminal' }));
 
       showQuickPickMock.mockResolvedValueOnce(terminalMoreItem);
 
@@ -691,14 +570,7 @@ describe('RangeLinkStatusBar', () => {
         },
       );
 
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
@@ -727,9 +599,7 @@ describe('RangeLinkStatusBar', () => {
         functionName: 'PasteDestinationManager.bind',
       });
 
-      mockAvailabilityService.getTerminalItems.mockResolvedValue([
-        createMockTerminalQuickPickItem(mockTerminal),
-      ]);
+      mockAvailabilityService.getTerminalItems.mockResolvedValue([createMockTerminalQuickPickItem(mockTerminal)]);
       mockDestinationManager.bind.mockResolvedValue(ExtensionResult.err(bindError));
 
       showQuickPickMock.mockResolvedValueOnce(terminalMoreItem);
@@ -745,14 +615,7 @@ describe('RangeLinkStatusBar', () => {
         },
       );
 
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
@@ -772,13 +635,9 @@ describe('RangeLinkStatusBar', () => {
     });
 
     it('re-opens status bar menu when user cancels secondary terminal picker', async () => {
-      mockAvailabilityService.getTerminalItems.mockResolvedValue([
-        createMockTerminalQuickPickItem(createMockTerminal()),
-      ]);
+      mockAvailabilityService.getTerminalItems.mockResolvedValue([createMockTerminalQuickPickItem(createMockTerminal())]);
 
-      showQuickPickMock
-        .mockResolvedValueOnce(terminalMoreItem)
-        .mockResolvedValueOnce(QUICK_PICK_DISMISSED);
+      showQuickPickMock.mockResolvedValueOnce(terminalMoreItem).mockResolvedValueOnce(QUICK_PICK_DISMISSED);
 
       showTerminalPickerSpy.mockImplementation(
         async (
@@ -791,14 +650,7 @@ describe('RangeLinkStatusBar', () => {
         },
       );
 
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
@@ -819,9 +671,7 @@ describe('RangeLinkStatusBar', () => {
       const fileItem = createMockTextEditorQuickPickItem(eligibleFile);
 
       mockAvailabilityService.getAllFileItems.mockReturnValue([fileItem]);
-      mockDestinationManager.bind.mockResolvedValue(
-        ExtensionResult.ok({ destinationName: 'app.ts', destinationKind: 'text-editor' }),
-      );
+      mockDestinationManager.bind.mockResolvedValue(ExtensionResult.ok({ destinationName: 'app.ts', destinationKind: 'text-editor' }));
 
       showQuickPickMock.mockResolvedValueOnce(fileMoreItem);
 
@@ -838,14 +688,7 @@ describe('RangeLinkStatusBar', () => {
         },
       );
 
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
@@ -887,14 +730,7 @@ describe('RangeLinkStatusBar', () => {
         },
       );
 
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
@@ -915,14 +751,7 @@ describe('RangeLinkStatusBar', () => {
 
       showQuickPickMock.mockResolvedValueOnce(fileMoreItem);
 
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
@@ -931,9 +760,7 @@ describe('RangeLinkStatusBar', () => {
         { fn: 'RangeLinkStatusBar.openMenu', selectedItem: fileMoreItem },
         'No files available in secondary picker',
       );
-      expect(showErrorMessageMock).toHaveBeenCalledWith(
-        'No bindable text editor. Open a file and try again.',
-      );
+      expect(showErrorMessageMock).toHaveBeenCalledWith('No bindable text editor. Open a file and try again.');
     });
 
     it('re-opens status bar menu when user cancels secondary file picker', async () => {
@@ -942,9 +769,7 @@ describe('RangeLinkStatusBar', () => {
 
       mockAvailabilityService.getAllFileItems.mockReturnValue([fileItem]);
 
-      showQuickPickMock
-        .mockResolvedValueOnce(fileMoreItem)
-        .mockResolvedValueOnce(QUICK_PICK_DISMISSED);
+      showQuickPickMock.mockResolvedValueOnce(fileMoreItem).mockResolvedValueOnce(QUICK_PICK_DISMISSED);
 
       showFilePickerSpy.mockImplementation(
         async (
@@ -957,14 +782,7 @@ describe('RangeLinkStatusBar', () => {
         },
       );
 
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
@@ -984,14 +802,7 @@ describe('RangeLinkStatusBar', () => {
         itemKind: 'bookmark',
         bookmarkId: 'bookmark-1',
       });
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
@@ -1023,14 +834,7 @@ describe('RangeLinkStatusBar', () => {
         bookmarkId: 'bookmark-1',
       });
       mockBookmarkService.sendBookmark.mockRejectedValue(sendError);
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
@@ -1039,21 +843,13 @@ describe('RangeLinkStatusBar', () => {
         itemKind: 'bookmark',
         bookmarkId: 'bookmark-1',
       };
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        { fn: 'RangeLinkStatusBar.openMenu', selectedItem, error: sendError },
-        'Bookmark send failed',
-      );
-      expect(showErrorMessageMock).toHaveBeenCalledWith(
-        'Cannot send bookmark — no destination is currently bound',
-      );
+      expect(mockLogger.error).toHaveBeenCalledWith({ fn: 'RangeLinkStatusBar.openMenu', selectedItem, error: sendError }, 'Bookmark send failed');
+      expect(showErrorMessageMock).toHaveBeenCalledWith('Cannot send bookmark — no destination is currently bound');
       expect(mockLogger.debug).toHaveBeenCalledWith(
         { fn: 'RangeLinkStatusBar.updateStatusBarAppearance', isBound: false },
         'Status bar appearance updated for unbound state',
       );
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'RangeLinkStatusBar.constructor' },
-        'Status bar item created',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'RangeLinkStatusBar.constructor' }, 'Status bar item created');
     });
 
     it('shows generic error message when sendBookmark throws a non-destination error', async () => {
@@ -1064,14 +860,7 @@ describe('RangeLinkStatusBar', () => {
         bookmarkId: 'bookmark-1',
       });
       mockBookmarkService.sendBookmark.mockRejectedValue(sendError);
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       await statusBar.openMenu();
 
@@ -1080,49 +869,27 @@ describe('RangeLinkStatusBar', () => {
         itemKind: 'bookmark',
         bookmarkId: 'bookmark-1',
       };
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        { fn: 'RangeLinkStatusBar.openMenu', selectedItem, error: sendError },
-        'Bookmark send failed',
-      );
+      expect(mockLogger.error).toHaveBeenCalledWith({ fn: 'RangeLinkStatusBar.openMenu', selectedItem, error: sendError }, 'Bookmark send failed');
       expect(showErrorMessageMock).toHaveBeenCalledWith('Failed to send bookmark');
     });
   });
 
   describe('dispose', () => {
     it('disposes status bar item and logs', () => {
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
       statusBar.dispose();
 
       expect(mockStatusBarItem.dispose).toHaveBeenCalledTimes(1);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'RangeLinkStatusBar.dispose' },
-        'Status bar disposed',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'RangeLinkStatusBar.dispose' }, 'Status bar disposed');
     });
   });
 
   describe('buildBookmarksQuickPickItems', () => {
     it('returns empty bookmarks message when no bookmarks', () => {
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
-      const items = (
-        statusBar as unknown as { buildBookmarksQuickPickItems: () => unknown[] }
-      ).buildBookmarksQuickPickItems();
+      const items = (statusBar as unknown as { buildBookmarksQuickPickItems: () => unknown[] }).buildBookmarksQuickPickItems();
 
       expect(items).toStrictEqual([
         MENU_ITEM_SEPARATOR,
@@ -1145,18 +912,9 @@ describe('RangeLinkStatusBar', () => {
 
     it('returns bookmark items when bookmarks exist', () => {
       mockBookmarkService.getAllBookmarks.mockReturnValue(MOCK_BOOKMARKS);
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
 
-      const items = (
-        statusBar as unknown as { buildBookmarksQuickPickItems: () => unknown[] }
-      ).buildBookmarksQuickPickItems();
+      const items = (statusBar as unknown as { buildBookmarksQuickPickItems: () => unknown[] }).buildBookmarksQuickPickItems();
 
       expect(items).toStrictEqual([
         MENU_ITEM_SEPARATOR,
@@ -1187,18 +945,8 @@ describe('RangeLinkStatusBar', () => {
     });
 
     it('is called by buildQuickPickItems', async () => {
-      const statusBar = new RangeLinkStatusBar(
-        mockAdapter,
-        mockDestinationManager,
-        mockSession,
-        mockAvailabilityService,
-        mockBookmarkService,
-        mockLogger,
-      );
-      const spy = jest.spyOn(
-        statusBar as unknown as { buildBookmarksQuickPickItems: () => unknown[] },
-        'buildBookmarksQuickPickItems',
-      );
+      const statusBar = new RangeLinkStatusBar(mockAdapter, mockDestinationManager, mockSession, mockAvailabilityService, mockBookmarkService, mockLogger);
+      const spy = jest.spyOn(statusBar as unknown as { buildBookmarksQuickPickItems: () => unknown[] }, 'buildBookmarksQuickPickItems');
 
       await statusBar.openMenu();
 

--- a/packages/rangelink-vscode-extension/src/__tests__/toInputSelection.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/toInputSelection.test.ts
@@ -14,12 +14,7 @@ let mockLogger: Logger;
 /**
  * Helper to create a mock vscode.Selection
  */
-const createSelection = (
-  startLine: number,
-  startPosition: number,
-  endLine: number,
-  endPosition: number,
-): vscode.Selection => {
+const createSelection = (startLine: number, startPosition: number, endLine: number, endPosition: number): vscode.Selection => {
   return {
     start: { line: startLine, character: startPosition },
     end: { line: endLine, character: endPosition },
@@ -33,10 +28,7 @@ const createSelection = (
 /**
  * Helper to create a mock TextEditor
  */
-const createMockEditor = (
-  selections: vscode.Selection[],
-  lineTexts: string[],
-): vscode.TextEditor => {
+const createMockEditor = (selections: vscode.Selection[], lineTexts: string[]): vscode.TextEditor => {
   const mockDocument = {
     lineAt: jest.fn((lineNumber: number) => {
       const text = lineTexts[lineNumber] ?? '';
@@ -82,10 +74,7 @@ describe('toInputSelection', () => {
 
       it('should detect FullLine when selection extends beyond actual line end', () => {
         const lineText = 'const x = 5;';
-        const editor = createMockEditor(
-          [createSelection(0, 0, 0, lineText.length + 10)],
-          [lineText],
-        );
+        const editor = createMockEditor([createSelection(0, 0, 0, lineText.length + 10)], [lineText]);
 
         (isRectangularSelection as jest.Mock).mockReturnValue(false);
 
@@ -151,10 +140,7 @@ describe('toInputSelection', () => {
       it('should detect PartialLine when selection does not start at column 0', () => {
         const lineText = 'const x = 5;';
         const startPosition = getUniqueInt();
-        const editor = createMockEditor(
-          [createSelection(0, startPosition, 0, lineText.length)],
-          [lineText],
-        );
+        const editor = createMockEditor([createSelection(0, startPosition, 0, lineText.length)], [lineText]);
 
         (isRectangularSelection as jest.Mock).mockReturnValue(false);
 
@@ -185,10 +171,7 @@ describe('toInputSelection', () => {
         const lineText = 'const x = 5; more text';
         const startPosition = getUniqueInt();
         const endPosition = startPosition + 5;
-        const editor = createMockEditor(
-          [createSelection(0, startPosition, 0, endPosition)],
-          [lineText],
-        );
+        const editor = createMockEditor([createSelection(0, startPosition, 0, endPosition)], [lineText]);
 
         (isRectangularSelection as jest.Mock).mockReturnValue(false);
 
@@ -461,8 +444,7 @@ describe('toInputSelection', () => {
       const result = toInputSelection(editor.document, editor.selections, mockLogger);
 
       expect(result).toHaveDetailedError('SELECTION_CONVERSION_FAILED', {
-        message:
-          'Cannot generate link: document was modified and selection is no longer valid. Please reselect and try again.',
+        message: 'Cannot generate link: document was modified and selection is no longer valid. Please reselect and try again.',
         functionName: 'toInputSelection',
       });
     });
@@ -495,8 +477,7 @@ describe('toInputSelection', () => {
       const result = toInputSelection(mockDocument, selections, mockLogger);
 
       expect(result).toHaveDetailedError('SELECTION_CONVERSION_FAILED', {
-        message:
-          'Cannot generate link: document was modified and selection is no longer valid. Please reselect and try again.',
+        message: 'Cannot generate link: document was modified and selection is no longer valid. Please reselect and try again.',
         functionName: 'toInputSelection',
       });
       expect(mockLogger.error).toHaveBeenCalledWith(
@@ -537,8 +518,7 @@ describe('toInputSelection', () => {
       const result = toInputSelection(mockDocument, selections, mockLogger);
 
       expect(result).toHaveDetailedError('SELECTION_CONVERSION_FAILED', {
-        message:
-          'Cannot generate link: document was modified and selection is no longer valid. Please reselect and try again.',
+        message: 'Cannot generate link: document was modified and selection is no longer valid. Please reselect and try again.',
         functionName: 'toInputSelection',
       });
       expect(mockLogger.error).toHaveBeenCalledWith(
@@ -636,10 +616,7 @@ describe('toInputSelection', () => {
   describe('Diagnostic logging', () => {
     it('should log DEBUG on entry with input selections and document state', () => {
       const lineTexts = ['const x = 5;', 'const y = 10;'];
-      const editor = createMockEditor(
-        [createSelection(0, 0, 0, 12), createSelection(1, 0, 1, 13)],
-        lineTexts,
-      );
+      const editor = createMockEditor([createSelection(0, 0, 0, 12), createSelection(1, 0, 1, 13)], lineTexts);
 
       (isRectangularSelection as jest.Mock).mockReturnValue(true);
 
@@ -707,8 +684,7 @@ describe('toInputSelection', () => {
       const result = toInputSelection(editor.document, editor.selections, mockLogger);
 
       expect(result).toHaveDetailedError('SELECTION_CONVERSION_FAILED', {
-        message:
-          'Cannot generate link: document was modified and selection is no longer valid. Please reselect and try again.',
+        message: 'Cannot generate link: document was modified and selection is no longer valid. Please reselect and try again.',
         functionName: 'toInputSelection',
       });
       expect(mockLogger.error).toHaveBeenCalledWith(

--- a/packages/rangelink-vscode-extension/src/__tests__/utils/expandPathForDisplay.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/utils/expandPathForDisplay.test.ts
@@ -11,9 +11,7 @@ describe('expandPathForDisplay', () => {
     it('should expand ~/ to the OS home directory', () => {
       jest.spyOn(os, 'homedir').mockReturnValue(MOCK_HOME);
 
-      expect(expandPathForDisplay('~/projects/app/main.ts', CONTEXT_FS_PATH)).toBe(
-        `${MOCK_HOME}/projects/app/main.ts`,
-      );
+      expect(expandPathForDisplay('~/projects/app/main.ts', CONTEXT_FS_PATH)).toBe(`${MOCK_HOME}/projects/app/main.ts`);
     });
 
     it('should expand ~/file.ts at root of home', () => {
@@ -25,41 +23,29 @@ describe('expandPathForDisplay', () => {
     it('should expand ~/ path containing spaces', () => {
       jest.spyOn(os, 'homedir').mockReturnValue(MOCK_HOME);
 
-      expect(expandPathForDisplay('~/my projects/app/main.ts', CONTEXT_FS_PATH)).toBe(
-        `${MOCK_HOME}/my projects/app/main.ts`,
-      );
+      expect(expandPathForDisplay('~/my projects/app/main.ts', CONTEXT_FS_PATH)).toBe(`${MOCK_HOME}/my projects/app/main.ts`);
     });
   });
 
   describe('relative paths', () => {
     it('should resolve ./ relative to context directory', () => {
-      expect(expandPathForDisplay('./src/file.ts', CONTEXT_FS_PATH)).toBe(
-        `${CONTEXT_DIR}/src/file.ts`,
-      );
+      expect(expandPathForDisplay('./src/file.ts', CONTEXT_FS_PATH)).toBe(`${CONTEXT_DIR}/src/file.ts`);
     });
 
     it('should resolve ./ path containing spaces', () => {
-      expect(expandPathForDisplay('./my components/button.tsx', CONTEXT_FS_PATH)).toBe(
-        `${CONTEXT_DIR}/my components/button.tsx`,
-      );
+      expect(expandPathForDisplay('./my components/button.tsx', CONTEXT_FS_PATH)).toBe(`${CONTEXT_DIR}/my components/button.tsx`);
     });
 
     it('should resolve ../ relative to context directory', () => {
-      expect(expandPathForDisplay('../lib/util.ts', CONTEXT_FS_PATH)).toBe(
-        '/workspace/lib/util.ts',
-      );
+      expect(expandPathForDisplay('../lib/util.ts', CONTEXT_FS_PATH)).toBe('/workspace/lib/util.ts');
     });
 
     it('should resolve ../ path containing spaces', () => {
-      expect(expandPathForDisplay('../shared lib/util.ts', CONTEXT_FS_PATH)).toBe(
-        '/workspace/shared lib/util.ts',
-      );
+      expect(expandPathForDisplay('../shared lib/util.ts', CONTEXT_FS_PATH)).toBe('/workspace/shared lib/util.ts');
     });
 
     it('should resolve multiple ../ segments', () => {
-      expect(expandPathForDisplay('../../shared/types.ts', CONTEXT_FS_PATH)).toBe(
-        '/shared/types.ts',
-      );
+      expect(expandPathForDisplay('../../shared/types.ts', CONTEXT_FS_PATH)).toBe('/shared/types.ts');
     });
   });
 
@@ -69,9 +55,7 @@ describe('expandPathForDisplay', () => {
     });
 
     it('should return absolute path with spaces unchanged', () => {
-      expect(expandPathForDisplay('/path/with spaces/file.ts', CONTEXT_FS_PATH)).toBe(
-        '/path/with spaces/file.ts',
-      );
+      expect(expandPathForDisplay('/path/with spaces/file.ts', CONTEXT_FS_PATH)).toBe('/path/with spaces/file.ts');
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/utils/formatClampingSummary.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/utils/formatClampingSummary.test.ts
@@ -78,15 +78,11 @@ describe('formatClampingSummary', () => {
 
   describe('no clamping (unexpected switch value)', () => {
     it('should throw UNEXPECTED_SWITCH_VALUE when no clamping flags are set', () => {
-      expect(() => formatClampingSummary(NO_CLAMPING, NO_CLAMPING)).toThrowDetailedError(
-        'UNEXPECTED_SWITCH_VALUE',
-        {
-          message:
-            'Unexpected clamping summary state: {"lineClamped":false,"characterClamped":false}',
-          functionName: 'formatClampingSummary',
-          details: { unexpectedValue: { lineClamped: false, characterClamped: false } },
-        },
-      );
+      expect(() => formatClampingSummary(NO_CLAMPING, NO_CLAMPING)).toThrowDetailedError('UNEXPECTED_SWITCH_VALUE', {
+        message: 'Unexpected clamping summary state: {"lineClamped":false,"characterClamped":false}',
+        functionName: 'formatClampingSummary',
+        details: { unexpectedValue: { lineClamped: false, characterClamped: false } },
+      });
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/utils/formatLinkTooltip.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/utils/formatLinkTooltip.test.ts
@@ -101,9 +101,7 @@ describe('formatLinkTooltip', () => {
         selectionType: SelectionType.Normal,
       };
 
-      expect(formatLinkTooltip(parsed)).toStrictEqual(
-        'Open C:\\Users\\dev\\project\\src\\file.ts:42:10 • RangeLink',
-      );
+      expect(formatLinkTooltip(parsed)).toStrictEqual('Open C:\\Users\\dev\\project\\src\\file.ts:42:10 • RangeLink');
     });
 
     it('should handle path with hash in filename', () => {
@@ -142,9 +140,7 @@ describe('formatLinkTooltip', () => {
         selectionType: SelectionType.Normal,
       };
 
-      expect(formatLinkTooltip(parsed)).toStrictEqual(
-        'Open /home/user/project/src/file.ts:100:25 • RangeLink',
-      );
+      expect(formatLinkTooltip(parsed)).toStrictEqual('Open /home/user/project/src/file.ts:100:25 • RangeLink');
     });
   });
 
@@ -172,9 +168,7 @@ describe('formatLinkTooltip', () => {
         selectionType: SelectionType.Normal,
       };
 
-      expect(formatLinkTooltip(parsed)).toStrictEqual(
-        'Open bigfile.ts:9999:99-10000:1 • RangeLink',
-      );
+      expect(formatLinkTooltip(parsed)).toStrictEqual('Open bigfile.ts:9999:99-10000:1 • RangeLink');
     });
 
     it('should handle character position 0', () => {

--- a/packages/rangelink-vscode-extension/src/__tests__/utils/generateLinkFromSelections.integration.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/utils/generateLinkFromSelections.integration.test.ts
@@ -7,10 +7,7 @@
  *
  * Purpose: Ensure mocks used in unit tests accurately represent real rangelink-core-ts behavior.
  */
-import {
-  generateLinkFromSelections,
-  type GenerateLinkFromSelectionsOptions,
-} from '../../utils/generateLinkFromSelections';
+import { generateLinkFromSelections, type GenerateLinkFromSelectionsOptions } from '../../utils/generateLinkFromSelections';
 import { createMockDocument, createMockPosition, createMockSelection } from '../helpers';
 
 import { createMockLogger } from '@couimet/logger-contract-testing';
@@ -26,12 +23,7 @@ const DELIMITERS: DelimiterConfig = {
 
 let mockLogger: ReturnType<typeof createMockLogger>;
 
-const mockSelection = (
-  startLine: number,
-  startCharacter: number,
-  endLine: number,
-  endCharacter: number,
-): vscode.Selection => {
+const mockSelection = (startLine: number, startCharacter: number, endLine: number, endCharacter: number): vscode.Selection => {
   const start = createMockPosition({ line: startLine, character: startCharacter });
   const end = createMockPosition({ line: endLine, character: endCharacter });
   return createMockSelection({
@@ -95,10 +87,7 @@ describe('trailing newline normalization integration', () => {
       selectionType: 'Normal',
     };
     expect(result).toBeSuccess(expectedFormattedLink);
-    expect(mockLogger.info).toHaveBeenCalledWith(
-      { fn: 'generateLinkFromSelections', formattedLink: expectedFormattedLink },
-      'Generated link: src/file.ts#L5',
-    );
+    expect(mockLogger.info).toHaveBeenCalledWith({ fn: 'generateLinkFromSelections', formattedLink: expectedFormattedLink }, 'Generated link: src/file.ts#L5');
   });
 
   it('multi-line full selection (Ctrl+L x3) produces #L5-L7 without character positions', () => {

--- a/packages/rangelink-vscode-extension/src/__tests__/utils/generateLinkFromSelections.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/utils/generateLinkFromSelections.test.ts
@@ -1,30 +1,12 @@
 import { RangeLinkExtensionError } from '../../errors/RangeLinkExtensionError';
 import { RangeLinkExtensionErrorCodes } from '../../errors/RangeLinkExtensionErrorCodes';
 import { ExtensionResult } from '../../types';
-import {
-  generateLinkFromSelections,
-  GenerateLinkFromSelectionsOptions,
-} from '../../utils/generateLinkFromSelections';
-import {
-  createMockDocument,
-  createMockFormattedLink,
-  createMockPosition,
-  createMockSelection,
-  spyOnFormatLink,
-  spyOnToInputSelection,
-} from '../helpers';
+import { generateLinkFromSelections, GenerateLinkFromSelectionsOptions } from '../../utils/generateLinkFromSelections';
+import { createMockDocument, createMockFormattedLink, createMockPosition, createMockSelection, spyOnFormatLink, spyOnToInputSelection } from '../helpers';
 
 import type { Logger } from '@couimet/logger-contract';
 import { createMockLogger } from '@couimet/logger-contract-testing';
-import {
-  CoreResult,
-  DelimiterConfig,
-  LinkType,
-  RangeLinkError,
-  RangeLinkErrorCodes,
-  SelectionCoverage,
-  SelectionType,
-} from 'rangelink-core-ts';
+import { CoreResult, DelimiterConfig, LinkType, RangeLinkError, RangeLinkErrorCodes, SelectionCoverage, SelectionType } from 'rangelink-core-ts';
 import * as vscode from 'vscode';
 
 const DELIMITERS: DelimiterConfig = {
@@ -36,13 +18,7 @@ const DELIMITERS: DelimiterConfig = {
 
 const REFERENCE_PATH = 'src/utils/test.ts';
 
-const mockSelection = (
-  startLine: number,
-  startCharacter: number,
-  endLine: number,
-  endCharacter: number,
-  isEmpty = false,
-): vscode.Selection => {
+const mockSelection = (startLine: number, startCharacter: number, endLine: number, endCharacter: number, isEmpty = false): vscode.Selection => {
   const start = createMockPosition({ line: startLine, character: startCharacter });
   const end = createMockPosition({ line: endLine, character: endCharacter });
   return createMockSelection({
@@ -98,10 +74,7 @@ describe('generateLinkFromSelections', () => {
         message: 'No selections provided',
         functionName: 'generateLinkFromSelections',
       });
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'generateLinkFromSelections' },
-        'No selections provided',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'generateLinkFromSelections' }, 'No selections provided');
     });
 
     it('returns error when all selections are empty', () => {
@@ -122,10 +95,7 @@ describe('generateLinkFromSelections', () => {
         message: 'All selections are empty',
         functionName: 'generateLinkFromSelections',
       });
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'generateLinkFromSelections' },
-        'All selections are empty',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'generateLinkFromSelections' }, 'All selections are empty');
     });
   });
 
@@ -292,10 +262,7 @@ describe('generateLinkFromSelections', () => {
         message: 'Invalid selection range',
         functionName: 'formatLink',
       });
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        { fn: 'generateLinkFromSelections', error: formatLinkError },
-        'Failed to generate link',
-      );
+      expect(mockLogger.error).toHaveBeenCalledWith({ fn: 'generateLinkFromSelections', error: formatLinkError }, 'Failed to generate link');
     });
 
     it('returns error with portable link type name when portable link fails', () => {
@@ -336,10 +303,7 @@ describe('generateLinkFromSelections', () => {
         message: 'Invalid selection range',
         functionName: 'formatLink',
       });
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        { fn: 'generateLinkFromSelections', error: formatLinkError },
-        'Failed to generate portable link',
-      );
+      expect(mockLogger.error).toHaveBeenCalledWith({ fn: 'generateLinkFromSelections', error: formatLinkError }, 'Failed to generate portable link');
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/__tests__/utils/isSameFileDestination.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/utils/isSameFileDestination.test.ts
@@ -8,10 +8,7 @@ const createMockUri = (path: string): vscode.Uri =>
     toString: () => `file://${path}`,
   }) as vscode.Uri;
 
-const createMockDestination = (
-  uri: vscode.Uri | undefined,
-  viewColumn?: vscode.ViewColumn,
-): PasteDestination =>
+const createMockDestination = (uri: vscode.Uri | undefined, viewColumn?: vscode.ViewColumn): PasteDestination =>
   ({
     getDestinationUri: () => uri,
     getDestinationViewColumn: () => viewColumn,

--- a/packages/rangelink-vscode-extension/src/__tests__/utils/resolveWorkspacePath.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/utils/resolveWorkspacePath.test.ts
@@ -1,8 +1,4 @@
-import {
-  FILENAME_AMBIGUOUS,
-  ResolvedPath,
-  ResolveWorkspacePathResult,
-} from '../../types/ResolvedPath';
+import { FILENAME_AMBIGUOUS, ResolvedPath, ResolveWorkspacePathResult } from '../../types/ResolvedPath';
 import { resolveWorkspacePath } from '../../utils';
 import { createMockUri, createMockWorkspaceFolder } from '../helpers';
 
@@ -63,10 +59,7 @@ describe('resolveWorkspacePath', () => {
     });
 
     it('should handle platform-native absolute paths', async () => {
-      const absolutePath =
-        process.platform === 'win32'
-          ? 'C:\\Users\\name\\project\\src\\file.ts'
-          : '/Users/name/project/src/file.ts';
+      const absolutePath = process.platform === 'win32' ? 'C:\\Users\\name\\project\\src\\file.ts' : '/Users/name/project/src/file.ts';
 
       mockStat.mockResolvedValueOnce({} as any);
 
@@ -102,10 +95,7 @@ describe('resolveWorkspacePath', () => {
       const relativePath = 'src/auth.ts';
       const expectedPath = path.join(workspace2, relativePath);
 
-      mockVscode.workspace.workspaceFolders = [
-        createMockWorkspaceFolder(workspace1),
-        createMockWorkspaceFolder(workspace2),
-      ];
+      mockVscode.workspace.workspaceFolders = [createMockWorkspaceFolder(workspace1), createMockWorkspaceFolder(workspace2)];
 
       mockStat.mockImplementation((uri: any) => {
         if (uri.fsPath.includes('project1')) {
@@ -129,10 +119,7 @@ describe('resolveWorkspacePath', () => {
       const workspace2 = '/Users/name/project2';
       const relativePath = 'src/nonexistent.ts';
 
-      mockVscode.workspace.workspaceFolders = [
-        createMockWorkspaceFolder(workspace1),
-        createMockWorkspaceFolder(workspace2),
-      ];
+      mockVscode.workspace.workspaceFolders = [createMockWorkspaceFolder(workspace1), createMockWorkspaceFolder(workspace2)];
 
       mockStat.mockImplementation(() => Promise.reject(new Error('File not found')));
 

--- a/packages/rangelink-vscode-extension/src/__tests__/wireSubscriptions.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/wireSubscriptions.test.ts
@@ -55,11 +55,7 @@ import {
 import * as destinationBuildersModule from '../destinations/destinationBuilders';
 import { wireSubscriptions } from '../wireSubscriptions';
 
-import {
-  createMockSubscriptionRegistrar,
-  createMockUri,
-  createMockWiringServices,
-} from './helpers';
+import { createMockSubscriptionRegistrar, createMockUri, createMockWiringServices } from './helpers';
 
 const EXPECTED_COMMANDS = [
   CMD_OPEN_STATUS_BAR_MENU,
@@ -129,9 +125,7 @@ describe('wireSubscriptions', () => {
   });
 
   it('registers all expected commands', () => {
-    const registeredCommands = registrar.registerCommand.mock.calls.map(
-      (call: unknown[]) => call[0] as string,
-    );
+    const registeredCommands = registrar.registerCommand.mock.calls.map((call: unknown[]) => call[0] as string);
 
     for (const cmd of EXPECTED_COMMANDS) {
       expect(registeredCommands).toContain(cmd);
@@ -193,9 +187,7 @@ describe('wireSubscriptions', () => {
 
     it('CMD_TERMINAL_PASTE_SELECTED_TEXT delegates to terminalSelectionService', () => {
       registrar.getHandler(CMD_TERMINAL_PASTE_SELECTED_TEXT)();
-      expect(
-        services.terminalSelectionService.pasteTerminalSelectionToDestination,
-      ).toHaveBeenCalledTimes(1);
+      expect(services.terminalSelectionService.pasteTerminalSelectionToDestination).toHaveBeenCalledTimes(1);
     });
 
     it('CMD_BOOKMARK_ADD delegates to addBookmarkCommand.execute', () => {
@@ -206,42 +198,29 @@ describe('wireSubscriptions', () => {
     it('CMD_PASTE_FILE_PATH_ABSOLUTE delegates to filePathPaster with uri and Absolute', () => {
       const mockUri = createMockUri('/workspace/src/file.ts');
       registrar.getHandler(CMD_PASTE_FILE_PATH_ABSOLUTE)(mockUri);
-      expect(services.filePathPaster.pasteFilePathToDestination).toHaveBeenCalledWith(
-        mockUri,
-        'absolute',
-      );
+      expect(services.filePathPaster.pasteFilePathToDestination).toHaveBeenCalledWith(mockUri, 'absolute');
     });
 
     it('CMD_CONTEXT_EDITOR_CONTENT_PASTE_FILE_PATH calls pasteFilePathToDestination when uri provided', () => {
       const mockUri = createMockUri('/workspace/src/file.ts');
       registrar.getHandler(CMD_CONTEXT_EDITOR_CONTENT_PASTE_FILE_PATH)(mockUri);
-      expect(services.filePathPaster.pasteFilePathToDestination).toHaveBeenCalledWith(
-        mockUri,
-        'absolute',
-      );
+      expect(services.filePathPaster.pasteFilePathToDestination).toHaveBeenCalledWith(mockUri, 'absolute');
     });
 
     it('CMD_CONTEXT_EDITOR_CONTENT_PASTE_FILE_PATH calls pasteCurrentFilePathToDestination when no uri', () => {
       registrar.getHandler(CMD_CONTEXT_EDITOR_CONTENT_PASTE_FILE_PATH)(undefined);
-      expect(services.filePathPaster.pasteCurrentFilePathToDestination).toHaveBeenCalledWith(
-        'absolute',
-      );
+      expect(services.filePathPaster.pasteCurrentFilePathToDestination).toHaveBeenCalledWith('absolute');
     });
 
     it('CMD_CONTEXT_EDITOR_CONTENT_PASTE_RELATIVE_FILE_PATH calls pasteFilePathToDestination when uri provided', () => {
       const mockUri = createMockUri('/workspace/src/file.ts');
       registrar.getHandler(CMD_CONTEXT_EDITOR_CONTENT_PASTE_RELATIVE_FILE_PATH)(mockUri);
-      expect(services.filePathPaster.pasteFilePathToDestination).toHaveBeenCalledWith(
-        mockUri,
-        'workspace-relative',
-      );
+      expect(services.filePathPaster.pasteFilePathToDestination).toHaveBeenCalledWith(mockUri, 'workspace-relative');
     });
 
     it('CMD_CONTEXT_EDITOR_CONTENT_PASTE_RELATIVE_FILE_PATH calls pasteCurrentFilePathToDestination when no uri', () => {
       registrar.getHandler(CMD_CONTEXT_EDITOR_CONTENT_PASTE_RELATIVE_FILE_PATH)(undefined);
-      expect(services.filePathPaster.pasteCurrentFilePathToDestination).toHaveBeenCalledWith(
-        'workspace-relative',
-      );
+      expect(services.filePathPaster.pasteCurrentFilePathToDestination).toHaveBeenCalledWith('workspace-relative');
     });
 
     it('CMD_COPY_PORTABLE_LINK_RELATIVE delegates to linkGenerator.createPortableLink', () => {
@@ -291,16 +270,12 @@ describe('wireSubscriptions', () => {
 
     it('CMD_PASTE_CURRENT_FILE_PATH_ABSOLUTE delegates to filePathPaster.pasteCurrentFilePathToDestination', () => {
       registrar.getHandler(CMD_PASTE_CURRENT_FILE_PATH_ABSOLUTE)();
-      expect(services.filePathPaster.pasteCurrentFilePathToDestination).toHaveBeenCalledWith(
-        'absolute',
-      );
+      expect(services.filePathPaster.pasteCurrentFilePathToDestination).toHaveBeenCalledWith('absolute');
     });
 
     it('CMD_PASTE_CURRENT_FILE_PATH_RELATIVE delegates to filePathPaster.pasteCurrentFilePathToDestination', () => {
       registrar.getHandler(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE)();
-      expect(services.filePathPaster.pasteCurrentFilePathToDestination).toHaveBeenCalledWith(
-        'workspace-relative',
-      );
+      expect(services.filePathPaster.pasteCurrentFilePathToDestination).toHaveBeenCalledWith('workspace-relative');
     });
 
     it('CMD_CONTEXT_EDITOR_COPY_LINK delegates to linkGenerator.createLink', () => {
@@ -344,9 +319,7 @@ describe('wireSubscriptions', () => {
     });
 
     it('CMD_BIND_TO_CUSTOM_AI_BY_ID resolves extensionId and delegates to destinationManager.bind', async () => {
-      const resolveSpy = jest
-        .spyOn(destinationBuildersModule, 'resolveKindByExtensionId')
-        .mockReturnValue('custom-ai:dummy-ai-extension');
+      const resolveSpy = jest.spyOn(destinationBuildersModule, 'resolveKindByExtensionId').mockReturnValue('custom-ai:dummy-ai-extension');
       await registrar.getHandler(CMD_BIND_TO_CUSTOM_AI_BY_ID)({
         extensionId: 'dummy-ai-extension',
       });
@@ -384,28 +357,19 @@ describe('wireSubscriptions', () => {
     it('CMD_PASTE_FILE_PATH_RELATIVE delegates to filePathPaster with WorkspaceRelative', () => {
       const mockUri = createMockUri('/workspace/src/file.ts');
       registrar.getHandler(CMD_PASTE_FILE_PATH_RELATIVE)(mockUri);
-      expect(services.filePathPaster.pasteFilePathToDestination).toHaveBeenCalledWith(
-        mockUri,
-        'workspace-relative',
-      );
+      expect(services.filePathPaster.pasteFilePathToDestination).toHaveBeenCalledWith(mockUri, 'workspace-relative');
     });
 
     it('CMD_CONTEXT_EXPLORER_PASTE_FILE_PATH delegates to filePathPaster with absolute', () => {
       const mockUri = createMockUri('/workspace/src/file.ts');
       registrar.getHandler(CMD_CONTEXT_EXPLORER_PASTE_FILE_PATH)(mockUri);
-      expect(services.filePathPaster.pasteFilePathToDestination).toHaveBeenCalledWith(
-        mockUri,
-        'absolute',
-      );
+      expect(services.filePathPaster.pasteFilePathToDestination).toHaveBeenCalledWith(mockUri, 'absolute');
     });
 
     it('CMD_CONTEXT_EXPLORER_PASTE_RELATIVE_FILE_PATH delegates to filePathPaster with workspace-relative', () => {
       const mockUri = createMockUri('/workspace/src/file.ts');
       registrar.getHandler(CMD_CONTEXT_EXPLORER_PASTE_RELATIVE_FILE_PATH)(mockUri);
-      expect(services.filePathPaster.pasteFilePathToDestination).toHaveBeenCalledWith(
-        mockUri,
-        'workspace-relative',
-      );
+      expect(services.filePathPaster.pasteFilePathToDestination).toHaveBeenCalledWith(mockUri, 'workspace-relative');
     });
 
     it('CMD_CONTEXT_EXPLORER_UNBIND delegates to destinationManager.unbind', () => {
@@ -416,19 +380,13 @@ describe('wireSubscriptions', () => {
     it('CMD_CONTEXT_EDITOR_TAB_PASTE_FILE_PATH delegates to filePathPaster with absolute', () => {
       const mockUri = createMockUri('/workspace/src/file.ts');
       registrar.getHandler(CMD_CONTEXT_EDITOR_TAB_PASTE_FILE_PATH)(mockUri);
-      expect(services.filePathPaster.pasteFilePathToDestination).toHaveBeenCalledWith(
-        mockUri,
-        'absolute',
-      );
+      expect(services.filePathPaster.pasteFilePathToDestination).toHaveBeenCalledWith(mockUri, 'absolute');
     });
 
     it('CMD_CONTEXT_EDITOR_TAB_PASTE_RELATIVE_FILE_PATH delegates to filePathPaster with workspace-relative', () => {
       const mockUri = createMockUri('/workspace/src/file.ts');
       registrar.getHandler(CMD_CONTEXT_EDITOR_TAB_PASTE_RELATIVE_FILE_PATH)(mockUri);
-      expect(services.filePathPaster.pasteFilePathToDestination).toHaveBeenCalledWith(
-        mockUri,
-        'workspace-relative',
-      );
+      expect(services.filePathPaster.pasteFilePathToDestination).toHaveBeenCalledWith(mockUri, 'workspace-relative');
     });
 
     it('CMD_CONTEXT_EDITOR_CONTENT_UNBIND delegates to destinationManager.unbind', () => {

--- a/packages/rangelink-vscode-extension/src/bookmarks/BookmarkService.ts
+++ b/packages/rangelink-vscode-extension/src/bookmarks/BookmarkService.ts
@@ -1,8 +1,5 @@
 import type { ConfigReader } from '../config/ConfigReader';
-import {
-  DEFAULT_FEATURES_BOOKMARKS_ENABLED,
-  SETTING_FEATURES_BOOKMARKS_ENABLED,
-} from '../constants';
+import { DEFAULT_FEATURES_BOOKMARKS_ENABLED, SETTING_FEATURES_BOOKMARKS_ENABLED } from '../constants';
 import type { BoundSession, PasteDestinationManager } from '../destinations';
 import { RangeLinkExtensionError } from '../errors/RangeLinkExtensionError';
 import { RangeLinkExtensionErrorCodes } from '../errors/RangeLinkExtensionErrorCodes';
@@ -38,10 +35,7 @@ export class BookmarkService {
    */
   isVisible(): boolean {
     // TODO [2026-12-31]: #366 remove when bookmarks graduates from beta
-    return this.configReader.getBoolean(
-      SETTING_FEATURES_BOOKMARKS_ENABLED,
-      DEFAULT_FEATURES_BOOKMARKS_ENABLED,
-    );
+    return this.configReader.getBoolean(SETTING_FEATURES_BOOKMARKS_ENABLED, DEFAULT_FEATURES_BOOKMARKS_ENABLED);
   }
 
   /**

--- a/packages/rangelink-vscode-extension/src/bookmarks/BookmarksStore.ts
+++ b/packages/rangelink-vscode-extension/src/bookmarks/BookmarksStore.ts
@@ -3,15 +3,7 @@ import { RangeLinkExtensionErrorCodes } from '../errors/RangeLinkExtensionErrorC
 import { ExtensionResult } from '../types';
 import { createIsoTimestamp } from '../utils';
 
-import type {
-  Bookmark,
-  BookmarkId,
-  BookmarkInput,
-  BookmarksStoreData,
-  BookmarkUpdate,
-  IdGenerator,
-  TimestampGenerator,
-} from './types';
+import type { Bookmark, BookmarkId, BookmarkInput, BookmarksStoreData, BookmarkUpdate, IdGenerator, TimestampGenerator } from './types';
 
 import type { Logger } from '@couimet/logger-contract';
 import { nanoid } from 'nanoid';
@@ -53,26 +45,17 @@ export class BookmarksStore {
     if ('setKeysForSync' in globalState && typeof globalState.setKeysForSync === 'function') {
       globalState.setKeysForSync([STORAGE_KEY]);
       this.syncEnabled = true;
-      this.logger.debug(
-        { fn: 'BookmarksStore.constructor', syncEnabled: true },
-        'Settings Sync enabled for bookmarks',
-      );
+      this.logger.debug({ fn: 'BookmarksStore.constructor', syncEnabled: true }, 'Settings Sync enabled for bookmarks');
     } else {
       this.syncEnabled = false;
-      this.logger.warn(
-        { fn: 'BookmarksStore.constructor', syncEnabled: false },
-        'Settings Sync not available - bookmarks will only be stored locally',
-      );
+      this.logger.warn({ fn: 'BookmarksStore.constructor', syncEnabled: false }, 'Settings Sync not available - bookmarks will only be stored locally');
     }
   }
 
   private findBookmarkIndex(data: BookmarksStoreData, id: BookmarkId, operation: string): number {
     const index = data.bookmarks.findIndex((b) => b.id === id);
     if (index === -1) {
-      this.logger.warn(
-        { fn: `BookmarksStore.${operation}`, bookmarkId: id },
-        `Cannot ${operation} bookmark: not found`,
-      );
+      this.logger.warn({ fn: `BookmarksStore.${operation}`, bookmarkId: id }, `Cannot ${operation} bookmark: not found`);
     }
     return index;
   }
@@ -83,10 +66,7 @@ export class BookmarksStore {
       if (!existingIds.has(id)) {
         return id;
       }
-      this.logger.debug(
-        { fn: 'BookmarksStore.generateUniqueId', attempt, collidingId: id },
-        'ID collision detected, generating new ID',
-      );
+      this.logger.debug({ fn: 'BookmarksStore.generateUniqueId', attempt, collidingId: id }, 'ID collision detected, generating new ID');
     }
     throw new RangeLinkExtensionError({
       code: RangeLinkExtensionErrorCodes.BOOKMARK_ID_GENERATION_FAILED,
@@ -114,10 +94,7 @@ export class BookmarksStore {
       data.bookmarks.unshift(bookmark);
       await this.save(data, 'add');
 
-      this.logger.debug(
-        { fn: 'BookmarksStore.add', bookmark, syncEnabled: this.syncEnabled },
-        `Added bookmark: ${bookmark.label}`,
-      );
+      this.logger.debug({ fn: 'BookmarksStore.add', bookmark, syncEnabled: this.syncEnabled }, `Added bookmark: ${bookmark.label}`);
 
       return ExtensionResult.ok(bookmark);
     } catch (error) {
@@ -232,10 +209,7 @@ export class BookmarksStore {
       const [removed] = data.bookmarks.splice(index, 1);
       await this.save(data, 'remove');
 
-      this.logger.debug(
-        { fn: 'BookmarksStore.remove', removedBookmark: removed, syncEnabled: this.syncEnabled },
-        `Removed bookmark: ${removed.label}`,
-      );
+      this.logger.debug({ fn: 'BookmarksStore.remove', removedBookmark: removed, syncEnabled: this.syncEnabled }, `Removed bookmark: ${removed.label}`);
 
       return ExtensionResult.ok(removed);
     } catch (error) {
@@ -312,10 +286,7 @@ export class BookmarksStore {
     try {
       await this.globalState.update(STORAGE_KEY, data);
     } catch (error) {
-      this.logger.error(
-        { fn: `BookmarksStore.${operation}`, error, syncEnabled: this.syncEnabled },
-        `Failed to save bookmarks during ${operation}`,
-      );
+      this.logger.error({ fn: `BookmarksStore.${operation}`, error, syncEnabled: this.syncEnabled }, `Failed to save bookmarks during ${operation}`);
       throw new RangeLinkExtensionError({
         code: RangeLinkExtensionErrorCodes.BOOKMARK_SAVE_FAILED,
         message: `Failed to persist bookmarks during ${operation}`,
@@ -337,10 +308,7 @@ export class BookmarksStore {
       return data as BookmarksStoreData;
     }
 
-    this.logger.warn(
-      { fn: 'BookmarksStore.migrate', data },
-      'Unknown bookmark data format, resetting to empty',
-    );
+    this.logger.warn({ fn: 'BookmarksStore.migrate', data }, 'Unknown bookmark data format, resetting to empty');
     return createEmptyStoreData();
   }
 }

--- a/packages/rangelink-vscode-extension/src/bookmarks/__tests__/BookmarkService.test.ts
+++ b/packages/rangelink-vscode-extension/src/bookmarks/__tests__/BookmarkService.test.ts
@@ -31,14 +31,7 @@ describe('BookmarkService', () => {
   const createService = (): BookmarkService => {
     const mockSession = createMockBoundSession();
     const mockDestinationManager = createMockDestinationManager();
-    return new BookmarkService(
-      mockBookmarksStore,
-      mockAdapter,
-      mockConfigReader,
-      mockDestinationManager,
-      mockSession,
-      mockLogger,
-    );
+    return new BookmarkService(mockBookmarksStore, mockAdapter, mockConfigReader, mockDestinationManager, mockSession, mockLogger);
   };
 
   beforeEach(() => {
@@ -54,10 +47,7 @@ describe('BookmarkService', () => {
 
   describe('constructor', () => {
     it('logs initialization', () => {
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'BookmarkService.constructor' },
-        'BookmarkService initialized',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BookmarkService.constructor' }, 'BookmarkService initialized');
     });
   });
 
@@ -122,44 +112,24 @@ describe('BookmarkService', () => {
     it('throws DESTINATION_NOT_BOUND when no destination is bound', async () => {
       const mockSession = createMockBoundSession();
       const mockDestinationManager = createMockDestinationManager();
-      const service = new BookmarkService(
-        mockBookmarksStore,
-        mockAdapter,
-        mockConfigReader,
-        mockDestinationManager,
-        mockSession,
-        mockLogger,
-      );
+      const service = new BookmarkService(mockBookmarksStore, mockAdapter, mockConfigReader, mockDestinationManager, mockSession, mockLogger);
 
-      await expect(() => service.sendBookmark('bookmark-1')).toThrowDetailedErrorAsync(
-        'DESTINATION_NOT_BOUND',
-        {
-          message: 'Cannot send bookmark: no destination is currently bound',
-          functionName: 'BookmarkService.sendBookmark',
-        },
-      );
+      await expect(() => service.sendBookmark('bookmark-1')).toThrowDetailedErrorAsync('DESTINATION_NOT_BOUND', {
+        message: 'Cannot send bookmark: no destination is currently bound',
+        functionName: 'BookmarkService.sendBookmark',
+      });
     });
 
     it('logs warning and returns early when bookmark is not found', async () => {
       const mockSession = createMockBoundSession({ isSet: jest.fn().mockReturnValue(true) });
       const mockDestinationManager = createMockDestinationManager();
-      const service = new BookmarkService(
-        mockBookmarksStore,
-        mockAdapter,
-        mockConfigReader,
-        mockDestinationManager,
-        mockSession,
-        mockLogger,
-      );
+      const service = new BookmarkService(mockBookmarksStore, mockAdapter, mockConfigReader, mockDestinationManager, mockSession, mockLogger);
 
       await service.sendBookmark('unknown-id');
 
       expect(mockClipboard.writeText).not.toHaveBeenCalled();
       expect(mockDestinationManager.sendTextToDestination).not.toHaveBeenCalled();
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        { fn: 'BookmarkService.sendBookmark', bookmarkId: 'unknown-id' },
-        'Bookmark not found',
-      );
+      expect(mockLogger.warn).toHaveBeenCalledWith({ fn: 'BookmarkService.sendBookmark', bookmarkId: 'unknown-id' }, 'Bookmark not found');
     });
 
     it('copies link to clipboard and sends to bound destination', async () => {
@@ -167,21 +137,12 @@ describe('BookmarkService', () => {
       const mockDestinationManager = createMockDestinationManager({
         sendTextToDestinationResult: true,
       });
-      const service = new BookmarkService(
-        mockBookmarksStore,
-        mockAdapter,
-        mockConfigReader,
-        mockDestinationManager,
-        mockSession,
-        mockLogger,
-      );
+      const service = new BookmarkService(mockBookmarksStore, mockAdapter, mockConfigReader, mockDestinationManager, mockSession, mockLogger);
 
       await service.sendBookmark('bookmark-1');
 
       expect(mockClipboard.writeText).toHaveBeenCalledWith('src/features/my-feature.ts#L10-L20');
-      expect(mockDestinationManager.sendTextToDestination).toHaveBeenCalledWith(
-        'src/features/my-feature.ts#L10-L20',
-      );
+      expect(mockDestinationManager.sendTextToDestination).toHaveBeenCalledWith('src/features/my-feature.ts#L10-L20');
       expect(mockLogger.debug).toHaveBeenCalledWith(
         { fn: 'BookmarkService.sendBookmark', bookmarkId: 'bookmark-1', bookmark: TEST_BOOKMARK },
         'Sent bookmark to destination: My Feature',
@@ -193,21 +154,12 @@ describe('BookmarkService', () => {
       const mockDestinationManager = createMockDestinationManager({
         sendTextToDestinationResult: true,
       });
-      const service = new BookmarkService(
-        mockBookmarksStore,
-        mockAdapter,
-        mockConfigReader,
-        mockDestinationManager,
-        mockSession,
-        mockLogger,
-      );
+      const service = new BookmarkService(mockBookmarksStore, mockAdapter, mockConfigReader, mockDestinationManager, mockSession, mockLogger);
 
       await service.sendBookmark('bookmark-1');
 
       expect(mockBookmarksStore.recordAccess).toHaveBeenCalledWith('bookmark-1');
-      expect(mockBookmarksStore.recordAccess.mock.invocationCallOrder[0]).toBeLessThan(
-        mockClipboard.writeText.mock.invocationCallOrder[0],
-      );
+      expect(mockBookmarksStore.recordAccess.mock.invocationCallOrder[0]).toBeLessThan(mockClipboard.writeText.mock.invocationCallOrder[0]);
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/bookmarks/__tests__/BookmarksStore.test.ts
+++ b/packages/rangelink-vscode-extension/src/bookmarks/__tests__/BookmarksStore.test.ts
@@ -29,10 +29,7 @@ describe('BookmarksStore', () => {
       new BookmarksStore(mockMemento, mockLogger);
 
       expect(mockMemento.setKeysForSync).toHaveBeenCalledWith([STORAGE_KEY]);
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'BookmarksStore.constructor', syncEnabled: true },
-        'Settings Sync enabled for bookmarks',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'BookmarksStore.constructor', syncEnabled: true }, 'Settings Sync enabled for bookmarks');
     });
 
     it('logs warning when setKeysForSync is not available', () => {
@@ -72,13 +69,10 @@ describe('BookmarksStore', () => {
     });
 
     it('throws when globalState is undefined', () => {
-      expect(() => new BookmarksStore(undefined as never, mockLogger)).toThrowDetailedError(
-        'BOOKMARK_STORE_NOT_AVAILABLE',
-        {
-          message: 'Cannot create BookmarksStore: globalState is required for bookmark persistence',
-          functionName: 'BookmarksStore.constructor',
-        },
-      );
+      expect(() => new BookmarksStore(undefined as never, mockLogger)).toThrowDetailedError('BOOKMARK_STORE_NOT_AVAILABLE', {
+        message: 'Cannot create BookmarksStore: globalState is required for bookmark persistence',
+        functionName: 'BookmarksStore.constructor',
+      });
     });
   });
 
@@ -308,9 +302,7 @@ describe('BookmarksStore', () => {
 
       const result = await store.update('existing-id', { label: 'New Label' });
 
-      expect(result).toBeSuccess(
-        expect.objectContaining({ label: 'New Label', link: '/original#L1' }),
-      );
+      expect(result).toBeSuccess(expect.objectContaining({ label: 'New Label', link: '/original#L1' }));
     });
 
     it('updates link field', async () => {
@@ -319,9 +311,7 @@ describe('BookmarksStore', () => {
 
       const result = await store.update('existing-id', { link: '/new/path#L10' });
 
-      expect(result).toBeSuccess(
-        expect.objectContaining({ link: '/new/path#L10', label: 'Original Label' }),
-      );
+      expect(result).toBeSuccess(expect.objectContaining({ link: '/new/path#L10', label: 'Original Label' }));
     });
 
     it('updates multiple fields', async () => {
@@ -395,10 +385,7 @@ describe('BookmarksStore', () => {
         functionName: 'BookmarksStore.update',
         details: { bookmarkId: 'non-existent' },
       });
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        { fn: 'BookmarksStore.update', bookmarkId: 'non-existent' },
-        'Cannot update bookmark: not found',
-      );
+      expect(mockLogger.warn).toHaveBeenCalledWith({ fn: 'BookmarksStore.update', bookmarkId: 'non-existent' }, 'Cannot update bookmark: not found');
     });
 
     it('persists changes', async () => {
@@ -457,10 +444,7 @@ describe('BookmarksStore', () => {
         functionName: 'BookmarksStore.remove',
         details: { bookmarkId: 'non-existent' },
       });
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        { fn: 'BookmarksStore.remove', bookmarkId: 'non-existent' },
-        'Cannot remove bookmark: not found',
-      );
+      expect(mockLogger.warn).toHaveBeenCalledWith({ fn: 'BookmarksStore.remove', bookmarkId: 'non-existent' }, 'Cannot remove bookmark: not found');
     });
 
     it('persists changes', async () => {
@@ -669,10 +653,7 @@ describe('BookmarksStore', () => {
         details: { operation: 'add' },
         cause: saveError,
       });
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        { fn: 'BookmarksStore.add', error: saveError, syncEnabled: true },
-        'Failed to save bookmarks during add',
-      );
+      expect(mockLogger.error).toHaveBeenCalledWith({ fn: 'BookmarksStore.add', error: saveError, syncEnabled: true }, 'Failed to save bookmarks during add');
     });
 
     it('wraps globalState.update error as BOOKMARK_SAVE_FAILED in update', async () => {

--- a/packages/rangelink-vscode-extension/src/bookmarks/index.ts
+++ b/packages/rangelink-vscode-extension/src/bookmarks/index.ts
@@ -1,12 +1,3 @@
 export { BookmarkService } from './BookmarkService';
 export { BookmarksStore } from './BookmarksStore';
-export type {
-  Bookmark,
-  BookmarkId,
-  BookmarkInput,
-  BookmarkScope,
-  BookmarksStoreData,
-  BookmarkUpdate,
-  IdGenerator,
-  TimestampGenerator,
-} from './types';
+export type { Bookmark, BookmarkId, BookmarkInput, BookmarkScope, BookmarksStoreData, BookmarkUpdate, IdGenerator, TimestampGenerator } from './types';

--- a/packages/rangelink-vscode-extension/src/clipboard/ClipboardService.ts
+++ b/packages/rangelink-vscode-extension/src/clipboard/ClipboardService.ts
@@ -48,10 +48,7 @@ export class ClipboardService {
   route<T>(fn: () => Promise<T>, shouldRestore?: () => boolean): Promise<ExtensionResult<T>> {
     const logCtx: LoggingContext = { fn: 'ClipboardService::route' };
 
-    const mode = this.configReader.getWithDefault(
-      SETTING_CLIPBOARD_PRESERVE,
-      DEFAULT_CLIPBOARD_PRESERVE,
-    );
+    const mode = this.configReader.getWithDefault(SETTING_CLIPBOARD_PRESERVE, DEFAULT_CLIPBOARD_PRESERVE);
 
     logCtx.mode = mode;
 
@@ -75,25 +72,18 @@ export class ClipboardService {
    * Restoration always happens in a finally block regardless of producer
    * or read outcome.
    */
-  async capture<T>(
-    producer: () => Promise<T>,
-    logCtxInput: LoggingContext,
-  ): Promise<ExtensionResult<{ clipboard: string; produced: T }>> {
+  async capture<T>(producer: () => Promise<T>, logCtxInput: LoggingContext): Promise<ExtensionResult<{ clipboard: string; produced: T }>> {
     const logCtx: LoggingContext = { ...logCtxInput, fn: `${logCtxInput.fn}::capture` };
 
     const priorResult = await this.read(logCtx);
-    if (!priorResult.success)
-      return priorResult as unknown as ExtensionResult<{ clipboard: string; produced: T }>;
+    if (!priorResult.success) return priorResult as unknown as ExtensionResult<{ clipboard: string; produced: T }>;
 
     try {
       let produced: T;
       try {
         produced = await producer();
       } catch (producerError) {
-        this.logger.error(
-          { ...logCtx, error: producerError },
-          'Producer callback threw during capture',
-        );
+        this.logger.error({ ...logCtx, error: producerError }, 'Producer callback threw during capture');
         return ExtensionResult.err(
           new RangeLinkExtensionError({
             code: RangeLinkExtensionErrorCodes.CLIPBOARD_CAPTURE_EXECUTION_FAILED,
@@ -105,8 +95,7 @@ export class ClipboardService {
       }
 
       const readResult = await this.read(logCtx);
-      if (!readResult.success)
-        return readResult as unknown as ExtensionResult<{ clipboard: string; produced: T }>;
+      if (!readResult.success) return readResult as unknown as ExtensionResult<{ clipboard: string; produced: T }>;
 
       return ExtensionResult.ok({ clipboard: readResult.value, produced });
     } finally {
@@ -157,10 +146,7 @@ export class ClipboardService {
 
     try {
       const text = await this.clipboard.readTextFromClipboard();
-      this.logger.debug(
-        { ...logCtx, priorLength: text.length },
-        'Clipboard current value read and saved',
-      );
+      this.logger.debug({ ...logCtx, priorLength: text.length }, 'Clipboard current value read and saved');
       return ExtensionResult.ok(text);
     } catch (err) {
       this.logger.error({ ...logCtx, error: err }, 'Clipboard read failed');
@@ -202,10 +188,7 @@ export class ClipboardService {
     }
   }
 
-  private async executeFn<T>(
-    fn: () => Promise<T>,
-    logCtx: LoggingContext,
-  ): Promise<ExtensionResult<T>> {
+  private async executeFn<T>(fn: () => Promise<T>, logCtx: LoggingContext): Promise<ExtensionResult<T>> {
     try {
       return ExtensionResult.ok(await fn());
     } catch (fnError) {

--- a/packages/rangelink-vscode-extension/src/commands/AddBookmarkCommand.ts
+++ b/packages/rangelink-vscode-extension/src/commands/AddBookmarkCommand.ts
@@ -5,12 +5,7 @@ import { formatMessage, generateLinkFromSelections } from '../utils';
 
 import type { Logger } from '@couimet/logger-contract';
 import * as path from 'node:path';
-import {
-  type DelimiterConfigGetter,
-  LinkType,
-  type ParsedLink,
-  parseLink,
-} from 'rangelink-core-ts';
+import { type DelimiterConfigGetter, LinkType, type ParsedLink, parseLink } from 'rangelink-core-ts';
 
 /**
  * Command handler for adding a bookmark from the current editor selection.
@@ -58,10 +53,7 @@ export class AddBookmarkCommand {
       // Source 1: Selection IS a valid RangeLink
       linkToBookmark = trimmedSelectedText;
       defaultLabel = path.basename(parsedExistingLink.path);
-      this.logger.info(
-        { ...logCtx, source: 'existing-link', link: linkToBookmark },
-        'Using existing link',
-      );
+      this.logger.info({ ...logCtx, source: 'existing-link', link: linkToBookmark }, 'Using existing link');
     } else {
       // Source 2: Generate link from selection (supports rectangular selections)
       // Check if file is untitled (cannot generate link to unsaved file)
@@ -82,9 +74,7 @@ export class AddBookmarkCommand {
 
       if (!result.success) {
         this.logger.error({ ...logCtx, error: result.error }, 'Failed to generate link');
-        this.ideAdapter.showErrorMessage(
-          formatMessage(MessageCode.ERROR_BOOKMARK_LINK_GENERATION_FAILED),
-        );
+        this.ideAdapter.showErrorMessage(formatMessage(MessageCode.ERROR_BOOKMARK_LINK_GENERATION_FAILED));
         return;
       }
 
@@ -101,10 +91,7 @@ export class AddBookmarkCommand {
         'Generated link from selection',
       );
     }
-    this.logger.debug(
-      { ...logCtx, link: linkToBookmark, defaultLabel },
-      'Showing bookmark label input',
-    );
+    this.logger.debug({ ...logCtx, link: linkToBookmark, defaultLabel }, 'Showing bookmark label input');
 
     const label = await this.ideAdapter.showInputBox({
       prompt: formatMessage(MessageCode.BOOKMARK_ADD_INPUT_PROMPT, { link: linkToBookmark }),
@@ -139,9 +126,7 @@ export class AddBookmarkCommand {
 
     this.logger.info({ ...logCtx, label: trimmedLabel, link: linkToBookmark }, 'Bookmark saved');
 
-    this.ideAdapter.setSuccessfulStatusBarMessage(
-      formatMessage(MessageCode.STATUS_BAR_BOOKMARK_SAVED, { label: trimmedLabel }),
-    );
+    this.ideAdapter.setSuccessfulStatusBarMessage(formatMessage(MessageCode.STATUS_BAR_BOOKMARK_SAVED, { label: trimmedLabel }));
   }
 
   /**

--- a/packages/rangelink-vscode-extension/src/commands/BindToDestinationCommand.ts
+++ b/packages/rangelink-vscode-extension/src/commands/BindToDestinationCommand.ts
@@ -21,10 +21,7 @@ export class BindToDestinationCommand {
     private readonly session: BoundSession,
     private readonly logger: Logger,
   ) {
-    this.logger.debug(
-      { fn: 'BindToDestinationCommand.constructor' },
-      'BindToDestinationCommand initialized',
-    );
+    this.logger.debug({ fn: 'BindToDestinationCommand.constructor' }, 'BindToDestinationCommand initialized');
   }
 
   async execute(): Promise<QuickPickBindResult> {

--- a/packages/rangelink-vscode-extension/src/commands/BindToTerminalCommand.ts
+++ b/packages/rangelink-vscode-extension/src/commands/BindToTerminalCommand.ts
@@ -1,14 +1,5 @@
-import type {
-  BindSuccessInfo,
-  BoundSession,
-  DestinationAvailabilityService,
-  DestinationBinder,
-} from '../destinations';
-import {
-  classifyTerminalForBinding,
-  resolveBoundTerminalProcessId,
-  showTerminalPicker,
-} from '../destinations/utils';
+import type { BindSuccessInfo, BoundSession, DestinationAvailabilityService, DestinationBinder } from '../destinations';
+import { classifyTerminalForBinding, resolveBoundTerminalProcessId, showTerminalPicker } from '../destinations/utils';
 import type { VscodeAdapter } from '../ide/vscode/VscodeAdapter';
 import { type ExtensionResult, MessageCode, type QuickPickBindResult } from '../types';
 import { formatMessage } from '../utils';
@@ -37,10 +28,7 @@ export class BindToTerminalCommand {
     private readonly session: BoundSession,
     private readonly logger: Logger,
   ) {
-    this.logger.debug(
-      { fn: 'BindToTerminalCommand.constructor' },
-      'BindToTerminalCommand initialized',
-    );
+    this.logger.debug({ fn: 'BindToTerminalCommand.constructor' }, 'BindToTerminalCommand initialized');
   }
 
   async execute(preferredTerminal?: vscode.Terminal): Promise<QuickPickBindResult> {
@@ -48,8 +36,7 @@ export class BindToTerminalCommand {
 
     if (preferredTerminal) {
       const classification = classifyTerminalForBinding(preferredTerminal);
-      const nonBindableReason =
-        classification.visible === true ? classification.nonBindableReason : undefined;
+      const nonBindableReason = classification.visible === true ? classification.nonBindableReason : undefined;
       if (!classification.visible || nonBindableReason !== undefined) {
         this.logger.debug(
           {
@@ -71,21 +58,13 @@ export class BindToTerminalCommand {
         { ...logCtx, terminalName: preferredTerminal.name, source: 'context-menu' },
         `Direct bind to terminal "${preferredTerminal.name}" from context menu`,
       );
-      return this.mapBindResult(
-        await this.binder.bind({ kind: 'terminal', terminal: preferredTerminal }),
-      );
+      return this.mapBindResult(await this.binder.bind({ kind: 'terminal', terminal: preferredTerminal }));
     }
 
     const boundTerminalProcessId = await resolveBoundTerminalProcessId(() => this.session.get());
-    const terminalItems = await this.availabilityService.getTerminalItems(
-      Infinity,
-      boundTerminalProcessId,
-    );
+    const terminalItems = await this.availabilityService.getTerminalItems(Infinity, boundTerminalProcessId);
 
-    this.logger.debug(
-      { ...logCtx, terminalCount: terminalItems.length },
-      'Starting bind to terminal command',
-    );
+    this.logger.debug({ ...logCtx, terminalCount: terminalItems.length }, 'Starting bind to terminal command');
 
     if (terminalItems.length === 0) {
       this.logger.debug(logCtx, 'No terminals available');
@@ -95,10 +74,7 @@ export class BindToTerminalCommand {
 
     if (terminalItems.length === 1) {
       const { terminalInfo } = terminalItems[0];
-      this.logger.debug(
-        { ...logCtx, terminalName: terminalInfo.name },
-        'Single terminal, auto-binding',
-      );
+      this.logger.debug({ ...logCtx, terminalName: terminalInfo.name }, 'Single terminal, auto-binding');
       return this.mapBindResult(await this.binder.bind(terminalInfo.bindOptions));
     }
 
@@ -108,10 +84,7 @@ export class BindToTerminalCommand {
       {
         getPlaceholder: () => formatMessage(MessageCode.TERMINAL_PICKER_BIND_ONLY_PLACEHOLDER),
         onSelected: (eligible) => {
-          this.logger.debug(
-            { ...logCtx, terminalName: eligible.name },
-            `Binding to terminal "${eligible.name}"`,
-          );
+          this.logger.debug({ ...logCtx, terminalName: eligible.name }, `Binding to terminal "${eligible.name}"`);
           return this.binder.bind(eligible.bindOptions);
         },
       },

--- a/packages/rangelink-vscode-extension/src/commands/BindToTextEditorCommand.ts
+++ b/packages/rangelink-vscode-extension/src/commands/BindToTextEditorCommand.ts
@@ -1,9 +1,4 @@
-import type {
-  BindSuccessInfo,
-  BoundSession,
-  DestinationAvailabilityService,
-  DestinationBinder,
-} from '../destinations';
+import type { BindSuccessInfo, BoundSession, DestinationAvailabilityService, DestinationBinder } from '../destinations';
 import { showFilePicker } from '../destinations/utils';
 import type { VscodeAdapter } from '../ide/vscode/VscodeAdapter';
 import { type ExtensionResult, MessageCode, type QuickPickBindResult } from '../types';
@@ -37,10 +32,7 @@ export class BindToTextEditorCommand {
     private readonly session: BoundSession,
     private readonly logger: Logger,
   ) {
-    this.logger.debug(
-      { fn: 'BindToTextEditorCommand.constructor' },
-      'BindToTextEditorCommand initialized',
-    );
+    this.logger.debug({ fn: 'BindToTextEditorCommand.constructor' }, 'BindToTextEditorCommand initialized');
   }
 
   execute(explorerUri?: vscode.Uri): Promise<QuickPickBindResult> {
@@ -65,14 +57,10 @@ export class BindToTextEditorCommand {
       }
     }
 
-    this.logger.debug(
-      { ...logCtx, matchCount: matchingViewColumns.length },
-      'Found tab groups containing URI',
-    );
+    this.logger.debug({ ...logCtx, matchCount: matchingViewColumns.length }, 'Found tab groups containing URI');
 
     if (matchingViewColumns.length <= 1) {
-      const showOptions =
-        matchingViewColumns.length === 1 ? { viewColumn: matchingViewColumns[0] } : undefined;
+      const showOptions = matchingViewColumns.length === 1 ? { viewColumn: matchingViewColumns[0] } : undefined;
       const editor = await this.ideAdapter.showTextDocument(uri, showOptions);
       const viewColumn = editor.viewColumn ?? 1;
       return this.mapBindResult(await this.binder.bind({ kind: 'text-editor', uri, viewColumn }));
@@ -105,15 +93,9 @@ export class BindToTextEditorCommand {
 
     const boundDest = this.session.get();
     const boundEditorDest = isEditorDestination(boundDest) ? boundDest : undefined;
-    const fileItems = this.availabilityService.getAllFileItems(
-      boundEditorDest?.resource.uri.toString(),
-      boundEditorDest?.resource.viewColumn,
-    );
+    const fileItems = this.availabilityService.getAllFileItems(boundEditorDest?.resource.uri.toString(), boundEditorDest?.resource.viewColumn);
 
-    this.logger.debug(
-      { ...logCtx, fileCount: fileItems.length },
-      'Starting bind to text editor command',
-    );
+    this.logger.debug({ ...logCtx, fileCount: fileItems.length }, 'Starting bind to text editor command');
 
     if (fileItems.length === 0) {
       this.logger.debug(logCtx, 'No files available');

--- a/packages/rangelink-vscode-extension/src/commands/GoToRangeLinkCommand.ts
+++ b/packages/rangelink-vscode-extension/src/commands/GoToRangeLinkCommand.ts
@@ -18,10 +18,7 @@ export class GoToRangeLinkCommand {
     private readonly navigationHandler: RangeLinkNavigationHandler,
     private readonly logger: Logger,
   ) {
-    this.logger.debug(
-      { fn: 'GoToRangeLinkCommand.constructor' },
-      'GoToRangeLinkCommand initialized',
-    );
+    this.logger.debug({ fn: 'GoToRangeLinkCommand.constructor' }, 'GoToRangeLinkCommand initialized');
   }
 
   async execute(): Promise<void> {
@@ -52,13 +49,8 @@ export class GoToRangeLinkCommand {
     const parseResult = this.navigationHandler.parseLink(trimmedInput);
 
     if (!parseResult.success) {
-      this.logger.debug(
-        { ...logCtx, input, trimmedInput, error: parseResult.error },
-        'Invalid link format',
-      );
-      this.ideAdapter.showErrorMessage(
-        formatMessage(MessageCode.INFO_NAVIGATION_INVALID_LINK, { input: trimmedInput }),
-      );
+      this.logger.debug({ ...logCtx, input, trimmedInput, error: parseResult.error }, 'Invalid link format');
+      this.ideAdapter.showErrorMessage(formatMessage(MessageCode.INFO_NAVIGATION_INVALID_LINK, { input: trimmedInput }));
       return;
     }
 

--- a/packages/rangelink-vscode-extension/src/commands/JumpToDestinationCommand.ts
+++ b/packages/rangelink-vscode-extension/src/commands/JumpToDestinationCommand.ts
@@ -22,10 +22,7 @@ export class JumpToDestinationCommand {
     private readonly destinationPicker: DestinationPicker,
     private readonly logger: Logger,
   ) {
-    this.logger.debug(
-      { fn: 'JumpToDestinationCommand.constructor' },
-      'JumpToDestinationCommand initialized',
-    );
+    this.logger.debug({ fn: 'JumpToDestinationCommand.constructor' }, 'JumpToDestinationCommand initialized');
   }
 
   async execute(): Promise<JumpToDestinationResult> {
@@ -77,10 +74,7 @@ export class JumpToDestinationCommand {
     return { outcome: 'focused', destinationName: focusResult.value.destinationName };
   }
 
-  private async bindAndFocus(
-    bindOptions: BindOptions,
-    logCtx: { fn: string },
-  ): Promise<JumpToDestinationResult> {
+  private async bindAndFocus(bindOptions: BindOptions, logCtx: { fn: string }): Promise<JumpToDestinationResult> {
     this.logger.debug(logCtx, 'Binding selected destination and focusing');
     const result = await this.focuser.bindAndFocus(bindOptions);
 

--- a/packages/rangelink-vscode-extension/src/commands/ListBookmarksCommand.ts
+++ b/packages/rangelink-vscode-extension/src/commands/ListBookmarksCommand.ts
@@ -2,12 +2,7 @@ import type { Bookmark, BookmarkService } from '../bookmarks';
 import { CMD_BOOKMARK_ADD, CMD_BOOKMARK_MANAGE } from '../constants';
 import { RangeLinkExtensionError, RangeLinkExtensionErrorCodes } from '../errors';
 import type { VscodeAdapter } from '../ide/vscode/VscodeAdapter';
-import {
-  BookmarkQuickPickItem,
-  CommandQuickPickItem,
-  InfoQuickPickItem,
-  MessageCode,
-} from '../types';
+import { BookmarkQuickPickItem, CommandQuickPickItem, InfoQuickPickItem, MessageCode } from '../types';
 import { formatMessage, isSelectableQuickPickItem } from '../utils';
 
 import type { Logger } from '@couimet/logger-contract';
@@ -28,10 +23,7 @@ export class ListBookmarksCommand {
     private readonly bookmarkService: BookmarkService,
     private readonly logger: Logger,
   ) {
-    this.logger.debug(
-      { fn: 'ListBookmarksCommand.constructor' },
-      'ListBookmarksCommand initialized',
-    );
+    this.logger.debug({ fn: 'ListBookmarksCommand.constructor' }, 'ListBookmarksCommand initialized');
   }
 
   async execute(): Promise<void> {
@@ -58,10 +50,7 @@ export class ListBookmarksCommand {
     switch (selected.itemKind) {
       case 'bookmark':
         await this.bookmarkService.sendBookmark(selected.bookmarkId);
-        this.logger.debug(
-          { ...logCtx, bookmarkId: selected.bookmarkId },
-          'Bookmark selected and sent',
-        );
+        this.logger.debug({ ...logCtx, bookmarkId: selected.bookmarkId }, 'Bookmark selected and sent');
         break;
       case 'command':
         await this.ideAdapter.executeCommand(selected.command);

--- a/packages/rangelink-vscode-extension/src/commands/ManageBookmarksCommand.ts
+++ b/packages/rangelink-vscode-extension/src/commands/ManageBookmarksCommand.ts
@@ -27,10 +27,7 @@ export class ManageBookmarksCommand {
     private readonly bookmarkService: BookmarkService,
     private readonly logger: Logger,
   ) {
-    this.logger.debug(
-      { fn: 'ManageBookmarksCommand.constructor' },
-      'ManageBookmarksCommand initialized',
-    );
+    this.logger.debug({ fn: 'ManageBookmarksCommand.constructor' }, 'ManageBookmarksCommand initialized');
   }
 
   async execute(): Promise<void> {
@@ -40,9 +37,7 @@ export class ManageBookmarksCommand {
 
     if (bookmarks.length === 0) {
       this.logger.debug(logCtx, 'No bookmarks to manage');
-      await this.ideAdapter.showInformationMessage(
-        formatMessage(MessageCode.BOOKMARK_MANAGE_EMPTY),
-      );
+      await this.ideAdapter.showInformationMessage(formatMessage(MessageCode.BOOKMARK_MANAGE_EMPTY));
       return;
     }
 
@@ -95,9 +90,7 @@ export class ManageBookmarksCommand {
     }));
   }
 
-  private async confirmAndDelete(
-    bookmark: Bookmark,
-  ): Promise<ExtensionResult<Bookmark> | undefined> {
+  private async confirmAndDelete(bookmark: Bookmark): Promise<ExtensionResult<Bookmark> | undefined> {
     const logCtx = { fn: 'ManageBookmarksCommand.confirmAndDelete', bookmark };
 
     const confirmMessage = formatMessage(MessageCode.BOOKMARK_MANAGE_CONFIRM_DELETE, {
@@ -106,11 +99,7 @@ export class ManageBookmarksCommand {
     const deleteLabel = formatMessage(MessageCode.BOOKMARK_MANAGE_CONFIRM_DELETE_YES);
     const cancelLabel = formatMessage(MessageCode.BOOKMARK_MANAGE_CONFIRM_DELETE_CANCEL);
 
-    const choice = await this.ideAdapter.showWarningMessage(
-      confirmMessage,
-      deleteLabel,
-      cancelLabel,
-    );
+    const choice = await this.ideAdapter.showWarningMessage(confirmMessage, deleteLabel, cancelLabel);
 
     if (choice !== deleteLabel) {
       this.logger.debug(logCtx, 'Delete cancelled by user');
@@ -121,14 +110,10 @@ export class ManageBookmarksCommand {
 
     if (result.success) {
       this.logger.debug(logCtx, 'Bookmark deleted successfully');
-      await this.ideAdapter.showInformationMessage(
-        formatMessage(MessageCode.BOOKMARK_MANAGE_DELETED, { label: bookmark.label }),
-      );
+      await this.ideAdapter.showInformationMessage(formatMessage(MessageCode.BOOKMARK_MANAGE_DELETED, { label: bookmark.label }));
     } else {
       this.logger.warn({ ...logCtx, error: result.error }, 'Failed to delete bookmark');
-      await this.ideAdapter.showErrorMessage(
-        formatMessage(MessageCode.BOOKMARK_MANAGE_ERROR_DELETE_FAILED),
-      );
+      await this.ideAdapter.showErrorMessage(formatMessage(MessageCode.BOOKMARK_MANAGE_ERROR_DELETE_FAILED));
     }
 
     return result;

--- a/packages/rangelink-vscode-extension/src/commands/ShowVersionCommand.ts
+++ b/packages/rangelink-vscode-extension/src/commands/ShowVersionCommand.ts
@@ -26,15 +26,11 @@ export class ShowVersionCommand {
 
     if (!versionInfo) {
       this.logger.error(logCtx, 'Failed to load version info');
-      await this.ideAdapter.showErrorMessage(
-        formatMessage(MessageCode.ERROR_VERSION_INFO_NOT_AVAILABLE),
-      );
+      await this.ideAdapter.showErrorMessage(formatMessage(MessageCode.ERROR_VERSION_INFO_NOT_AVAILABLE));
       return;
     }
 
-    const isDirtyIndicator = versionInfo.isDirty
-      ? formatMessage(MessageCode.INFO_VERSION_DIRTY_INDICATOR)
-      : '';
+    const isDirtyIndicator = versionInfo.isDirty ? formatMessage(MessageCode.INFO_VERSION_DIRTY_INDICATOR) : '';
     const message = formatMessage(MessageCode.INFO_VERSION_INFO, {
       version: versionInfo.version,
       commit: versionInfo.commit,
@@ -48,9 +44,7 @@ export class ShowVersionCommand {
 
     if (selection === copyButtonLabel) {
       await this.ideAdapter.writeTextToClipboard(versionInfo.commitFull);
-      await this.ideAdapter.showInformationMessage(
-        formatMessage(MessageCode.INFO_COMMIT_HASH_COPIED),
-      );
+      await this.ideAdapter.showInformationMessage(formatMessage(MessageCode.INFO_COMMIT_HASH_COPIED));
     }
 
     this.logger.info(

--- a/packages/rangelink-vscode-extension/src/commands/createBindAIAssistantCommand.ts
+++ b/packages/rangelink-vscode-extension/src/commands/createBindAIAssistantCommand.ts
@@ -24,9 +24,7 @@ export const createBindAIAssistantCommand = (
 
     if (!(await availabilityService.isAIAssistantAvailable(kind))) {
       logger.info({ fn, kind }, `${kind} not available`);
-      void ideAdapter.showInformationMessage(
-        formatMessage(availabilityService.getUnavailableMessageCode(kind)),
-      );
+      void ideAdapter.showInformationMessage(formatMessage(availabilityService.getUnavailableMessageCode(kind)));
       return;
     }
 

--- a/packages/rangelink-vscode-extension/src/commands/createBindToCustomAiByIdCommand.ts
+++ b/packages/rangelink-vscode-extension/src/commands/createBindToCustomAiByIdCommand.ts
@@ -1,9 +1,6 @@
 import type { CustomAiAssistantConfig } from '../config/parseCustomAiAssistants';
 import { resolveKindByExtensionId } from '../destinations/destinationBuilders';
-import type {
-  BindSuccessInfo,
-  PasteDestinationManager,
-} from '../destinations/PasteDestinationManager';
+import type { BindSuccessInfo, PasteDestinationManager } from '../destinations/PasteDestinationManager';
 import { RangeLinkExtensionError, RangeLinkExtensionErrorCodes } from '../errors';
 import { ExtensionResult } from '../types';
 
@@ -41,9 +38,7 @@ export const createBindToCustomAiByIdCommand = (
 
     logger.debug({ fn: FN, extensionId, kind }, 'Binding to custom AI by ID');
 
-    return await destinationManager.bind({ kind } as Parameters<
-      PasteDestinationManager['bind']
-    >[0]);
+    return await destinationManager.bind({ kind } as Parameters<PasteDestinationManager['bind']>[0]);
   };
 };
 

--- a/packages/rangelink-vscode-extension/src/config/ConfigReader.ts
+++ b/packages/rangelink-vscode-extension/src/config/ConfigReader.ts
@@ -36,10 +36,7 @@ export class ConfigReader implements ConfigGetter {
     const value = this.get<T>(key);
 
     if (value === undefined) {
-      this.logger.debug(
-        { fn: 'ConfigReader.getSetting', key, defaultValue },
-        `No ${key} configured, using default: ${String(defaultValue)}`,
-      );
+      this.logger.debug({ fn: 'ConfigReader.getSetting', key, defaultValue }, `No ${key} configured, using default: ${String(defaultValue)}`);
       return defaultValue;
     }
 

--- a/packages/rangelink-vscode-extension/src/config/DelimiterCache.ts
+++ b/packages/rangelink-vscode-extension/src/config/DelimiterCache.ts
@@ -22,10 +22,7 @@ export class DelimiterCache implements vscode.Disposable {
     this.delimiters = getDelimitersForExtension(config, ideAdapter, logger);
     this.subscription = ideAdapter.onDidChangeConfiguration((event) => {
       if (event.affectsConfiguration('rangelink')) {
-        logger.info(
-          { fn: 'DelimiterCache' },
-          'rangelink configuration changed — reloading delimiter config',
-        );
+        logger.info({ fn: 'DelimiterCache' }, 'rangelink configuration changed — reloading delimiter config');
         this.delimiters = getDelimitersForExtension(config, ideAdapter, logger);
       }
     });

--- a/packages/rangelink-vscode-extension/src/config/__tests__/ConfigReader.test.ts
+++ b/packages/rangelink-vscode-extension/src/config/__tests__/ConfigReader.test.ts
@@ -34,17 +34,13 @@ describe('ConfigReader', () => {
 
   describe('getSetting()', () => {
     it('should return configured value when present', () => {
-      const factory: ConfigGetterFactory = () =>
-        createMockConfigGetter({ myKey: 'configured-value' });
+      const factory: ConfigGetterFactory = () => createMockConfigGetter({ myKey: 'configured-value' });
       const reader = new (ConfigReader as any)(factory, mockLogger) as ConfigReader;
 
       const result = reader.getWithDefault('myKey', 'default-value');
 
       expect(result).toBe('configured-value');
-      expect(mockLogger.debug).toHaveBeenCalledWith(
-        { fn: 'ConfigReader.getSetting', key: 'myKey', value: 'configured-value' },
-        'Using configured value',
-      );
+      expect(mockLogger.debug).toHaveBeenCalledWith({ fn: 'ConfigReader.getSetting', key: 'myKey', value: 'configured-value' }, 'Using configured value');
     });
 
     it('should return default value when setting not configured', () => {
@@ -94,8 +90,7 @@ describe('ConfigReader', () => {
 
   describe('getPaddingMode()', () => {
     it('should return configured padding mode', () => {
-      const factory: ConfigGetterFactory = () =>
-        createMockConfigGetter({ 'smartPadding.pasteLink': 'before' });
+      const factory: ConfigGetterFactory = () => createMockConfigGetter({ 'smartPadding.pasteLink': 'before' });
       const reader = new (ConfigReader as any)(factory, mockLogger) as ConfigReader;
 
       const result = reader.getPaddingMode('smartPadding.pasteLink', 'both');
@@ -129,8 +124,7 @@ describe('ConfigReader', () => {
 
   describe('getBoolean()', () => {
     it('should return configured boolean value', () => {
-      const factory: ConfigGetterFactory = () =>
-        createMockConfigGetter({ warnOnDirtyBuffer: false });
+      const factory: ConfigGetterFactory = () => createMockConfigGetter({ warnOnDirtyBuffer: false });
       const reader = new (ConfigReader as any)(factory, mockLogger) as ConfigReader;
 
       const result = reader.getBoolean('warnOnDirtyBuffer', true);

--- a/packages/rangelink-vscode-extension/src/config/__tests__/DelimiterCache.test.ts
+++ b/packages/rangelink-vscode-extension/src/config/__tests__/DelimiterCache.test.ts
@@ -1,8 +1,4 @@
-import {
-  createMockConfigGetter,
-  createMockVscodeAdapter,
-  type VscodeAdapterWithTestHooks,
-} from '../../__tests__/helpers';
+import { createMockConfigGetter, createMockVscodeAdapter, type VscodeAdapterWithTestHooks } from '../../__tests__/helpers';
 import { DelimiterCache } from '../DelimiterCache';
 
 import { createMockLogger } from '@couimet/logger-contract-testing';
@@ -68,9 +64,7 @@ describe('DelimiterCache', () => {
     it('registers exactly one onDidChangeConfiguration listener', () => {
       new DelimiterCache(createDefaultConfig(), ideAdapter, createMockLogger());
 
-      expect(
-        ideAdapter.__getVscodeInstance().workspace.onDidChangeConfiguration,
-      ).toHaveBeenCalledTimes(1);
+      expect(ideAdapter.__getVscodeInstance().workspace.onDidChangeConfiguration).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -80,15 +74,11 @@ describe('DelimiterCache', () => {
       const cache = new DelimiterCache(createDefaultConfig(), ideAdapter, logger);
       expect(cache.getDelimiters()).toStrictEqual(DEFAULT_DELIMITERS);
 
-      const [capturedListener] =
-        ideAdapter.__getVscodeInstance().workspace.onDidChangeConfiguration.mock.calls[0];
+      const [capturedListener] = ideAdapter.__getVscodeInstance().workspace.onDidChangeConfiguration.mock.calls[0];
 
       capturedListener({ affectsConfiguration: (ns: string) => ns === 'rangelink' });
 
-      expect(logger.info).toHaveBeenCalledWith(
-        { fn: 'DelimiterCache' },
-        'rangelink configuration changed — reloading delimiter config',
-      );
+      expect(logger.info).toHaveBeenCalledWith({ fn: 'DelimiterCache' }, 'rangelink configuration changed — reloading delimiter config');
       expect(cache.getDelimiters()).toStrictEqual(DEFAULT_DELIMITERS);
     });
 
@@ -96,8 +86,7 @@ describe('DelimiterCache', () => {
       const logger = createMockLogger();
       const cache = new DelimiterCache(createDefaultConfig(), ideAdapter, logger);
 
-      const [capturedListener] =
-        ideAdapter.__getVscodeInstance().workspace.onDidChangeConfiguration.mock.calls[0];
+      const [capturedListener] = ideAdapter.__getVscodeInstance().workspace.onDidChangeConfiguration.mock.calls[0];
 
       // Simulate a non-rangelink change
       capturedListener({ affectsConfiguration: (_ns: string) => false });
@@ -113,8 +102,7 @@ describe('DelimiterCache', () => {
     it('shows error message when updated config is invalid', () => {
       const cache = new DelimiterCache(createInvalidConfig(), ideAdapter, createMockLogger());
 
-      const [capturedListener] =
-        ideAdapter.__getVscodeInstance().workspace.onDidChangeConfiguration.mock.calls[0];
+      const [capturedListener] = ideAdapter.__getVscodeInstance().workspace.onDidChangeConfiguration.mock.calls[0];
       capturedListener({ affectsConfiguration: (ns: string) => ns === 'rangelink' });
 
       expect(ideAdapter.__getVscodeInstance().window.showErrorMessage).toHaveBeenCalledTimes(2);
@@ -125,9 +113,7 @@ describe('DelimiterCache', () => {
   describe('dispose', () => {
     it('disposes the underlying subscription', () => {
       const mockDisposable = { dispose: jest.fn() };
-      ideAdapter
-        .__getVscodeInstance()
-        .workspace.onDidChangeConfiguration.mockReturnValue(mockDisposable);
+      ideAdapter.__getVscodeInstance().workspace.onDidChangeConfiguration.mockReturnValue(mockDisposable);
 
       const cache = new DelimiterCache(createDefaultConfig(), ideAdapter, createMockLogger());
       cache.dispose();

--- a/packages/rangelink-vscode-extension/src/config/__tests__/parseCustomAiAssistants.test.ts
+++ b/packages/rangelink-vscode-extension/src/config/__tests__/parseCustomAiAssistants.test.ts
@@ -102,9 +102,7 @@ describe('parseCustomAiAssistants', () => {
           {
             extensionId: 'acme.fancy',
             extensionName: 'Fancy',
-            insertCommands: [
-              { command: 'fancy.insert', args: [{ text: '${content}', format: 'markdown' }] },
-            ],
+            insertCommands: [{ command: 'fancy.insert', args: [{ text: '${content}', format: 'markdown' }] }],
           },
         ]),
       });
@@ -116,9 +114,7 @@ describe('parseCustomAiAssistants', () => {
           kind: 'custom-ai:acme.fancy',
           extensionId: 'acme.fancy',
           extensionName: 'Fancy',
-          insertCommands: [
-            { command: 'fancy.insert', args: [{ text: '${content}', format: 'markdown' }] },
-          ],
+          insertCommands: [{ command: 'fancy.insert', args: [{ text: '${content}', format: 'markdown' }] }],
         },
       ]);
     });
@@ -222,9 +218,7 @@ describe('parseCustomAiAssistants', () => {
 
     it('skips entry with missing extensionId and logs warning', () => {
       const configReader = createMockConfigReader({
-        get: jest
-          .fn()
-          .mockReturnValue([{ extensionName: 'Missing ID', focusCommands: ['cmd.focus'] }]),
+        get: jest.fn().mockReturnValue([{ extensionName: 'Missing ID', focusCommands: ['cmd.focus'] }]),
       });
 
       const result = parseCustomAiAssistants(configReader, mockLogger);
@@ -310,19 +304,12 @@ describe('parseCustomAiAssistants', () => {
 
     it('logs loaded count with extension IDs', () => {
       const configReader = createMockConfigReader({
-        get: jest
-          .fn()
-          .mockReturnValue([
-            { extensionId: 'acme.ai', extensionName: 'Acme', focusCommands: ['acme.focus'] },
-          ]),
+        get: jest.fn().mockReturnValue([{ extensionId: 'acme.ai', extensionName: 'Acme', focusCommands: ['acme.focus'] }]),
       });
 
       parseCustomAiAssistants(configReader, mockLogger);
 
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        { fn: 'parseCustomAiAssistants', count: 1, ids: ['acme.ai'] },
-        'Loaded 1 custom AI assistant(s)',
-      );
+      expect(mockLogger.info).toHaveBeenCalledWith({ fn: 'parseCustomAiAssistants', count: 1, ids: ['acme.ai'] }, 'Loaded 1 custom AI assistant(s)');
     });
 
     it('trims whitespace from extensionId and extensionName', () => {
@@ -364,11 +351,7 @@ describe('parseCustomAiAssistants', () => {
 
     it('warns when focusCommands is present but malformed', () => {
       const configReader = createMockConfigReader({
-        get: jest
-          .fn()
-          .mockReturnValue([
-            { extensionId: 'acme.ai', extensionName: 'Acme', focusCommands: [123, null] },
-          ]),
+        get: jest.fn().mockReturnValue([{ extensionId: 'acme.ai', extensionName: 'Acme', focusCommands: [123, null] }]),
       });
 
       const result = parseCustomAiAssistants(configReader, mockLogger);

--- a/packages/rangelink-vscode-extension/src/config/getDelimitersForExtension.ts
+++ b/packages/rangelink-vscode-extension/src/config/getDelimitersForExtension.ts
@@ -14,17 +14,11 @@ import type { DelimiterConfig } from 'rangelink-core-ts';
  * Encapsulates the pattern of loading delimiters, validating them,
  * and notifying the user if configuration is invalid.
  */
-export const getDelimitersForExtension = (
-  config: ConfigGetter,
-  errorFeedbackProvider: ErrorFeedbackProvider,
-  logger: Logger,
-): DelimiterConfig => {
+export const getDelimitersForExtension = (config: ConfigGetter, errorFeedbackProvider: ErrorFeedbackProvider, logger: Logger): DelimiterConfig => {
   const result = loadDelimiterConfig(config, logger);
 
   if (result.errors.length > 0) {
-    void errorFeedbackProvider.showErrorMessage(
-      formatMessage(MessageCode.ERROR_INVALID_DELIMITER_CONFIG),
-    );
+    void errorFeedbackProvider.showErrorMessage(formatMessage(MessageCode.ERROR_INVALID_DELIMITER_CONFIG));
   }
 
   return result.delimiters;

--- a/packages/rangelink-vscode-extension/src/config/index.ts
+++ b/packages/rangelink-vscode-extension/src/config/index.ts
@@ -1,10 +1,5 @@
 // Public types
-export type {
-  ConfigGetterFactory,
-  ConfigSource,
-  DelimiterConfigSources,
-  LoadDelimiterConfigResult,
-} from './types';
+export type { ConfigGetterFactory, ConfigSource, DelimiterConfigSources, LoadDelimiterConfigResult } from './types';
 
 // Public classes
 export { ConfigReader } from './ConfigReader';

--- a/packages/rangelink-vscode-extension/src/config/loadDelimiterConfig.ts
+++ b/packages/rangelink-vscode-extension/src/config/loadDelimiterConfig.ts
@@ -1,9 +1,4 @@
-import {
-  SETTING_DELIMITER_HASH,
-  SETTING_DELIMITER_LINE,
-  SETTING_DELIMITER_POSITION,
-  SETTING_DELIMITER_RANGE,
-} from '../constants';
+import { SETTING_DELIMITER_HASH, SETTING_DELIMITER_LINE, SETTING_DELIMITER_POSITION, SETTING_DELIMITER_RANGE } from '../constants';
 
 import { logSuccessfulConfig, logValidationErrors } from './logging';
 import { determineAllSources } from './sources';
@@ -36,10 +31,7 @@ const createDefaultResult = (errors: RangeLinkError[]): LoadDelimiterConfigResul
  * @param logger - Logger for output
  * @returns Result with delimiters, sources, and errors (empty array if success)
  */
-export const loadDelimiterConfig = (
-  config: ConfigGetter,
-  logger: Logger,
-): LoadDelimiterConfigResult => {
+export const loadDelimiterConfig = (config: ConfigGetter, logger: Logger): LoadDelimiterConfigResult => {
   // Get raw config values (undefined = not set, '' = explicitly set to invalid)
   const userLine = config.get<string>(SETTING_DELIMITER_LINE);
   const userPosition = config.get<string>(SETTING_DELIMITER_POSITION);
@@ -47,11 +39,7 @@ export const loadDelimiterConfig = (
   const userRange = config.get<string>(SETTING_DELIMITER_RANGE);
 
   // If no config provided at all (all undefined), use defaults silently (no errors)
-  const hasNoConfig =
-    userLine === undefined &&
-    userPosition === undefined &&
-    userHash === undefined &&
-    userRange === undefined;
+  const hasNoConfig = userLine === undefined && userPosition === undefined && userHash === undefined && userRange === undefined;
   if (hasNoConfig) {
     logger.debug({ fn: 'loadDelimiterConfig' }, 'No delimiter config provided, using defaults');
     return createDefaultResult([]);
@@ -64,12 +52,7 @@ export const loadDelimiterConfig = (
   const rangeToValidate = userRange ?? '';
 
   // Validate individual fields (accumulate errors)
-  const fieldErrors = validateDelimiterFields(
-    lineToValidate,
-    positionToValidate,
-    hashToValidate,
-    rangeToValidate,
-  );
+  const fieldErrors = validateDelimiterFields(lineToValidate, positionToValidate, hashToValidate, rangeToValidate);
 
   // If field validation failed, log and return defaults
   if (fieldErrors.length > 0) {

--- a/packages/rangelink-vscode-extension/src/config/logging.ts
+++ b/packages/rangelink-vscode-extension/src/config/logging.ts
@@ -29,11 +29,7 @@ export const logValidationErrors = (logger: Logger, errors: RangeLinkError[]): v
  * @param delimiters - Loaded delimiter configuration
  * @param sources - Source for each delimiter field
  */
-export const logSuccessfulConfig = (
-  logger: Logger,
-  delimiters: DelimiterConfig,
-  sources: DelimiterConfigSources,
-): void => {
+export const logSuccessfulConfig = (logger: Logger, delimiters: DelimiterConfig, sources: DelimiterConfigSources): void => {
   logger.info(
     {
       fn: 'logSuccessfulConfig',

--- a/packages/rangelink-vscode-extension/src/config/parseCustomAiAssistants.ts
+++ b/packages/rangelink-vscode-extension/src/config/parseCustomAiAssistants.ts
@@ -24,11 +24,9 @@ interface RawCustomAiAssistantEntry {
   focusCommands?: unknown;
 }
 
-const isNonEmptyString = (value: unknown): value is string =>
-  typeof value === 'string' && value.trim().length > 0;
+const isNonEmptyString = (value: unknown): value is string => typeof value === 'string' && value.trim().length > 0;
 
-const isNonEmptyStringArray = (value: unknown): value is string[] =>
-  Array.isArray(value) && value.length > 0 && value.every((item) => isNonEmptyString(item));
+const isNonEmptyStringArray = (value: unknown): value is string[] => Array.isArray(value) && value.length > 0 && value.every((item) => isNonEmptyString(item));
 
 /**
  * Validate and normalize a single insertCommands entry.
@@ -41,9 +39,7 @@ const normalizeInsertCommandEntry = (item: unknown): InsertCommandEntry | undefi
   if (item && typeof item === 'object' && !Array.isArray(item)) {
     const obj = item as Record<string, unknown>;
     if (typeof obj.command === 'string' && obj.command.trim().length > 0) {
-      return obj.args !== undefined
-        ? { command: obj.command, args: obj.args }
-        : { command: obj.command };
+      return obj.args !== undefined ? { command: obj.command, args: obj.args } : { command: obj.command };
     }
   }
   return undefined;
@@ -53,11 +49,7 @@ const normalizeInsertCommandEntry = (item: unknown): InsertCommandEntry | undefi
  * Parse and normalize an insertCommands array from raw config.
  * Returns undefined if the array is absent/empty, or a normalized array skipping invalid entries.
  */
-const parseInsertCommands = (
-  raw: unknown,
-  index: number,
-  logger: Logger,
-): InsertCommandEntry[] | undefined => {
+const parseInsertCommands = (raw: unknown, index: number, logger: Logger): InsertCommandEntry[] | undefined => {
   if (raw === undefined) {
     return undefined;
   }
@@ -71,10 +63,7 @@ const parseInsertCommands = (
     if (normalized) {
       entries.push(normalized);
     } else {
-      logger.warn(
-        { fn: 'parseCustomAiAssistants', index, itemIndex },
-        `Skipping customAiAssistants[${index}].insertCommands[${itemIndex}]: invalid entry`,
-      );
+      logger.warn({ fn: 'parseCustomAiAssistants', index, itemIndex }, `Skipping customAiAssistants[${index}].insertCommands[${itemIndex}]: invalid entry`);
     }
   }
 
@@ -85,22 +74,14 @@ const parseInsertCommands = (
  * Parse an optional string array field. Returns undefined if absent or invalid.
  * Logs a warning when the value exists but is malformed.
  */
-const parseOptionalStringArray = (
-  raw: unknown,
-  fieldName: string,
-  index: number,
-  logger: Logger,
-): string[] | undefined => {
+const parseOptionalStringArray = (raw: unknown, fieldName: string, index: number, logger: Logger): string[] | undefined => {
   if (raw === undefined) {
     return undefined;
   }
   if (isNonEmptyStringArray(raw)) {
     return raw;
   }
-  logger.warn(
-    { fn: 'parseCustomAiAssistants', index, fieldName },
-    `Skipping customAiAssistants[${index}].${fieldName}: must be a non-empty array of strings`,
-  );
+  logger.warn({ fn: 'parseCustomAiAssistants', index, fieldName }, `Skipping customAiAssistants[${index}].${fieldName}: must be a non-empty array of strings`);
   return undefined;
 };
 
@@ -113,10 +94,7 @@ const parseOptionalStringArray = (
  * - focusAndPasteCommands: Tier 2 — focus + auto-paste via clipboard
  * - focusCommands: Tier 3 — focus only, user pastes manually
  */
-export const parseCustomAiAssistants = (
-  configReader: ConfigReader,
-  logger: Logger,
-): CustomAiAssistantConfig[] => {
+export const parseCustomAiAssistants = (configReader: ConfigReader, logger: Logger): CustomAiAssistantConfig[] => {
   const raw = configReader.get<RawCustomAiAssistantEntry[]>(SETTING_KEY);
 
   if (!Array.isArray(raw) || raw.length === 0) {
@@ -128,10 +106,7 @@ export const parseCustomAiAssistants = (
 
   for (const [index, entry] of raw.entries()) {
     if (!entry || typeof entry !== 'object') {
-      logger.warn(
-        { fn: 'parseCustomAiAssistants', index },
-        `Skipping customAiAssistants[${index}]: not an object`,
-      );
+      logger.warn({ fn: 'parseCustomAiAssistants', index }, `Skipping customAiAssistants[${index}]: not an object`);
       continue;
     }
 
@@ -157,18 +132,8 @@ export const parseCustomAiAssistants = (
     const extensionName = rawExtensionName.trim();
 
     const insertCommands = parseInsertCommands(entry.insertCommands, index, logger);
-    const focusAndPasteCommands = parseOptionalStringArray(
-      entry.focusAndPasteCommands,
-      'focusAndPasteCommands',
-      index,
-      logger,
-    );
-    const focusCommands = parseOptionalStringArray(
-      entry.focusCommands,
-      'focusCommands',
-      index,
-      logger,
-    );
+    const focusAndPasteCommands = parseOptionalStringArray(entry.focusAndPasteCommands, 'focusAndPasteCommands', index, logger);
+    const focusCommands = parseOptionalStringArray(entry.focusCommands, 'focusCommands', index, logger);
 
     if (!insertCommands && !focusAndPasteCommands && !focusCommands) {
       logger.warn(
@@ -179,10 +144,7 @@ export const parseCustomAiAssistants = (
     }
 
     if (seenIds.has(extensionId)) {
-      logger.warn(
-        { fn: 'parseCustomAiAssistants', index, extensionId },
-        `Skipping customAiAssistants[${index}]: duplicate extensionId '${extensionId}'`,
-      );
+      logger.warn({ fn: 'parseCustomAiAssistants', index, extensionId }, `Skipping customAiAssistants[${index}]: duplicate extensionId '${extensionId}'`);
       continue;
     }
 

--- a/packages/rangelink-vscode-extension/src/config/sources.ts
+++ b/packages/rangelink-vscode-extension/src/config/sources.ts
@@ -1,9 +1,4 @@
-import {
-  SETTING_DELIMITER_HASH,
-  SETTING_DELIMITER_LINE,
-  SETTING_DELIMITER_POSITION,
-  SETTING_DELIMITER_RANGE,
-} from '../constants';
+import { SETTING_DELIMITER_HASH, SETTING_DELIMITER_LINE, SETTING_DELIMITER_POSITION, SETTING_DELIMITER_RANGE } from '../constants';
 
 import type { ConfigGetter, ConfigInspection, ConfigSource, DelimiterConfigSources } from './types';
 

--- a/packages/rangelink-vscode-extension/src/config/validation.ts
+++ b/packages/rangelink-vscode-extension/src/config/validation.ts
@@ -1,10 +1,4 @@
-import {
-  type DelimiterConfig,
-  type RangeLinkError,
-  validateDelimiter,
-  validateSubstringConflicts,
-  validateUniqueness,
-} from 'rangelink-core-ts';
+import { type DelimiterConfig, type RangeLinkError, validateDelimiter, validateSubstringConflicts, validateUniqueness } from 'rangelink-core-ts';
 
 // ============================================================================
 // Validation Functions
@@ -25,12 +19,7 @@ import {
  * @param userRange - Range delimiter value from config
  * @returns Array of RangeLinkError (empty if all valid)
  */
-export const validateDelimiterFields = (
-  userLine: string,
-  userPosition: string,
-  userHash: string,
-  userRange: string,
-): RangeLinkError[] => {
+export const validateDelimiterFields = (userLine: string, userPosition: string, userHash: string, userRange: string): RangeLinkError[] => {
   const errors: RangeLinkError[] = [];
 
   const lineResult = validateDelimiter(userLine, false);

--- a/packages/rangelink-vscode-extension/src/constants/aiAssistantPasteConstants.ts
+++ b/packages/rangelink-vscode-extension/src/constants/aiAssistantPasteConstants.ts
@@ -45,8 +45,4 @@ export const CLIPBOARD_POST_PASTE_DELAY_MS = 200;
  * for parking focus inside the AI panel before this loop runs, so #1 typically
  * throws (no editor focused) and the loop falls through to #2.
  */
-export const AI_ASSISTANT_PASTE_COMMANDS = [
-  'editor.action.clipboardPasteAction',
-  'execPaste',
-  'paste',
-] as const;
+export const AI_ASSISTANT_PASTE_COMMANDS = ['editor.action.clipboardPasteAction', 'execPaste', 'paste'] as const;

--- a/packages/rangelink-vscode-extension/src/constants/commandIds.ts
+++ b/packages/rangelink-vscode-extension/src/constants/commandIds.ts
@@ -20,23 +20,19 @@ export const CMD_BOOKMARK_MANAGE = 'rangelink.bookmark.manage';
 export const CMD_BOOKMARK_NAVIGATE = 'rangelink.bookmark.navigate';
 export const CMD_CONTEXT_EDITOR_CONTENT_BIND = 'rangelink.editorContent.bind';
 export const CMD_CONTEXT_EDITOR_CONTENT_PASTE_FILE_PATH = 'rangelink.editorContent.pasteFilePath';
-export const CMD_CONTEXT_EDITOR_CONTENT_PASTE_RELATIVE_FILE_PATH =
-  'rangelink.editorContent.pasteRelativeFilePath';
+export const CMD_CONTEXT_EDITOR_CONTENT_PASTE_RELATIVE_FILE_PATH = 'rangelink.editorContent.pasteRelativeFilePath';
 export const CMD_CONTEXT_EDITOR_CONTENT_UNBIND = 'rangelink.editorContent.unbind';
 export const CMD_CONTEXT_EDITOR_COPY_LINK = 'rangelink.editorContext.copyLink';
 export const CMD_CONTEXT_EDITOR_COPY_LINK_ABSOLUTE = 'rangelink.editorContext.copyLinkAbsolute';
 export const CMD_CONTEXT_EDITOR_COPY_PORTABLE_LINK = 'rangelink.editorContext.copyPortableLink';
-export const CMD_CONTEXT_EDITOR_COPY_PORTABLE_LINK_ABSOLUTE =
-  'rangelink.editorContext.copyPortableLinkAbsolute';
+export const CMD_CONTEXT_EDITOR_COPY_PORTABLE_LINK_ABSOLUTE = 'rangelink.editorContext.copyPortableLinkAbsolute';
 export const CMD_CONTEXT_EDITOR_PASTE_SELECTED_TEXT = 'rangelink.editorContext.pasteSelectedText';
 export const CMD_CONTEXT_EDITOR_SAVE_BOOKMARK = 'rangelink.editorContext.saveBookmark';
 export const CMD_CONTEXT_EDITOR_TAB_PASTE_FILE_PATH = 'rangelink.editorTab.pasteFilePath';
-export const CMD_CONTEXT_EDITOR_TAB_PASTE_RELATIVE_FILE_PATH =
-  'rangelink.editorTab.pasteRelativeFilePath';
+export const CMD_CONTEXT_EDITOR_TAB_PASTE_RELATIVE_FILE_PATH = 'rangelink.editorTab.pasteRelativeFilePath';
 export const CMD_CONTEXT_EXPLORER_BIND = 'rangelink.explorer.bind';
 export const CMD_CONTEXT_EXPLORER_PASTE_FILE_PATH = 'rangelink.explorer.pasteFilePath';
-export const CMD_CONTEXT_EXPLORER_PASTE_RELATIVE_FILE_PATH =
-  'rangelink.explorer.pasteRelativeFilePath';
+export const CMD_CONTEXT_EXPLORER_PASTE_RELATIVE_FILE_PATH = 'rangelink.explorer.pasteRelativeFilePath';
 export const CMD_CONTEXT_EXPLORER_UNBIND = 'rangelink.explorer.unbind';
 export const CMD_CONTEXT_TERMINAL_BIND = 'rangelink.terminal.bind';
 export const CMD_CONTEXT_TERMINAL_UNBIND = 'rangelink.terminal.unbind';

--- a/packages/rangelink-vscode-extension/src/constants/contextKeys.ts
+++ b/packages/rangelink-vscode-extension/src/constants/contextKeys.ts
@@ -8,8 +8,7 @@
  */
 
 export const CONTEXT_IS_ACTIVE_TERMINAL_BINDABLE = 'rangelink.isActiveTerminalBindable';
-export const CONTEXT_IS_ACTIVE_TERMINAL_PASTE_DESTINATION =
-  'rangelink.isActiveTerminalPasteDestination';
+export const CONTEXT_IS_ACTIVE_TERMINAL_PASTE_DESTINATION = 'rangelink.isActiveTerminalPasteDestination';
 export const CONTEXT_IS_BOUND = 'rangelink.isBound';
 
 // Keep entries sorted alphabetically by constant name.

--- a/packages/rangelink-vscode-extension/src/constants/settingKeys.ts
+++ b/packages/rangelink-vscode-extension/src/constants/settingKeys.ts
@@ -23,14 +23,10 @@ export const SETTING_CLIPBOARD_PRESERVE = 'clipboard.preserve';
 
 export const SETTINGS_DESTINATIONS_PREFIX = 'destinations.';
 
-export const SETTING_DESTINATIONS_CLAUDE_CODE_COLD_REFOCUS_INTERVAL_MS =
-  'destinations.claudeCode.coldRefocusIntervalMs';
-export const SETTING_DESTINATIONS_CLAUDE_CODE_COLD_START_DELAY_MS =
-  'destinations.claudeCode.coldStartDelayMs';
-export const SETTING_DESTINATIONS_GEMINI_COLD_REFOCUS_INTERVAL_MS =
-  'destinations.gemini.coldRefocusIntervalMs';
-export const SETTING_DESTINATIONS_GEMINI_COLD_START_DELAY_MS =
-  'destinations.gemini.coldStartDelayMs';
+export const SETTING_DESTINATIONS_CLAUDE_CODE_COLD_REFOCUS_INTERVAL_MS = 'destinations.claudeCode.coldRefocusIntervalMs';
+export const SETTING_DESTINATIONS_CLAUDE_CODE_COLD_START_DELAY_MS = 'destinations.claudeCode.coldStartDelayMs';
+export const SETTING_DESTINATIONS_GEMINI_COLD_REFOCUS_INTERVAL_MS = 'destinations.gemini.coldRefocusIntervalMs';
+export const SETTING_DESTINATIONS_GEMINI_COLD_START_DELAY_MS = 'destinations.gemini.coldStartDelayMs';
 
 // =============================================================================
 // Feature Flags — TODO [2026-12-31]: #366 remove when bookmarks graduates from beta

--- a/packages/rangelink-vscode-extension/src/contextKeys/ContextKeyService.ts
+++ b/packages/rangelink-vscode-extension/src/contextKeys/ContextKeyService.ts
@@ -1,8 +1,4 @@
-import {
-  CONTEXT_IS_ACTIVE_TERMINAL_BINDABLE,
-  CONTEXT_IS_ACTIVE_TERMINAL_PASTE_DESTINATION,
-  CONTEXT_IS_BOUND,
-} from '../constants/contextKeys';
+import { CONTEXT_IS_ACTIVE_TERMINAL_BINDABLE, CONTEXT_IS_ACTIVE_TERMINAL_PASTE_DESTINATION, CONTEXT_IS_BOUND } from '../constants/contextKeys';
 import type { BoundSession } from '../destinations';
 import { classifyTerminalForBinding } from '../destinations/utils';
 import type { VscodeAdapter } from '../ide/vscode/VscodeAdapter';
@@ -71,27 +67,17 @@ export class ContextKeyService implements vscode.Disposable {
   private updateBindability(): void {
     const activeTerminal = this.ideAdapter.activeTerminal;
     const classification = classifyTerminalForBinding(activeTerminal);
-    const bindable =
-      classification.visible === true && classification.nonBindableReason === undefined;
+    const bindable = classification.visible === true && classification.nonBindableReason === undefined;
     this.lastSetValues[CONTEXT_IS_ACTIVE_TERMINAL_BINDABLE] = bindable;
-    this.logger.debug(
-      { fn: `${FN}.updateBindability`, bindable, terminalName: activeTerminal?.name },
-      'Evaluating isActiveTerminalBindable context key',
-    );
+    this.logger.debug({ fn: `${FN}.updateBindability`, bindable, terminalName: activeTerminal?.name }, 'Evaluating isActiveTerminalBindable context key');
     this.ideAdapter.setContext(CONTEXT_IS_ACTIVE_TERMINAL_BINDABLE, bindable);
   }
 
   private updateActiveTerminalPasteDestination(): void {
     const bound = this.session.get();
-    const active =
-      bound !== undefined &&
-      isTerminalDestination(bound) &&
-      bound.resource.terminal === this.ideAdapter.activeTerminal;
+    const active = bound !== undefined && isTerminalDestination(bound) && bound.resource.terminal === this.ideAdapter.activeTerminal;
     this.lastSetValues[CONTEXT_IS_ACTIVE_TERMINAL_PASTE_DESTINATION] = active;
-    this.logger.debug(
-      { fn: `${FN}.updateActiveTerminalPasteDestination`, active },
-      'Evaluating isActiveTerminalPasteDestination context key',
-    );
+    this.logger.debug({ fn: `${FN}.updateActiveTerminalPasteDestination`, active }, 'Evaluating isActiveTerminalPasteDestination context key');
     this.ideAdapter.setContext(CONTEXT_IS_ACTIVE_TERMINAL_PASTE_DESTINATION, active);
   }
 }

--- a/packages/rangelink-vscode-extension/src/createWiringServices.ts
+++ b/packages/rangelink-vscode-extension/src/createWiringServices.ts
@@ -30,15 +30,7 @@ import { ConfigReader, DelimiterCache } from './config';
 import { ContextKeyService } from './contextKeys';
 import { BoundSession } from './destinations';
 import { OperationFeedbackProvider } from './feedback';
-import {
-  FilePathPaster,
-  LinkGenerator,
-  SelectionValidator,
-  SendRouter,
-  TerminalPasteService,
-  TerminalSelectionService,
-  TextSelectionPaster,
-} from './services';
+import { FilePathPaster, LinkGenerator, SelectionValidator, SendRouter, TerminalPasteService, TerminalSelectionService, TextSelectionPaster } from './services';
 import { RangeLinkStatusBar } from './statusBar';
 import type { VersionInfo } from './types';
 
@@ -85,10 +77,7 @@ export interface ExtensionDependencies {
  * Build the full object graph from foundational dependencies.
  * Returns all services needed by wireSubscriptions.
  */
-export const createWiringServices = (
-  deps: ExtensionDependencies,
-  context: vscode.ExtensionContext,
-): WiringServices => {
+export const createWiringServices = (deps: ExtensionDependencies, context: vscode.ExtensionContext): WiringServices => {
   const { ideAdapter, logger, versionInfo } = deps;
 
   const configReader = ConfigReader.create(ideAdapter, logger);
@@ -100,116 +89,34 @@ export const createWiringServices = (
 
   const clipboardService = new ClipboardService(ideAdapter, configReader, logger);
   const terminalPasteService = new TerminalPasteService(ideAdapter, clipboardService, logger);
-  const focusCapabilityFactory = new FocusCapabilityFactory(
-    ideAdapter,
-    terminalPasteService,
-    logger,
-  );
+  const focusCapabilityFactory = new FocusCapabilityFactory(ideAdapter, terminalPasteService, logger);
   const eligibilityCheckerFactory = new EligibilityCheckerFactory(logger);
-  const registry = new DestinationRegistry(
-    focusCapabilityFactory,
-    eligibilityCheckerFactory,
-    ideAdapter,
-    configReader,
-    logger,
-  );
+  const registry = new DestinationRegistry(focusCapabilityFactory, eligibilityCheckerFactory, ideAdapter, configReader, logger);
   const customAssistants = parseCustomAiAssistants(configReader, logger);
   registerAllDestinationBuilders(registry, customAssistants);
 
-  const availabilityService = new DestinationAvailabilityService(
-    registry,
-    ideAdapter,
-    configReader,
-    logger,
-  );
+  const availabilityService = new DestinationAvailabilityService(registry, ideAdapter, configReader, logger);
   const destinationPicker = new DestinationPicker(ideAdapter, availabilityService, logger);
   const feedbackProvider = new OperationFeedbackProvider(ideAdapter);
-  const boundSession = new BoundSession(
-    ideAdapter,
-    ideAdapter,
-    feedbackProvider,
-    ideAdapter,
-    logger,
-  );
-  const destinationManager = new PasteDestinationManager(
-    registry,
-    ideAdapter,
-    boundSession,
-    feedbackProvider,
-    logger,
-  );
+  const boundSession = new BoundSession(ideAdapter, ideAdapter, feedbackProvider, ideAdapter, logger);
+  const destinationManager = new PasteDestinationManager(registry, ideAdapter, boundSession, feedbackProvider, logger);
   const contextKeyService = new ContextKeyService(ideAdapter, boundSession, logger);
 
-  const bindToTerminalCommand = new BindToTerminalCommand(
-    ideAdapter,
-    availabilityService,
-    destinationManager,
-    boundSession,
-    logger,
-  );
-  const bindToTextEditorCommand = new BindToTextEditorCommand(
-    ideAdapter,
-    availabilityService,
-    destinationManager,
-    boundSession,
-    logger,
-  );
+  const bindToTerminalCommand = new BindToTerminalCommand(ideAdapter, availabilityService, destinationManager, boundSession, logger);
+  const bindToTextEditorCommand = new BindToTextEditorCommand(ideAdapter, availabilityService, destinationManager, boundSession, logger);
 
-  const bookmarkService = new BookmarkService(
-    bookmarksStore,
-    ideAdapter,
-    configReader,
-    destinationManager,
-    boundSession,
-    logger,
-  );
-  const addBookmarkCommand = new AddBookmarkCommand(
-    getDelimiters,
-    ideAdapter,
-    bookmarkService,
-    logger,
-  );
+  const bookmarkService = new BookmarkService(bookmarksStore, ideAdapter, configReader, destinationManager, boundSession, logger);
+  const addBookmarkCommand = new AddBookmarkCommand(getDelimiters, ideAdapter, bookmarkService, logger);
   const showVersionCommand = new ShowVersionCommand(ideAdapter, logger, versionInfo);
-  const bindToDestinationCommand = new BindToDestinationCommand(
-    destinationManager,
-    destinationPicker,
-    boundSession,
-    logger,
-  );
-  const jumpToDestinationCommand = new JumpToDestinationCommand(
-    destinationManager,
-    boundSession,
-    destinationPicker,
-    logger,
-  );
+  const bindToDestinationCommand = new BindToDestinationCommand(destinationManager, destinationPicker, boundSession, logger);
+  const jumpToDestinationCommand = new JumpToDestinationCommand(destinationManager, boundSession, destinationPicker, logger);
   const listBookmarksCommand = new ListBookmarksCommand(ideAdapter, bookmarkService, logger);
   const manageBookmarksCommand = new ManageBookmarksCommand(ideAdapter, bookmarkService, logger);
 
   const selectionValidator = new SelectionValidator(ideAdapter, logger);
-  const sendRouter = new SendRouter(
-    ideAdapter,
-    destinationManager,
-    boundSession,
-    destinationPicker,
-    clipboardService,
-    feedbackProvider,
-    logger,
-  );
-  const terminalSelectionService = new TerminalSelectionService(
-    ideAdapter,
-    destinationManager,
-    configReader,
-    clipboardService,
-    sendRouter,
-    logger,
-  );
-  const filePathPaster = new FilePathPaster(
-    ideAdapter,
-    destinationManager,
-    configReader,
-    sendRouter,
-    logger,
-  );
+  const sendRouter = new SendRouter(ideAdapter, destinationManager, boundSession, destinationPicker, clipboardService, feedbackProvider, logger);
+  const terminalSelectionService = new TerminalSelectionService(ideAdapter, destinationManager, configReader, clipboardService, sendRouter, logger);
+  const filePathPaster = new FilePathPaster(ideAdapter, destinationManager, configReader, sendRouter, logger);
   const linkGenerator = new LinkGenerator(
     getDelimiters,
     ideAdapter,
@@ -220,55 +127,18 @@ export const createWiringServices = (
     feedbackProvider,
     logger,
   );
-  const textSelectionPaster = new TextSelectionPaster(
-    destinationManager,
-    configReader,
-    sendRouter,
-    selectionValidator,
-    logger,
-  );
-  const statusBar = new RangeLinkStatusBar(
-    ideAdapter,
-    destinationManager,
-    boundSession,
-    availabilityService,
-    bookmarkService,
-    logger,
-  );
+  const textSelectionPaster = new TextSelectionPaster(destinationManager, configReader, sendRouter, selectionValidator, logger);
+  const statusBar = new RangeLinkStatusBar(ideAdapter, destinationManager, boundSession, availabilityService, bookmarkService, logger);
 
-  const navigationHandler = new RangeLinkNavigationHandler(
-    getDelimiters,
-    ideAdapter,
-    configReader,
-    logger,
-  );
+  const navigationHandler = new RangeLinkNavigationHandler(getDelimiters, ideAdapter, configReader, logger);
   logger.debug({ fn: 'createWiringServices' }, 'Navigation handler created');
   const filePathNavigationHandler = new FilePathNavigationHandler(ideAdapter, logger);
   const goToRangeLinkCommand = new GoToRangeLinkCommand(ideAdapter, navigationHandler, logger);
 
-  const filePathTerminalProvider = new FilePathTerminalProvider(
-    getDelimiters,
-    filePathNavigationHandler,
-    logger,
-  );
-  const filePathDocumentProvider = new FilePathDocumentProvider(
-    getDelimiters,
-    filePathNavigationHandler,
-    ideAdapter,
-    logger,
-  );
-  const terminalLinkProvider = new RangeLinkTerminalProvider(
-    navigationHandler,
-    getDelimiters,
-    ideAdapter,
-    logger,
-  );
-  const documentLinkProvider = new RangeLinkDocumentProvider(
-    navigationHandler,
-    getDelimiters,
-    ideAdapter,
-    logger,
-  );
+  const filePathTerminalProvider = new FilePathTerminalProvider(getDelimiters, filePathNavigationHandler, logger);
+  const filePathDocumentProvider = new FilePathDocumentProvider(getDelimiters, filePathNavigationHandler, ideAdapter, logger);
+  const terminalLinkProvider = new RangeLinkTerminalProvider(navigationHandler, getDelimiters, ideAdapter, logger);
+  const documentLinkProvider = new RangeLinkDocumentProvider(navigationHandler, getDelimiters, ideAdapter, logger);
 
   return {
     ideAdapter,

--- a/packages/rangelink-vscode-extension/src/destinations/BoundSession.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/BoundSession.ts
@@ -97,9 +97,7 @@ export class BoundSession implements vscode.Disposable {
   }
 
   getInfo(): BoundDestinationInfo | undefined {
-    return this.bound !== undefined
-      ? { id: this.bound.id, displayName: this.bound.displayName }
-      : undefined;
+    return this.bound !== undefined ? { id: this.bound.id, displayName: this.bound.displayName } : undefined;
   }
 
   /**
@@ -143,10 +141,7 @@ export class BoundSession implements vscode.Disposable {
       if (this.bound.resource.terminal === closedTerminal) {
         const destinationName = this.bound.displayName;
         const terminalName = closedTerminal.name || 'Unnamed Terminal'; // log-only, no i18n needed
-        this.logger.info(
-          { fn: 'BoundSession.setupTerminalCloseListener', terminalName },
-          `Bound terminal closed: ${terminalName} - auto-unbinding`,
-        );
+        this.logger.info({ fn: 'BoundSession.setupTerminalCloseListener', terminalName }, `Bound terminal closed: ${terminalName} - auto-unbinding`);
         this.clear();
         this.feedback.notifyAutoUnbind(destinationName, 'terminal-closed');
       }
@@ -187,17 +182,11 @@ export class BoundSession implements vscode.Disposable {
       };
 
       if (!closedDocument.isClosed) {
-        this.logger.info(
-          logCtx,
-          `Document close event with isClosed=false — language-mode transition detected, keeping binding for ${editorDisplayName}`,
-        );
+        this.logger.info(logCtx, `Document close event with isClosed=false — language-mode transition detected, keeping binding for ${editorDisplayName}`);
         return;
       }
 
-      this.logger.info(
-        logCtx,
-        `Bound document closed (isClosed=true): ${editorDisplayName} — auto-unbinding`,
-      );
+      this.logger.info(logCtx, `Bound document closed (isClosed=true): ${editorDisplayName} — auto-unbinding`);
       const destinationName = this.bound.displayName;
       this.clear();
       this.feedback.notifyAutoUnbind(destinationName, 'editor-closed');

--- a/packages/rangelink-vscode-extension/src/destinations/ComposablePasteDestination.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/ComposablePasteDestination.ts
@@ -1,10 +1,4 @@
-import {
-  type AIAssistantDestinationKind,
-  type AutoPasteResult,
-  type CustomAiAssistantKind,
-  type DestinationKind,
-  PasteContentType,
-} from '../types';
+import { type AIAssistantDestinationKind, type AutoPasteResult, type CustomAiAssistantKind, type DestinationKind, PasteContentType } from '../types';
 
 import { ContentEligibilityChecker } from './capabilities/ContentEligibilityChecker';
 import type { EligibilityChecker } from './capabilities/EligibilityChecker';
@@ -325,11 +319,7 @@ export class ComposablePasteDestination implements PasteDestination {
    * @param contentType - Type of content being pasted (for log messages)
    * @returns Promise resolving to true if paste succeeded, false otherwise
    */
-  private async performPaste(
-    text: string,
-    context: LoggingContext,
-    contentType: PasteContentType,
-  ): Promise<boolean> {
+  private async performPaste(text: string, context: LoggingContext, contentType: PasteContentType): Promise<boolean> {
     const contentLabel = contentType === PasteContentType.Link ? 'link' : 'content';
 
     // Check availability
@@ -342,10 +332,7 @@ export class ComposablePasteDestination implements PasteDestination {
     const focusResult = await this.focusCapability.focus(context);
 
     if (!focusResult.success) {
-      this.logger.warn(
-        { ...context, reason: focusResult.error.reason },
-        `Focus failed, cannot paste ${contentLabel}`,
-      );
+      this.logger.warn({ ...context, reason: focusResult.error.reason }, `Focus failed, cannot paste ${contentLabel}`);
       return false;
     }
 

--- a/packages/rangelink-vscode-extension/src/destinations/DestinationAvailabilityService.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/DestinationAvailabilityService.ts
@@ -1,8 +1,5 @@
 import type { ConfigReader } from '../config';
-import {
-  DEFAULT_TERMINAL_PICKER_MAX_INLINE,
-  SETTING_TERMINAL_PICKER_MAX_INLINE,
-} from '../constants';
+import { DEFAULT_TERMINAL_PICKER_MAX_INLINE, SETTING_TERMINAL_PICKER_MAX_INLINE } from '../constants';
 import { RangeLinkExtensionError, RangeLinkExtensionErrorCodes } from '../errors';
 import type { VscodeAdapter } from '../ide/vscode/VscodeAdapter';
 import {
@@ -38,8 +35,7 @@ import type { Logger } from '@couimet/logger-contract';
 
 const MIN_THRESHOLD = 1;
 
-const isValidThreshold = (value: number): boolean =>
-  value === Infinity || (Number.isFinite(value) && value >= MIN_THRESHOLD);
+const isValidThreshold = (value: number): boolean => value === Infinity || (Number.isFinite(value) && value >= MIN_THRESHOLD);
 
 /**
  * MessageCode lookup for AI assistant unavailable
@@ -81,16 +77,11 @@ export class DestinationAvailabilityService {
    * @param kind - AI assistant destination kind
    * @returns Promise<true> if available, Promise<false> otherwise
    */
-  async isAIAssistantAvailable(
-    kind: AIAssistantDestinationKind | CustomAiAssistantKind,
-  ): Promise<boolean> {
+  async isAIAssistantAvailable(kind: AIAssistantDestinationKind | CustomAiAssistantKind): Promise<boolean> {
     const destination = this.registry.create({ kind });
     const available = await destination.isAvailable();
 
-    this.logger.debug(
-      { fn: 'DestinationAvailabilityService.isAIAssistantAvailable', kind, available },
-      `AI assistant ${kind} availability: ${available}`,
-    );
+    this.logger.debug({ fn: 'DestinationAvailabilityService.isAIAssistantAvailable', kind, available }, `AI assistant ${kind} availability: ${available}`);
 
     return available;
   }
@@ -106,10 +97,7 @@ export class DestinationAvailabilityService {
    * @param terminalThreshold - Max terminals to show inline (use Infinity for all)
    * @param boundTerminalProcessId - processId of the currently bound terminal for badge display
    */
-  async getTerminalItems(
-    terminalThreshold: number,
-    boundTerminalProcessId?: number,
-  ): Promise<TerminalBindableQuickPickItem[]> {
+  async getTerminalItems(terminalThreshold: number, boundTerminalProcessId?: number): Promise<TerminalBindableQuickPickItem[]> {
     const grouped = await this.getGroupedDestinationItems({
       destinationKinds: ['terminal'],
       terminalThreshold,
@@ -128,10 +116,7 @@ export class DestinationAvailabilityService {
    * @param boundFileUriString - URI string of the currently bound file for badge display
    * @param boundFileViewColumn - viewColumn of the bound editor for precise matching
    */
-  getAllFileItems(
-    boundFileUriString?: string,
-    boundFileViewColumn?: number,
-  ): FileBindableQuickPickItem[] {
+  getAllFileItems(boundFileUriString?: string, boundFileViewColumn?: number): FileBindableQuickPickItem[] {
     const rawFiles = getEligibleFiles(this.ideAdapter);
     if (rawFiles.length === 0) {
       return [];
@@ -141,10 +126,7 @@ export class DestinationAvailabilityService {
     const sorted = sortEligibleFiles(enriched);
     const disambiguators = disambiguateFilenames(sorted);
 
-    this.logger.debug(
-      { fn: 'DestinationAvailabilityService.getAllFileItems', fileCount: sorted.length },
-      'Built all file items',
-    );
+    this.logger.debug({ fn: 'DestinationAvailabilityService.getAllFileItems', fileCount: sorted.length }, 'Built all file items');
 
     return sorted.map((file, i) => this.buildFileItem(file, disambiguators[i]));
   }
@@ -157,19 +139,14 @@ export class DestinationAvailabilityService {
    * @param options - Optional filtering and threshold configuration
    * @returns Grouped destination items keyed by DestinationKind
    */
-  async getGroupedDestinationItems(
-    options?: GetAvailableDestinationItemsOptions,
-  ): Promise<GroupedDestinationItems> {
+  async getGroupedDestinationItems(options?: GetAvailableDestinationItemsOptions): Promise<GroupedDestinationItems> {
     const result: {
       -readonly [K in keyof GroupedDestinationItems]: GroupedDestinationItems[K];
     } = {};
 
     const destinationKinds = options?.destinationKinds ?? this.registry.getSupportedKinds();
     if (options?.destinationKinds) {
-      this.logger.debug(
-        { fn: 'DestinationAvailabilityService.getGroupedDestinationItems', destinationKinds },
-        'Using provided destinationKinds filter',
-      );
+      this.logger.debug({ fn: 'DestinationAvailabilityService.getGroupedDestinationItems', destinationKinds }, 'Using provided destinationKinds filter');
     } else {
       this.logger.debug(
         {
@@ -188,11 +165,7 @@ export class DestinationAvailabilityService {
           const rawFiles = getEligibleFiles(this.ideAdapter);
           if (rawFiles.length === 0) break;
 
-          const enriched = markBoundFile(
-            rawFiles,
-            options?.boundFileUriString,
-            options?.boundFileViewColumn,
-          );
+          const enriched = markBoundFile(rawFiles, options?.boundFileUriString, options?.boundFileViewColumn);
           const sorted = sortEligibleFiles(enriched);
           const disambiguators = disambiguateFilenames(sorted);
 
@@ -213,10 +186,7 @@ export class DestinationAvailabilityService {
           const enriched = markBoundTerminal(rawTerminals, options?.boundTerminalProcessId);
           const eligibleTerminals = sortEligibleTerminals(enriched);
 
-          const { items, moreItem } = this.buildGroupedTerminalItems(
-            eligibleTerminals,
-            terminalThreshold,
-          );
+          const { items, moreItem } = this.buildGroupedTerminalItems(eligibleTerminals, terminalThreshold);
           if (items.length > 0) {
             result['terminal'] = items;
           }
@@ -320,10 +290,7 @@ export class DestinationAvailabilityService {
     };
   }
 
-  private buildFileItem(
-    eligibleFile: EligibleFile,
-    disambiguator: string,
-  ): FileBindableQuickPickItem {
+  private buildFileItem(eligibleFile: EligibleFile, disambiguator: string): FileBindableQuickPickItem {
     return {
       label: eligibleFile.filename,
       displayName: eligibleFile.filename,
@@ -386,10 +353,7 @@ export class DestinationAvailabilityService {
   private resolveTerminalThreshold(options?: GetAvailableDestinationItemsOptions): number {
     const fallback = DEFAULT_TERMINAL_PICKER_MAX_INLINE;
     const providedThreshold = options?.terminalThreshold;
-    const configThreshold = this.configReader.getWithDefault(
-      SETTING_TERMINAL_PICKER_MAX_INLINE,
-      fallback,
-    );
+    const configThreshold = this.configReader.getWithDefault(SETTING_TERMINAL_PICKER_MAX_INLINE, fallback);
 
     let effectiveThreshold = providedThreshold ?? configThreshold;
 

--- a/packages/rangelink-vscode-extension/src/destinations/DestinationBinder.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/DestinationBinder.ts
@@ -3,8 +3,5 @@ import type { BindOptions, ExtensionResult, StatusBarOptions } from '../types';
 import type { BindSuccessInfo } from './PasteDestinationManager';
 
 export interface DestinationBinder {
-  bind(
-    options: BindOptions,
-    statusBarOptions?: StatusBarOptions,
-  ): Promise<ExtensionResult<BindSuccessInfo>>;
+  bind(options: BindOptions, statusBarOptions?: StatusBarOptions): Promise<ExtensionResult<BindSuccessInfo>>;
 }

--- a/packages/rangelink-vscode-extension/src/destinations/DestinationPicker.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/DestinationPicker.ts
@@ -14,8 +14,7 @@ import type { Logger } from '@couimet/logger-contract';
  * Internal result type that includes 'returned-to-main-picker' for loop control.
  * Not exposed publicly - pick() converts this to DestinationPickerResult.
  */
-type InternalPickerResult =
-  DestinationPickerResult | { readonly outcome: 'returned-to-main-picker' };
+type InternalPickerResult = DestinationPickerResult | { readonly outcome: 'returned-to-main-picker' };
 
 /**
  * Context-specific options for the destination picker.
@@ -46,13 +45,7 @@ export class DestinationPicker {
   }
 
   async pick(options: DestinationPickerOptions): Promise<DestinationPickerResult> {
-    const {
-      noDestinationsMessageCode,
-      placeholderMessageCode,
-      boundTerminalProcessId,
-      boundFileUriString,
-      boundFileViewColumn,
-    } = options;
+    const { noDestinationsMessageCode, placeholderMessageCode, boundTerminalProcessId, boundFileUriString, boundFileViewColumn } = options;
     const logCtx = { fn: 'DestinationPicker.pick' };
 
     this.logger.debug(logCtx, 'Showing destination picker');
@@ -72,10 +65,7 @@ export class DestinationPicker {
     }
 
     while (true) {
-      this.logger.debug(
-        { ...logCtx, availableCount: quickPickItems.length },
-        `Showing quick pick with ${quickPickItems.length} items`,
-      );
+      this.logger.debug({ ...logCtx, availableCount: quickPickItems.length }, `Showing quick pick with ${quickPickItems.length} items`);
 
       const selected = await this.uiProvider.showQuickPick(quickPickItems, {
         placeHolder: formatMessage(placeholderMessageCode),
@@ -86,13 +76,7 @@ export class DestinationPicker {
         return { outcome: 'cancelled' };
       }
 
-      const result = await this.handleQuickPickSelection(
-        selected,
-        placeholderMessageCode,
-        boundTerminalProcessId,
-        boundFileUriString,
-        boundFileViewColumn,
-      );
+      const result = await this.handleQuickPickSelection(selected, placeholderMessageCode, boundTerminalProcessId, boundFileUriString, boundFileViewColumn);
 
       if (result.outcome !== 'returned-to-main-picker') {
         return result;
@@ -113,10 +97,7 @@ export class DestinationPicker {
 
     switch (selected.itemKind) {
       case 'bindable': {
-        this.logger.debug(
-          { ...logCtx, bindOptions: selected.bindOptions },
-          `User selected destination with bind options`,
-        );
+        this.logger.debug({ ...logCtx, bindOptions: selected.bindOptions }, `User selected destination with bind options`);
         return {
           outcome: 'selected',
           bindOptions: selected.bindOptions,
@@ -125,18 +106,11 @@ export class DestinationPicker {
 
       case 'file-more':
         this.logger.debug(logCtx, 'User selected "More files...", showing secondary picker');
-        return await this.showSecondaryFilePicker(
-          placeholderMessageCode,
-          boundFileUriString,
-          boundFileViewColumn,
-        );
+        return await this.showSecondaryFilePicker(placeholderMessageCode, boundFileUriString, boundFileViewColumn);
 
       case 'terminal-more':
         this.logger.debug(logCtx, 'User selected "More terminals...", showing secondary picker');
-        return await this.showSecondaryTerminalPicker(
-          placeholderMessageCode,
-          boundTerminalProcessId,
-        );
+        return await this.showSecondaryTerminalPicker(placeholderMessageCode, boundTerminalProcessId);
 
       default: {
         const _exhaustiveCheck: never = selected;
@@ -156,10 +130,7 @@ export class DestinationPicker {
     boundFileViewColumn?: number,
   ): Promise<InternalPickerResult> {
     const logCtx = { fn: 'DestinationPicker.showSecondaryFilePicker' };
-    const fileItems = this.availabilityService.getAllFileItems(
-      boundFileUriString,
-      boundFileViewColumn,
-    );
+    const fileItems = this.availabilityService.getAllFileItems(boundFileUriString, boundFileViewColumn);
 
     if (fileItems.length === 0) {
       this.logger.debug(logCtx, 'No files available in secondary picker');
@@ -186,15 +157,9 @@ export class DestinationPicker {
     return result ?? { outcome: 'returned-to-main-picker' };
   }
 
-  private async showSecondaryTerminalPicker(
-    placeholderMessageCode: MessageCode,
-    boundTerminalProcessId?: number,
-  ): Promise<InternalPickerResult> {
+  private async showSecondaryTerminalPicker(placeholderMessageCode: MessageCode, boundTerminalProcessId?: number): Promise<InternalPickerResult> {
     const logCtx = { fn: 'DestinationPicker.showSecondaryTerminalPicker' };
-    const terminalItems = await this.availabilityService.getTerminalItems(
-      Infinity,
-      boundTerminalProcessId,
-    );
+    const terminalItems = await this.availabilityService.getTerminalItems(Infinity, boundTerminalProcessId);
 
     const result = await showTerminalPicker<InternalPickerResult>(
       terminalItems,

--- a/packages/rangelink-vscode-extension/src/destinations/DestinationRegistry.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/DestinationRegistry.ts
@@ -59,10 +59,7 @@ export interface DestinationBuilderContext {
  * @param context - Factory bundle and infrastructure dependencies
  * @returns Configured PasteDestination instance
  */
-export type DestinationBuilder = (
-  options: BindOptions,
-  context: DestinationBuilderContext,
-) => PasteDestination;
+export type DestinationBuilder = (options: BindOptions, context: DestinationBuilderContext) => PasteDestination;
 
 /**
  * Registry for destination builders supporting IoC pattern.
@@ -111,10 +108,7 @@ export class DestinationRegistry {
    * @param builder - Function that creates PasteDestination instances
    */
   register(kind: DestinationKind, builder: DestinationBuilder): void {
-    this.context.logger.debug(
-      { fn: 'DestinationRegistry.register', kind },
-      `Registering builder for destination: ${kind}`,
-    );
+    this.context.logger.debug({ fn: 'DestinationRegistry.register', kind }, `Registering builder for destination: ${kind}`);
     this.builders.set(kind, builder);
   }
 
@@ -141,10 +135,7 @@ export class DestinationRegistry {
       });
     }
 
-    this.context.logger.debug(
-      { fn: 'DestinationRegistry.create', kind },
-      `Creating destination: ${kind}`,
-    );
+    this.context.logger.debug({ fn: 'DestinationRegistry.create', kind }, `Creating destination: ${kind}`);
     return builder(options, this.context);
   }
 
@@ -172,8 +163,6 @@ export class DestinationRegistry {
    * @returns Record mapping destination kinds to display names
    */
   getDisplayNames(): Record<DestinationKind, string> {
-    return Object.fromEntries(
-      Object.entries(DISPLAY_NAME_CODES).map(([kind, code]) => [kind, formatMessage(code)]),
-    ) as Record<DestinationKind, string>;
+    return Object.fromEntries(Object.entries(DISPLAY_NAME_CODES).map(([kind, code]) => [kind, formatMessage(code)])) as Record<DestinationKind, string>;
   }
 }

--- a/packages/rangelink-vscode-extension/src/destinations/PasteDestinationManager.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/PasteDestinationManager.ts
@@ -51,10 +51,7 @@ export class PasteDestinationManager implements DestinationBinder, DestinationFo
     private readonly logger: Logger,
   ) {}
 
-  bind(
-    options: BindOptions,
-    statusBarOptions?: StatusBarOptions,
-  ): Promise<ExtensionResult<BindSuccessInfo>> {
+  bind(options: BindOptions, statusBarOptions?: StatusBarOptions): Promise<ExtensionResult<BindSuccessInfo>> {
     switch (options.kind) {
       case 'terminal': {
         const newDestination = this.registry.create({
@@ -114,10 +111,7 @@ export class PasteDestinationManager implements DestinationBinder, DestinationFo
 
     this.session.clear();
 
-    this.logger.info(
-      { fn: 'PasteDestinationManager.unbind', displayName },
-      `Successfully unbound from ${displayName}`,
-    );
+    this.logger.info({ fn: 'PasteDestinationManager.unbind', displayName }, `Successfully unbound from ${displayName}`);
 
     this.feedback.notifyUnbound(displayName);
   }
@@ -131,9 +125,7 @@ export class PasteDestinationManager implements DestinationBinder, DestinationFo
    *   Used by bindAndFocus() where the binding toast is already shown.
    * @returns ExtensionResult with FocusSuccessInfo on success, error on failure
    */
-  async focusBoundDestination(
-    options?: StatusBarOptions,
-  ): Promise<ExtensionResult<FocusSuccessInfo>> {
+  async focusBoundDestination(options?: StatusBarOptions): Promise<ExtensionResult<FocusSuccessInfo>> {
     const bound = this.session.get();
     if (!bound) {
       return ExtensionResult.err(
@@ -212,10 +204,7 @@ export class PasteDestinationManager implements DestinationBinder, DestinationFo
    *
    * @returns ExtensionResult with bind success info or error
    */
-  private async bindTextEditor(
-    options: TextEditorBindOptions,
-    statusBarOptions?: StatusBarOptions,
-  ): Promise<ExtensionResult<BindSuccessInfo>> {
+  private async bindTextEditor(options: TextEditorBindOptions, statusBarOptions?: StatusBarOptions): Promise<ExtensionResult<BindSuccessInfo>> {
     const fnName = 'bindTextEditor';
 
     const fileName = this.vscodeAdapter.getFilenameFromUri(options.uri);
@@ -247,11 +236,7 @@ export class PasteDestinationManager implements DestinationBinder, DestinationFo
         this.feedback.notifyBindFailedEditor(MessageCode.ERROR_BACKGROUND_TAB_WRONG_VIEW_COLUMN, {
           fileName,
         });
-        return this.bindFailedResult(
-          fnName,
-          `Editor opened but not visible at expected viewColumn ${options.viewColumn}`,
-          BindFailureReason.NO_ACTIVE_EDITOR,
-        );
+        return this.bindFailedResult(fnName, `Editor opened but not visible at expected viewColumn ${options.viewColumn}`, BindFailureReason.NO_ACTIVE_EDITOR);
       }
       this.feedback.notifyBackgroundTabOpened(fileName);
       wasBackgroundTab = true;
@@ -264,21 +249,13 @@ export class PasteDestinationManager implements DestinationBinder, DestinationFo
     if (!isWritableScheme(scheme)) {
       this.logger.warn(logCtx, `Cannot bind: Editor is read-only (scheme: ${scheme})`);
       this.feedback.notifyBindFailedEditor(MessageCode.ERROR_TEXT_EDITOR_READ_ONLY, { scheme });
-      return this.bindFailedResult(
-        fnName,
-        `Editor is read-only (scheme: ${scheme})`,
-        BindFailureReason.EDITOR_READ_ONLY,
-      );
+      return this.bindFailedResult(fnName, `Editor is read-only (scheme: ${scheme})`, BindFailureReason.EDITOR_READ_ONLY);
     }
 
     if (isBinaryFile(scheme, fsPath)) {
       this.logger.warn(logCtx, 'Cannot bind: Editor is a binary file');
       this.feedback.notifyBindFailedEditor(MessageCode.ERROR_TEXT_EDITOR_BINARY_FILE, { fileName });
-      return this.bindFailedResult(
-        fnName,
-        'Editor is a binary file',
-        BindFailureReason.EDITOR_BINARY_FILE,
-      );
+      return this.bindFailedResult(fnName, 'Editor is a binary file', BindFailureReason.EDITOR_BINARY_FILE);
     }
 
     const newDestination = this.registry.create(options);
@@ -293,27 +270,17 @@ export class PasteDestinationManager implements DestinationBinder, DestinationFo
    * @param kind - The destination kind (AI assistants only)
    * @returns ExtensionResult with bind success info or error
    */
-  private async bindGenericDestination(
-    kind: DestinationKind,
-    statusBarOptions?: StatusBarOptions,
-  ): Promise<ExtensionResult<BindSuccessInfo>> {
+  private async bindGenericDestination(kind: DestinationKind, statusBarOptions?: StatusBarOptions): Promise<ExtensionResult<BindSuccessInfo>> {
     const fnName = 'bindGenericDestination';
 
     const newDestination = this.registry.create({ kind } as BindOptions);
 
     if (!(await newDestination.isAvailable())) {
-      this.logger.warn(
-        { fn: 'PasteDestinationManager.bindGenericDestination', kind },
-        `Cannot bind: ${newDestination.displayName} not available`,
-      );
+      this.logger.warn({ fn: 'PasteDestinationManager.bindGenericDestination', kind }, `Cannot bind: ${newDestination.displayName} not available`);
 
       this.feedback.notifyBindFailedNotAvailable(newDestination.displayName, kind);
 
-      return this.bindFailedResult(
-        fnName,
-        `${newDestination.displayName} not available`,
-        BindFailureReason.DESTINATION_NOT_AVAILABLE,
-      );
+      return this.bindFailedResult(fnName, `${newDestination.displayName} not available`, BindFailureReason.DESTINATION_NOT_AVAILABLE);
     }
 
     return this.commitBind(newDestination, statusBarOptions ? { statusBarOptions } : undefined);
@@ -337,42 +304,24 @@ export class PasteDestinationManager implements DestinationBinder, DestinationFo
 
     const currentBound = this.session.get();
     if (currentBound && (await currentBound.equals(newDestination))) {
-      this.logger.debug(
-        { ...logCtx, displayName: newDestination.displayName },
-        `Already bound to ${newDestination.displayName}, no action taken`,
-      );
+      this.logger.debug({ ...logCtx, displayName: newDestination.displayName }, `Already bound to ${newDestination.displayName}, no action taken`);
       this.feedback.notifyAlreadyBound(newDestination.displayName);
 
-      return this.bindFailedResult(
-        'commitBind',
-        'Already bound to same destination',
-        BindFailureReason.ALREADY_BOUND_TO_SAME,
-      );
+      return this.bindFailedResult('commitBind', 'Already bound to same destination', BindFailureReason.ALREADY_BOUND_TO_SAME);
     }
 
     let replacedName: string | undefined;
 
     if (currentBound) {
-      const confirmed = await this.confirmReplaceBinding(
-        currentBound,
-        kind,
-        newDestination.displayName,
-      );
+      const confirmed = await this.confirmReplaceBinding(currentBound, kind, newDestination.displayName);
 
       if (!confirmed) {
         this.logger.debug(logCtx, 'User cancelled binding replacement');
-        return this.bindFailedResult(
-          'commitBind',
-          'User cancelled binding replacement',
-          BindFailureReason.USER_CANCELLED_REPLACEMENT,
-        );
+        return this.bindFailedResult('commitBind', 'User cancelled binding replacement', BindFailureReason.USER_CANCELLED_REPLACEMENT);
       }
 
       replacedName = currentBound.displayName;
-      this.logger.info(
-        { ...logCtx, displayName: replacedName },
-        `Unbinding "${replacedName}" for replacement`,
-      );
+      this.logger.info({ ...logCtx, displayName: replacedName }, `Unbinding "${replacedName}" for replacement`);
       this.session.clear();
     }
 
@@ -443,11 +392,7 @@ export class PasteDestinationManager implements DestinationBinder, DestinationFo
     return pasteSucceeded;
   }
 
-  private bindFailedResult(
-    functionName: string,
-    message: string,
-    failedBindDetails: BindFailureReason,
-  ): ExtensionResult<BindSuccessInfo> {
+  private bindFailedResult(functionName: string, message: string, failedBindDetails: BindFailureReason): ExtensionResult<BindSuccessInfo> {
     return ExtensionResult.err(
       new RangeLinkExtensionError({
         code: RangeLinkExtensionErrorCodes.DESTINATION_BIND_FAILED,
@@ -469,11 +414,7 @@ export class PasteDestinationManager implements DestinationBinder, DestinationFo
    * @param newDisplayName - Display name of new destination
    * @returns true if user confirms replacement, false if cancelled
    */
-  private async confirmReplaceBinding(
-    currentDestination: PasteDestination,
-    newKind: DestinationKind,
-    newDisplayName: string,
-  ): Promise<boolean> {
+  private async confirmReplaceBinding(currentDestination: PasteDestination, newKind: DestinationKind, newDisplayName: string): Promise<boolean> {
     const params = {
       currentDestination: currentDestination.displayName,
       newDestination: newDisplayName,

--- a/packages/rangelink-vscode-extension/src/destinations/__tests__/BoundSession.test.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/__tests__/BoundSession.test.ts
@@ -29,8 +29,7 @@ describe('BoundSession', () => {
     onDidDelete: jest.fn(),
   });
 
-  const createSession = (): BoundSession =>
-    new BoundSession(mockEvents, mockEditors, mockFeedback, mockWatcherFactory, mockLogger);
+  const createSession = (): BoundSession => new BoundSession(mockEvents, mockEditors, mockFeedback, mockWatcherFactory, mockLogger);
 
   beforeEach(() => {
     mockEvents = {
@@ -84,9 +83,7 @@ describe('BoundSession', () => {
 
     it('returns undefined after set then clear', () => {
       const session = createSession();
-      session.set(
-        createMockSingletonComposablePasteDestination({ id: 'terminal', displayName: 'Terminal' }),
-      );
+      session.set(createMockSingletonComposablePasteDestination({ id: 'terminal', displayName: 'Terminal' }));
       session.clear();
 
       expect(session.get()).toBeUndefined();
@@ -102,18 +99,14 @@ describe('BoundSession', () => {
 
     it('returns true after set', () => {
       const session = createSession();
-      session.set(
-        createMockSingletonComposablePasteDestination({ id: 'terminal', displayName: 'Terminal' }),
-      );
+      session.set(createMockSingletonComposablePasteDestination({ id: 'terminal', displayName: 'Terminal' }));
 
       expect(session.isSet()).toBe(true);
     });
 
     it('returns false after set then clear', () => {
       const session = createSession();
-      session.set(
-        createMockSingletonComposablePasteDestination({ id: 'terminal', displayName: 'Terminal' }),
-      );
+      session.set(createMockSingletonComposablePasteDestination({ id: 'terminal', displayName: 'Terminal' }));
       session.clear();
 
       expect(session.isSet()).toBe(false);
@@ -163,9 +156,7 @@ describe('BoundSession', () => {
 
     it('throws when set is called while already bound', () => {
       const session = createSession();
-      session.set(
-        createMockSingletonComposablePasteDestination({ id: 'terminal', displayName: 'Terminal' }),
-      );
+      session.set(createMockSingletonComposablePasteDestination({ id: 'terminal', displayName: 'Terminal' }));
 
       expect(() =>
         session.set(
@@ -183,9 +174,7 @@ describe('BoundSession', () => {
   describe('clear', () => {
     it('fires onDidChange with undefined', () => {
       const session = createSession();
-      session.set(
-        createMockSingletonComposablePasteDestination({ id: 'terminal', displayName: 'Terminal' }),
-      );
+      session.set(createMockSingletonComposablePasteDestination({ id: 'terminal', displayName: 'Terminal' }));
       const listener = jest.fn();
       session.onDidChange(listener);
 
@@ -254,9 +243,7 @@ describe('BoundSession', () => {
       const dispose1 = jest.fn();
       const dispose2 = jest.fn();
       const fileDeleteDispose1 = jest.fn();
-      mockEvents.onDidChangeTabs
-        .mockReturnValueOnce({ dispose: dispose1 })
-        .mockReturnValueOnce({ dispose: dispose2 });
+      mockEvents.onDidChangeTabs.mockReturnValueOnce({ dispose: dispose1 }).mockReturnValueOnce({ dispose: dispose2 });
       mockWatcherFactory.createFileSystemWatcherForFile.mockReturnValueOnce({
         dispose: fileDeleteDispose1,
         onDidDelete: jest.fn(),
@@ -276,9 +263,7 @@ describe('BoundSession', () => {
       const dispose3 = jest.fn();
       const dispose4 = jest.fn();
       const fileDeleteDispose2 = jest.fn();
-      mockEvents.onDidChangeTabs
-        .mockReturnValueOnce({ dispose: dispose3 })
-        .mockReturnValueOnce({ dispose: dispose4 });
+      mockEvents.onDidChangeTabs.mockReturnValueOnce({ dispose: dispose3 }).mockReturnValueOnce({ dispose: dispose4 });
       mockWatcherFactory.createFileSystemWatcherForFile.mockReturnValueOnce({
         dispose: fileDeleteDispose2,
         onDidDelete: jest.fn(),
@@ -340,11 +325,7 @@ describe('BoundSession', () => {
       const dest = createMockSingletonComposablePasteDestination({
         id: 'terminal',
         displayName: 'Terminal',
-        getUserInstruction: jest
-          .fn()
-          .mockImplementation((result: AutoPasteResult) =>
-            result === AutoPasteResult.Failure ? undefined : 'Press Cmd+V',
-          ),
+        getUserInstruction: jest.fn().mockImplementation((result: AutoPasteResult) => (result === AutoPasteResult.Failure ? undefined : 'Press Cmd+V')),
       });
       session.set(dest);
 
@@ -397,9 +378,7 @@ describe('BoundSession', () => {
       const disposable = session.subscribe(listener);
       listener.mockClear();
 
-      session.set(
-        createMockSingletonComposablePasteDestination({ id: 'terminal', displayName: 'Terminal' }),
-      );
+      session.set(createMockSingletonComposablePasteDestination({ id: 'terminal', displayName: 'Terminal' }));
       expect(listener).toHaveBeenCalledTimes(1);
 
       disposable.dispose();
@@ -443,10 +422,7 @@ describe('BoundSession', () => {
         { fn: 'BoundSession.setupTerminalCloseListener', terminalName: 'bash' },
         'Bound terminal closed: bash - auto-unbinding',
       );
-      expect(mockFeedback.notifyAutoUnbind).toHaveBeenCalledWith(
-        'Terminal ("bash")',
-        'terminal-closed',
-      );
+      expect(mockFeedback.notifyAutoUnbind).toHaveBeenCalledWith('Terminal ("bash")', 'terminal-closed');
     });
 
     it('does not unbind when a different terminal closes', () => {
@@ -533,10 +509,7 @@ describe('BoundSession', () => {
         },
         'Bound document closed (isClosed=true): Text Editor ("test.ts") — auto-unbinding',
       );
-      expect(mockFeedback.notifyAutoUnbind).toHaveBeenCalledWith(
-        'Text Editor ("test.ts")',
-        'editor-closed',
-      );
+      expect(mockFeedback.notifyAutoUnbind).toHaveBeenCalledWith('Text Editor ("test.ts")', 'editor-closed');
     });
 
     it('falls back to Unknown in log when editor displayName is empty', () => {

--- a/packages/rangelink-vscode-extension/src/destinations/__tests__/createFileDeleteWatcher.test.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/__tests__/createFileDeleteWatcher.test.ts
@@ -39,12 +39,7 @@ describe('createFileDeleteWatcher', () => {
   it('creates a FileSystemWatcher scoped to the bound file with only delete events enabled', () => {
     createGuard();
 
-    expect(mockWatcherFactory.createFileSystemWatcherForFile).toHaveBeenCalledWith(
-      testUri,
-      true,
-      true,
-      false,
-    );
+    expect(mockWatcherFactory.createFileSystemWatcherForFile).toHaveBeenCalledWith(testUri, true, true, false);
   });
 
   it('subscribes to onDidDelete on the watcher', () => {
@@ -64,10 +59,7 @@ describe('createFileDeleteWatcher', () => {
       'Bound file deleted from disk: Text Editor ("test.ts") — auto-unbinding',
     );
     expect(clearBinding).toHaveBeenCalledTimes(1);
-    expect(mockFeedback.notifyAutoUnbind).toHaveBeenCalledWith(
-      'Text Editor ("test.ts")',
-      'file-deleted',
-    );
+    expect(mockFeedback.notifyAutoUnbind).toHaveBeenCalledWith('Text Editor ("test.ts")', 'file-deleted');
   });
 
   it('does nothing when a different file is deleted', () => {
@@ -88,10 +80,7 @@ describe('createFileDeleteWatcher', () => {
     handler(testUri);
 
     expect(clearBinding).toHaveBeenCalledTimes(1);
-    expect(mockFeedback.notifyAutoUnbind).toHaveBeenCalledWith(
-      'Text Editor ("test.ts")',
-      'file-deleted',
-    );
+    expect(mockFeedback.notifyAutoUnbind).toHaveBeenCalledWith('Text Editor ("test.ts")', 'file-deleted');
 
     guard.dispose();
   });

--- a/packages/rangelink-vscode-extension/src/destinations/__tests__/createTabCloseGuard.test.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/__tests__/createTabCloseGuard.test.ts
@@ -53,16 +53,11 @@ describe('createTabCloseGuard', () => {
       'Bound editor tab closed: Text Editor ("test.ts") — auto-unbinding',
     );
     expect(clearBinding).toHaveBeenCalledTimes(1);
-    expect(mockFeedback.notifyAutoUnbind).toHaveBeenCalledWith(
-      'Text Editor ("test.ts")',
-      'editor-closed',
-    );
+    expect(mockFeedback.notifyAutoUnbind).toHaveBeenCalledWith('Text Editor ("test.ts")', 'editor-closed');
   });
 
   it('does not unbind when another tab of the same file is still open', () => {
-    (vscode.window.tabGroups as unknown as { all: unknown[] }).all = [
-      { tabs: [{ input: { uri: testUri } }] },
-    ];
+    (vscode.window.tabGroups as unknown as { all: unknown[] }).all = [{ tabs: [{ input: { uri: testUri } }] }];
 
     createGuard();
 

--- a/packages/rangelink-vscode-extension/src/destinations/capabilities/AIAssistantFocusCapability.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/capabilities/AIAssistantFocusCapability.ts
@@ -60,10 +60,7 @@ export class AIAssistantFocusCapability implements FocusCapability {
 
   private async refocusDuring(context: LoggingContext, refocus: ColdRefocusConfig): Promise<void> {
     if (refocus.totalMs <= 0 || refocus.intervalMs <= 0 || refocus.totalMs <= refocus.intervalMs) {
-      this.logger.warn(
-        { ...context, totalMs: refocus.totalMs, intervalMs: refocus.intervalMs },
-        'Invalid cold refocus config, falling back to warm delay',
-      );
+      this.logger.warn({ ...context, totalMs: refocus.totalMs, intervalMs: refocus.intervalMs }, 'Invalid cold refocus config, falling back to warm delay');
       await new Promise<void>((resolve) => setTimeout(resolve, FOCUS_TO_PASTE_DELAY_MS));
       return;
     }
@@ -90,9 +87,6 @@ export class AIAssistantFocusCapability implements FocusCapability {
       }
     }
 
-    this.logger.debug(
-      { ...context, totalMs: Date.now() - start, intervalMs: refocus.intervalMs },
-      'Cold refocus loop completed',
-    );
+    this.logger.debug({ ...context, totalMs: Date.now() - start, intervalMs: refocus.intervalMs }, 'Cold refocus loop completed');
   }
 }

--- a/packages/rangelink-vscode-extension/src/destinations/capabilities/ContentEligibilityChecker.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/capabilities/ContentEligibilityChecker.ts
@@ -20,10 +20,7 @@ export class ContentEligibilityChecker implements EligibilityChecker {
     const eligible = isEligibleForPaste(text);
 
     if (!eligible) {
-      this.logger.info(
-        { ...context, contentLength: text.length },
-        'Content not eligible for paste',
-      );
+      this.logger.info({ ...context, contentLength: text.length }, 'Content not eligible for paste');
     }
 
     return Promise.resolve(eligible);

--- a/packages/rangelink-vscode-extension/src/destinations/capabilities/EditorFocusCapability.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/capabilities/EditorFocusCapability.ts
@@ -57,20 +57,14 @@ export class EditorFocusCapability implements FocusCapability {
         viewColumn: resolvedViewColumn,
       });
     } catch (error) {
-      this.logger.warn(
-        { ...context, editorUri, viewColumn: resolvedViewColumn, error },
-        'Failed to focus editor',
-      );
+      this.logger.warn({ ...context, editorUri, viewColumn: resolvedViewColumn, error }, 'Failed to focus editor');
       return FocusResult.err({
         reason: FocusErrorReason.SHOW_DOCUMENT_FAILED,
         cause: error,
       });
     }
 
-    this.logger.debug(
-      { ...context, editorUri, viewColumn: resolvedViewColumn },
-      'Editor focused via showTextDocument()',
-    );
+    this.logger.debug({ ...context, editorUri, viewColumn: resolvedViewColumn }, 'Editor focused via showTextDocument()');
 
     return FocusResult.ok({ inserter: this.insertFactory.forTarget(freshEditor) });
   }
@@ -99,15 +93,10 @@ export class EditorFocusCapability implements FocusCapability {
           },
           'Bound editor at expected viewColumn but also found in other tab groups — ambiguous target',
         );
-        this.ideAdapter.showErrorMessage(
-          formatMessage(MessageCode.ERROR_TEXT_EDITOR_AMBIGUOUS_COLUMNS),
-        );
+        this.ideAdapter.showErrorMessage(formatMessage(MessageCode.ERROR_TEXT_EDITOR_AMBIGUOUS_COLUMNS));
         return 'ambiguous';
       }
-      this.logger.debug(
-        { fn, editorUri, viewColumn: this.boundViewColumn },
-        'Editor at bound viewColumn',
-      );
+      this.logger.debug({ fn, editorUri, viewColumn: this.boundViewColumn }, 'Editor at bound viewColumn');
       return this.boundViewColumn;
     }
 
@@ -117,29 +106,18 @@ export class EditorFocusCapability implements FocusCapability {
       const hiddenGroups = this.ideAdapter.findAllTabGroupsForDocument(this.documentUri);
       const matchingHiddenGroup = hiddenGroups.find((g) => g.viewColumn === this.boundViewColumn);
       if (matchingHiddenGroup) {
-        this.logger.debug(
-          { fn, editorUri, viewColumn: this.boundViewColumn },
-          'Editor hidden behind other tabs at bound viewColumn',
-        );
+        this.logger.debug({ fn, editorUri, viewColumn: this.boundViewColumn }, 'Editor hidden behind other tabs at bound viewColumn');
         return this.boundViewColumn;
       }
 
-      this.logger.warn(
-        { fn, editorUri },
-        'Bound editor not visible (defensive: auto-unbind should prevent this)',
-      );
+      this.logger.warn({ fn, editorUri }, 'Bound editor not visible (defensive: auto-unbind should prevent this)');
       this.ideAdapter.showErrorMessage(formatMessage(MessageCode.ERROR_TEXT_EDITOR_NOT_VISIBLE));
       return undefined;
     }
 
     if (matchingEditors.length > 1) {
-      this.logger.warn(
-        { fn, editorUri, matchCount: matchingEditors.length },
-        'Bound editor moved but found in multiple tab groups — ambiguous target',
-      );
-      this.ideAdapter.showErrorMessage(
-        formatMessage(MessageCode.ERROR_TEXT_EDITOR_AMBIGUOUS_COLUMNS),
-      );
+      this.logger.warn({ fn, editorUri, matchCount: matchingEditors.length }, 'Bound editor moved but found in multiple tab groups — ambiguous target');
+      this.ideAdapter.showErrorMessage(formatMessage(MessageCode.ERROR_TEXT_EDITOR_AMBIGUOUS_COLUMNS));
       return 'ambiguous';
     }
 

--- a/packages/rangelink-vscode-extension/src/destinations/capabilities/FocusCapability.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/capabilities/FocusCapability.ts
@@ -34,11 +34,7 @@ export interface FocusError {
 }
 
 export class FocusResult extends DetailedResult<FocusedDestination, FocusError> {
-  private constructor(
-    success: boolean,
-    value: FocusedDestination | undefined,
-    error: FocusError | undefined,
-  ) {
+  private constructor(success: boolean, value: FocusedDestination | undefined, error: FocusError | undefined) {
     super(success, value, error);
   }
 

--- a/packages/rangelink-vscode-extension/src/destinations/capabilities/FocusCapabilityFactory.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/capabilities/FocusCapabilityFactory.ts
@@ -7,13 +7,7 @@ import { AIAssistantFocusCapability } from './AIAssistantFocusCapability';
 import type { ColdRefocusConfig } from './ColdRefocusConfig';
 import { EditorFocusCapability } from './EditorFocusCapability';
 import type { FocusCapability } from './FocusCapability';
-import {
-  AIAssistantInsertFactory,
-  DirectInsertFactory,
-  EditorInsertFactory,
-  ManualPasteInsertFactory,
-  TerminalInsertFactory,
-} from './insertFactories';
+import { AIAssistantInsertFactory, DirectInsertFactory, EditorInsertFactory, ManualPasteInsertFactory, TerminalInsertFactory } from './insertFactories';
 import { LazyResolvedFocusCapability } from './LazyResolvedFocusCapability';
 import { TerminalFocusCapability } from './TerminalFocusCapability';
 
@@ -34,28 +28,14 @@ export class FocusCapabilityFactory {
   ) {}
 
   createEditorCapability(uri: vscode.Uri, viewColumn: number): FocusCapability {
-    return new EditorFocusCapability(
-      this.ideAdapter,
-      uri,
-      viewColumn,
-      new EditorInsertFactory(this.ideAdapter, this.logger),
-      this.logger,
-    );
+    return new EditorFocusCapability(this.ideAdapter, uri, viewColumn, new EditorInsertFactory(this.ideAdapter, this.logger), this.logger);
   }
 
   createTerminalCapability(terminal: vscode.Terminal): FocusCapability {
-    return new TerminalFocusCapability(
-      this.ideAdapter,
-      terminal,
-      new TerminalInsertFactory(this.terminalPasteService, this.logger),
-      this.logger,
-    );
+    return new TerminalFocusCapability(this.ideAdapter, terminal, new TerminalInsertFactory(this.terminalPasteService, this.logger), this.logger);
   }
 
-  createAIAssistantCapability(
-    focusCommands: string[],
-    getColdRefocus: (() => ColdRefocusConfig) | undefined,
-  ): FocusCapability {
+  createAIAssistantCapability(focusCommands: string[], getColdRefocus: (() => ColdRefocusConfig) | undefined): FocusCapability {
     return new AIAssistantFocusCapability(
       this.ideAdapter,
       focusCommands,
@@ -127,17 +107,7 @@ export class FocusCapabilityFactory {
    * the winning tier is cached, and all subsequent focus() calls use the
    * resolved tier directly.
    */
-  createLazyResolvedCapability(
-    tiers: readonly FocusTier[],
-    logPrefix: string,
-    fallbackTierIndex?: number,
-  ): LazyResolvedFocusCapability {
-    return new LazyResolvedFocusCapability(
-      this.ideAdapter,
-      tiers,
-      this.logger,
-      logPrefix,
-      fallbackTierIndex,
-    );
+  createLazyResolvedCapability(tiers: readonly FocusTier[], logPrefix: string, fallbackTierIndex?: number): LazyResolvedFocusCapability {
+    return new LazyResolvedFocusCapability(this.ideAdapter, tiers, this.logger, logPrefix, fallbackTierIndex);
   }
 }

--- a/packages/rangelink-vscode-extension/src/destinations/capabilities/LazyResolvedFocusCapability.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/capabilities/LazyResolvedFocusCapability.ts
@@ -75,20 +75,11 @@ export class LazyResolvedFocusCapability implements FocusCapability {
 
   private async resolve(context: LoggingContext): Promise<void> {
     const registeredCommands = await this.ideAdapter.getCommands();
-    const result = resolveFocusTier(
-      this.tiers,
-      registeredCommands,
-      this.logger,
-      this.logPrefix,
-      this.fallbackTierIndex,
-    );
+    const result = resolveFocusTier(this.tiers, registeredCommands, this.logger, this.logPrefix, this.fallbackTierIndex);
 
     if (!result) {
       this.resolutionFailed = true;
-      this.logger.warn(
-        { ...context, logPrefix: this.logPrefix },
-        `${this.logPrefix}: tier resolution failed — no commands registered`,
-      );
+      this.logger.warn({ ...context, logPrefix: this.logPrefix }, `${this.logPrefix}: tier resolution failed — no commands registered`);
       return;
     }
 

--- a/packages/rangelink-vscode-extension/src/destinations/capabilities/ResolvedFocusCapability.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/capabilities/ResolvedFocusCapability.ts
@@ -36,10 +36,7 @@ export class ResolvedFocusCapability implements FocusCapability {
     const { resolvedTier } = this;
 
     if (resolvedTier.probeMode === 'none') {
-      this.logger.debug(
-        { ...context, tier: resolvedTier.label },
-        `Resolved tier ${resolvedTier.label} — returning inserter directly`,
-      );
+      this.logger.debug({ ...context, tier: resolvedTier.label }, `Resolved tier ${resolvedTier.label} — returning inserter directly`);
       return FocusResult.ok({
         inserter: resolvedTier.insertFactory.forTarget(),
       });
@@ -48,25 +45,16 @@ export class ResolvedFocusCapability implements FocusCapability {
     for (const command of resolvedTier.commands) {
       try {
         await this.ideAdapter.executeCommand(command);
-        this.logger.debug(
-          { ...context, command, tier: resolvedTier.label },
-          `Focus command succeeded (${resolvedTier.label})`,
-        );
+        this.logger.debug({ ...context, command, tier: resolvedTier.label }, `Focus command succeeded (${resolvedTier.label})`);
         return FocusResult.ok({
           inserter: resolvedTier.insertFactory.forTarget(),
         });
       } catch (error) {
-        this.logger.debug(
-          { ...context, command, tier: resolvedTier.label, error },
-          'Focus command failed, trying next',
-        );
+        this.logger.debug({ ...context, command, tier: resolvedTier.label, error }, 'Focus command failed, trying next');
       }
     }
 
-    this.logger.warn(
-      { ...context, tier: resolvedTier.label, allCommandsFailed: true },
-      `All focus commands failed for resolved tier ${resolvedTier.label}`,
-    );
+    this.logger.warn({ ...context, tier: resolvedTier.label, allCommandsFailed: true }, `All focus commands failed for resolved tier ${resolvedTier.label}`);
     return FocusResult.err({
       reason: FocusErrorReason.COMMAND_FOCUS_FAILED,
     });

--- a/packages/rangelink-vscode-extension/src/destinations/capabilities/index.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/capabilities/index.ts
@@ -4,19 +4,10 @@ export { ContentEligibilityChecker } from './ContentEligibilityChecker';
 export { EditorFocusCapability } from './EditorFocusCapability';
 export type { EligibilityChecker } from './EligibilityChecker';
 export { EligibilityCheckerFactory } from './EligibilityCheckerFactory';
-export type {
-  FocusCapability,
-  FocusedDestination,
-  FocusError,
-  FocusResult,
-} from './FocusCapability';
+export type { FocusCapability, FocusedDestination, FocusError, FocusResult } from './FocusCapability';
 export { FocusErrorReason } from './FocusCapability';
 export { FocusCapabilityFactory } from './FocusCapabilityFactory';
 export type { InsertFactory } from './insertFactories';
-export {
-  AIAssistantInsertFactory,
-  EditorInsertFactory,
-  TerminalInsertFactory,
-} from './insertFactories';
+export { AIAssistantInsertFactory, EditorInsertFactory, TerminalInsertFactory } from './insertFactories';
 export { LazyResolvedFocusCapability } from './LazyResolvedFocusCapability';
 export { TerminalFocusCapability } from './TerminalFocusCapability';

--- a/packages/rangelink-vscode-extension/src/destinations/capabilities/insertFactories/directInsertFactory.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/capabilities/insertFactories/directInsertFactory.ts
@@ -45,10 +45,7 @@ export class DirectInsertFactory implements InsertFactory<void> {
           this.logger.info({ fn, command: entry.command }, 'Direct insert succeeded');
           return true;
         } catch (error) {
-          this.logger.debug(
-            { fn, command: entry.command, error },
-            'Direct insert command failed, trying next',
-          );
+          this.logger.debug({ fn, command: entry.command, error }, 'Direct insert command failed, trying next');
         }
       }
 

--- a/packages/rangelink-vscode-extension/src/destinations/capabilities/insertFactories/manualPasteInsertFactory.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/capabilities/insertFactories/manualPasteInsertFactory.ts
@@ -14,10 +14,7 @@ export class ManualPasteInsertFactory implements InsertFactory<void> {
 
   forTarget(): (text: string) => Promise<boolean> {
     return async (text: string): Promise<boolean> => {
-      this.logger.info(
-        { fn: 'ManualPasteInsertFactory.insert', textLength: text.length },
-        'Link ready for manual paste',
-      );
+      this.logger.info({ fn: 'ManualPasteInsertFactory.insert', textLength: text.length }, 'Link ready for manual paste');
       return await true;
     };
   }

--- a/packages/rangelink-vscode-extension/src/destinations/capabilities/resolveFocusTier.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/capabilities/resolveFocusTier.ts
@@ -59,9 +59,6 @@ export const resolveFocusTier = (
     );
   }
 
-  logger.warn(
-    { fn, logPrefix, tierCount: tiers.length },
-    `${logPrefix}: no tiers have registered commands — resolution failed`,
-  );
+  logger.warn({ fn, logPrefix, tierCount: tiers.length }, `${logPrefix}: no tiers have registered commands — resolution failed`);
   return undefined;
 };

--- a/packages/rangelink-vscode-extension/src/destinations/createFileDeleteWatcher.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/createFileDeleteWatcher.ts
@@ -33,10 +33,7 @@ export const createFileDeleteWatcher = (deps: {
       return;
     }
 
-    deps.logger.info(
-      { fn: 'createFileDeleteWatcher', fileUri: boundUriString },
-      `Bound file deleted from disk: ${deps.displayName} — auto-unbinding`,
-    );
+    deps.logger.info({ fn: 'createFileDeleteWatcher', fileUri: boundUriString }, `Bound file deleted from disk: ${deps.displayName} — auto-unbinding`);
     deps.clearBinding();
     deps.feedback.notifyAutoUnbind(deps.displayName, 'file-deleted');
   });

--- a/packages/rangelink-vscode-extension/src/destinations/createTabCloseGuard.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/createTabCloseGuard.ts
@@ -21,9 +21,7 @@ export const createTabCloseGuard = (deps: {
   const boundUriString = deps.boundUri.toString();
 
   return deps.events.onDidChangeTabs((event) => {
-    const closedTab = event.closed.find(
-      (tab) => (tab.input as { uri?: vscode.Uri })?.uri?.toString() === boundUriString,
-    );
+    const closedTab = event.closed.find((tab) => (tab.input as { uri?: vscode.Uri })?.uri?.toString() === boundUriString);
     if (!closedTab) return;
 
     const remainingTabs = vscode.window.tabGroups.all
@@ -31,10 +29,7 @@ export const createTabCloseGuard = (deps: {
       .filter((t) => (t.input as { uri?: vscode.Uri })?.uri?.toString() === boundUriString);
     if (remainingTabs.length > 0) return;
 
-    deps.logger.info(
-      { fn: 'createTabCloseGuard', editorUri: boundUriString },
-      `Bound editor tab closed: ${deps.displayName} — auto-unbinding`,
-    );
+    deps.logger.info({ fn: 'createTabCloseGuard', editorUri: boundUriString }, `Bound editor tab closed: ${deps.displayName} — auto-unbinding`);
     deps.clearBinding();
     deps.feedback.notifyAutoUnbind(deps.displayName, 'editor-closed');
   });

--- a/packages/rangelink-vscode-extension/src/destinations/destinationBuilders.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/destinationBuilders.ts
@@ -19,14 +19,7 @@ import {
   SETTING_DESTINATIONS_GEMINI_COLD_START_DELAY_MS,
 } from '../constants/settingKeys';
 import { RangeLinkExtensionError, RangeLinkExtensionErrorCodes } from '../errors';
-import {
-  type AIAssistantDestinationKind,
-  AutoPasteResult,
-  type CustomAiAssistantKind,
-  type DestinationKind,
-  MessageCode,
-  RelativePathFormat,
-} from '../types';
+import { type AIAssistantDestinationKind, AutoPasteResult, type CustomAiAssistantKind, type DestinationKind, MessageCode, RelativePathFormat } from '../types';
 import {
   formatMessage,
   getUntitledDisplayName,
@@ -35,11 +28,7 @@ import {
   isGeminiCodeAssistAvailable,
   isGitHubCopilotChatAvailable,
 } from '../utils';
-import {
-  EXTENSION_ID_CLAUDE_CODE,
-  EXTENSION_ID_GEMINI_CODE_ASSIST,
-  EXTENSION_ID_GITHUB_COPILOT_CHAT,
-} from '../utils/aiAssistants/';
+import { EXTENSION_ID_CLAUDE_CODE, EXTENSION_ID_GEMINI_CODE_ASSIST, EXTENSION_ID_GITHUB_COPILOT_CHAT } from '../utils/aiAssistants/';
 
 import type { ColdRefocusConfig } from './capabilities/ColdRefocusConfig';
 import { compareEditorsByUri } from './equality/compareEditorsByUri';
@@ -254,10 +243,7 @@ export const buildTextEditorDestination: DestinationBuilder = (options, context)
  *
  * Uses the standard focus+paste flow via AIAssistantFocusCapability.
  */
-const buildBuiltinAiAssistantDestination = (
-  def: BuiltinAiAssistantDef,
-  context: DestinationBuilderContext,
-): ComposablePasteDestination =>
+const buildBuiltinAiAssistantDestination = (def: BuiltinAiAssistantDef, context: DestinationBuilderContext): ComposablePasteDestination =>
   ComposablePasteDestination.createAiAssistant({
     id: def.kind,
     displayName: def.displayName,
@@ -269,10 +255,7 @@ const buildBuiltinAiAssistantDestination = (
     jumpSuccessMessage: formatMessage(def.jumpMessageCode),
     loggingDetails: {},
     logger: context.logger,
-    getUserInstruction: (autoPasteResult) =>
-      autoPasteResult === AutoPasteResult.Success
-        ? undefined
-        : formatMessage(def.userInstructionMessageCode),
+    getUserInstruction: (autoPasteResult) => (autoPasteResult === AutoPasteResult.Success ? undefined : formatMessage(def.userInstructionMessageCode)),
   });
 
 /**
@@ -294,22 +277,13 @@ const createBuiltinAiAssistantBuilder =
  * configured with the user's extensionId, displayName, and three-tier commands.
  * Tier resolution happens lazily on first focus() call via LazyResolvedFocusCapability.
  */
-export const createCustomAiAssistantBuilder = (
-  config: CustomAiAssistantConfig,
-): DestinationBuilder => {
+export const createCustomAiAssistantBuilder = (config: CustomAiAssistantConfig): DestinationBuilder => {
   const { kind, extensionId, extensionName } = config;
-  const allCommands = [
-    ...(config.insertCommands ?? []).map((e) => e.command),
-    ...(config.focusAndPasteCommands ?? []),
-    ...(config.focusCommands ?? []),
-  ];
+  const allCommands = [...(config.insertCommands ?? []).map((e) => e.command), ...(config.focusAndPasteCommands ?? []), ...(config.focusCommands ?? [])];
 
   return (_options, context) => {
     const tiers = context.factories.focusCapability.buildCustomAIAssistantTiers(config);
-    const lazyCapability = context.factories.focusCapability.createLazyResolvedCapability(
-      tiers,
-      extensionName,
-    );
+    const lazyCapability = context.factories.focusCapability.createLazyResolvedCapability(tiers, extensionName);
 
     return ComposablePasteDestination.createAiAssistant({
       id: kind,
@@ -375,18 +349,12 @@ const createOverriddenBuiltinBuilder =
   (config: CustomAiAssistantConfig, builtin: BuiltinAiAssistantDef): DestinationBuilder =>
   (_options, context) => {
     const userTiers = context.factories.focusCapability.buildCustomAIAssistantTiers(config);
-    const fallbackTier = context.factories.focusCapability.buildBuiltinFallbackTier(
-      builtin.focusCommands,
-    );
+    const fallbackTier = context.factories.focusCapability.buildBuiltinFallbackTier(builtin.focusCommands);
 
     const allTiers = [...userTiers, fallbackTier];
     const fallbackTierIndex = userTiers.length;
 
-    const lazyCapability = context.factories.focusCapability.createLazyResolvedCapability(
-      allTiers,
-      builtin.displayName,
-      fallbackTierIndex,
-    );
+    const lazyCapability = context.factories.focusCapability.createLazyResolvedCapability(allTiers, builtin.displayName, fallbackTierIndex);
 
     return ComposablePasteDestination.createAiAssistant({
       id: builtin.kind,

--- a/packages/rangelink-vscode-extension/src/destinations/equality/compareTerminalsByProcessId.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/equality/compareTerminalsByProcessId.ts
@@ -13,10 +13,7 @@ import type * as vscode from 'vscode';
  * @param other - The destination to compare against
  * @returns Promise resolving to true if both terminals have matching process IDs
  */
-export const compareTerminalsByProcessId = async (
-  thisTerminal: vscode.Terminal,
-  other: PasteDestination,
-): Promise<boolean> => {
+export const compareTerminalsByProcessId = async (thisTerminal: vscode.Terminal, other: PasteDestination): Promise<boolean> => {
   if (!isTerminalDestination(other)) {
     return false;
   }

--- a/packages/rangelink-vscode-extension/src/destinations/types/FocusTier.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/types/FocusTier.ts
@@ -19,8 +19,7 @@ export type FocusTierProbeMode = 'execute' | 'none';
  * Used to make tier-dependent decisions type-safe (e.g., clipboard
  * preservation checks compare against this union, not raw strings).
  */
-export type FocusTierLabel =
-  'insertCommands' | 'focusAndPasteCommands' | 'focusCommands' | 'builtinFallback';
+export type FocusTierLabel = 'insertCommands' | 'focusAndPasteCommands' | 'focusCommands' | 'builtinFallback';
 
 /**
  * A tier in the tiered focus strategy.

--- a/packages/rangelink-vscode-extension/src/destinations/utils/buildDestinationQuickPickItems.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/utils/buildDestinationQuickPickItems.ts
@@ -21,14 +21,11 @@ import * as vscode from 'vscode';
 
 export const BUILTIN_AI_COUNT = AI_ASSISTANT_KINDS.length;
 
-const isDestinationKind = (key: string): key is DestinationKind =>
-  (DESTINATION_KINDS as readonly string[]).includes(key) || key.startsWith('custom-ai:');
+const isDestinationKind = (key: string): key is DestinationKind => (DESTINATION_KINDS as readonly string[]).includes(key) || key.startsWith('custom-ai:');
 
-const isTerminalItem = (item: BindableQuickPickItem): item is TerminalBindableQuickPickItem =>
-  'terminalInfo' in item;
+const isTerminalItem = (item: BindableQuickPickItem): item is TerminalBindableQuickPickItem => 'terminalInfo' in item;
 
-const isFileItem = (item: BindableQuickPickItem): item is FileBindableQuickPickItem =>
-  'fileInfo' in item;
+const isFileItem = (item: BindableQuickPickItem): item is FileBindableQuickPickItem => 'fileInfo' in item;
 
 type PickerSequenceKey = DestinationKind | 'file-more' | 'terminal-more';
 
@@ -90,9 +87,7 @@ export const buildDestinationQuickPickItems = (
   const items: (DestinationQuickPickItem | vscode.QuickPickItem)[] = [];
   let currentGroup: DestinationGroup | undefined;
 
-  const customAiKinds = Object.keys(grouped).filter(
-    (key) => isCustomAiAssistantKind(key) && grouped[key as keyof GroupedDestinationItems],
-  );
+  const customAiKinds = Object.keys(grouped).filter((key) => isCustomAiAssistantKind(key) && grouped[key as keyof GroupedDestinationItems]);
   const fullSequence: PickerSequenceKey[] = [
     ...DESTINATION_PICKER_SEQUENCE.slice(0, BUILTIN_AI_COUNT),
     ...(customAiKinds as PickerSequenceKey[]),
@@ -103,8 +98,7 @@ export const buildDestinationQuickPickItems = (
     const groupItems = grouped[key];
     if (!groupItems) continue;
 
-    const nextGroup =
-      DESTINATION_GROUP_MAP[key] ?? (isCustomAiAssistantKind(key) ? 'ai' : undefined);
+    const nextGroup = DESTINATION_GROUP_MAP[key] ?? (isCustomAiAssistantKind(key) ? 'ai' : undefined);
     if (!nextGroup) continue;
     if (nextGroup !== currentGroup) {
       items.push({
@@ -157,9 +151,7 @@ export const buildDestinationQuickPickItems = (
         });
       }
 
-      const groupLabel = isFileItem(item)
-        ? formatMessage(MessageCode.FILE_PICKER_GROUP_FORMAT, { index: item.fileInfo.viewColumn })
-        : undefined;
+      const groupLabel = isFileItem(item) ? formatMessage(MessageCode.FILE_PICKER_GROUP_FORMAT, { index: item.fileInfo.viewColumn }) : undefined;
       const description = isTerminalItem(item)
         ? buildTerminalDescription(item.terminalInfo)
         : isFileItem(item)

--- a/packages/rangelink-vscode-extension/src/destinations/utils/buildFileDescription.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/utils/buildFileDescription.ts
@@ -11,10 +11,7 @@ import { formatMessage } from '../../utils';
  * @param disambiguator - VSCode-style disambiguator string (e.g., '…/src', './', or '')
  * @returns Description string, or undefined if no segments to show
  */
-export const buildFileDescription = (
-  file: EligibleFile,
-  disambiguator: string,
-): string | undefined => {
+export const buildFileDescription = (file: EligibleFile, disambiguator: string): string | undefined => {
   const segments: string[] = [];
 
   if (disambiguator !== '') {

--- a/packages/rangelink-vscode-extension/src/destinations/utils/buildFilePickerItems.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/utils/buildFilePickerItems.ts
@@ -21,9 +21,7 @@ const makeSeparator = (label: string): vscode.QuickPickItem => ({
  * @param items - Pre-built file picker items (from getAllFileItems())
  * @returns Interleaved array of separator items and file items
  */
-export const buildFilePickerItems = (
-  items: readonly FileBindableQuickPickItem[],
-): (FileBindableQuickPickItem | vscode.QuickPickItem)[] => {
+export const buildFilePickerItems = (items: readonly FileBindableQuickPickItem[]): (FileBindableQuickPickItem | vscode.QuickPickItem)[] => {
   const result: (FileBindableQuickPickItem | vscode.QuickPickItem)[] = [];
 
   const activeFiles = items.filter((item) => item.fileInfo.isCurrentInGroup);

--- a/packages/rangelink-vscode-extension/src/destinations/utils/classifyTerminalForBinding.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/utils/classifyTerminalForBinding.ts
@@ -14,17 +14,13 @@ import type * as vscode from 'vscode';
  *   picker but cannot be bound to; the reason drives the disabled-style
  *   rendering and selection rejection.
  */
-export type TerminalBindingClassification =
-  | { readonly visible: false }
-  | { readonly visible: true; readonly nonBindableReason?: NonBindableReason };
+export type TerminalBindingClassification = { readonly visible: false } | { readonly visible: true; readonly nonBindableReason?: NonBindableReason };
 
 const isHiddenFromUser = (terminal: vscode.Terminal): boolean =>
-  'hideFromUser' in terminal.creationOptions &&
-  (terminal.creationOptions as vscode.TerminalOptions).hideFromUser === true;
+  'hideFromUser' in terminal.creationOptions && (terminal.creationOptions as vscode.TerminalOptions).hideFromUser === true;
 
 const isExtensionManaged = (terminal: vscode.Terminal): boolean =>
-  'pty' in terminal.creationOptions &&
-  (terminal.creationOptions as vscode.ExtensionTerminalOptions).pty != null;
+  'pty' in terminal.creationOptions && (terminal.creationOptions as vscode.ExtensionTerminalOptions).pty != null;
 
 /**
  * Classify whether a terminal belongs in the destination picker, and if so
@@ -41,9 +37,7 @@ const isExtensionManaged = (terminal: vscode.Terminal): boolean =>
  * for "this terminal is owned by an extension and does not accept arbitrary
  * shell input."
  */
-export const classifyTerminalForBinding = (
-  terminal: vscode.Terminal | null | undefined,
-): TerminalBindingClassification => {
+export const classifyTerminalForBinding = (terminal: vscode.Terminal | null | undefined): TerminalBindingClassification => {
   if (terminal == null) return { visible: false };
   if (terminal.exitStatus !== undefined) return { visible: false };
   if (isRangeLinkTestFixture(terminal)) return { visible: true };

--- a/packages/rangelink-vscode-extension/src/destinations/utils/disambiguateFilenames.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/utils/disambiguateFilenames.ts
@@ -14,9 +14,7 @@
  * @param files - Array of objects with `filename` and `displayPath` (forward-slash separated)
  * @returns Array of disambiguator strings, same length and order as input
  */
-export const disambiguateFilenames = (
-  files: readonly { readonly filename: string; readonly displayPath: string }[],
-): string[] => {
+export const disambiguateFilenames = (files: readonly { readonly filename: string; readonly displayPath: string }[]): string[] => {
   const disambiguators: string[] = files.map(() => '');
 
   const groupsByFilename = new Map<string, number[]>();

--- a/packages/rangelink-vscode-extension/src/destinations/utils/getEligibleFiles.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/utils/getEligibleFiles.ts
@@ -37,8 +37,7 @@ export const getEligibleFiles = (ideAdapter: VscodeAdapter): EligibleFile[] => {
         displayPath: ideAdapter.asRelativePath(uri, RelativePathFormat.PathOnly),
         viewColumn: group.viewColumn,
         isCurrentInGroup: tab === group.activeTab,
-        isActiveEditor:
-          activeEditorUriString !== undefined && uri.toString() === activeEditorUriString,
+        isActiveEditor: activeEditorUriString !== undefined && uri.toString() === activeEditorUriString,
       });
     }
   }

--- a/packages/rangelink-vscode-extension/src/destinations/utils/getEligibleTerminals.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/utils/getEligibleTerminals.ts
@@ -14,9 +14,7 @@ import { classifyTerminalForBinding } from './classifyTerminalForBinding';
  * @param ideAdapter - IDE adapter for reading terminal state
  * @returns Array of bindable terminals (empty if none qualify)
  */
-export const getEligibleTerminals = async (
-  ideAdapter: VscodeAdapter,
-): Promise<EligibleTerminal[]> => {
+export const getEligibleTerminals = async (ideAdapter: VscodeAdapter): Promise<EligibleTerminal[]> => {
   const allTerminals = ideAdapter.terminals;
 
   const bindableTerminals: Array<(typeof allTerminals)[number]> = [];

--- a/packages/rangelink-vscode-extension/src/destinations/utils/isFileEligible.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/utils/isFileEligible.ts
@@ -15,5 +15,4 @@ import { isWritableScheme } from '../../utils/isWritableScheme';
  * @param fsPath - The file system path (e.g., '/workspace/src/app.ts')
  * @returns true if file can be used as a text editor destination
  */
-export const isFileEligible = (scheme: string, fsPath: string): boolean =>
-  isWritableScheme(scheme) && !isBinaryFile(scheme, fsPath);
+export const isFileEligible = (scheme: string, fsPath: string): boolean => isWritableScheme(scheme) && !isBinaryFile(scheme, fsPath);

--- a/packages/rangelink-vscode-extension/src/destinations/utils/markBoundFile.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/utils/markBoundFile.ts
@@ -17,11 +17,7 @@ import type { EligibleFile } from '../../types';
  * @param boundFileViewColumn - viewColumn of the currently bound editor, or undefined for URI-only match
  * @returns New array with boundState set on every item
  */
-export const markBoundFile = (
-  files: readonly EligibleFile[],
-  boundFileUriString: string | undefined,
-  boundFileViewColumn?: number,
-): EligibleFile[] =>
+export const markBoundFile = (files: readonly EligibleFile[], boundFileUriString: string | undefined, boundFileViewColumn?: number): EligibleFile[] =>
   files.map((f) => ({
     ...f,
     boundState:

--- a/packages/rangelink-vscode-extension/src/destinations/utils/markBoundTerminal.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/utils/markBoundTerminal.ts
@@ -11,16 +11,8 @@ import type { EligibleTerminal } from '../../types';
  * @param boundTerminalProcessId - processId of the currently bound terminal, or undefined
  * @returns New array with boundState set on every item
  */
-export const markBoundTerminal = (
-  terminals: readonly EligibleTerminal[],
-  boundTerminalProcessId: number | undefined,
-): EligibleTerminal[] =>
+export const markBoundTerminal = (terminals: readonly EligibleTerminal[], boundTerminalProcessId: number | undefined): EligibleTerminal[] =>
   terminals.map((t) => ({
     ...t,
-    boundState:
-      boundTerminalProcessId !== undefined &&
-      t.processId !== undefined &&
-      t.processId === boundTerminalProcessId
-        ? 'bound'
-        : 'not-bound',
+    boundState: boundTerminalProcessId !== undefined && t.processId !== undefined && t.processId === boundTerminalProcessId ? 'bound' : 'not-bound',
   }));

--- a/packages/rangelink-vscode-extension/src/destinations/utils/resolveBoundTerminalProcessId.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/utils/resolveBoundTerminalProcessId.ts
@@ -7,9 +7,7 @@ import type { PasteDestination } from '../PasteDestination';
  * @returns The bound terminal's processId, or undefined if no terminal is bound
  *          or the terminal has no processId yet.
  */
-export const resolveBoundTerminalProcessId = async (
-  getBound: () => PasteDestination | undefined,
-): Promise<number | undefined> => {
+export const resolveBoundTerminalProcessId = async (getBound: () => PasteDestination | undefined): Promise<number | undefined> => {
   const boundDest = getBound();
   if (!isTerminalDestination(boundDest)) return undefined;
   return (await boundDest.resource.terminal.processId) ?? undefined;

--- a/packages/rangelink-vscode-extension/src/extension.ts
+++ b/packages/rangelink-vscode-extension/src/extension.ts
@@ -33,10 +33,7 @@ export function activate(context: vscode.ExtensionContext): RangeLinkExtensionAp
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     versionInfo = require('./version.json') as VersionInfo;
   } catch (error) {
-    logger.warn(
-      { fn: 'activate', error },
-      'RangeLink extension activated (version info unavailable)',
-    );
+    logger.warn({ fn: 'activate', error }, 'RangeLink extension activated (version info unavailable)');
   }
 
   try {

--- a/packages/rangelink-vscode-extension/src/feedback/OperationFeedbackProvider.ts
+++ b/packages/rangelink-vscode-extension/src/feedback/OperationFeedbackProvider.ts
@@ -1,13 +1,7 @@
 import { RangeLinkExtensionError } from '../errors/RangeLinkExtensionError';
 import { RangeLinkExtensionErrorCodes } from '../errors/RangeLinkExtensionErrorCodes';
 import type { VscodeAdapter } from '../ide/vscode/VscodeAdapter';
-import {
-  type AIAssistantDestinationKind,
-  type BindContext,
-  type DestinationKind,
-  isAnyAiAssistantKind,
-  MessageCode,
-} from '../types';
+import { type AIAssistantDestinationKind, type BindContext, type DestinationKind, isAnyAiAssistantKind, MessageCode } from '../types';
 import { formatMessage } from '../utils';
 
 import type { BindingFeedback } from './BindingFeedback';
@@ -37,31 +31,21 @@ export class OperationFeedbackProvider implements LifecycleFeedbackProvider, Bin
         messageCode = MessageCode.STATUS_BAR_DESTINATION_UNBOUND_FILE_DELETED;
         break;
       default:
-        throw RangeLinkExtensionError.forUnexpectedSwitchDefault(
-          'auto-unbind reason',
-          reason,
-          'OperationFeedbackProvider.notifyAutoUnbind',
-        );
+        throw RangeLinkExtensionError.forUnexpectedSwitchDefault('auto-unbind reason', reason, 'OperationFeedbackProvider.notifyAutoUnbind');
     }
     this.vscodeAdapter.setStatusBarMessage(formatMessage(messageCode, { destinationName }));
 
     if (reason === 'file-deleted') {
-      void this.vscodeAdapter.showWarningMessage(
-        formatMessage(MessageCode.WARN_DESTINATION_UNBOUND_FILE_DELETED, { destinationName }),
-      );
+      void this.vscodeAdapter.showWarningMessage(formatMessage(MessageCode.WARN_DESTINATION_UNBOUND_FILE_DELETED, { destinationName }));
     }
   }
 
   notifyDuplicateTabWarning(): void {
-    void this.vscodeAdapter.showWarningMessage(
-      formatMessage(MessageCode.WARN_TEXT_EDITOR_DUPLICATE_TAB_GROUPS),
-    );
+    void this.vscodeAdapter.showWarningMessage(formatMessage(MessageCode.WARN_TEXT_EDITOR_DUPLICATE_TAB_GROUPS));
   }
 
   notifyBound(destinationName: string): void {
-    this.vscodeAdapter.setSuccessfulStatusBarMessage(
-      formatMessage(MessageCode.STATUS_BAR_DESTINATION_BOUND, { destinationName }),
-    );
+    this.vscodeAdapter.setSuccessfulStatusBarMessage(formatMessage(MessageCode.STATUS_BAR_DESTINATION_BOUND, { destinationName }));
   }
 
   notifyRebound(newDestinationName: string, previousDestinationName: string): void {
@@ -74,9 +58,7 @@ export class OperationFeedbackProvider implements LifecycleFeedbackProvider, Bin
   }
 
   notifyAlreadyBound(destinationName: string): void {
-    void this.vscodeAdapter.showInformationMessage(
-      formatMessage(MessageCode.ALREADY_BOUND_TO_DESTINATION, { destinationName }),
-    );
+    void this.vscodeAdapter.showInformationMessage(formatMessage(MessageCode.ALREADY_BOUND_TO_DESTINATION, { destinationName }));
   }
 
   notifyBindFailedEditor(messageCode: MessageCode, params: Record<string, string>): void {
@@ -88,28 +70,20 @@ export class OperationFeedbackProvider implements LifecycleFeedbackProvider, Bin
     if (messageCode !== undefined) {
       this.vscodeAdapter.showErrorMessage(formatMessage(messageCode));
     } else {
-      this.vscodeAdapter.showErrorMessage(
-        formatMessage(MessageCode.ERROR_CUSTOM_AI_NOT_AVAILABLE, { extensionName: displayName }),
-      );
+      this.vscodeAdapter.showErrorMessage(formatMessage(MessageCode.ERROR_CUSTOM_AI_NOT_AVAILABLE, { extensionName: displayName }));
     }
   }
 
   notifyBackgroundTabOpened(fileName: string): void {
-    void this.vscodeAdapter.showInformationMessage(
-      formatMessage(MessageCode.INFO_BACKGROUND_TAB_OPENED, { fileName }),
-    );
+    void this.vscodeAdapter.showInformationMessage(formatMessage(MessageCode.INFO_BACKGROUND_TAB_OPENED, { fileName }));
   }
 
   notifyUnbound(destinationName: string): void {
-    this.vscodeAdapter.setSuccessfulStatusBarMessage(
-      formatMessage(MessageCode.STATUS_BAR_DESTINATION_UNBOUND, { destinationName }),
-    );
+    this.vscodeAdapter.setSuccessfulStatusBarMessage(formatMessage(MessageCode.STATUS_BAR_DESTINATION_UNBOUND, { destinationName }));
   }
 
   notifyNothingToUnbind(): void {
-    this.vscodeAdapter.setStatusBarMessage(
-      formatMessage(MessageCode.STATUS_BAR_DESTINATION_NOT_BOUND),
-    );
+    this.vscodeAdapter.setStatusBarMessage(formatMessage(MessageCode.STATUS_BAR_DESTINATION_NOT_BOUND));
   }
 
   notifyJumpFocused(message: string): void {
@@ -117,9 +91,7 @@ export class OperationFeedbackProvider implements LifecycleFeedbackProvider, Bin
   }
 
   notifyJumpFailed(destinationName: string): void {
-    void this.vscodeAdapter.showInformationMessage(
-      formatMessage(MessageCode.INFO_JUMP_FOCUS_FAILED, { destinationName }),
-    );
+    void this.vscodeAdapter.showInformationMessage(formatMessage(MessageCode.INFO_JUMP_FOCUS_FAILED, { destinationName }));
   }
 
   showError(message: string): void {
@@ -133,11 +105,7 @@ export class OperationFeedbackProvider implements LifecycleFeedbackProvider, Bin
     this.vscodeAdapter.setSuccessfulStatusBarMessage(message);
   }
 
-  provideSendFeedback(
-    context: PasteContext,
-    outcome: PasteSendOutcome,
-    bindContext?: BindContext,
-  ): void {
+  provideSendFeedback(context: PasteContext, outcome: PasteSendOutcome, bindContext?: BindContext): void {
     const linkTypeName = formatMessage(context.contentType);
     switch (outcome.kind) {
       case 'sent-automatic': {
@@ -155,9 +123,7 @@ export class OperationFeedbackProvider implements LifecycleFeedbackProvider, Bin
       }
       case 'sent-manual':
       case 'failed-manual': {
-        this.vscodeAdapter.setSuccessfulStatusBarMessage(
-          this.buildClipboardMessage(linkTypeName, bindContext),
-        );
+        this.vscodeAdapter.setSuccessfulStatusBarMessage(this.buildClipboardMessage(linkTypeName, bindContext));
         if (outcome.kind === 'sent-manual') {
           void this.vscodeAdapter.showInformationMessage(outcome.instruction);
         } else {
@@ -167,33 +133,23 @@ export class OperationFeedbackProvider implements LifecycleFeedbackProvider, Bin
       }
       case 'failed-automatic': {
         const failureMessage = this.buildPasteFailureMessage(outcome.destinationKind);
-        void this.vscodeAdapter.showWarningMessage(
-          bindContext ? `${this.buildBoundPrefix(bindContext)}${failureMessage}` : failureMessage,
-        );
+        void this.vscodeAdapter.showWarningMessage(bindContext ? `${this.buildBoundPrefix(bindContext)}${failureMessage}` : failureMessage);
         break;
       }
       case 'self-paste-blocked': {
         void this.vscodeAdapter.showInformationMessage(outcome.toastMessage);
         if (outcome.clipboardWritten) {
-          this.vscodeAdapter.setSuccessfulStatusBarMessage(
-            this.buildClipboardMessage(linkTypeName, bindContext),
-          );
+          this.vscodeAdapter.setSuccessfulStatusBarMessage(this.buildClipboardMessage(linkTypeName, bindContext));
         }
         break;
       }
       case 'clipboard-preservation-failed': {
         const warningMessage = formatMessage(MessageCode.WARN_CLIPBOARD_PRESERVATION_FAILED);
-        void this.vscodeAdapter.showWarningMessage(
-          bindContext ? `${this.buildBoundPrefix(bindContext)}${warningMessage}` : warningMessage,
-        );
+        void this.vscodeAdapter.showWarningMessage(bindContext ? `${this.buildBoundPrefix(bindContext)}${warningMessage}` : warningMessage);
         break;
       }
       default:
-        throw RangeLinkExtensionError.forUnexpectedSwitchDefault(
-          'paste send outcome',
-          outcome,
-          'OperationFeedbackProvider.provideSendFeedback',
-        );
+        throw RangeLinkExtensionError.forUnexpectedSwitchDefault('paste send outcome', outcome, 'OperationFeedbackProvider.provideSendFeedback');
     }
   }
 

--- a/packages/rangelink-vscode-extension/src/i18n/LocaleManager.ts
+++ b/packages/rangelink-vscode-extension/src/i18n/LocaleManager.ts
@@ -1,9 +1,4 @@
-import {
-  DEFAULT_LOCALE,
-  type LocaleCode,
-  type MessageMap,
-  supportedLocales,
-} from './supportedLocales';
+import { DEFAULT_LOCALE, type LocaleCode, type MessageMap, supportedLocales } from './supportedLocales';
 
 import { getLogger } from '@couimet/logger-contract';
 

--- a/packages/rangelink-vscode-extension/src/i18n/messages.en.ts
+++ b/packages/rangelink-vscode-extension/src/i18n/messages.en.ts
@@ -1,7 +1,6 @@
 import { MessageCode } from '../types';
 
-const NO_DESTINATIONS_AVAILABLE =
-  'No destinations available. Open a terminal, a file, or install an AI assistant extension.';
+const NO_DESTINATIONS_AVAILABLE = 'No destinations available. Open a terminal, a file, or install an AI assistant extension.';
 
 /**
  * English message templates for VSCode extension.
@@ -11,8 +10,7 @@ export const messagesEn: Record<MessageCode, string> = {
   // Keep the keys in alphabetical order.
 
   [MessageCode.ALREADY_BOUND_TO_DESTINATION]: 'Already bound to {destinationName}',
-  [MessageCode.BIND_TO_TERMINAL_NOT_BINDABLE_REJECT]:
-    'Cannot bind to "{name}": this terminal is not bindable.',
+  [MessageCode.BIND_TO_TERMINAL_NOT_BINDABLE_REJECT]: 'Cannot bind to "{name}": this terminal is not bindable.',
   [MessageCode.BOOKMARK_ACTION_ADD]: '$(add) Save Selection as Bookmark',
   [MessageCode.BOOKMARK_ACTION_MANAGE]: '$(gear) Manage Bookmarks...',
   [MessageCode.BOOKMARK_ADD_INPUT_PLACEHOLDER]: 'Enter a label for this bookmark',
@@ -50,62 +48,41 @@ export const messagesEn: Record<MessageCode, string> = {
   [MessageCode.DESTINATION_TERMINAL_DISPLAY_FORMAT]: 'Terminal ("{name}")',
   [MessageCode.DESTINATION_TEXT_EDITOR_DISPLAY_FORMAT]: 'Text Editor ("{name}")',
 
-  [MessageCode.ERROR_BACKGROUND_TAB_OPEN_FAILED]:
-    'Could not open "{fileName}". Try again or choose another file.',
-  [MessageCode.ERROR_BACKGROUND_TAB_WRONG_VIEW_COLUMN]:
-    '"{fileName}" opened in a different editor group. Try again or choose another file.',
+  [MessageCode.ERROR_BACKGROUND_TAB_OPEN_FAILED]: 'Could not open "{fileName}". Try again or choose another file.',
+  [MessageCode.ERROR_BACKGROUND_TAB_WRONG_VIEW_COLUMN]: '"{fileName}" opened in a different editor group. Try again or choose another file.',
   [MessageCode.ERROR_BOOKMARK_EMPTY_LABEL]: 'Bookmark label cannot be empty',
-  [MessageCode.ERROR_BOOKMARK_LINK_GENERATION_FAILED]:
-    'Cannot add bookmark - failed to generate link from selection',
+  [MessageCode.ERROR_BOOKMARK_LINK_GENERATION_FAILED]: 'Cannot add bookmark - failed to generate link from selection',
   [MessageCode.ERROR_BOOKMARK_NO_ACTIVE_EDITOR]: 'Cannot add bookmark - no active editor',
   [MessageCode.ERROR_BOOKMARK_SAVE_FAILED]: 'Failed to save bookmark',
   [MessageCode.ERROR_BOOKMARK_SEND_FAILED]: 'Failed to send bookmark',
-  [MessageCode.ERROR_BOOKMARK_SEND_NO_DESTINATION]:
-    'Cannot send bookmark — no destination is currently bound',
-  [MessageCode.ERROR_BOOKMARK_UNTITLED_FILE]:
-    'Cannot bookmark unsaved file. Save the file first, or select an existing RangeLink to bookmark.',
+  [MessageCode.ERROR_BOOKMARK_SEND_NO_DESTINATION]: 'Cannot send bookmark — no destination is currently bound',
+  [MessageCode.ERROR_BOOKMARK_UNTITLED_FILE]: 'Cannot bookmark unsaved file. Save the file first, or select an existing RangeLink to bookmark.',
   [MessageCode.ERROR_BIND_FAILED]: 'Failed to bind destination',
-  [MessageCode.ERROR_CLAUDE_CODE_NOT_AVAILABLE]:
-    'Cannot bind Claude Code - extension not installed or not active',
-  [MessageCode.ERROR_CURSOR_AI_NOT_AVAILABLE]:
-    'Cannot bind Cursor AI Assistant - not running in Cursor IDE',
-  [MessageCode.ERROR_CUSTOM_AI_NOT_AVAILABLE]:
-    'Cannot bind {extensionName} - extension not installed or not active',
+  [MessageCode.ERROR_CLAUDE_CODE_NOT_AVAILABLE]: 'Cannot bind Claude Code - extension not installed or not active',
+  [MessageCode.ERROR_CURSOR_AI_NOT_AVAILABLE]: 'Cannot bind Cursor AI Assistant - not running in Cursor IDE',
+  [MessageCode.ERROR_CUSTOM_AI_NOT_AVAILABLE]: 'Cannot bind {extensionName} - extension not installed or not active',
   [MessageCode.ERROR_FILE_PATH_NAVIGATION_FAILED]: 'Failed to open file {path}: {error}',
-  [MessageCode.ERROR_GEMINI_CODE_ASSIST_NOT_AVAILABLE]:
-    'Cannot bind Gemini Code Assist - extension not installed or not active',
-  [MessageCode.ERROR_GITHUB_COPILOT_CHAT_NOT_AVAILABLE]:
-    'Cannot bind GitHub Copilot Chat - extension not installed or not active',
-  [MessageCode.ERROR_INVALID_DELIMITER_CONFIG]:
-    'Invalid delimiter configuration. Using defaults. Check Output → RangeLink for details.',
+  [MessageCode.ERROR_GEMINI_CODE_ASSIST_NOT_AVAILABLE]: 'Cannot bind Gemini Code Assist - extension not installed or not active',
+  [MessageCode.ERROR_GITHUB_COPILOT_CHAT_NOT_AVAILABLE]: 'Cannot bind GitHub Copilot Chat - extension not installed or not active',
+  [MessageCode.ERROR_INVALID_DELIMITER_CONFIG]: 'Invalid delimiter configuration. Using defaults. Check Output → RangeLink for details.',
   [MessageCode.ERROR_LINK_GENERATION_FAILED]: 'Failed to generate {linkTypeName}',
   [MessageCode.ERROR_LINK_TYPE_NAME_PORTABLE]: 'portable link',
   [MessageCode.ERROR_LINK_TYPE_NAME_REGULAR]: 'link',
   [MessageCode.ERROR_NAVIGATION_FAILED]: 'Failed to navigate to {path}: {error}',
   [MessageCode.ERROR_NO_ACTIVE_EDITOR]: 'No active editor',
   [MessageCode.ERROR_NO_ACTIVE_TERMINAL]: 'No active terminal. Open a terminal and try again.',
-  [MessageCode.ERROR_NO_BINDABLE_TERMINAL]:
-    'No bindable terminal. Open a new terminal and try again.',
-  [MessageCode.ERROR_NO_BINDABLE_TEXT_EDITOR]:
-    'No bindable text editor. Open a file and try again.',
-  [MessageCode.ERROR_NO_TERMINAL_TEXT_SELECTED]:
-    'No text selected in the terminal. Select text and try again.',
-  [MessageCode.ERROR_NO_TEXT_SELECTED]:
-    'No text selected. Click in the file, select text, and try again.',
+  [MessageCode.ERROR_NO_BINDABLE_TERMINAL]: 'No bindable terminal. Open a new terminal and try again.',
+  [MessageCode.ERROR_NO_BINDABLE_TEXT_EDITOR]: 'No bindable text editor. Open a file and try again.',
+  [MessageCode.ERROR_NO_TERMINAL_TEXT_SELECTED]: 'No text selected in the terminal. Select text and try again.',
+  [MessageCode.ERROR_NO_TEXT_SELECTED]: 'No text selected. Click in the file, select text, and try again.',
   [MessageCode.ERROR_PASTE_FILE_PATH_NO_ACTIVE_FILE]: 'No active file. Open a file and try again.',
-  [MessageCode.ERROR_TERMINAL_CLIPBOARD_READ_FAILED]:
-    'Could not read terminal selection. Please try again.',
-  [MessageCode.ERROR_TERMINAL_COPY_COMMAND_FAILED]:
-    'Could not read terminal selection. Please try again.',
-  [MessageCode.ERROR_TERMINAL_COPY_LINK_NOT_SUPPORTED]:
-    'R-C generates code location links and requires an editor selection. Use R-V to paste terminal text.',
-  [MessageCode.ERROR_TERMINAL_LINK_INVALID_FORMAT]:
-    'Cannot navigate - invalid link format: {linkText}',
-  [MessageCode.ERROR_TEXT_EDITOR_AMBIGUOUS_COLUMNS]:
-    'Bound editor is open in multiple tab groups. Close the duplicate tab and try again.',
+  [MessageCode.ERROR_TERMINAL_CLIPBOARD_READ_FAILED]: 'Could not read terminal selection. Please try again.',
+  [MessageCode.ERROR_TERMINAL_COPY_COMMAND_FAILED]: 'Could not read terminal selection. Please try again.',
+  [MessageCode.ERROR_TERMINAL_COPY_LINK_NOT_SUPPORTED]: 'R-C generates code location links and requires an editor selection. Use R-V to paste terminal text.',
+  [MessageCode.ERROR_TERMINAL_LINK_INVALID_FORMAT]: 'Cannot navigate - invalid link format: {linkText}',
+  [MessageCode.ERROR_TEXT_EDITOR_AMBIGUOUS_COLUMNS]: 'Bound editor is open in multiple tab groups. Close the duplicate tab and try again.',
   [MessageCode.ERROR_TEXT_EDITOR_BINARY_FILE]: 'Cannot bind to {fileName} - binary file',
-  [MessageCode.ERROR_TEXT_EDITOR_NOT_VISIBLE]:
-    'Bound editor is no longer visible. Re-open the file and bind again.',
+  [MessageCode.ERROR_TEXT_EDITOR_NOT_VISIBLE]: 'Bound editor is no longer visible. Re-open the file and bind again.',
   [MessageCode.ERROR_TEXT_EDITOR_READ_ONLY]: 'Cannot bind to read-only editor ({scheme})',
   [MessageCode.ERROR_VERSION_INFO_NOT_AVAILABLE]: 'Version information not available',
 
@@ -119,14 +96,12 @@ export const messagesEn: Record<MessageCode, string> = {
   [MessageCode.FILE_PICKER_PLACEHOLDER]: 'Select file to bind and jump to',
   [MessageCode.FILE_PICKER_TITLE]: 'RangeLink',
 
-  [MessageCode.INFO_BACKGROUND_TAB_OPENED]:
-    '"{fileName}" opened at last cursor position. Adjust cursor before pasting.',
+  [MessageCode.INFO_BACKGROUND_TAB_OPENED]: '"{fileName}" opened at last cursor position. Adjust cursor before pasting.',
   [MessageCode.INFO_BIND_NO_DESTINATIONS_AVAILABLE]: NO_DESTINATIONS_AVAILABLE,
   [MessageCode.INFO_BIND_QUICK_PICK_PLACEHOLDER]: 'RangeLink: Choose a destination to bind to',
   [MessageCode.INFO_CLAUDE_CODE_NOT_AVAILABLE]:
     'RangeLink can seamlessly integrate with Claude Code for faster context sharing of precise code ranges.\n\nInstall and activate the Claude Code extension to use it as a paste destination.',
-  [MessageCode.INFO_CLAUDE_CODE_USER_INSTRUCTIONS]:
-    'Paste (Cmd/Ctrl+V) in Claude Code chat to use.',
+  [MessageCode.INFO_CLAUDE_CODE_USER_INSTRUCTIONS]: 'Paste (Cmd/Ctrl+V) in Claude Code chat to use.',
   [MessageCode.INFO_COMMIT_HASH_COPIED]: 'Commit hash copied to clipboard',
   [MessageCode.INFO_CUSTOM_AI_USER_INSTRUCTIONS]: 'Paste (Cmd/Ctrl+V) in {extensionName} to use.',
   [MessageCode.INFO_CURSOR_AI_NOT_AVAILABLE]:
@@ -134,16 +109,13 @@ export const messagesEn: Record<MessageCode, string> = {
   [MessageCode.INFO_CURSOR_AI_USER_INSTRUCTIONS]: 'Paste (Cmd/Ctrl+V) in Cursor chat to use.',
   [MessageCode.INFO_GEMINI_CODE_ASSIST_NOT_AVAILABLE]:
     'RangeLink can seamlessly integrate with Gemini Code Assist for faster context sharing of precise code ranges.\n\nInstall and activate the Gemini Code Assist extension to use it as a paste destination.',
-  [MessageCode.INFO_GEMINI_CODE_ASSIST_USER_INSTRUCTIONS]:
-    'Paste (Cmd/Ctrl+V) in Gemini Code Assist to use.',
+  [MessageCode.INFO_GEMINI_CODE_ASSIST_USER_INSTRUCTIONS]: 'Paste (Cmd/Ctrl+V) in Gemini Code Assist to use.',
   [MessageCode.INFO_GITHUB_COPILOT_CHAT_NOT_AVAILABLE]:
     'RangeLink can seamlessly integrate with GitHub Copilot Chat for faster context sharing of precise code ranges.\n\nInstall and activate the GitHub Copilot Chat extension to use it as a paste destination.',
-  [MessageCode.INFO_GITHUB_COPILOT_CHAT_USER_INSTRUCTIONS]:
-    'Paste (Cmd/Ctrl+V) in GitHub Copilot chat to use.',
+  [MessageCode.INFO_GITHUB_COPILOT_CHAT_USER_INSTRUCTIONS]: 'Paste (Cmd/Ctrl+V) in GitHub Copilot chat to use.',
   [MessageCode.INFO_JUMP_FOCUS_FAILED]: 'Failed to focus {destinationName}',
   [MessageCode.INFO_JUMP_NO_DESTINATIONS_AVAILABLE]: NO_DESTINATIONS_AVAILABLE,
-  [MessageCode.INFO_JUMP_QUICK_PICK_PLACEHOLDER]:
-    'RangeLink: No destination bound. Choose destination to jump to',
+  [MessageCode.INFO_JUMP_QUICK_PICK_PLACEHOLDER]: 'RangeLink: No destination bound. Choose destination to jump to',
   [MessageCode.INFO_NAVIGATION_EMPTY_INPUT]: 'Please enter a link to navigate',
   [MessageCode.INFO_NAVIGATION_INPUT_BOX_PLACEHOLDER]: 'recipes/baking/chickenpie.ts#L3C14-L15C9',
   [MessageCode.INFO_NAVIGATION_INPUT_BOX_PROMPT]: 'Enter RangeLink to navigate',
@@ -152,46 +124,32 @@ export const messagesEn: Record<MessageCode, string> = {
   [MessageCode.INFO_NEW_VERSION_NOTIFICATION]: 'RangeLink updated to v{version}. See what changed!',
   [MessageCode.INFO_NEW_VERSION_SKIP_BUTTON]: 'Skip for this version',
   [MessageCode.INFO_NEW_VERSION_WHATS_NEW_BUTTON]: "What's New",
-  [MessageCode.INFO_OPERATION_ABORTED_DIRTY_BUFFER]:
-    'Operation cancelled — file has unsaved changes.',
+  [MessageCode.INFO_OPERATION_ABORTED_DIRTY_BUFFER]: 'Operation cancelled — file has unsaved changes.',
   [MessageCode.INFO_PASTE_CONTENT_NO_DESTINATIONS_AVAILABLE]: NO_DESTINATIONS_AVAILABLE,
-  [MessageCode.INFO_PASTE_CONTENT_QUICK_PICK_DESTINATIONS_CHOOSE_BELOW]:
-    'RangeLink: No bound destination. Choose below to bind and paste',
-  [MessageCode.INFO_SELF_PASTE_FILE_PATH_BLOCKED_BY_SELECTION]:
-    'Cannot paste when bound editor has an active selection. File path copied to clipboard.',
-  [MessageCode.INFO_SELF_PASTE_LINK_SKIPPED]:
-    'Cannot auto-paste to same file. Link copied to clipboard. Tip: Use R-C for clipboard-only links.',
-  [MessageCode.INFO_SELF_PASTE_SELECTED_TEXT_BLOCKED_BY_SELECTION]:
-    'Cannot paste when bound editor has an active selection.',
-  [MessageCode.INFO_TERMINAL_LINK_BRIDGE_TIP]:
-    'Terminal text pasted to destination. Tip: Use R-V directly for terminal selections.',
+  [MessageCode.INFO_PASTE_CONTENT_QUICK_PICK_DESTINATIONS_CHOOSE_BELOW]: 'RangeLink: No bound destination. Choose below to bind and paste',
+  [MessageCode.INFO_SELF_PASTE_FILE_PATH_BLOCKED_BY_SELECTION]: 'Cannot paste when bound editor has an active selection. File path copied to clipboard.',
+  [MessageCode.INFO_SELF_PASTE_LINK_SKIPPED]: 'Cannot auto-paste to same file. Link copied to clipboard. Tip: Use R-C for clipboard-only links.',
+  [MessageCode.INFO_SELF_PASTE_SELECTED_TEXT_BLOCKED_BY_SELECTION]: 'Cannot paste when bound editor has an active selection.',
+  [MessageCode.INFO_TERMINAL_LINK_BRIDGE_TIP]: 'Terminal text pasted to destination. Tip: Use R-V directly for terminal selections.',
   [MessageCode.INFO_VERSION_COPY_COMMIT_HASH_BUTTON]: 'Copy Commit Hash',
   [MessageCode.INFO_VERSION_DIRTY_INDICATOR]: ' (with uncommitted changes)',
-  [MessageCode.INFO_VERSION_INFO]:
-    'RangeLink v{version}\nCommit: {commit}{isDirtyIndicator}\nBranch: {branch}\nBuild: {buildDate}',
+  [MessageCode.INFO_VERSION_INFO]: 'RangeLink v{version}\nCommit: {commit}{isDirtyIndicator}\nBranch: {branch}\nBuild: {buildDate}',
 
   [MessageCode.SMART_BIND_CONFIRM_NO_DESCRIPTION]: 'Stay bound to {currentDestination}',
   [MessageCode.SMART_BIND_CONFIRM_NO_KEEP]: 'No, keep current binding',
-  [MessageCode.SMART_BIND_CONFIRM_PLACEHOLDER]:
-    'Already bound to {currentDestination}. Replace with {newDestination}?',
-  [MessageCode.SMART_BIND_CONFIRM_YES_DESCRIPTION]:
-    'Switch from {currentDestination} to {newDestination}',
+  [MessageCode.SMART_BIND_CONFIRM_PLACEHOLDER]: 'Already bound to {currentDestination}. Replace with {newDestination}?',
+  [MessageCode.SMART_BIND_CONFIRM_YES_DESCRIPTION]: 'Switch from {currentDestination} to {newDestination}',
   [MessageCode.SMART_BIND_CONFIRM_YES_REPLACE]: 'Yes, replace',
 
   [MessageCode.STATUS_BAR_DESTINATION_BOUND]: 'Bound to {destinationName}',
-  [MessageCode.STATUS_BAR_DESTINATION_BOUND_AND_SENT]:
-    'Bound to {destinationName} — {linkTypeName} sent',
+  [MessageCode.STATUS_BAR_DESTINATION_BOUND_AND_SENT]: 'Bound to {destinationName} — {linkTypeName} sent',
   [MessageCode.STATUS_BAR_DESTINATION_BOUND_PREFIX]: 'Bound to {destinationName} — ',
   [MessageCode.STATUS_BAR_DESTINATION_NOT_BOUND]: 'No destination bound',
-  [MessageCode.STATUS_BAR_DESTINATION_REBOUND]:
-    'Unbound {previousDestination}, now bound to {newDestination}',
+  [MessageCode.STATUS_BAR_DESTINATION_REBOUND]: 'Unbound {previousDestination}, now bound to {newDestination}',
   [MessageCode.STATUS_BAR_DESTINATION_UNBOUND]: 'Unbound from {destinationName}',
-  [MessageCode.STATUS_BAR_DESTINATION_UNBOUND_EDITOR_CLOSED]:
-    'Unbound from {destinationName} — editor closed',
-  [MessageCode.STATUS_BAR_DESTINATION_UNBOUND_FILE_DELETED]:
-    'Unbound from {destinationName} — file deleted',
-  [MessageCode.STATUS_BAR_DESTINATION_UNBOUND_TERMINAL_CLOSED]:
-    'Unbound from {destinationName} — terminal closed',
+  [MessageCode.STATUS_BAR_DESTINATION_UNBOUND_EDITOR_CLOSED]: 'Unbound from {destinationName} — editor closed',
+  [MessageCode.STATUS_BAR_DESTINATION_UNBOUND_FILE_DELETED]: 'Unbound from {destinationName} — file deleted',
+  [MessageCode.STATUS_BAR_DESTINATION_UNBOUND_TERMINAL_CLOSED]: 'Unbound from {destinationName} — terminal closed',
   [MessageCode.STATUS_BAR_ITEM_TEXT]: '$(link) RangeLink',
   [MessageCode.STATUS_BAR_ITEM_TOOLTIP_BOUND]: 'RangeLink — {destinationName}',
   [MessageCode.STATUS_BAR_ITEM_TOOLTIP_UNBOUND]: 'RangeLink — no destination bound',
@@ -206,8 +164,7 @@ export const messagesEn: Record<MessageCode, string> = {
   [MessageCode.STATUS_BAR_LINK_COPIED_TO_CLIPBOARD]: '{linkTypeName} copied to clipboard',
   [MessageCode.STATUS_BAR_LINK_SENT_TO_DESTINATION]: '{linkTypeName} sent to {destinationName}',
   [MessageCode.STATUS_BAR_MENU_BOOKMARKS_SECTION_LABEL]: 'Bookmarks',
-  [MessageCode.STATUS_BAR_MENU_DESTINATIONS_CHOOSE_BELOW]:
-    'No bound destination. Choose below to bind:',
+  [MessageCode.STATUS_BAR_MENU_DESTINATIONS_CHOOSE_BELOW]: 'No bound destination. Choose below to bind:',
   [MessageCode.STATUS_BAR_MENU_DESTINATIONS_NONE_AVAILABLE]: 'No destinations available',
   [MessageCode.STATUS_BAR_MENU_ITEM_JUMP_ENABLED_LABEL]: '$(arrow-right) Jump to Bound Destination',
   [MessageCode.STATUS_BAR_MENU_ITEM_NAVIGATE_TO_LINK_LABEL]: '$(link-external) Go to Link',
@@ -229,38 +186,28 @@ export const messagesEn: Record<MessageCode, string> = {
 
   [MessageCode.UNKNOWN_FILENAME_FALLBACK]: 'Unknown',
 
-  [MessageCode.WARN_CLIPBOARD_PRESERVATION_FAILED]:
-    'Clipboard preservation failed. Content was not sent.',
+  [MessageCode.WARN_CLIPBOARD_PRESERVATION_FAILED]: 'Clipboard preservation failed. Content was not sent.',
 
-  [MessageCode.WARN_DESTINATION_UNBOUND_FILE_DELETED]:
-    'Unbound from {destinationName} — file was deleted from disk',
+  [MessageCode.WARN_DESTINATION_UNBOUND_FILE_DELETED]: 'Unbound from {destinationName} — file was deleted from disk',
 
-  [MessageCode.WARN_FILE_PATH_DIRTY_BUFFER]:
-    'File has unsaved changes. The AI tool may read stale content from disk.',
+  [MessageCode.WARN_FILE_PATH_DIRTY_BUFFER]: 'File has unsaved changes. The AI tool may read stale content from disk.',
   [MessageCode.WARN_FILE_PATH_DIRTY_BUFFER_CONTINUE]: 'Send Anyway',
   [MessageCode.WARN_FILE_PATH_DIRTY_BUFFER_SAVE]: 'Save & Send',
-  [MessageCode.WARN_FILE_PATH_DIRTY_BUFFER_SAVE_FAILED]:
-    'File could not be saved. File path send aborted.',
+  [MessageCode.WARN_FILE_PATH_DIRTY_BUFFER_SAVE_FAILED]: 'File could not be saved. File path send aborted.',
   [MessageCode.WARN_FILE_PATH_DOES_NOT_EXIST]: 'File does not exist at: {path}',
-  [MessageCode.WARN_LINK_DIRTY_BUFFER]:
-    'File has unsaved changes. Link may point to wrong position after save.',
+  [MessageCode.WARN_LINK_DIRTY_BUFFER]: 'File has unsaved changes. Link may point to wrong position after save.',
   [MessageCode.WARN_LINK_DIRTY_BUFFER_CONTINUE]: 'Generate Anyway',
   [MessageCode.WARN_LINK_DIRTY_BUFFER_SAVE]: 'Save & Generate',
-  [MessageCode.WARN_LINK_DIRTY_BUFFER_SAVE_FAILED]:
-    'File could not be saved. Link generation aborted.',
-  [MessageCode.WARN_NAVIGATION_CLAMPED]:
-    'Navigated to {path} @ {position} (clamped: {clampingSummary})',
+  [MessageCode.WARN_LINK_DIRTY_BUFFER_SAVE_FAILED]: 'File could not be saved. Link generation aborted.',
+  [MessageCode.WARN_NAVIGATION_CLAMPED]: 'Navigated to {path} @ {position} (clamped: {clampingSummary})',
   [MessageCode.WARN_NAVIGATION_CLAMPED_SUMMARY_BOTH]: 'line and column exceeded bounds',
   [MessageCode.WARN_NAVIGATION_CLAMPED_SUMMARY_CHARACTER]: 'column exceeded line length',
   [MessageCode.WARN_NAVIGATION_CLAMPED_SUMMARY_LINE]: 'line exceeded file length',
   [MessageCode.WARN_NAVIGATION_FILENAME_AMBIGUOUS]: 'Multiple files match: {path}',
   [MessageCode.WARN_NAVIGATION_FILE_NOT_FOUND]: 'Cannot find file: {path}',
-  [MessageCode.WARN_PASTE_FAILED_EDITOR_HIDDEN]:
-    'Could not send to editor. Make sure the bound editor is visible and focused.',
-  [MessageCode.WARN_PASTE_FAILED_TERMINAL]:
-    'Could not send to terminal. Terminal may be closed or not accepting input.',
-  [MessageCode.WARN_TEXT_EDITOR_DUPLICATE_TAB_GROUPS]:
-    'Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed.',
+  [MessageCode.WARN_PASTE_FAILED_EDITOR_HIDDEN]: 'Could not send to editor. Make sure the bound editor is visible and focused.',
+  [MessageCode.WARN_PASTE_FAILED_TERMINAL]: 'Could not send to terminal. Terminal may be closed or not accepting input.',
+  [MessageCode.WARN_TEXT_EDITOR_DUPLICATE_TAB_GROUPS]: 'Bound file is open in multiple editor groups. Paste will not work until the duplicate tab is closed.',
 
   // Keep the keys in alphabetical order.
 };

--- a/packages/rangelink-vscode-extension/src/ide/QuickPickProvider.ts
+++ b/packages/rangelink-vscode-extension/src/ide/QuickPickProvider.ts
@@ -6,8 +6,5 @@ import type * as vscode from 'vscode';
  * Avoids coupling showTerminalPicker and DestinationPicker to the full VscodeAdapter.
  */
 export interface QuickPickProvider {
-  showQuickPick<T extends vscode.QuickPickItem>(
-    items: T[],
-    options?: vscode.QuickPickOptions,
-  ): Promise<T | undefined>;
+  showQuickPick<T extends vscode.QuickPickItem>(items: T[], options?: vscode.QuickPickOptions): Promise<T | undefined>;
 }

--- a/packages/rangelink-vscode-extension/src/ide/vscode/VscodeAdapter.ts
+++ b/packages/rangelink-vscode-extension/src/ide/vscode/VscodeAdapter.ts
@@ -1,25 +1,10 @@
 import { displayName } from '../../../package.json';
-import {
-  AI_ASSISTANT_PASTE_COMMANDS,
-  CLIPBOARD_POST_PASTE_DELAY_MS,
-  ENV_RANGELINK_CAPTURE_LOGS,
-  FOCUS_TO_PASTE_DELAY_MS,
-} from '../../constants';
+import { AI_ASSISTANT_PASTE_COMMANDS, CLIPBOARD_POST_PASTE_DELAY_MS, ENV_RANGELINK_CAPTURE_LOGS, FOCUS_TO_PASTE_DELAY_MS } from '../../constants';
 import { RangeLinkExtensionError } from '../../errors/RangeLinkExtensionError';
 import { RangeLinkExtensionErrorCodes } from '../../errors/RangeLinkExtensionErrorCodes';
-import {
-  MessageCode,
-  RelativePathFormat,
-  type ResolveWorkspacePathResult,
-  TerminalFocusType,
-} from '../../types';
+import { MessageCode, RelativePathFormat, type ResolveWorkspacePathResult, TerminalFocusType } from '../../types';
 import { ExtensionResult } from '../../types/ExtensionResult';
-import {
-  formatMessage,
-  getUntitledDisplayName,
-  resolveWorkspacePath,
-  validateTerminalDefined,
-} from '../../utils';
+import { formatMessage, getUntitledDisplayName, resolveWorkspacePath, validateTerminalDefined } from '../../utils';
 import type { ClipboardProvider } from '../ClipboardProvider';
 import type { ConfigurationProvider } from '../ConfigurationProvider';
 import type { ErrorFeedbackProvider } from '../ErrorFeedbackProvider';
@@ -50,8 +35,7 @@ const getUnknownFilename = (): string => formatMessage(MessageCode.UNKNOWN_FILEN
  */
 const isLogCaptureEnabled = process.env[ENV_RANGELINK_CAPTURE_LOGS] === 'true';
 
-const isObject = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null;
+const isObject = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
 
 /**
  * Test-only projection: pull the status fields integration tests destructure
@@ -63,9 +47,7 @@ const isObject = (value: unknown): value is Record<string, unknown> =>
  *
  * Exported for direct unit testing; not part of the adapter's public API.
  */
-export const projectTestStatusFields = (
-  record: Record<string, unknown>,
-): { isActive?: boolean; boundState?: string } => {
+export const projectTestStatusFields = (record: Record<string, unknown>): { isActive?: boolean; boundState?: string } => {
   const fields: { isActive?: boolean; boundState?: string } = {};
   const terminalInfo = isObject(record.terminalInfo) ? record.terminalInfo : undefined;
   const fileInfo = isObject(record.fileInfo) ? record.fileInfo : undefined;
@@ -135,10 +117,7 @@ export class VscodeAdapter
    * Direct calls are only appropriate inside ClipboardService itself.
    */
   async writeTextToClipboard(text: string): Promise<void> {
-    this.logger.debug(
-      { fn: 'VscodeAdapter.writeTextToClipboard', textLength: text.length },
-      'Writing to clipboard',
-    );
+    this.logger.debug({ fn: 'VscodeAdapter.writeTextToClipboard', textLength: text.length }, 'Writing to clipboard');
     return await this.ideInstance.env.clipboard.writeText(text);
   }
 
@@ -198,36 +177,18 @@ export class VscodeAdapter
   /**
    * Show temporary status bar message prefixed with "RangeLink: ".
    */
-  setStatusBarMessage(
-    message: string,
-    timeout: number = DEFAULT_STATUS_BAR_TIMEOUT_MS,
-  ): vscode.Disposable {
-    return this.setStatusBarMessageInternal(
-      `${STATUS_BAR_PREFIX}${message}`,
-      timeout,
-      'VscodeAdapter.setStatusBarMessage',
-    );
+  setStatusBarMessage(message: string, timeout: number = DEFAULT_STATUS_BAR_TIMEOUT_MS): vscode.Disposable {
+    return this.setStatusBarMessageInternal(`${STATUS_BAR_PREFIX}${message}`, timeout, 'VscodeAdapter.setStatusBarMessage');
   }
 
   /**
    * Show temporary success status bar message prefixed with "✓ RangeLink: ".
    */
-  setSuccessfulStatusBarMessage(
-    message: string,
-    timeout: number = DEFAULT_STATUS_BAR_TIMEOUT_MS,
-  ): vscode.Disposable {
-    return this.setStatusBarMessageInternal(
-      `${STATUS_BAR_SUCCESS_PREFIX}${message}`,
-      timeout,
-      'VscodeAdapter.setSuccessfulStatusBarMessage',
-    );
+  setSuccessfulStatusBarMessage(message: string, timeout: number = DEFAULT_STATUS_BAR_TIMEOUT_MS): vscode.Disposable {
+    return this.setStatusBarMessageInternal(`${STATUS_BAR_SUCCESS_PREFIX}${message}`, timeout, 'VscodeAdapter.setSuccessfulStatusBarMessage');
   }
 
-  private setStatusBarMessageInternal(
-    message: string,
-    timeout: number,
-    fn: string,
-  ): vscode.Disposable {
+  private setStatusBarMessageInternal(message: string, timeout: number, fn: string): vscode.Disposable {
     this.logger.debug({ fn, message, timeout }, 'Setting status bar message');
     return this.ideInstance.window.setStatusBarMessage(message, timeout);
   }
@@ -240,10 +201,7 @@ export class VscodeAdapter
    * @returns Promise resolving to selected button label, or undefined if dismissed
    */
   async showWarningMessage(message: string, ...items: string[]): Promise<string | undefined> {
-    this.logger.debug(
-      { fn: 'VscodeAdapter.showWarningMessage', message, items },
-      'Showing warning message',
-    );
+    this.logger.debug({ fn: 'VscodeAdapter.showWarningMessage', message, items }, 'Showing warning message');
     return await this.ideInstance.window.showWarningMessage(message, ...items);
   }
 
@@ -263,10 +221,7 @@ export class VscodeAdapter
    * @returns Promise resolving to selected button label, or undefined if dismissed
    */
   async showInformationMessage(message: string, ...items: string[]): Promise<string | undefined> {
-    this.logger.debug(
-      { fn: 'VscodeAdapter.showInformationMessage', message, items },
-      'Showing info message',
-    );
+    this.logger.debug({ fn: 'VscodeAdapter.showInformationMessage', message, items }, 'Showing info message');
     return await this.ideInstance.window.showInformationMessage(message, ...items);
   }
 
@@ -277,10 +232,7 @@ export class VscodeAdapter
    * @param options - Optional configuration for the quick pick
    * @returns Promise resolving to the selected item, or undefined if cancelled
    */
-  async showQuickPick<T extends vscode.QuickPickItem>(
-    items: T[],
-    options?: vscode.QuickPickOptions,
-  ): Promise<T | undefined> {
+  async showQuickPick<T extends vscode.QuickPickItem>(items: T[], options?: vscode.QuickPickOptions): Promise<T | undefined> {
     this.logger.debug(
       {
         fn: 'VscodeAdapter.showQuickPick',
@@ -339,10 +291,7 @@ export class VscodeAdapter
    * @param options - Optional view configuration (preserveFocus, viewColumn, etc.)
    * @returns Promise resolving to the text editor showing the document
    */
-  async showTextDocument(
-    uri: vscode.Uri,
-    options?: vscode.TextDocumentShowOptions,
-  ): Promise<vscode.TextEditor> {
+  async showTextDocument(uri: vscode.Uri, options?: vscode.TextDocumentShowOptions): Promise<vscode.TextEditor> {
     const document = await this.ideInstance.workspace.openTextDocument(uri);
     return this.ideInstance.window.showTextDocument(document, options);
   }
@@ -398,10 +347,7 @@ export class VscodeAdapter
   getTerminalName(terminal: vscode.Terminal): ExtensionResult<string> {
     const validationResult = validateTerminalDefined(terminal);
     if (!validationResult.success) {
-      this.logger.error(
-        { fn: 'VscodeAdapter.getTerminalName', error: validationResult.error },
-        'Terminal validation failed',
-      );
+      this.logger.error({ fn: 'VscodeAdapter.getTerminalName', error: validationResult.error }, 'Terminal validation failed');
       return validationResult as unknown as ExtensionResult<string>;
     }
     return ExtensionResult.ok(terminal.name);
@@ -433,10 +379,7 @@ export class VscodeAdapter
       editBuilder.insert(editor.selection.active, text);
     });
     if (!success) {
-      this.logger.warn(
-        { fn: 'VscodeAdapter.insertTextAtCursor', editorUri: editor.document.uri.toString() },
-        'Editor edit failed',
-      );
+      this.logger.warn({ fn: 'VscodeAdapter.insertTextAtCursor', editorUri: editor.document.uri.toString() }, 'Editor edit failed');
     }
     return success;
   }
@@ -558,10 +501,7 @@ export class VscodeAdapter
    * to log context-key changes themselves.
    */
   setContext(key: string, value: unknown): void {
-    this.logger.debug(
-      { fn: 'VscodeAdapter.setContext', key, value },
-      `Setting context key: ${key} = ${value}`,
-    );
+    this.logger.debug({ fn: 'VscodeAdapter.setContext', key, value }, `Setting context key: ${key} = ${value}`);
     void this.ideInstance.commands.executeCommand('setContext', key, value);
   }
 
@@ -638,9 +578,7 @@ export class VscodeAdapter
    * invocation on a closed file).
    */
   findOpenDocument(uri: vscode.Uri): vscode.TextDocument | undefined {
-    return this.ideInstance.workspace.textDocuments.find(
-      (doc) => doc.uri.toString() === uri.toString(),
-    );
+    return this.ideInstance.workspace.textDocuments.find((doc) => doc.uri.toString() === uri.toString());
   }
 
   // ============================================================================
@@ -664,10 +602,7 @@ export class VscodeAdapter
    * @param priority - Priority determines position relative to other items (higher = more left)
    * @returns StatusBarItem instance
    */
-  createStatusBarItem(
-    alignment: vscode.StatusBarAlignment,
-    priority?: number,
-  ): vscode.StatusBarItem {
+  createStatusBarItem(alignment: vscode.StatusBarAlignment, priority?: number): vscode.StatusBarItem {
     return this.ideInstance.window.createStatusBarItem(alignment, priority);
   }
 
@@ -700,9 +635,7 @@ export class VscodeAdapter
    * @param provider - Terminal link provider instance
    * @returns Disposable to unregister the provider
    */
-  registerTerminalLinkProvider<T extends vscode.TerminalLink>(
-    provider: vscode.TerminalLinkProvider<T>,
-  ): vscode.Disposable {
+  registerTerminalLinkProvider<T extends vscode.TerminalLink>(provider: vscode.TerminalLinkProvider<T>): vscode.Disposable {
     return this.ideInstance.window.registerTerminalLinkProvider(provider);
   }
 
@@ -713,10 +646,7 @@ export class VscodeAdapter
    * @param provider - Document link provider instance
    * @returns Disposable to unregister the provider
    */
-  registerDocumentLinkProvider(
-    selector: vscode.DocumentSelector,
-    provider: vscode.DocumentLinkProvider,
-  ): vscode.Disposable {
+  registerDocumentLinkProvider(selector: vscode.DocumentSelector, provider: vscode.DocumentLinkProvider): vscode.Disposable {
     return this.ideInstance.languages.registerDocumentLinkProvider(selector, provider);
   }
 
@@ -808,9 +738,7 @@ export class VscodeAdapter
    * @param listener - Callback invoked when the active terminal changes
    * @returns Disposable to unregister the listener
    */
-  onDidChangeActiveTerminal(
-    listener: (terminal: vscode.Terminal | undefined) => void,
-  ): vscode.Disposable {
+  onDidChangeActiveTerminal(listener: (terminal: vscode.Terminal | undefined) => void): vscode.Disposable {
     return this.ideInstance.window.onDidChangeActiveTerminal(listener);
   }
 
@@ -830,9 +758,7 @@ export class VscodeAdapter
    * @param listener - Callback invoked when any configuration changes
    * @returns Disposable to unregister the listener
    */
-  onDidChangeConfiguration(
-    listener: (event: vscode.ConfigurationChangeEvent) => void,
-  ): vscode.Disposable {
+  onDidChangeConfiguration(listener: (event: vscode.ConfigurationChangeEvent) => void): vscode.Disposable {
     return this.ideInstance.workspace.onDidChangeConfiguration(listener);
   }
 
@@ -862,12 +788,7 @@ export class VscodeAdapter
     ignoreDeleteEvents?: boolean,
   ): vscode.FileSystemWatcher {
     const pattern = new this.ideInstance.RelativePattern(fileUri, '*');
-    return this.ideInstance.workspace.createFileSystemWatcher(
-      pattern,
-      ignoreCreateEvents,
-      ignoreChangeEvents,
-      ignoreDeleteEvents,
-    );
+    return this.ideInstance.workspace.createFileSystemWatcher(pattern, ignoreCreateEvents, ignoreChangeEvents, ignoreDeleteEvents);
   }
 
   // ============================================================================
@@ -910,10 +831,7 @@ export class VscodeAdapter
    * @returns URI of active document or undefined if no editor is active
    */
   getActiveTextEditorUri(): vscode.Uri | undefined {
-    this.logger.debug(
-      { fn: 'VscodeAdapter.getActiveTextEditorUri' },
-      'Getting active text editor URI',
-    );
+    this.logger.debug({ fn: 'VscodeAdapter.getActiveTextEditorUri' }, 'Getting active text editor URI');
     return this.activeTextEditor?.document.uri;
   }
 
@@ -942,10 +860,7 @@ export class VscodeAdapter
   getActiveTabUri(): vscode.Uri | undefined {
     const activeTab = this.ideInstance.window.tabGroups.activeTabGroup?.activeTab;
     if (!activeTab) {
-      this.logger.debug(
-        { fn: 'VscodeAdapter.getActiveTabUri', inputKind: 'none' },
-        'Resolving active tab URI',
-      );
+      this.logger.debug({ fn: 'VscodeAdapter.getActiveTabUri', inputKind: 'none' }, 'Resolving active tab URI');
       return undefined;
     }
     // Dynamic property check: TabInputText/Custom/Notebook expose `.uri`;
@@ -954,18 +869,11 @@ export class VscodeAdapter
     const input = activeTab.input as Record<string, unknown>;
     const candidate = input.uri ?? input.modified;
     if (candidate && typeof candidate === 'object' && 'fsPath' in candidate) {
-      const inputKind =
-        (input as { constructor?: { name?: string } }).constructor?.name ?? 'unknown';
-      this.logger.debug(
-        { fn: 'VscodeAdapter.getActiveTabUri', inputKind },
-        'Resolving active tab URI',
-      );
+      const inputKind = (input as { constructor?: { name?: string } }).constructor?.name ?? 'unknown';
+      this.logger.debug({ fn: 'VscodeAdapter.getActiveTabUri', inputKind }, 'Resolving active tab URI');
       return candidate as vscode.Uri;
     }
-    this.logger.debug(
-      { fn: 'VscodeAdapter.getActiveTabUri', inputKind: 'unsupported' },
-      'No file URI on active tab input',
-    );
+    this.logger.debug({ fn: 'VscodeAdapter.getActiveTabUri', inputKind: 'unsupported' }, 'No file URI on active tab input');
     return undefined;
   }
 
@@ -1007,9 +915,7 @@ export class VscodeAdapter
    */
   hasVisibleEditorAt(uri: vscode.Uri, viewColumn: number): boolean {
     const uriString = uri.toString();
-    return this.visibleTextEditors.some(
-      (editor) => editor.document.uri.toString() === uriString && editor.viewColumn === viewColumn,
-    );
+    return this.visibleTextEditors.some((editor) => editor.document.uri.toString() === uriString && editor.viewColumn === viewColumn);
   }
 
   /**
@@ -1024,8 +930,7 @@ export class VscodeAdapter
    */
   editorHasActiveSelection(uri: vscode.Uri, viewColumn?: vscode.ViewColumn): boolean {
     const editors = this.findVisibleEditorsByUri(uri);
-    const relevantEditors =
-      viewColumn !== undefined ? editors.filter((e) => e.viewColumn === viewColumn) : editors;
+    const relevantEditors = viewColumn !== undefined ? editors.filter((e) => e.viewColumn === viewColumn) : editors;
     return relevantEditors.length > 0 && relevantEditors.some((e) => !e.selection.isEmpty);
   }
 
@@ -1131,9 +1036,6 @@ export class VscodeAdapter
    * @returns Workspace-relative path
    */
   asRelativePath(pathOrUri: string | vscode.Uri, format: RelativePathFormat): string {
-    return this.ideInstance.workspace.asRelativePath(
-      pathOrUri,
-      format === RelativePathFormat.WithWorkspaceFolder,
-    );
+    return this.ideInstance.workspace.asRelativePath(pathOrUri, format === RelativePathFormat.WithWorkspaceFolder);
   }
 }

--- a/packages/rangelink-vscode-extension/src/isRectangularSelection.ts
+++ b/packages/rangelink-vscode-extension/src/isRectangularSelection.ts
@@ -23,9 +23,7 @@ export function isRectangularSelection(selections: readonly vscode.Selection[]):
   const firstEndChar = selections[0].end.character;
 
   // Check if all selections have the same character range
-  const allHaveSameCharacterRange = selections.every(
-    (sel) => sel.start.character === firstStartChar && sel.end.character === firstEndChar,
-  );
+  const allHaveSameCharacterRange = selections.every((sel) => sel.start.character === firstStartChar && sel.end.character === firstEndChar);
 
   if (!allHaveSameCharacterRange) {
     return false;

--- a/packages/rangelink-vscode-extension/src/navigation/FilePathDocumentProvider.ts
+++ b/packages/rangelink-vscode-extension/src/navigation/FilePathDocumentProvider.ts
@@ -40,10 +40,7 @@ export class FilePathDocumentProvider implements vscode.DocumentLinkProvider {
     private readonly ideAdapter: VscodeAdapter,
     private readonly logger: Logger,
   ) {
-    this.logger.debug(
-      { fn: 'FilePathDocumentProvider.constructor' },
-      'FilePathDocumentProvider initialized',
-    );
+    this.logger.debug({ fn: 'FilePathDocumentProvider.constructor' }, 'FilePathDocumentProvider initialized');
   }
 
   /**
@@ -55,9 +52,7 @@ export class FilePathDocumentProvider implements vscode.DocumentLinkProvider {
    * @param document - The document to scan for file paths
    * @returns Array of detected document links
    */
-  provideDocumentLinks(
-    document: vscode.TextDocument,
-  ): vscode.ProviderResult<vscode.DocumentLink[]> {
+  provideDocumentLinks(document: vscode.TextDocument): vscode.ProviderResult<vscode.DocumentLink[]> {
     const text = document.getText();
     const pattern = buildFilePathPattern(this.getDelimiters());
     const links: vscode.DocumentLink[] = [];
@@ -72,9 +67,7 @@ export class FilePathDocumentProvider implements vscode.DocumentLinkProvider {
       const displayPath = expandPathForDisplay(rawPath, document.uri.fsPath);
       const docLink = new vscode.DocumentLink(range);
       docLink.tooltip = formatMessage(MessageCode.TOOLTIP_FILE_PATH, { path: displayPath });
-      docLink.target = this.ideAdapter.parseUri(
-        `command:${CMD_HANDLE_FILE_PATH_CLICK}?${encodeURIComponent(JSON.stringify([{ filePath: rawPath }]))}`,
-      );
+      docLink.target = this.ideAdapter.parseUri(`command:${CMD_HANDLE_FILE_PATH_CLICK}?${encodeURIComponent(JSON.stringify([{ filePath: rawPath }]))}`);
 
       links.push(docLink);
     }
@@ -108,10 +101,7 @@ export class FilePathDocumentProvider implements vscode.DocumentLinkProvider {
     try {
       await this.handler.navigateToFile(args.filePath);
     } catch (error) {
-      this.logger.debug(
-        { ...logCtx, error },
-        'Document link handling completed with error (already handled by navigation handler)',
-      );
+      this.logger.debug({ ...logCtx, error }, 'Document link handling completed with error (already handled by navigation handler)');
     }
   }
 }

--- a/packages/rangelink-vscode-extension/src/navigation/FilePathNavigationHandler.ts
+++ b/packages/rangelink-vscode-extension/src/navigation/FilePathNavigationHandler.ts
@@ -24,10 +24,7 @@ export class FilePathNavigationHandler {
     private readonly ideAdapter: VscodeAdapter,
     private readonly logger: Logger,
   ) {
-    this.logger.debug(
-      { fn: 'FilePathNavigationHandler.constructor' },
-      'FilePathNavigationHandler initialized',
-    );
+    this.logger.debug({ fn: 'FilePathNavigationHandler.constructor' }, 'FilePathNavigationHandler initialized');
   }
 
   /**
@@ -51,24 +48,17 @@ export class FilePathNavigationHandler {
 
     if (resolved === FILENAME_AMBIGUOUS) {
       this.logger.warn({ ...logCtx, expandedPath }, 'Multiple files match bare filename');
-      await this.ideAdapter.showWarningMessage(
-        formatMessage(MessageCode.WARN_NAVIGATION_FILENAME_AMBIGUOUS, { path: rawPath }),
-      );
+      await this.ideAdapter.showWarningMessage(formatMessage(MessageCode.WARN_NAVIGATION_FILENAME_AMBIGUOUS, { path: rawPath }));
       return;
     }
 
     if (resolved) {
-      this.logger.debug(
-        { ...logCtx, expandedPath, resolvedVia: resolved.resolvedVia },
-        'Path resolved',
-      );
+      this.logger.debug({ ...logCtx, expandedPath, resolvedVia: resolved.resolvedVia }, 'Path resolved');
     }
 
     if (!resolved) {
       this.logger.warn({ ...logCtx, expandedPath }, 'Cannot resolve file path');
-      await this.ideAdapter.showWarningMessage(
-        formatMessage(MessageCode.WARN_FILE_PATH_DOES_NOT_EXIST, { path: rawPath }),
-      );
+      await this.ideAdapter.showWarningMessage(formatMessage(MessageCode.WARN_FILE_PATH_DOES_NOT_EXIST, { path: rawPath }));
       return;
     }
 

--- a/packages/rangelink-vscode-extension/src/navigation/FilePathTerminalProvider.ts
+++ b/packages/rangelink-vscode-extension/src/navigation/FilePathTerminalProvider.ts
@@ -32,10 +32,7 @@ export class FilePathTerminalProvider implements vscode.TerminalLinkProvider<Fil
     private readonly handler: FilePathNavigationHandler,
     private readonly logger: Logger,
   ) {
-    this.logger.debug(
-      { fn: 'FilePathTerminalProvider.constructor' },
-      'FilePathTerminalProvider initialized',
-    );
+    this.logger.debug({ fn: 'FilePathTerminalProvider.constructor' }, 'FilePathTerminalProvider initialized');
   }
 
   /**
@@ -47,9 +44,7 @@ export class FilePathTerminalProvider implements vscode.TerminalLinkProvider<Fil
    * @param context - Terminal line context from VS Code
    * @returns Array of detected terminal links
    */
-  provideTerminalLinks(
-    context: vscode.TerminalLinkContext,
-  ): vscode.ProviderResult<FilePathTerminalLink[]> {
+  provideTerminalLinks(context: vscode.TerminalLinkContext): vscode.ProviderResult<FilePathTerminalLink[]> {
     const pattern = buildFilePathPattern(this.getDelimiters());
     const links: FilePathTerminalLink[] = [];
     let match: RegExpExecArray | null;

--- a/packages/rangelink-vscode-extension/src/navigation/RangeLinkDocumentProvider.ts
+++ b/packages/rangelink-vscode-extension/src/navigation/RangeLinkDocumentProvider.ts
@@ -40,10 +40,7 @@ export class RangeLinkDocumentProvider implements vscode.DocumentLinkProvider {
     private readonly ideAdapter: VscodeAdapter,
     private readonly logger: Logger,
   ) {
-    this.logger.debug(
-      { fn: 'RangeLinkDocumentProvider.constructor' },
-      'RangeLinkDocumentProvider initialized',
-    );
+    this.logger.debug({ fn: 'RangeLinkDocumentProvider.constructor' }, 'RangeLinkDocumentProvider initialized');
   }
 
   /**
@@ -56,10 +53,7 @@ export class RangeLinkDocumentProvider implements vscode.DocumentLinkProvider {
    * @param token - Cancellation token
    * @returns Array of detected document links
    */
-  provideDocumentLinks(
-    document: vscode.TextDocument,
-    token: vscode.CancellationToken,
-  ): vscode.ProviderResult<vscode.DocumentLink[]> {
+  provideDocumentLinks(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.DocumentLink[]> {
     const text = document.getText();
     const detectedLinks = findLinksInText(text, this.getDelimiters(), this.logger, token);
 
@@ -79,9 +73,7 @@ export class RangeLinkDocumentProvider implements vscode.DocumentLinkProvider {
 
       const docLink = new vscode.DocumentLink(range);
       docLink.tooltip = formatLinkTooltip(parsed);
-      docLink.target = this.ideAdapter.parseUri(
-        `command:rangelink.handleDocumentLinkClick?${encodeURIComponent(JSON.stringify({ linkText, parsed }))}`,
-      );
+      docLink.target = this.ideAdapter.parseUri(`command:rangelink.handleDocumentLinkClick?${encodeURIComponent(JSON.stringify({ linkText, parsed }))}`);
 
       return docLink;
     });
@@ -104,10 +96,7 @@ export class RangeLinkDocumentProvider implements vscode.DocumentLinkProvider {
     try {
       await this.handler.navigateToLink(parsed, linkText);
     } catch (error) {
-      this.logger.debug(
-        { ...logCtx, error },
-        'Document link handling completed with error (already handled by navigation handler)',
-      );
+      this.logger.debug({ ...logCtx, error }, 'Document link handling completed with error (already handled by navigation handler)');
     }
   }
 }

--- a/packages/rangelink-vscode-extension/src/navigation/RangeLinkNavigationHandler.ts
+++ b/packages/rangelink-vscode-extension/src/navigation/RangeLinkNavigationHandler.ts
@@ -1,29 +1,12 @@
 import type { ConfigReader } from '../config/ConfigReader';
-import {
-  DEFAULT_NAVIGATION_SHOW_CLAMPING_WARNING,
-  DEFAULT_NAVIGATION_SHOW_NAVIGATED_TOAST,
-} from '../constants/settingDefaults';
-import {
-  SETTING_NAVIGATION_SHOW_CLAMPING_WARNING,
-  SETTING_NAVIGATION_SHOW_NAVIGATED_TOAST,
-} from '../constants/settingKeys';
+import { DEFAULT_NAVIGATION_SHOW_CLAMPING_WARNING, DEFAULT_NAVIGATION_SHOW_NAVIGATED_TOAST } from '../constants/settingDefaults';
+import { SETTING_NAVIGATION_SHOW_CLAMPING_WARNING, SETTING_NAVIGATION_SHOW_NAVIGATED_TOAST } from '../constants/settingKeys';
 import { VscodeAdapter } from '../ide/vscode/VscodeAdapter';
 import { FILENAME_AMBIGUOUS, MessageCode } from '../types';
-import {
-  convertRangeLinkPosition,
-  formatClampingSummary,
-  formatLinkPosition,
-  formatMessage,
-} from '../utils';
+import { convertRangeLinkPosition, formatClampingSummary, formatLinkPosition, formatMessage } from '../utils';
 
 import type { Logger } from '@couimet/logger-contract';
-import {
-  CoreResult,
-  DelimiterConfigGetter,
-  ParsedLink,
-  parseLink,
-  SelectionType,
-} from 'rangelink-core-ts';
+import { CoreResult, DelimiterConfigGetter, ParsedLink, parseLink, SelectionType } from 'rangelink-core-ts';
 import * as vscode from 'vscode';
 
 /**
@@ -49,10 +32,7 @@ export class RangeLinkNavigationHandler {
     private readonly configReader: ConfigReader,
     private readonly logger: Logger,
   ) {
-    this.logger.debug(
-      { fn: 'RangeLinkNavigationHandler.constructor' },
-      'RangeLinkNavigationHandler initialized',
-    );
+    this.logger.debug({ fn: 'RangeLinkNavigationHandler.constructor' }, 'RangeLinkNavigationHandler initialized');
   }
 
   /**
@@ -86,9 +66,7 @@ export class RangeLinkNavigationHandler {
 
     if (resolved === FILENAME_AMBIGUOUS) {
       this.logger.warn({ ...logCtx, path }, 'Multiple files match bare filename');
-      await this.ideAdapter.showWarningMessage(
-        formatMessage(MessageCode.WARN_NAVIGATION_FILENAME_AMBIGUOUS, { path }),
-      );
+      await this.ideAdapter.showWarningMessage(formatMessage(MessageCode.WARN_NAVIGATION_FILENAME_AMBIGUOUS, { path }));
       return;
     }
 
@@ -106,15 +84,10 @@ export class RangeLinkNavigationHandler {
       const untitledUri = this.ideAdapter.findOpenUntitledFile(path);
 
       if (untitledUri) {
-        this.logger.info(
-          { ...logCtx, path, uri: untitledUri.toString() },
-          'Found open untitled file, navigating',
-        );
+        this.logger.info({ ...logCtx, path, uri: untitledUri.toString() }, 'Found open untitled file, navigating');
         fileUri = untitledUri;
       } else {
-        await this.ideAdapter.showWarningMessage(
-          formatMessage(MessageCode.WARN_NAVIGATION_FILE_NOT_FOUND, { path }),
-        );
+        await this.ideAdapter.showWarningMessage(formatMessage(MessageCode.WARN_NAVIGATION_FILE_NOT_FOUND, { path }));
         return;
       }
     }
@@ -133,11 +106,7 @@ export class RangeLinkNavigationHandler {
       const convertedStart = convertRangeLinkPosition(start, document);
       const convertedEnd = convertRangeLinkPosition(end, document);
 
-      const anyClamping =
-        convertedStart.lineClamped ||
-        convertedStart.characterClamped ||
-        convertedEnd.lineClamped ||
-        convertedEnd.characterClamped;
+      const anyClamping = convertedStart.lineClamped || convertedStart.characterClamped || convertedEnd.lineClamped || convertedEnd.characterClamped;
 
       if (anyClamping) {
         this.logger.warn(
@@ -227,10 +196,7 @@ export class RangeLinkNavigationHandler {
         }
         editor.selections = selections;
 
-        this.logger.info(
-          { ...logCtx, lineCount: selections.length },
-          'Set rectangular selection (multi-cursor)',
-        );
+        this.logger.info({ ...logCtx, lineCount: selections.length }, 'Set rectangular selection (multi-cursor)');
       } else {
         // Single or range selection
         const selection = this.ideAdapter.createSelection(vsStart, vsEnd);
@@ -240,10 +206,7 @@ export class RangeLinkNavigationHandler {
       }
 
       // Reveal the selection
-      editor.revealRange(
-        this.ideAdapter.createRange(vsStart, vsEnd),
-        vscode.TextEditorRevealType.InCenterIfOutsideViewport,
-      );
+      editor.revealRange(this.ideAdapter.createRange(vsStart, vsEnd), vscode.TextEditorRevealType.InCenterIfOutsideViewport);
 
       this.logger.info(
         {
@@ -267,41 +230,23 @@ export class RangeLinkNavigationHandler {
           position,
           clampingSummary,
         });
-        if (
-          this.configReader.getBoolean(
-            SETTING_NAVIGATION_SHOW_CLAMPING_WARNING,
-            DEFAULT_NAVIGATION_SHOW_CLAMPING_WARNING,
-          )
-        ) {
+        if (this.configReader.getBoolean(SETTING_NAVIGATION_SHOW_CLAMPING_WARNING, DEFAULT_NAVIGATION_SHOW_CLAMPING_WARNING)) {
           await this.ideAdapter.showWarningMessage(clampingMessage);
         } else {
-          this.logger.debug(
-            { ...logCtx, suppressedMessage: clampingMessage },
-            'Clamping warning suppressed by setting',
-          );
+          this.logger.debug({ ...logCtx, suppressedMessage: clampingMessage }, 'Clamping warning suppressed by setting');
         }
       } else {
         const toastMessage = formatMessage(MessageCode.INFO_NAVIGATION_SUCCESS, { path, position });
-        if (
-          this.configReader.getBoolean(
-            SETTING_NAVIGATION_SHOW_NAVIGATED_TOAST,
-            DEFAULT_NAVIGATION_SHOW_NAVIGATED_TOAST,
-          )
-        ) {
+        if (this.configReader.getBoolean(SETTING_NAVIGATION_SHOW_NAVIGATED_TOAST, DEFAULT_NAVIGATION_SHOW_NAVIGATED_TOAST)) {
           await this.ideAdapter.showInformationMessage(toastMessage);
         } else {
-          this.logger.debug(
-            { ...logCtx, suppressedMessage: toastMessage },
-            'Navigated toast suppressed by setting',
-          );
+          this.logger.debug({ ...logCtx, suppressedMessage: toastMessage }, 'Navigated toast suppressed by setting');
         }
       }
     } catch (error) {
       this.logger.error({ ...logCtx, error }, 'Navigation failed');
       const errorMessage = error instanceof Error ? error.message : String(error);
-      await this.ideAdapter.showErrorMessage(
-        formatMessage(MessageCode.ERROR_NAVIGATION_FAILED, { path, error: errorMessage }),
-      );
+      await this.ideAdapter.showErrorMessage(formatMessage(MessageCode.ERROR_NAVIGATION_FAILED, { path, error: errorMessage }));
       throw error; // Re-throw for caller to handle if needed
     }
   }

--- a/packages/rangelink-vscode-extension/src/navigation/RangeLinkTerminalProvider.ts
+++ b/packages/rangelink-vscode-extension/src/navigation/RangeLinkTerminalProvider.ts
@@ -35,10 +35,7 @@ export class RangeLinkTerminalProvider implements vscode.TerminalLinkProvider<Ra
     private readonly ideAdapter: VscodeAdapter,
     private readonly logger: Logger,
   ) {
-    this.logger.debug(
-      { fn: 'RangeLinkTerminalProvider.constructor' },
-      'RangeLinkTerminalProvider initialized',
-    );
+    this.logger.debug({ fn: 'RangeLinkTerminalProvider.constructor' }, 'RangeLinkTerminalProvider initialized');
   }
 
   /**
@@ -51,10 +48,7 @@ export class RangeLinkTerminalProvider implements vscode.TerminalLinkProvider<Ra
    * @param token - Cancellation token
    * @returns Array of detected terminal links
    */
-  provideTerminalLinks(
-    context: vscode.TerminalLinkContext,
-    token: vscode.CancellationToken,
-  ): vscode.ProviderResult<RangeLinkTerminalLink[]> {
+  provideTerminalLinks(context: vscode.TerminalLinkContext, token: vscode.CancellationToken): vscode.ProviderResult<RangeLinkTerminalLink[]> {
     const detectedLinks = findLinksInText(context.line, this.getDelimiters(), this.logger, token);
 
     this.logger.debug(
@@ -99,19 +93,14 @@ export class RangeLinkTerminalProvider implements vscode.TerminalLinkProvider<Ra
         'Terminal link clicked but parse data missing (safety net triggered)',
       );
 
-      await this.ideAdapter.showWarningMessage(
-        formatMessage(MessageCode.ERROR_TERMINAL_LINK_INVALID_FORMAT, { linkText }),
-      );
+      await this.ideAdapter.showWarningMessage(formatMessage(MessageCode.ERROR_TERMINAL_LINK_INVALID_FORMAT, { linkText }));
       return;
     }
 
     try {
       await this.handler.navigateToLink(link.parsed, linkText);
     } catch (error) {
-      this.logger.debug(
-        { ...logCtx, error },
-        'Terminal link handling completed with error (already handled by navigation handler)',
-      );
+      this.logger.debug({ ...logCtx, error }, 'Terminal link handling completed with error (already handled by navigation handler)');
     }
   }
 }

--- a/packages/rangelink-vscode-extension/src/notification/ReleaseNotifier.ts
+++ b/packages/rangelink-vscode-extension/src/notification/ReleaseNotifier.ts
@@ -42,25 +42,16 @@ export class ReleaseNotifier {
 
     if (storedVersion === undefined) {
       await this.setLastNotifiedVersion(currentVersion);
-      this.logger.debug(
-        { ...logCtx, version: currentVersion },
-        'First install — stored version, skipping notification',
-      );
+      this.logger.debug({ ...logCtx, version: currentVersion }, 'First install — stored version, skipping notification');
       return;
     }
 
     if (storedVersion === currentVersion) {
-      this.logger.debug(
-        { ...logCtx, version: currentVersion },
-        'Same version — skipping release notification',
-      );
+      this.logger.debug({ ...logCtx, version: currentVersion }, 'Same version — skipping release notification');
       return;
     }
 
-    this.logger.info(
-      { ...logCtx, previousVersion: storedVersion, currentVersion },
-      'Version upgrade detected — showing release notification',
-    );
+    this.logger.info({ ...logCtx, previousVersion: storedVersion, currentVersion }, 'Version upgrade detected — showing release notification');
 
     const whatsNewButton = formatMessage(MessageCode.INFO_NEW_VERSION_WHATS_NEW_BUTTON);
     const skipButton = formatMessage(MessageCode.INFO_NEW_VERSION_SKIP_BUTTON);
@@ -76,15 +67,9 @@ export class ReleaseNotifier {
       this.logger.debug({ ...logCtx, version: currentVersion }, 'Opened release notes in browser');
     } else if (selection === skipButton) {
       await this.setLastNotifiedVersion(currentVersion);
-      this.logger.debug(
-        { ...logCtx, version: currentVersion },
-        'Release notification skipped for this version',
-      );
+      this.logger.debug({ ...logCtx, version: currentVersion }, 'Release notification skipped for this version');
     } else {
-      this.logger.debug(
-        { ...logCtx, version: currentVersion },
-        'Release notification dismissed — will reappear on next activation',
-      );
+      this.logger.debug({ ...logCtx, version: currentVersion }, 'Release notification dismissed — will reappear on next activation');
     }
   }
 

--- a/packages/rangelink-vscode-extension/src/services/FilePathPaster.ts
+++ b/packages/rangelink-vscode-extension/src/services/FilePathPaster.ts
@@ -1,17 +1,8 @@
 import type { ConfigReader } from '../config/ConfigReader';
-import {
-  DEFAULT_SMART_PADDING_PASTE_FILE_PATH,
-  SETTING_SMART_PADDING_PASTE_FILE_PATH,
-} from '../constants';
+import { DEFAULT_SMART_PADDING_PASTE_FILE_PATH, SETTING_SMART_PADDING_PASTE_FILE_PATH } from '../constants';
 import type { PasteDestinationManager } from '../destinations/PasteDestinationManager';
 import type { VscodeAdapter } from '../ide/vscode/VscodeAdapter';
-import {
-  DirtyBufferWarningResult,
-  MessageCode,
-  PasteContentType,
-  PathFormat,
-  RelativePathFormat,
-} from '../types';
+import { DirtyBufferWarningResult, MessageCode, PasteContentType, PathFormat, RelativePathFormat } from '../types';
 import { applySmartPadding, formatMessage } from '../utils';
 
 import { handleDirtyBufferWarning } from './handleDirtyBufferWarning';
@@ -32,11 +23,7 @@ import type * as vscode from 'vscode';
  *
  * Falls back to absolute fsPath otherwise.
  */
-export const getReferencePath = (
-  ideAdapter: VscodeAdapter,
-  uri: vscode.Uri,
-  pathFormat: PathFormat,
-): string => {
+export const getReferencePath = (ideAdapter: VscodeAdapter, uri: vscode.Uri, pathFormat: PathFormat): string => {
   const workspaceFolder = ideAdapter.getWorkspaceFolder(uri);
   if (workspaceFolder && pathFormat === PathFormat.WorkspaceRelative) {
     return ideAdapter.asRelativePath(uri, RelativePathFormat.PathOnly);
@@ -68,38 +55,20 @@ export class FilePathPaster {
   private async pasteCurrentFilePath(pathFormat: PathFormat): Promise<void> {
     const uri = this.ideAdapter.getActiveTabUri();
     if (!uri) {
-      this.logger.debug(
-        { fn: 'FilePathPaster.pasteCurrentFilePath', pathFormat },
-        'No active editor',
-      );
-      await this.ideAdapter.showErrorMessage(
-        formatMessage(MessageCode.ERROR_PASTE_FILE_PATH_NO_ACTIVE_FILE),
-      );
+      this.logger.debug({ fn: 'FilePathPaster.pasteCurrentFilePath', pathFormat }, 'No active editor');
+      await this.ideAdapter.showErrorMessage(formatMessage(MessageCode.ERROR_PASTE_FILE_PATH_NO_ACTIVE_FILE));
       return;
     }
     await this.pasteFilePath(uri, pathFormat, 'command-palette');
   }
 
-  private async pasteFilePath(
-    uri: vscode.Uri,
-    pathFormat: PathFormat,
-    uriSource: 'context-menu' | 'command-palette',
-  ): Promise<void> {
+  private async pasteFilePath(uri: vscode.Uri, pathFormat: PathFormat, uriSource: 'context-menu' | 'command-palette'): Promise<void> {
     const logCtx = { fn: 'FilePathPaster.pasteFilePath', pathFormat, uriSource };
 
     const document = this.ideAdapter.findOpenDocument(uri);
     if (document) {
-      const warningResult = await handleDirtyBufferWarning(
-        document,
-        this.configReader,
-        this.ideAdapter,
-        this.logger,
-        FILE_PATH_DIRTY_BUFFER_CODES,
-      );
-      if (
-        warningResult === DirtyBufferWarningResult.Dismissed ||
-        warningResult === DirtyBufferWarningResult.SaveFailed
-      ) {
+      const warningResult = await handleDirtyBufferWarning(document, this.configReader, this.ideAdapter, this.logger, FILE_PATH_DIRTY_BUFFER_CODES);
+      if (warningResult === DirtyBufferWarningResult.Dismissed || warningResult === DirtyBufferWarningResult.SaveFailed) {
         return;
       }
     }
@@ -107,10 +76,7 @@ export class FilePathPaster {
     const filePath = getReferencePath(this.ideAdapter, uri, pathFormat);
     this.logger.debug({ ...logCtx, filePath }, `Resolved file path: ${filePath}`);
 
-    const paddingMode = this.configReader.getPaddingMode(
-      SETTING_SMART_PADDING_PASTE_FILE_PATH,
-      DEFAULT_SMART_PADDING_PASTE_FILE_PATH,
-    );
+    const paddingMode = this.configReader.getPaddingMode(SETTING_SMART_PADDING_PASTE_FILE_PATH, DEFAULT_SMART_PADDING_PASTE_FILE_PATH);
 
     const resolveResult = await this.sendRouter.resolveDestination(logCtx);
     if (!resolveResult.canProceed) return;
@@ -121,10 +87,7 @@ export class FilePathPaster {
     const bindContext = toBindContext(resolveResult);
 
     if (destinationFilePath !== filePath) {
-      this.logger.debug(
-        { ...logCtx, before: filePath, after: destinationFilePath },
-        'Quoted path for unsafe characters',
-      );
+      this.logger.debug({ ...logCtx, before: filePath, after: destinationFilePath }, 'Quoted path for unsafe characters');
     }
 
     await this.sendRouter.sendToDestination(

--- a/packages/rangelink-vscode-extension/src/services/LinkGenerator.ts
+++ b/packages/rangelink-vscode-extension/src/services/LinkGenerator.ts
@@ -3,13 +3,7 @@ import { DEFAULT_SMART_PADDING_PASTE_LINK, SETTING_SMART_PADDING_PASTE_LINK } fr
 import type { PasteDestinationManager } from '../destinations/PasteDestinationManager';
 import type { OperationFeedbackProvider } from '../feedback';
 import type { VscodeAdapter } from '../ide/vscode/VscodeAdapter';
-import {
-  type BindContext,
-  DirtyBufferWarningResult,
-  MessageCode,
-  PasteContentType,
-  PathFormat,
-} from '../types';
+import { type BindContext, DirtyBufferWarningResult, MessageCode, PasteContentType, PathFormat } from '../types';
 import { applySmartPadding, formatMessage, generateLinkFromSelections } from '../utils';
 
 import { getReferencePath } from './FilePathPaster';
@@ -50,26 +44,15 @@ export class LinkGenerator {
       await this.ideAdapter.writeTextToClipboard(formattedLink.link);
       this.feedbackProvider.provideCopyFeedback(MessageCode.CONTENT_NAME_RANGELINK);
     } else {
-      this.logger.debug(
-        { fn: 'LinkGenerator.createLinkOnly' },
-        'generateLinkFromSelection returned undefined, aborting',
-      );
+      this.logger.debug({ fn: 'LinkGenerator.createLinkOnly' }, 'generateLinkFromSelection returned undefined, aborting');
     }
   }
 
   async createPortableLink(pathFormat: PathFormat = PathFormat.WorkspaceRelative): Promise<void> {
-    await this.createLinkCore(
-      pathFormat,
-      LinkType.Portable,
-      MessageCode.CONTENT_NAME_PORTABLE_RANGELINK,
-    );
+    await this.createLinkCore(pathFormat, LinkType.Portable, MessageCode.CONTENT_NAME_PORTABLE_RANGELINK);
   }
 
-  private async createLinkCore(
-    pathFormat: PathFormat,
-    linkType: LinkType,
-    contentNameCode: MessageCode,
-  ): Promise<void> {
+  private async createLinkCore(pathFormat: PathFormat, linkType: LinkType, contentNameCode: MessageCode): Promise<void> {
     const logCtx = { fn: 'LinkGenerator.createLinkCore', linkType };
     const formattedLink = await this.generateLinkFromSelection(pathFormat, linkType);
     if (formattedLink) {
@@ -81,21 +64,13 @@ export class LinkGenerator {
       const resolveResult = await this.sendRouter.resolveDestination(logCtx);
       if (!resolveResult.canProceed) return;
       const bindContext = toBindContext(resolveResult);
-      await this.copyToClipboardAndDestination(
-        formattedLink,
-        contentNameCode,
-        sourceUri,
-        bindContext,
-      );
+      await this.copyToClipboardAndDestination(formattedLink, contentNameCode, sourceUri, bindContext);
     } else {
       this.logger.debug(logCtx, 'generateLinkFromSelection returned undefined, aborting');
     }
   }
 
-  private async generateLinkFromSelection(
-    pathFormat: PathFormat,
-    linkType: LinkType,
-  ): Promise<FormattedLink | undefined> {
+  private async generateLinkFromSelection(pathFormat: PathFormat, linkType: LinkType): Promise<FormattedLink | undefined> {
     const validated = this.selectionValidator.validateSelectionsAndShowError();
     if (!validated) {
       return undefined;
@@ -104,17 +79,8 @@ export class LinkGenerator {
     let { editor, selections } = validated;
     let document = editor.document;
 
-    const warningResult = await handleDirtyBufferWarning(
-      document,
-      this.configReader,
-      this.ideAdapter,
-      this.logger,
-      LINK_DIRTY_BUFFER_CODES,
-    );
-    if (
-      warningResult === DirtyBufferWarningResult.Dismissed ||
-      warningResult === DirtyBufferWarningResult.SaveFailed
-    ) {
+    const warningResult = await handleDirtyBufferWarning(document, this.configReader, this.ideAdapter, this.logger, LINK_DIRTY_BUFFER_CODES);
+    if (warningResult === DirtyBufferWarningResult.Dismissed || warningResult === DirtyBufferWarningResult.SaveFailed) {
       return undefined;
     }
 
@@ -122,10 +88,7 @@ export class LinkGenerator {
       const preSaveSelections = selections;
       const revalidated = this.selectionValidator.validateSelectionsAndShowError();
       if (!revalidated) {
-        this.logger.debug(
-          { fn: 'generateLinkFromSelection' },
-          'Post-save re-validation returned no selections, aborting',
-        );
+        this.logger.debug({ fn: 'generateLinkFromSelection' }, 'Post-save re-validation returned no selections, aborting');
         return undefined;
       }
       ({ editor, selections } = revalidated);
@@ -152,26 +115,14 @@ export class LinkGenerator {
     });
 
     if (!result.success) {
-      const linkTypeName = formatMessage(
-        linkType === LinkType.Portable
-          ? MessageCode.ERROR_LINK_TYPE_NAME_PORTABLE
-          : MessageCode.ERROR_LINK_TYPE_NAME_REGULAR,
-      );
-      this.logger.error(
-        { fn: 'generateLinkFromSelection', error: result.error, linkType },
-        `Failed to generate ${linkTypeName}`,
-      );
-      this.feedbackProvider.showError(
-        formatMessage(MessageCode.ERROR_LINK_GENERATION_FAILED, { linkTypeName }),
-      );
+      const linkTypeName = formatMessage(linkType === LinkType.Portable ? MessageCode.ERROR_LINK_TYPE_NAME_PORTABLE : MessageCode.ERROR_LINK_TYPE_NAME_REGULAR);
+      this.logger.error({ fn: 'generateLinkFromSelection', error: result.error, linkType }, `Failed to generate ${linkTypeName}`);
+      this.feedbackProvider.showError(formatMessage(MessageCode.ERROR_LINK_GENERATION_FAILED, { linkTypeName }));
       return undefined;
     }
 
     const formattedLink = result.value;
-    this.logger.info(
-      { fn: 'generateLinkFromSelection', formattedLink },
-      `Generated link: ${formattedLink.link}`,
-    );
+    this.logger.info({ fn: 'generateLinkFromSelection', formattedLink }, `Generated link: ${formattedLink.link}`);
 
     return formattedLink;
   }
@@ -183,17 +134,11 @@ export class LinkGenerator {
     bindContext?: BindContext,
   ): Promise<void> {
     const logCtx = { fn: 'LinkGenerator.copyToClipboardAndDestination' };
-    const paddingMode = this.configReader.getPaddingMode(
-      SETTING_SMART_PADDING_PASTE_LINK,
-      DEFAULT_SMART_PADDING_PASTE_LINK,
-    );
+    const paddingMode = this.configReader.getPaddingMode(SETTING_SMART_PADDING_PASTE_LINK, DEFAULT_SMART_PADDING_PASTE_LINK);
 
     const paddedLink = applySmartPadding(formattedLink.link, paddingMode);
 
-    this.logger.debug(
-      { ...logCtx, link: formattedLink.link, rawLink: formattedLink.rawLink },
-      'Sending link to destination',
-    );
+    this.logger.debug({ ...logCtx, link: formattedLink.link, rawLink: formattedLink.rawLink }, 'Sending link to destination');
 
     await this.sendRouter.sendToDestination(
       {

--- a/packages/rangelink-vscode-extension/src/services/SelectionValidator.ts
+++ b/packages/rangelink-vscode-extension/src/services/SelectionValidator.ts
@@ -20,8 +20,7 @@ export class SelectionValidator {
    *
    * @returns Object with editor and selections if valid, undefined if validation failed
    */
-  validateSelectionsAndShowError():
-    { editor: vscode.TextEditor; selections: readonly vscode.Selection[] } | undefined {
+  validateSelectionsAndShowError(): { editor: vscode.TextEditor; selections: readonly vscode.Selection[] } | undefined {
     const logCtx = { fn: 'SelectionValidator.validateSelectionsAndShowError' };
     const activeSelections = ActiveSelections.create(this.ideAdapter.activeTextEditor);
 
@@ -42,15 +41,11 @@ export class SelectionValidator {
     const nonEmptySelections = activeSelections.getNonEmptySelections();
 
     if (!nonEmptySelections) {
-      const errorCode = activeSelections.editor
-        ? MessageCode.ERROR_NO_TEXT_SELECTED
-        : MessageCode.ERROR_NO_ACTIVE_EDITOR;
+      const errorCode = activeSelections.editor ? MessageCode.ERROR_NO_TEXT_SELECTED : MessageCode.ERROR_NO_ACTIVE_EDITOR;
       const errorMsg = formatMessage(errorCode);
 
       const editor = activeSelections.editor;
-      const lineContentAtBoundaries = editor
-        ? this.getLineContentAtSelectionBoundaries(editor.document, activeSelections.selections)
-        : undefined;
+      const lineContentAtBoundaries = editor ? this.getLineContentAtSelectionBoundaries(editor.document, activeSelections.selections) : undefined;
 
       this.logger.warn(
         {

--- a/packages/rangelink-vscode-extension/src/services/SendRouter.ts
+++ b/packages/rangelink-vscode-extension/src/services/SendRouter.ts
@@ -1,21 +1,10 @@
 import type { ClipboardService } from '../clipboard/ClipboardService';
-import type {
-  BoundSession,
-  DestinationBinder,
-  DestinationPicker,
-  PasteDestination,
-} from '../destinations';
+import type { BoundSession, DestinationBinder, DestinationPicker, PasteDestination } from '../destinations';
 import { resolveBoundTerminalProcessId } from '../destinations/utils';
 import { RangeLinkExtensionError, RangeLinkExtensionErrorCodes } from '../errors';
 import type { OperationFeedbackProvider, PasteContext, PasteSendOutcome } from '../feedback';
 import type { ClipboardWriter } from '../ide/ClipboardProvider';
-import {
-  AutoPasteResult,
-  type BindContext,
-  MessageCode,
-  type QuickPickBindResult,
-  type SendOptions,
-} from '../types';
+import { AutoPasteResult, type BindContext, MessageCode, type QuickPickBindResult, type SendOptions } from '../types';
 import { formatMessage, isEditorDestination, isSameFileDestination } from '../utils';
 
 import type { ResolveResult } from './types';
@@ -54,10 +43,7 @@ export class SendRouter {
           destinationName: pickerResult.bindInfo.destinationName,
         };
       }
-      this.logger.debug(
-        { ...logCtx, outcome: pickerResult.outcome },
-        'Picker did not bind, aborting',
-      );
+      this.logger.debug({ ...logCtx, outcome: pickerResult.outcome }, 'Picker did not bind, aborting');
       return { canProceed: false };
     }
     return { canProceed: true, bindPerformed: false };
@@ -79,10 +65,7 @@ export class SendRouter {
         () => this.shouldRestoreClipboard(outcome, destinationSnapshot),
       );
       if (!routeResult.success) {
-        this.logger.error(
-          { fn: 'SendRouter.sendToDestination', error: routeResult.error },
-          'Clipboard routing failed',
-        );
+        this.logger.error({ fn: 'SendRouter.sendToDestination', error: routeResult.error }, 'Clipboard routing failed');
         if (destinationSnapshot) {
           this.feedbackProvider.provideSendFeedback(
             this.buildPasteContext(options, destinationSnapshot),
@@ -93,21 +76,14 @@ export class SendRouter {
         return;
       }
       if (outcome !== undefined && destinationSnapshot) {
-        this.feedbackProvider.provideSendFeedback(
-          this.buildPasteContext(options, destinationSnapshot),
-          outcome,
-          bindContext,
-        );
+        this.feedbackProvider.provideSendFeedback(this.buildPasteContext(options, destinationSnapshot), outcome, bindContext);
       }
     } else {
       await this.executeSend(options);
     }
   }
 
-  private buildPasteContext<T>(
-    options: SendOptions<T>,
-    destination: PasteDestination,
-  ): PasteContext {
+  private buildPasteContext<T>(options: SendOptions<T>, destination: PasteDestination): PasteContext {
     return {
       contentType: options.contentNameCode,
       destination: {
@@ -139,35 +115,22 @@ export class SendRouter {
 
     const isEligible = await strategies.isEligibleFn(destination, content.send);
     if (!isEligible) {
-      this.logger.debug(
-        { fn: fnName, boundDestination: displayName },
-        'Content not eligible for paste - skipping auto-paste',
-      );
+      this.logger.debug({ fn: fnName, boundDestination: displayName }, 'Content not eligible for paste - skipping auto-paste');
       return undefined;
     }
 
-    this.logger.debug(
-      { fn: fnName, boundDestination: displayName },
-      `Attempting to send content to bound destination: ${displayName}`,
-    );
+    this.logger.debug({ fn: fnName, boundDestination: displayName }, `Attempting to send content to bound destination: ${displayName}`);
 
     const pasteSucceeded = await strategies.sendFn(content.send);
 
     return this.computeOutcome(destination, pasteSucceeded);
   }
 
-  private async checkSelfPaste<T>(
-    options: SendOptions<T>,
-    destination: PasteDestination,
-  ): Promise<PasteSendOutcome | undefined> {
+  private async checkSelfPaste<T>(options: SendOptions<T>, destination: PasteDestination): Promise<PasteSendOutcome | undefined> {
     const { content, fnName, selfPastePolicy, writeClipboardOnSelfPasteBlock } = options;
     if (!content.sourceUri) return undefined;
 
-    const isSameFile = isSameFileDestination(
-      content.sourceUri,
-      destination,
-      content.sourceViewColumn,
-    );
+    const isSameFile = isSameFileDestination(content.sourceUri, destination, content.sourceViewColumn);
     if (!isSameFile) return undefined;
 
     const policyIsDefault = !selfPastePolicy;
@@ -240,10 +203,7 @@ export class SendRouter {
    * clipboard — the written content must survive. Otherwise delegates to
    * PasteDestinationManager's restoration logic.
    */
-  private shouldRestoreClipboard(
-    outcome: PasteSendOutcome | undefined,
-    destination: PasteDestination | undefined,
-  ): boolean {
+  private shouldRestoreClipboard(outcome: PasteSendOutcome | undefined, destination: PasteDestination | undefined): boolean {
     if (outcome?.kind === 'self-paste-blocked' && outcome.clipboardWritten) {
       return false;
     }
@@ -289,10 +249,7 @@ export class SendRouter {
       case 'selected': {
         const bindResult = await this.binder.bind(result.bindOptions, { skipMessage: true });
         if (!bindResult.success) {
-          this.logger.error(
-            { ...logCtx, error: bindResult.error },
-            'Binding failed - no action taken',
-          );
+          this.logger.error({ ...logCtx, error: bindResult.error }, 'Binding failed - no action taken');
           this.feedbackProvider.showError(formatMessage(MessageCode.ERROR_BIND_FAILED));
           return { outcome: 'bind-failed', error: bindResult.error };
         }

--- a/packages/rangelink-vscode-extension/src/services/TerminalPasteService.ts
+++ b/packages/rangelink-vscode-extension/src/services/TerminalPasteService.ts
@@ -23,11 +23,7 @@ export class TerminalPasteService {
     private readonly logger: Logger,
   ) {}
 
-  async pasteIntoTerminal(
-    content: string,
-    terminal: vscode.Terminal,
-    options?: SendTextToTerminalOptions,
-  ): Promise<ExtensionResult<void>> {
+  async pasteIntoTerminal(content: string, terminal: vscode.Terminal, options?: SendTextToTerminalOptions): Promise<ExtensionResult<void>> {
     const logCtx: LoggingContext = {
       fn: 'TerminalPasteService.pasteIntoTerminal',
       terminalName: terminal?.name,
@@ -35,10 +31,7 @@ export class TerminalPasteService {
 
     const validationResult = validateTerminalDefined(terminal);
     if (!validationResult.success) {
-      this.logger.error(
-        { ...logCtx, error: validationResult.error },
-        'Terminal paste failed - terminal not defined',
-      );
+      this.logger.error({ ...logCtx, error: validationResult.error }, 'Terminal paste failed - terminal not defined');
       return validationResult as unknown as ExtensionResult<void>;
     }
 
@@ -52,10 +45,7 @@ export class TerminalPasteService {
     });
 
     if (!stageResult.success) {
-      this.logger.error(
-        { ...logCtx, error: stageResult.error },
-        'Terminal paste failed - clipboard service problem',
-      );
+      this.logger.error({ ...logCtx, error: stageResult.error }, 'Terminal paste failed - clipboard service problem');
       return stageResult;
     }
 

--- a/packages/rangelink-vscode-extension/src/services/TerminalSelectionService.ts
+++ b/packages/rangelink-vscode-extension/src/services/TerminalSelectionService.ts
@@ -1,10 +1,6 @@
 import type { ClipboardService } from '../clipboard/ClipboardService';
 import type { ConfigReader } from '../config/ConfigReader';
-import {
-  DEFAULT_SMART_PADDING_PASTE_CONTENT,
-  SETTING_SMART_PADDING_PASTE_CONTENT,
-  VSCODE_CMD_TERMINAL_COPY_SELECTION,
-} from '../constants';
+import { DEFAULT_SMART_PADDING_PASTE_CONTENT, SETTING_SMART_PADDING_PASTE_CONTENT, VSCODE_CMD_TERMINAL_COPY_SELECTION } from '../constants';
 import type { PasteDestinationManager } from '../destinations/PasteDestinationManager';
 import { RangeLinkExtensionErrorCodes } from '../errors/RangeLinkExtensionErrorCodes';
 import type { VscodeAdapter } from '../ide/vscode/VscodeAdapter';
@@ -62,15 +58,11 @@ export class TerminalSelectionService {
 
     logCtx.terminalName = activeTerminal.name;
 
-    const captureResult = await this.clipboardService.capture(
-      () => this.ideAdapter.executeCommand(VSCODE_CMD_TERMINAL_COPY_SELECTION),
-      logCtx,
-    );
+    const captureResult = await this.clipboardService.capture(() => this.ideAdapter.executeCommand(VSCODE_CMD_TERMINAL_COPY_SELECTION), logCtx);
 
     if (!captureResult.success) {
       const error = captureResult.error;
-      const isCopyFailure =
-        error.code === RangeLinkExtensionErrorCodes.CLIPBOARD_CAPTURE_EXECUTION_FAILED;
+      const isCopyFailure = error.code === RangeLinkExtensionErrorCodes.CLIPBOARD_CAPTURE_EXECUTION_FAILED;
       const errorInfo = isCopyFailure ? COPY_FAILURE : CAPTURE_FAILURE;
 
       this.logger.error({ ...logCtx, error, isCopyFailure }, errorInfo.logMessage);
@@ -86,18 +78,12 @@ export class TerminalSelectionService {
       return { outcome: 'no-text-selected' };
     }
 
-    this.logger.debug(
-      { ...logCtx, contentLength: terminalText.length },
-      `Read ${terminalText.length} chars from terminal selection`,
-    );
+    this.logger.debug({ ...logCtx, contentLength: terminalText.length }, `Read ${terminalText.length} chars from terminal selection`);
 
     const resolveResult = await this.sendRouter.resolveDestination(logCtx);
     if (!resolveResult.canProceed) return { outcome: 'picker-cancelled' };
 
-    const paddingMode = this.configReader.getPaddingMode(
-      SETTING_SMART_PADDING_PASTE_CONTENT,
-      DEFAULT_SMART_PADDING_PASTE_CONTENT,
-    );
+    const paddingMode = this.configReader.getPaddingMode(SETTING_SMART_PADDING_PASTE_CONTENT, DEFAULT_SMART_PADDING_PASTE_CONTENT);
 
     const paddedText = applySmartPadding(terminalText, paddingMode);
     const bindContext = toBindContext(resolveResult);
@@ -137,9 +123,7 @@ export class TerminalSelectionService {
     const result = await this.pasteTerminalSelectionToDestination();
 
     if (result.outcome === 'success') {
-      this.ideAdapter.showInformationMessage(
-        formatMessage(MessageCode.INFO_TERMINAL_LINK_BRIDGE_TIP),
-      );
+      this.ideAdapter.showInformationMessage(formatMessage(MessageCode.INFO_TERMINAL_LINK_BRIDGE_TIP));
     }
   }
 
@@ -153,8 +137,6 @@ export class TerminalSelectionService {
     const logCtx = { fn: 'TerminalSelectionService.terminalCopyLinkGuard' };
     this.logger.debug(logCtx, 'R-C pressed in terminal context');
 
-    this.ideAdapter.showErrorMessage(
-      formatMessage(MessageCode.ERROR_TERMINAL_COPY_LINK_NOT_SUPPORTED),
-    );
+    this.ideAdapter.showErrorMessage(formatMessage(MessageCode.ERROR_TERMINAL_COPY_LINK_NOT_SUPPORTED));
   }
 }

--- a/packages/rangelink-vscode-extension/src/services/TextSelectionPaster.ts
+++ b/packages/rangelink-vscode-extension/src/services/TextSelectionPaster.ts
@@ -1,8 +1,5 @@
 import type { ConfigReader } from '../config/ConfigReader';
-import {
-  DEFAULT_SMART_PADDING_PASTE_CONTENT,
-  SETTING_SMART_PADDING_PASTE_CONTENT,
-} from '../constants';
+import { DEFAULT_SMART_PADDING_PASTE_CONTENT, SETTING_SMART_PADDING_PASTE_CONTENT } from '../constants';
 import type { PasteDestinationManager } from '../destinations/PasteDestinationManager';
 import { MessageCode, PasteContentType } from '../types';
 import { applySmartPadding } from '../utils';
@@ -44,10 +41,7 @@ export class TextSelectionPaster {
       `Extracted ${content.length} chars from ${selectedTexts.length} selection(s)`,
     );
 
-    const paddingMode = this.configReader.getPaddingMode(
-      SETTING_SMART_PADDING_PASTE_CONTENT,
-      DEFAULT_SMART_PADDING_PASTE_CONTENT,
-    );
+    const paddingMode = this.configReader.getPaddingMode(SETTING_SMART_PADDING_PASTE_CONTENT, DEFAULT_SMART_PADDING_PASTE_CONTENT);
 
     const resolveResult = await this.sendRouter.resolveDestination(logCtx);
     if (!resolveResult.canProceed) return;

--- a/packages/rangelink-vscode-extension/src/services/__tests__/SelectionValidator.test.ts
+++ b/packages/rangelink-vscode-extension/src/services/__tests__/SelectionValidator.test.ts
@@ -1,11 +1,4 @@
-import {
-  createMockDocument,
-  createMockEditor,
-  createMockLineAt,
-  createMockPos,
-  createMockSelection,
-  createMockVscodeAdapter,
-} from '../../__tests__/helpers';
+import { createMockDocument, createMockEditor, createMockLineAt, createMockPos, createMockSelection, createMockVscodeAdapter } from '../../__tests__/helpers';
 import { SelectionValidator } from '../SelectionValidator';
 
 import { createMockLogger } from '@couimet/logger-contract-testing';
@@ -36,9 +29,7 @@ describe('SelectionValidator', () => {
           fn: 'SelectionValidator.validateSelectionsAndShowError',
           hasEditor: true,
           selectionCount: 1,
-          selections: [
-            { index: 0, start: { line: 0, char: 0 }, end: { line: 0, char: 10 }, isEmpty: false },
-          ],
+          selections: [{ index: 0, start: { line: 0, char: 0 }, end: { line: 0, char: 10 }, isEmpty: false }],
           documentVersion: undefined,
           documentLineCount: undefined,
           documentIsDirty: undefined,
@@ -92,25 +83,19 @@ describe('SelectionValidator', () => {
       const result = validator.validateSelectionsAndShowError();
 
       expect(result).toBeUndefined();
-      expect(showErrorSpy).toHaveBeenCalledWith(
-        'No text selected. Click in the file, select text, and try again.',
-      );
+      expect(showErrorSpy).toHaveBeenCalledWith('No text selected. Click in the file, select text, and try again.');
       expect(mockLogger.warn).toHaveBeenCalledWith(
         {
           fn: 'SelectionValidator.validateSelectionsAndShowError',
           hasEditor: true,
           errorCode: 'ERROR_NO_TEXT_SELECTED',
           selectionCount: 1,
-          selections: [
-            { index: 0, start: { line: 5, char: 0 }, end: { line: 5, char: 0 }, isEmpty: true },
-          ],
+          selections: [{ index: 0, start: { line: 5, char: 0 }, end: { line: 5, char: 0 }, isEmpty: true }],
           documentVersion: undefined,
           documentLineCount: undefined,
           documentIsDirty: undefined,
           documentIsClosed: undefined,
-          lineContentAtBoundaries: [
-            { index: 0, startLineContent: undefined, endLineContent: undefined },
-          ],
+          lineContentAtBoundaries: [{ index: 0, startLineContent: undefined, endLineContent: undefined }],
         },
         'Selection validation failed - full diagnostic context',
       );
@@ -165,9 +150,7 @@ describe('SelectionValidator', () => {
 
       const result = validator.getLineContentAtSelectionBoundaries(document, [selection]);
 
-      expect(result).toStrictEqual([
-        { index: 0, startLineContent: 'line content', endLineContent: 'line content' },
-      ]);
+      expect(result).toStrictEqual([{ index: 0, startLineContent: 'line content', endLineContent: 'line content' }]);
     });
 
     it('returns undefined for out-of-bounds line numbers', () => {
@@ -185,9 +168,7 @@ describe('SelectionValidator', () => {
 
       const result = validator.getLineContentAtSelectionBoundaries(document, [selection]);
 
-      expect(result).toStrictEqual([
-        { index: 0, startLineContent: undefined, endLineContent: undefined },
-      ]);
+      expect(result).toStrictEqual([{ index: 0, startLineContent: undefined, endLineContent: undefined }]);
     });
 
     it('returns undefined when lineAt throws', () => {
@@ -207,9 +188,7 @@ describe('SelectionValidator', () => {
 
       const result = validator.getLineContentAtSelectionBoundaries(document, [selection]);
 
-      expect(result).toStrictEqual([
-        { index: 0, startLineContent: undefined, endLineContent: undefined },
-      ]);
+      expect(result).toStrictEqual([{ index: 0, startLineContent: undefined, endLineContent: undefined }]);
     });
 
     it('handles negative line numbers as out-of-bounds', () => {
@@ -227,9 +206,7 @@ describe('SelectionValidator', () => {
 
       const result = validator.getLineContentAtSelectionBoundaries(document, [selection]);
 
-      expect(result).toStrictEqual([
-        { index: 0, startLineContent: undefined, endLineContent: 'content' },
-      ]);
+      expect(result).toStrictEqual([{ index: 0, startLineContent: undefined, endLineContent: 'content' }]);
     });
   });
 });

--- a/packages/rangelink-vscode-extension/src/services/handleDirtyBufferWarning.ts
+++ b/packages/rangelink-vscode-extension/src/services/handleDirtyBufferWarning.ts
@@ -39,23 +39,14 @@ export const handleDirtyBufferWarning = async (
     return DirtyBufferWarningResult.Clean;
   }
 
-  const shouldWarnOnDirty = configReader.getBoolean(
-    SETTING_WARN_ON_DIRTY_BUFFER,
-    DEFAULT_WARN_ON_DIRTY_BUFFER,
-  );
+  const shouldWarnOnDirty = configReader.getBoolean(SETTING_WARN_ON_DIRTY_BUFFER, DEFAULT_WARN_ON_DIRTY_BUFFER);
 
   if (!shouldWarnOnDirty) {
-    logger.debug(
-      { fn, documentUri: document.uri.toString() },
-      'Document has unsaved changes but warning is disabled by setting',
-    );
+    logger.debug({ fn, documentUri: document.uri.toString() }, 'Document has unsaved changes but warning is disabled by setting');
     return DirtyBufferWarningResult.ContinueAnyway;
   }
 
-  logger.debug(
-    { fn, documentUri: document.uri.toString() },
-    'Document has unsaved changes, showing warning',
-  );
+  logger.debug({ fn, documentUri: document.uri.toString() }, 'Document has unsaved changes, showing warning');
 
   const warningMessage = formatMessage(messageCodes.warning);
   const saveLabel = formatMessage(messageCodes.save);
@@ -87,15 +78,9 @@ export const handleDirtyBufferWarning = async (
       return result;
     case DirtyBufferWarningResult.Dismissed:
       logger.debug({ fn }, 'User dismissed warning, aborting');
-      void ideAdapter.showInformationMessage(
-        formatMessage(MessageCode.INFO_OPERATION_ABORTED_DIRTY_BUFFER),
-      );
+      void ideAdapter.showInformationMessage(formatMessage(MessageCode.INFO_OPERATION_ABORTED_DIRTY_BUFFER));
       return result;
     default:
-      throw RangeLinkExtensionError.forUnexpectedSwitchDefault(
-        'dirty buffer warning result',
-        result,
-        'handleDirtyBufferWarning',
-      );
+      throw RangeLinkExtensionError.forUnexpectedSwitchDefault('dirty buffer warning result', result, 'handleDirtyBufferWarning');
   }
 };

--- a/packages/rangelink-vscode-extension/src/services/toBindContext.ts
+++ b/packages/rangelink-vscode-extension/src/services/toBindContext.ts
@@ -3,6 +3,4 @@ import type { BindContext } from '../types';
 import type { ResolveResult } from './types';
 
 export const toBindContext = (result: ResolveResult): BindContext | undefined =>
-  result.canProceed && result.bindPerformed
-    ? { destinationName: result.destinationName }
-    : undefined;
+  result.canProceed && result.bindPerformed ? { destinationName: result.destinationName } : undefined;

--- a/packages/rangelink-vscode-extension/src/services/types/ResolveResult.ts
+++ b/packages/rangelink-vscode-extension/src/services/types/ResolveResult.ts
@@ -1,4 +1,2 @@
 export type ResolveResult =
-  | { canProceed: true; bindPerformed: false }
-  | { canProceed: true; bindPerformed: true; destinationName: string }
-  | { canProceed: false };
+  { canProceed: true; bindPerformed: false } | { canProceed: true; bindPerformed: true; destinationName: string } | { canProceed: false };

--- a/packages/rangelink-vscode-extension/src/statusBar/RangeLinkStatusBar.ts
+++ b/packages/rangelink-vscode-extension/src/statusBar/RangeLinkStatusBar.ts
@@ -8,17 +8,8 @@ import {
   CMD_SHOW_VERSION,
   CMD_UNBIND_DESTINATION,
 } from '../constants';
-import {
-  type BoundSession,
-  buildDestinationQuickPickItems,
-  type DestinationAvailabilityService,
-  type DestinationBinder,
-} from '../destinations';
-import {
-  resolveBoundTerminalProcessId,
-  showFilePicker,
-  showTerminalPicker,
-} from '../destinations/utils';
+import { type BoundSession, buildDestinationQuickPickItems, type DestinationAvailabilityService, type DestinationBinder } from '../destinations';
+import { resolveBoundTerminalProcessId, showFilePicker, showTerminalPicker } from '../destinations/utils';
 import { RangeLinkExtensionError, RangeLinkExtensionErrorCodes } from '../errors';
 import type { VscodeAdapter } from '../ide/vscode/VscodeAdapter';
 import {
@@ -64,10 +55,7 @@ export class RangeLinkStatusBar implements vscode.Disposable {
     private readonly bookmarkService: BookmarkService,
     private readonly logger: Logger,
   ) {
-    this.statusBarItem = this.ideAdapter.createStatusBarItem(
-      vscode.StatusBarAlignment.Right,
-      STATUS_BAR_PRIORITY,
-    );
+    this.statusBarItem = this.ideAdapter.createStatusBarItem(vscode.StatusBarAlignment.Right, STATUS_BAR_PRIORITY);
 
     this.statusBarItem.text = formatMessage(MessageCode.STATUS_BAR_ITEM_TEXT);
     this.statusBarItem.command = CMD_OPEN_STATUS_BAR_MENU;
@@ -107,9 +95,7 @@ export class RangeLinkStatusBar implements vscode.Disposable {
         isBound,
         ...(isBound && { destinationName: boundDest.displayName }),
       },
-      isBound
-        ? `Status bar appearance updated for bound destination "${boundDest.displayName}"`
-        : 'Status bar appearance updated for unbound state',
+      isBound ? `Status bar appearance updated for bound destination "${boundDest.displayName}"` : 'Status bar appearance updated for unbound state',
     );
   }
 
@@ -160,8 +146,7 @@ export class RangeLinkStatusBar implements vscode.Disposable {
         } catch (error) {
           this.logger.error({ ...logCtx, error }, 'Bookmark send failed');
           const messageCode =
-            error instanceof RangeLinkExtensionError &&
-            error.code === RangeLinkExtensionErrorCodes.DESTINATION_NOT_BOUND
+            error instanceof RangeLinkExtensionError && error.code === RangeLinkExtensionErrorCodes.DESTINATION_NOT_BOUND
               ? MessageCode.ERROR_BOOKMARK_SEND_NO_DESTINATION
               : MessageCode.ERROR_BOOKMARK_SEND_FAILED;
           this.ideAdapter.showErrorMessage(formatMessage(messageCode));
@@ -196,10 +181,7 @@ export class RangeLinkStatusBar implements vscode.Disposable {
     // Dynamic read — re-evaluates the current bound state at call time
     // rather than using a snapshot, since the binding may have changed.
     const boundTerminalProcessId = await resolveBoundTerminalProcessId(() => this.session.get());
-    const terminalItems = await this.availabilityService.getTerminalItems(
-      Infinity,
-      boundTerminalProcessId,
-    );
+    const terminalItems = await this.availabilityService.getTerminalItems(Infinity, boundTerminalProcessId);
 
     await showTerminalPicker(
       terminalItems,
@@ -209,10 +191,7 @@ export class RangeLinkStatusBar implements vscode.Disposable {
         onSelected: async (eligible) => {
           const bindResult = await this.binder.bind(eligible.bindOptions);
           if (!bindResult.success) {
-            this.logger.error(
-              { ...logCtx, error: bindResult.error },
-              'Bind failed from overflow terminal picker',
-            );
+            this.logger.error({ ...logCtx, error: bindResult.error }, 'Bind failed from overflow terminal picker');
             this.ideAdapter.showErrorMessage(formatMessage(MessageCode.ERROR_BIND_FAILED));
             return;
           }
@@ -234,16 +213,11 @@ export class RangeLinkStatusBar implements vscode.Disposable {
   private async showSecondaryFilePicker(logCtx: LoggingContext): Promise<void> {
     const boundDest = this.session.get();
     const boundEditorDest = isEditorDestination(boundDest) ? boundDest : undefined;
-    const fileItems = this.availabilityService.getAllFileItems(
-      boundEditorDest?.resource.uri.toString(),
-      boundEditorDest?.resource.viewColumn,
-    );
+    const fileItems = this.availabilityService.getAllFileItems(boundEditorDest?.resource.uri.toString(), boundEditorDest?.resource.viewColumn);
 
     if (fileItems.length === 0) {
       this.logger.debug(logCtx, 'No files available in secondary picker');
-      void this.ideAdapter.showErrorMessage(
-        formatMessage(MessageCode.ERROR_NO_BINDABLE_TEXT_EDITOR),
-      );
+      void this.ideAdapter.showErrorMessage(formatMessage(MessageCode.ERROR_NO_BINDABLE_TEXT_EDITOR));
       return;
     }
 
@@ -255,10 +229,7 @@ export class RangeLinkStatusBar implements vscode.Disposable {
         onSelected: async (file) => {
           const bindResult = await this.binder.bind(file.bindOptions);
           if (!bindResult.success) {
-            this.logger.error(
-              { ...logCtx, error: bindResult.error },
-              'Bind failed from overflow file picker',
-            );
+            this.logger.error({ ...logCtx, error: bindResult.error }, 'Bind failed from overflow file picker');
             this.ideAdapter.showErrorMessage(formatMessage(MessageCode.ERROR_BIND_FAILED));
             return;
           }
@@ -276,9 +247,7 @@ export class RangeLinkStatusBar implements vscode.Disposable {
   /**
    * Build QuickPick items with context-aware enabled/disabled states.
    */
-  private async buildQuickPickItems(): Promise<
-    (StatusBarMenuQuickPickItem | vscode.QuickPickItem)[]
-  > {
+  private async buildQuickPickItems(): Promise<(StatusBarMenuQuickPickItem | vscode.QuickPickItem)[]> {
     return [
       ...(await this.buildJumpOrDestinationsSection()),
       { label: '', kind: vscode.QuickPickItemKind.Separator },
@@ -299,9 +268,7 @@ export class RangeLinkStatusBar implements vscode.Disposable {
   /**
    * Build the jump item (when bound) or inline destinations (when unbound).
    */
-  private buildJumpOrDestinationsSection(): Promise<
-    (StatusBarMenuQuickPickItem | vscode.QuickPickItem)[]
-  > {
+  private buildJumpOrDestinationsSection(): Promise<(StatusBarMenuQuickPickItem | vscode.QuickPickItem)[]> {
     const boundDest = this.session.get();
     if (boundDest) {
       const jumpDescription = isEditorDestination(boundDest)
@@ -327,19 +294,14 @@ export class RangeLinkStatusBar implements vscode.Disposable {
   /**
    * Build QuickPick items for available destinations when unbound.
    */
-  private async buildDestinationsQuickPickItems(): Promise<
-    (DestinationQuickPickItem | InfoQuickPickItem | vscode.QuickPickItem)[]
-  > {
+  private async buildDestinationsQuickPickItems(): Promise<(DestinationQuickPickItem | InfoQuickPickItem | vscode.QuickPickItem)[]> {
     // Dynamic read — re-evaluates the current bound state at call time
     // rather than using a snapshot, since the binding may have changed.
     const boundTerminalProcessId = await resolveBoundTerminalProcessId(() => this.session.get());
     const grouped = await this.availabilityService.getGroupedDestinationItems({
       boundTerminalProcessId,
     });
-    const destinationItems = buildDestinationQuickPickItems(
-      grouped,
-      (displayName) => `${MENU_ITEM_INDENT}$(arrow-right) ${displayName}`,
-    );
+    const destinationItems = buildDestinationQuickPickItems(grouped, (displayName) => `${MENU_ITEM_INDENT}$(arrow-right) ${displayName}`);
 
     if (destinationItems.length === 0) {
       return [
@@ -359,9 +321,7 @@ export class RangeLinkStatusBar implements vscode.Disposable {
     ];
   }
 
-  private buildBookmarksQuickPickItems(): (
-    BookmarkQuickPickItem | CommandQuickPickItem | InfoQuickPickItem | vscode.QuickPickItem
-  )[] {
+  private buildBookmarksQuickPickItems(): (BookmarkQuickPickItem | CommandQuickPickItem | InfoQuickPickItem | vscode.QuickPickItem)[] {
     const bookmarks = this.bookmarkService.getAllBookmarks();
 
     const bookmarkItems: (BookmarkQuickPickItem | InfoQuickPickItem)[] =

--- a/packages/rangelink-vscode-extension/src/types/ActiveSelections.ts
+++ b/packages/rangelink-vscode-extension/src/types/ActiveSelections.ts
@@ -39,10 +39,7 @@ export class ActiveSelections {
    * @param editor - The active text editor
    * @param selections - The editor's selections
    */
-  private constructor(
-    editor: vscode.TextEditor | undefined,
-    selections: readonly vscode.Selection[],
-  ) {
+  private constructor(editor: vscode.TextEditor | undefined, selections: readonly vscode.Selection[]) {
     this.editor = editor;
     this.selections = selections;
   }

--- a/packages/rangelink-vscode-extension/src/types/DestinationKind.ts
+++ b/packages/rangelink-vscode-extension/src/types/DestinationKind.ts
@@ -4,14 +4,7 @@
  * Single source of truth - DestinationKind is derived from this array.
  * Keep in alphabetical order for maintainability.
  */
-export const DESTINATION_KINDS = [
-  'claude-code',
-  'cursor-ai',
-  'gemini-code-assist',
-  'github-copilot-chat',
-  'terminal',
-  'text-editor',
-] as const;
+export const DESTINATION_KINDS = ['claude-code', 'cursor-ai', 'gemini-code-assist', 'github-copilot-chat', 'terminal', 'text-editor'] as const;
 
 /**
  * Built-in paste destination kinds (derived from DESTINATION_KINDS array)
@@ -31,8 +24,7 @@ export type DestinationKind = BuiltInDestinationKind | CustomAiAssistantKind;
 /**
  * Type guard for custom AI assistant kinds.
  */
-export const isCustomAiAssistantKind = (kind: string): kind is CustomAiAssistantKind =>
-  kind.startsWith('custom-ai:');
+export const isCustomAiAssistantKind = (kind: string): kind is CustomAiAssistantKind => kind.startsWith('custom-ai:');
 
 /**
  * Built-in AI assistant destination kind identifiers.
@@ -56,9 +48,7 @@ export type AIAssistantDestinationKind = (typeof AI_ASSISTANT_KINDS)[number];
 /**
  * Check if a destination kind is any AI assistant (built-in or custom).
  */
-export const isAnyAiAssistantKind = (
-  kind: string,
-): kind is AIAssistantDestinationKind | CustomAiAssistantKind =>
+export const isAnyAiAssistantKind = (kind: string): kind is AIAssistantDestinationKind | CustomAiAssistantKind =>
   isCustomAiAssistantKind(kind) || (AI_ASSISTANT_KINDS as readonly string[]).includes(kind);
 
 /**

--- a/packages/rangelink-vscode-extension/src/types/QuickPickBindResult.ts
+++ b/packages/rangelink-vscode-extension/src/types/QuickPickBindResult.ts
@@ -8,8 +8,7 @@ import type { RangeLinkExtensionError } from '../errors/RangeLinkExtensionError'
  * Variants use Extract<QuickPickBindOutcome, 'x'> to ensure compile-time
  * failure if a literal is removed from this union.
  */
-export type QuickPickBindOutcome =
-  'bound' | 'bound-no-paste' | 'no-resource' | 'cancelled' | 'bind-failed';
+export type QuickPickBindOutcome = 'bound' | 'bound-no-paste' | 'no-resource' | 'cancelled' | 'bind-failed';
 
 /**
  * Result of showing quick pick for destination binding.

--- a/packages/rangelink-vscode-extension/src/types/QuickPickTypes.ts
+++ b/packages/rangelink-vscode-extension/src/types/QuickPickTypes.ts
@@ -9,14 +9,7 @@ import type * as vscode from 'vscode';
  * Discriminator values for QuickPick items across all RangeLink menus.
  * Used for runtime validation in type guards.
  */
-export const PICKER_ITEM_KINDS = [
-  'bindable',
-  'file-more',
-  'terminal-more',
-  'command',
-  'bookmark',
-  'info',
-] as const;
+export const PICKER_ITEM_KINDS = ['bindable', 'file-more', 'terminal-more', 'command', 'bookmark', 'info'] as const;
 
 /**
  * Discriminator for QuickPick items across all RangeLink menus.
@@ -65,8 +58,7 @@ export interface FileBindableQuickPickItem extends BindableQuickPickItem<TextEdi
 /**
  * QuickPickItem representing the "More files..." overflow trigger.
  */
-export interface FileMoreQuickPickItem
-  extends BaseQuickPickItem, WithDisplayName, WithRemainingCount {
+export interface FileMoreQuickPickItem extends BaseQuickPickItem, WithDisplayName, WithRemainingCount {
   readonly itemKind: Extract<PickerItemKind, 'file-more'>;
 }
 
@@ -77,8 +69,7 @@ export interface FileMoreQuickPickItem
 /**
  * QuickPickItem representing the "More terminals..." overflow trigger.
  */
-export interface TerminalMoreQuickPickItem
-  extends BaseQuickPickItem, WithDisplayName, WithRemainingCount {
+export interface TerminalMoreQuickPickItem extends BaseQuickPickItem, WithDisplayName, WithRemainingCount {
   readonly itemKind: Extract<PickerItemKind, 'terminal-more'>;
 }
 
@@ -95,8 +86,7 @@ export interface TerminalMoreQuickPickItem
  * - `BindableQuickPickItem` - any destination (default)
  * - `BindableQuickPickItem<TerminalBindOptions>` - terminal only
  */
-export interface BindableQuickPickItem<T extends BindOptions = BindOptions>
-  extends BaseQuickPickItem, WithBindOptions<T>, WithDisplayName {
+export interface BindableQuickPickItem<T extends BindOptions = BindOptions> extends BaseQuickPickItem, WithBindOptions<T>, WithDisplayName {
   readonly itemKind: Extract<PickerItemKind, 'bindable'>;
 }
 
@@ -117,8 +107,7 @@ export interface TerminalBindableQuickPickItem extends BindableQuickPickItem<Ter
  * Union of all QuickPickItem types used in destination pickers.
  * Includes bindable destinations and overflow items for files and terminals.
  */
-export type DestinationQuickPickItem =
-  BindableQuickPickItem | FileMoreQuickPickItem | TerminalMoreQuickPickItem;
+export type DestinationQuickPickItem = BindableQuickPickItem | FileMoreQuickPickItem | TerminalMoreQuickPickItem;
 
 // ============================================================================
 // Menu Item Types (StatusBar, ListBookmarks, etc.)
@@ -164,9 +153,4 @@ export interface ConfirmationQuickPickItem extends vscode.QuickPickItem {
  * Separators (QuickPickItemKind.Separator) are not selectable and use plain vscode.QuickPickItem.
  */
 export type StatusBarMenuQuickPickItem =
-  | BindableQuickPickItem
-  | FileMoreQuickPickItem
-  | TerminalMoreQuickPickItem
-  | CommandQuickPickItem
-  | BookmarkQuickPickItem
-  | InfoQuickPickItem;
+  BindableQuickPickItem | FileMoreQuickPickItem | TerminalMoreQuickPickItem | CommandQuickPickItem | BookmarkQuickPickItem | InfoQuickPickItem;

--- a/packages/rangelink-vscode-extension/src/types/TerminalPasteOutcome.ts
+++ b/packages/rangelink-vscode-extension/src/types/TerminalPasteOutcome.ts
@@ -4,13 +4,7 @@
  * Each literal must appear in exactly one TerminalPasteResult variant.
  */
 export type TerminalPasteOutcome =
-  | 'success'
-  | 'no-active-terminal'
-  | 'copy-command-failed'
-  | 'clipboard-read-failed'
-  | 'no-text-selected'
-  | 'picker-cancelled'
-  | 'self-paste';
+  'success' | 'no-active-terminal' | 'copy-command-failed' | 'clipboard-read-failed' | 'no-text-selected' | 'picker-cancelled' | 'self-paste';
 
 /**
  * Result of a terminal paste operation.

--- a/packages/rangelink-vscode-extension/src/types/__tests__/ActiveSelections.test.ts
+++ b/packages/rangelink-vscode-extension/src/types/__tests__/ActiveSelections.test.ts
@@ -7,9 +7,7 @@ describe('ActiveSelections', () => {
   describe('create', () => {
     it('should create instance with editor and selections', () => {
       const mockEditor = createMockEditor({
-        selections: [
-          { isEmpty: false, start: { line: 0, character: 0 }, end: { line: 0, character: 5 } },
-        ] as any,
+        selections: [{ isEmpty: false, start: { line: 0, character: 0 }, end: { line: 0, character: 5 } }] as any,
       });
 
       const result = ActiveSelections.create(mockEditor);

--- a/packages/rangelink-vscode-extension/src/utils/__tests__/aiAssistants/isClaudeCodeAvailable.test.ts
+++ b/packages/rangelink-vscode-extension/src/utils/__tests__/aiAssistants/isClaudeCodeAvailable.test.ts
@@ -1,7 +1,4 @@
-import {
-  createMockVscodeAdapter,
-  type VscodeAdapterWithTestHooks,
-} from '../../../__tests__/helpers';
+import { createMockVscodeAdapter, type VscodeAdapterWithTestHooks } from '../../../__tests__/helpers';
 import { CLAUDE_CODE_FOCUS_COMMANDS } from '../../../destinations/aiAssistantFocusCommands';
 import { EXTENSION_ID_CLAUDE_CODE } from '../../aiAssistants/builtInAiAssistants';
 import { isClaudeCodeAvailable } from '../../aiAssistants/isClaudeCodeAvailable';
@@ -117,10 +114,6 @@ describe('isClaudeCodeAvailable', () => {
 
 describe('CLAUDE_CODE_FOCUS_COMMANDS', () => {
   it('should export focus commands array with primary and fallback commands', () => {
-    expect(CLAUDE_CODE_FOCUS_COMMANDS).toStrictEqual([
-      'claude-vscode.focus',
-      'claude-vscode.sidebar.open',
-      'claude-vscode.editor.open',
-    ]);
+    expect(CLAUDE_CODE_FOCUS_COMMANDS).toStrictEqual(['claude-vscode.focus', 'claude-vscode.sidebar.open', 'claude-vscode.editor.open']);
   });
 });

--- a/packages/rangelink-vscode-extension/src/utils/__tests__/aiAssistants/isCursorIDEDetected.test.ts
+++ b/packages/rangelink-vscode-extension/src/utils/__tests__/aiAssistants/isCursorIDEDetected.test.ts
@@ -2,10 +2,7 @@
  * Tests for isCursorIDEDetected utility.
  */
 
-import {
-  createMockVscodeAdapter,
-  type VscodeAdapterWithTestHooks,
-} from '../../../__tests__/helpers';
+import { createMockVscodeAdapter, type VscodeAdapterWithTestHooks } from '../../../__tests__/helpers';
 import { CURSOR_AI_FOCUS_COMMANDS } from '../../../destinations/aiAssistantFocusCommands';
 import { isCursorIDEDetected } from '../../aiAssistants/isCursorIDEDetected';
 
@@ -254,9 +251,6 @@ describe('isCursorIDEDetected', () => {
 
 describe('CURSOR_AI_FOCUS_COMMANDS', () => {
   it('should export focus commands array with primary and fallback commands', () => {
-    expect(CURSOR_AI_FOCUS_COMMANDS).toStrictEqual([
-      'aichat.newchataction',
-      'workbench.action.toggleAuxiliaryBar',
-    ]);
+    expect(CURSOR_AI_FOCUS_COMMANDS).toStrictEqual(['aichat.newchataction', 'workbench.action.toggleAuxiliaryBar']);
   });
 });

--- a/packages/rangelink-vscode-extension/src/utils/__tests__/aiAssistants/isGeminiCodeAssistAvailable.test.ts
+++ b/packages/rangelink-vscode-extension/src/utils/__tests__/aiAssistants/isGeminiCodeAssistAvailable.test.ts
@@ -1,7 +1,4 @@
-import {
-  createMockVscodeAdapter,
-  type VscodeAdapterWithTestHooks,
-} from '../../../__tests__/helpers';
+import { createMockVscodeAdapter, type VscodeAdapterWithTestHooks } from '../../../__tests__/helpers';
 import { GEMINI_CODE_ASSIST_FOCUS_COMMANDS } from '../../../destinations/aiAssistantFocusCommands';
 import { EXTENSION_ID_GEMINI_CODE_ASSIST } from '../../aiAssistants/builtInAiAssistants';
 import { isGeminiCodeAssistAvailable } from '../../aiAssistants/isGeminiCodeAssistAvailable';

--- a/packages/rangelink-vscode-extension/src/utils/__tests__/aiAssistants/isGitHubCopilotChatAvailable.test.ts
+++ b/packages/rangelink-vscode-extension/src/utils/__tests__/aiAssistants/isGitHubCopilotChatAvailable.test.ts
@@ -1,13 +1,7 @@
-import {
-  createMockVscodeAdapter,
-  type VscodeAdapterWithTestHooks,
-} from '../../../__tests__/helpers';
+import { createMockVscodeAdapter, type VscodeAdapterWithTestHooks } from '../../../__tests__/helpers';
 import { GITHUB_COPILOT_CHAT_FOCUS_COMMANDS } from '../../../destinations/aiAssistantFocusCommands';
 import { EXTENSION_ID_GITHUB_COPILOT_CHAT } from '../../aiAssistants/builtInAiAssistants';
-import {
-  GITHUB_COPILOT_CHAT_COMMAND,
-  isGitHubCopilotChatAvailable,
-} from '../../aiAssistants/isGitHubCopilotChatAvailable';
+import { GITHUB_COPILOT_CHAT_COMMAND, isGitHubCopilotChatAvailable } from '../../aiAssistants/isGitHubCopilotChatAvailable';
 
 import { createMockLogger } from '@couimet/logger-contract-testing';
 
@@ -41,11 +35,7 @@ describe('isGitHubCopilotChatAvailable', () => {
     it('should return true when chat command is among many commands', async () => {
       mockAdapter = createMockVscodeAdapter({
         commandsOptions: {
-          availableCommands: [
-            'other.command.one',
-            GITHUB_COPILOT_CHAT_COMMAND,
-            'another.command.two',
-          ],
+          availableCommands: ['other.command.one', GITHUB_COPILOT_CHAT_COMMAND, 'another.command.two'],
         },
       });
 
@@ -220,9 +210,6 @@ describe('isGitHubCopilotChatAvailable', () => {
 
 describe('GITHUB_COPILOT_CHAT_FOCUS_COMMANDS', () => {
   it('should export focus commands array with primary and fallback commands', () => {
-    expect(GITHUB_COPILOT_CHAT_FOCUS_COMMANDS).toStrictEqual([
-      'workbench.action.chat.open',
-      'workbench.panel.chat.view.copilot.focus',
-    ]);
+    expect(GITHUB_COPILOT_CHAT_FOCUS_COMMANDS).toStrictEqual(['workbench.action.chat.open', 'workbench.panel.chat.view.copilot.focus']);
   });
 });

--- a/packages/rangelink-vscode-extension/src/utils/__tests__/destinationKindGuards.test.ts
+++ b/packages/rangelink-vscode-extension/src/utils/__tests__/destinationKindGuards.test.ts
@@ -4,12 +4,7 @@ import {
   createMockEditorComposablePasteDestination,
   createMockTerminalComposablePasteDestination,
 } from '../../__tests__/helpers';
-import {
-  isEditorDestination,
-  isPasteDestinationKind,
-  isSingletonDestination,
-  isTerminalDestination,
-} from '..';
+import { isEditorDestination, isPasteDestinationKind, isSingletonDestination, isTerminalDestination } from '..';
 
 describe('destinationKindGuards', () => {
   describe('isPasteDestinationKind', () => {

--- a/packages/rangelink-vscode-extension/src/utils/__tests__/formatMessage.test.ts
+++ b/packages/rangelink-vscode-extension/src/utils/__tests__/formatMessage.test.ts
@@ -1,11 +1,5 @@
 import { RangeLinkExtensionError, RangeLinkExtensionErrorCodes } from '../../errors';
-import {
-  getCurrentLocale,
-  type LocaleCode,
-  messagesEn,
-  setLocale,
-  supportedLocales,
-} from '../../i18n';
+import { getCurrentLocale, type LocaleCode, messagesEn, setLocale, supportedLocales } from '../../i18n';
 import { MessageCode } from '../../types';
 import { formatMessage } from '..';
 
@@ -87,13 +81,10 @@ describe('formatMessage', () => {
     });
 
     it('should substitute multiple parameters', () => {
-      const result = formatMessage(
-        TestMessageCode.MESSAGE_WITH_MULTIPLE_PARAMS as unknown as MessageCode,
-        {
-          name: 'Bob',
-          count: 5,
-        },
-      );
+      const result = formatMessage(TestMessageCode.MESSAGE_WITH_MULTIPLE_PARAMS as unknown as MessageCode, {
+        name: 'Bob',
+        count: 5,
+      });
 
       expect(result).toBe('User Bob has 5 items');
     });
@@ -206,9 +197,7 @@ describe('formatMessage', () => {
         formatMessage(invalidCode);
       } catch (error) {
         expect(error).toBeInstanceOf(RangeLinkExtensionError);
-        expect((error as RangeLinkExtensionError).code).toBe(
-          RangeLinkExtensionErrorCodes.MISSING_MESSAGE_CODE,
-        );
+        expect((error as RangeLinkExtensionError).code).toBe(RangeLinkExtensionErrorCodes.MISSING_MESSAGE_CODE);
       }
     });
 
@@ -260,11 +249,7 @@ describe('formatMessage', () => {
       setLocale('en'); // Set current locale to English
 
       // Override to English explicitly (same as current, but tests override mechanism)
-      const result = formatMessage(
-        TestMessageCode.SIMPLE_MESSAGE as unknown as MessageCode,
-        undefined,
-        'en',
-      );
+      const result = formatMessage(TestMessageCode.SIMPLE_MESSAGE as unknown as MessageCode, undefined, 'en');
 
       expect(result).toBe('This is a simple message');
     });
@@ -302,10 +287,7 @@ describe('formatMessage', () => {
 
   describe('Edge Cases', () => {
     it('should handle undefined params (no substitution needed)', () => {
-      const result = formatMessage(
-        TestMessageCode.SIMPLE_MESSAGE as unknown as MessageCode,
-        undefined,
-      );
+      const result = formatMessage(TestMessageCode.SIMPLE_MESSAGE as unknown as MessageCode, undefined);
 
       expect(result).toBe('This is a simple message');
     });
@@ -416,11 +398,7 @@ describe('formatMessage', () => {
       (supportedLocales as any)['fr'] = {};
       const enResult = formatMessage(MessageCode.STATUS_BAR_DESTINATION_NOT_BOUND);
 
-      const result = formatMessage(
-        MessageCode.STATUS_BAR_DESTINATION_NOT_BOUND,
-        undefined,
-        'fr' as LocaleCode,
-      );
+      const result = formatMessage(MessageCode.STATUS_BAR_DESTINATION_NOT_BOUND, undefined, 'fr' as LocaleCode);
 
       expect(result).toBe(enResult);
       expect(loggerWarnSpy).toHaveBeenCalledWith(

--- a/packages/rangelink-vscode-extension/src/utils/__tests__/interpolateArgs.test.ts
+++ b/packages/rangelink-vscode-extension/src/utils/__tests__/interpolateArgs.test.ts
@@ -9,15 +9,11 @@ describe('interpolateArgs', () => {
     });
 
     it('replaces ${content} within a larger string', () => {
-      expect(interpolateArgs('prefix-${content}-suffix', LINK_TEXT)).toBe(
-        'prefix-src/app.ts#L10-L20-suffix',
-      );
+      expect(interpolateArgs('prefix-${content}-suffix', LINK_TEXT)).toBe('prefix-src/app.ts#L10-L20-suffix');
     });
 
     it('replaces all ${content} occurrences in a single string', () => {
-      expect(interpolateArgs('${content} and ${content}', LINK_TEXT)).toBe(
-        'src/app.ts#L10-L20 and src/app.ts#L10-L20',
-      );
+      expect(interpolateArgs('${content} and ${content}', LINK_TEXT)).toBe('src/app.ts#L10-L20 and src/app.ts#L10-L20');
     });
 
     it('returns string unchanged when no placeholder present', () => {
@@ -31,10 +27,7 @@ describe('interpolateArgs', () => {
 
   describe('array templates', () => {
     it('interpolates each element in an array', () => {
-      expect(interpolateArgs(['${content}', 'static'], LINK_TEXT)).toStrictEqual([
-        'src/app.ts#L10-L20',
-        'static',
-      ]);
+      expect(interpolateArgs(['${content}', 'static'], LINK_TEXT)).toStrictEqual(['src/app.ts#L10-L20', 'static']);
     });
 
     it('handles empty array', () => {
@@ -67,18 +60,14 @@ describe('interpolateArgs', () => {
 
   describe('mixed structures', () => {
     it('interpolates through objects containing arrays', () => {
-      expect(
-        interpolateArgs({ items: ['${content}', 'other'], label: '${content}' }, LINK_TEXT),
-      ).toStrictEqual({
+      expect(interpolateArgs({ items: ['${content}', 'other'], label: '${content}' }, LINK_TEXT)).toStrictEqual({
         items: ['src/app.ts#L10-L20', 'other'],
         label: 'src/app.ts#L10-L20',
       });
     });
 
     it('interpolates through arrays containing objects', () => {
-      expect(
-        interpolateArgs([{ text: '${content}' }, { text: 'static' }], LINK_TEXT),
-      ).toStrictEqual([{ text: 'src/app.ts#L10-L20' }, { text: 'static' }]);
+      expect(interpolateArgs([{ text: '${content}' }, { text: 'static' }], LINK_TEXT)).toStrictEqual([{ text: 'src/app.ts#L10-L20' }, { text: 'static' }]);
     });
   });
 
@@ -100,9 +89,7 @@ describe('interpolateArgs', () => {
     });
 
     it('preserves non-string values inside objects', () => {
-      expect(
-        interpolateArgs({ text: '${content}', count: 5, enabled: true }, LINK_TEXT),
-      ).toStrictEqual({
+      expect(interpolateArgs({ text: '${content}', count: 5, enabled: true }, LINK_TEXT)).toStrictEqual({
         text: 'src/app.ts#L10-L20',
         count: 5,
         enabled: true,

--- a/packages/rangelink-vscode-extension/src/utils/aiAssistants/isClaudeCodeAvailable.ts
+++ b/packages/rangelink-vscode-extension/src/utils/aiAssistants/isClaudeCodeAvailable.ts
@@ -16,9 +16,7 @@ export const isClaudeCodeAvailable = (ideAdapter: VscodeAdapter, logger: Logger)
       extensionActive: extension?.isActive ?? false,
       isAvailable,
     },
-    isAvailable
-      ? 'Claude Code extension detected and active'
-      : 'Claude Code extension not available (not installed or not active)',
+    isAvailable ? 'Claude Code extension detected and active' : 'Claude Code extension not available (not installed or not active)',
   );
 
   return isAvailable;

--- a/packages/rangelink-vscode-extension/src/utils/aiAssistants/isCursorIDEDetected.ts
+++ b/packages/rangelink-vscode-extension/src/utils/aiAssistants/isCursorIDEDetected.ts
@@ -19,9 +19,7 @@ export const isCursorIDEDetected = (ideAdapter: VscodeAdapter, logger: Logger): 
     return true;
   }
 
-  const cursorExtensions = ideAdapter.extensions.filter((ext: Extension<unknown>) =>
-    ext.id.startsWith('cursor.'),
-  );
+  const cursorExtensions = ideAdapter.extensions.filter((ext: Extension<unknown>) => ext.id.startsWith('cursor.'));
   if (cursorExtensions.length > 0) {
     logger.debug(
       {

--- a/packages/rangelink-vscode-extension/src/utils/aiAssistants/isGeminiCodeAssistAvailable.ts
+++ b/packages/rangelink-vscode-extension/src/utils/aiAssistants/isGeminiCodeAssistAvailable.ts
@@ -15,9 +15,7 @@ export const isGeminiCodeAssistAvailable = (ideAdapter: VscodeAdapter, logger: L
       extensionFound: extension !== undefined,
       extensionActive: extension?.isActive ?? false,
     },
-    isAvailable
-      ? 'Gemini Code Assist detected and active'
-      : 'Gemini Code Assist not available (not installed or not active)',
+    isAvailable ? 'Gemini Code Assist detected and active' : 'Gemini Code Assist not available (not installed or not active)',
   );
 
   return isAvailable;

--- a/packages/rangelink-vscode-extension/src/utils/aiAssistants/isGitHubCopilotChatAvailable.ts
+++ b/packages/rangelink-vscode-extension/src/utils/aiAssistants/isGitHubCopilotChatAvailable.ts
@@ -7,14 +7,9 @@ import type { Logger } from '@couimet/logger-contract';
 
 export const GITHUB_COPILOT_CHAT_COMMAND = 'workbench.action.chat.open';
 
-export const isGitHubCopilotChatAvailable = async (
-  ideAdapter: VscodeAdapter,
-  logger: Logger,
-): Promise<boolean> => {
+export const isGitHubCopilotChatAvailable = async (ideAdapter: VscodeAdapter, logger: Logger): Promise<boolean> => {
   const commands = await ideAdapter.getCommands();
-  const chatCommand = GITHUB_COPILOT_CHAT_FOCUS_COMMANDS.find((command) =>
-    commands.includes(command),
-  );
+  const chatCommand = GITHUB_COPILOT_CHAT_FOCUS_COMMANDS.find((command) => commands.includes(command));
   const commandExists = chatCommand !== undefined;
 
   if (commandExists) {
@@ -40,9 +35,7 @@ export const isGitHubCopilotChatAvailable = async (
       extensionActive: extension?.isActive ?? false,
       detectionMethod: extensionAvailable ? 'extension' : 'none',
     },
-    extensionAvailable
-      ? 'GitHub Copilot Chat detected via extension'
-      : 'GitHub Copilot Chat not available (command not found, extension not active)',
+    extensionAvailable ? 'GitHub Copilot Chat detected via extension' : 'GitHub Copilot Chat not available (command not found, extension not active)',
   );
 
   return extensionAvailable;

--- a/packages/rangelink-vscode-extension/src/utils/convertRangeLinkPosition.ts
+++ b/packages/rangelink-vscode-extension/src/utils/convertRangeLinkPosition.ts
@@ -35,10 +35,7 @@ export interface ConvertedPosition {
  * @param document - VSCode document for bounds checking
  * @returns Converted position (0-indexed, clamped to document bounds)
  */
-export const convertRangeLinkPosition = (
-  position: LinkPosition,
-  document: vscode.TextDocument,
-): ConvertedPosition => {
+export const convertRangeLinkPosition = (position: LinkPosition, document: vscode.TextDocument): ConvertedPosition => {
   const requestedLine = position.line - 1;
   const maxLine = document.lineCount - 1;
   const line = Math.max(0, Math.min(requestedLine, maxLine));

--- a/packages/rangelink-vscode-extension/src/utils/destinationKindGuards.ts
+++ b/packages/rangelink-vscode-extension/src/utils/destinationKindGuards.ts
@@ -20,10 +20,7 @@ import type * as vscode from 'vscode';
  * @param kind - The expected destination kind
  * @returns True if destination exists and matches the kind
  */
-export const isPasteDestinationKind = (
-  destination: PasteDestination | undefined,
-  kind: DestinationKind,
-): destination is PasteDestination => {
+export const isPasteDestinationKind = (destination: PasteDestination | undefined, kind: DestinationKind): destination is PasteDestination => {
   return destination?.id === kind;
 };
 
@@ -43,9 +40,7 @@ export const isTerminalDestination = (
 ): destination is ComposablePasteDestination & {
   resource: { kind: 'terminal'; terminal: vscode.Terminal };
 } => {
-  return (
-    destination instanceof ComposablePasteDestination && destination.resource.kind === 'terminal'
-  );
+  return destination instanceof ComposablePasteDestination && destination.resource.kind === 'terminal';
 };
 
 /**
@@ -65,9 +60,7 @@ export const isEditorDestination = (
 ): destination is ComposablePasteDestination & {
   resource: { kind: 'editor'; uri: vscode.Uri; viewColumn: number };
 } => {
-  return (
-    destination instanceof ComposablePasteDestination && destination.resource.kind === 'editor'
-  );
+  return destination instanceof ComposablePasteDestination && destination.resource.kind === 'editor';
 };
 
 /**
@@ -85,7 +78,5 @@ export const isSingletonDestination = (
 ): destination is ComposablePasteDestination & {
   resource: { kind: 'singleton' };
 } => {
-  return (
-    destination instanceof ComposablePasteDestination && destination.resource.kind === 'singleton'
-  );
+  return destination instanceof ComposablePasteDestination && destination.resource.kind === 'singleton';
 };

--- a/packages/rangelink-vscode-extension/src/utils/formatClampingSummary.ts
+++ b/packages/rangelink-vscode-extension/src/utils/formatClampingSummary.ts
@@ -28,9 +28,5 @@ export const formatClampingSummary = (start: ConvertedPosition, end: ConvertedPo
     return formatMessage(MessageCode.WARN_NAVIGATION_CLAMPED_SUMMARY_CHARACTER);
   }
 
-  throw RangeLinkExtensionError.forUnexpectedSwitchDefault(
-    'clamping summary state',
-    { lineClamped, characterClamped },
-    'formatClampingSummary',
-  );
+  throw RangeLinkExtensionError.forUnexpectedSwitchDefault('clamping summary state', { lineClamped, characterClamped }, 'formatClampingSummary');
 };

--- a/packages/rangelink-vscode-extension/src/utils/formatLinkPosition.ts
+++ b/packages/rangelink-vscode-extension/src/utils/formatLinkPosition.ts
@@ -16,8 +16,7 @@ import type { LinkPosition } from 'rangelink-core-ts';
  */
 export const formatLinkPosition = (start: LinkPosition, end: LinkPosition): string => {
   // Format individual positions
-  const startPos =
-    start.character !== undefined ? `${start.line}:${start.character}` : `${start.line}`;
+  const startPos = start.character !== undefined ? `${start.line}:${start.character}` : `${start.line}`;
   const endPos = end.character !== undefined ? `${end.line}:${end.character}` : `${end.line}`;
 
   // Check if start and end are the same position

--- a/packages/rangelink-vscode-extension/src/utils/formatMessage.ts
+++ b/packages/rangelink-vscode-extension/src/utils/formatMessage.ts
@@ -1,11 +1,5 @@
 import { RangeLinkExtensionError, RangeLinkExtensionErrorCodes } from '../errors';
-import {
-  getCurrentLocale,
-  getMessages,
-  type LocaleCode,
-  messagesEn,
-  supportedLocales,
-} from '../i18n';
+import { getCurrentLocale, getMessages, type LocaleCode, messagesEn, supportedLocales } from '../i18n';
 import { MessageCode } from '../types';
 
 import { getLogger } from '@couimet/logger-contract';
@@ -31,11 +25,7 @@ const logger = getLogger();
  * @returns Formatted message string with substituted parameters
  * @throws {RangeLinkExtensionError} If message code missing in all locales (programming error)
  */
-export const formatMessage = (
-  code: MessageCode,
-  params?: Record<string, unknown>,
-  localeOverride?: LocaleCode,
-): string => {
+export const formatMessage = (code: MessageCode, params?: Record<string, unknown>, localeOverride?: LocaleCode): string => {
   // Determine which messages to use (override or current locale)
   const messages = localeOverride ? supportedLocales[localeOverride] : getMessages();
   const activeLocale = localeOverride || getCurrentLocale();
@@ -85,10 +75,7 @@ export const formatMessage = (
       return JSON.stringify(value);
     } catch (error) {
       // Fallback for circular references or other JSON errors
-      logger.warn(
-        { fn: 'formatMessage', key, valueType: typeof value, error },
-        'Failed to stringify parameter value, using String() fallback',
-      );
+      logger.warn({ fn: 'formatMessage', key, valueType: typeof value, error }, 'Failed to stringify parameter value, using String() fallback');
       return String(value);
     }
   });

--- a/packages/rangelink-vscode-extension/src/utils/generateLinkFromSelections.ts
+++ b/packages/rangelink-vscode-extension/src/utils/generateLinkFromSelections.ts
@@ -5,13 +5,7 @@ import { ExtensionResult } from '../types';
 import { toInputSelection } from './toInputSelection';
 
 import type { Logger } from '@couimet/logger-contract';
-import {
-  DelimiterConfig,
-  formatLink,
-  FormatOptions,
-  type FormattedLink,
-  LinkType,
-} from 'rangelink-core-ts';
+import { DelimiterConfig, formatLink, FormatOptions, type FormattedLink, LinkType } from 'rangelink-core-ts';
 import * as vscode from 'vscode';
 
 /**
@@ -65,9 +59,7 @@ const FN_NAME = 'generateLinkFromSelections';
  * @param options - Configuration for link generation
  * @returns Result containing FormattedLink on success, or RangeLinkExtensionError on failure
  */
-export const generateLinkFromSelections = (
-  options: GenerateLinkFromSelectionsOptions,
-): ExtensionResult<FormattedLink> => {
+export const generateLinkFromSelections = (options: GenerateLinkFromSelectionsOptions): ExtensionResult<FormattedLink> => {
   const { referencePath, document, selections, delimiters, linkType, logger } = options;
 
   if (selections.length === 0) {
@@ -93,10 +85,7 @@ export const generateLinkFromSelections = (
 
   const inputSelectionResult = toInputSelection(document, selections, logger);
   if (!inputSelectionResult.success) {
-    logger.error(
-      { fn: FN_NAME, error: inputSelectionResult.error },
-      'Failed to convert selections to InputSelection',
-    );
+    logger.error({ fn: FN_NAME, error: inputSelectionResult.error }, 'Failed to convert selections to InputSelection');
     return ExtensionResult.err(
       new RangeLinkExtensionError({
         code: RangeLinkExtensionErrorCodes.GENERATE_LINK_SELECTION_CONVERSION_FAILED,

--- a/packages/rangelink-vscode-extension/src/utils/interpolateArgs.ts
+++ b/packages/rangelink-vscode-extension/src/utils/interpolateArgs.ts
@@ -24,12 +24,7 @@ export const interpolateArgs = (template: unknown, content: string): unknown => 
   }
 
   if (template !== null && template !== undefined && typeof template === 'object') {
-    return Object.fromEntries(
-      Object.entries(template as Record<string, unknown>).map(([key, value]) => [
-        key,
-        interpolateArgs(value, content),
-      ]),
-    );
+    return Object.fromEntries(Object.entries(template as Record<string, unknown>).map(([key, value]) => [key, interpolateArgs(value, content)]));
   }
 
   return template;

--- a/packages/rangelink-vscode-extension/src/utils/isSameFileDestination.ts
+++ b/packages/rangelink-vscode-extension/src/utils/isSameFileDestination.ts
@@ -14,11 +14,7 @@ import type * as vscode from 'vscode';
  * @param sourceViewColumn - Optional view column of the source editor
  * @returns true if source and destination are the same file AND same view column
  */
-export const isSameFileDestination = (
-  sourceUri: vscode.Uri,
-  destination: PasteDestination | undefined,
-  sourceViewColumn?: vscode.ViewColumn,
-): boolean => {
+export const isSameFileDestination = (sourceUri: vscode.Uri, destination: PasteDestination | undefined, sourceViewColumn?: vscode.ViewColumn): boolean => {
   if (!destination) return false;
 
   const destUri = destination.getDestinationUri();

--- a/packages/rangelink-vscode-extension/src/utils/isSelectableQuickPickItem.ts
+++ b/packages/rangelink-vscode-extension/src/utils/isSelectableQuickPickItem.ts
@@ -14,8 +14,5 @@ import type * as vscode from 'vscode';
  * @param item - The QuickPickItem returned from showQuickPick, or undefined if cancelled
  * @returns True if the item exists and has a valid `itemKind` discriminator
  */
-export const isSelectableQuickPickItem = <
-  T extends vscode.QuickPickItem & { itemKind: PickerItemKind },
->(
-  item: vscode.QuickPickItem | undefined,
-): item is T => !!item && 'itemKind' in item && PICKER_ITEM_KINDS.includes((item as T).itemKind);
+export const isSelectableQuickPickItem = <T extends vscode.QuickPickItem & { itemKind: PickerItemKind }>(item: vscode.QuickPickItem | undefined): item is T =>
+  !!item && 'itemKind' in item && PICKER_ITEM_KINDS.includes((item as T).itemKind);

--- a/packages/rangelink-vscode-extension/src/utils/registerWithLogging.ts
+++ b/packages/rangelink-vscode-extension/src/utils/registerWithLogging.ts
@@ -11,10 +11,7 @@ import type * as vscode from 'vscode';
  * @param message - Human-readable description of what was registered
  * @returns The disposable (for fluent chaining if needed)
  */
-export const registerWithLogging = <T extends vscode.Disposable>(
-  disposable: T,
-  message: string,
-): T => {
+export const registerWithLogging = <T extends vscode.Disposable>(disposable: T, message: string): T => {
   getLogger().debug({ fn: 'activate' }, message);
   return disposable;
 };

--- a/packages/rangelink-vscode-extension/src/utils/resolveWorkspacePath.ts
+++ b/packages/rangelink-vscode-extension/src/utils/resolveWorkspacePath.ts
@@ -40,10 +40,7 @@ const escapeGlobPattern = (filename: string): string => {
  * @param ideInstance - VSCode module instance for workspace/URI operations
  * @returns ResolvedPath if found, 'filename-ambiguous' if multiple matches, undefined if not found
  */
-export const resolveWorkspacePath = async (
-  linkPath: string,
-  ideInstance: typeof vscode,
-): Promise<ResolveWorkspacePathResult> => {
+export const resolveWorkspacePath = async (linkPath: string, ideInstance: typeof vscode): Promise<ResolveWorkspacePathResult> => {
   // Try as absolute path first
   if (path.isAbsolute(linkPath)) {
     const uri = ideInstance.Uri.file(linkPath);
@@ -67,11 +64,7 @@ export const resolveWorkspacePath = async (
   if (isBareFilename) {
     const pattern = `**/${escapeGlobPattern(linkPath)}`;
     try {
-      const matches = await ideInstance.workspace.findFiles(
-        pattern,
-        undefined,
-        AMBIGUITY_THRESHOLD,
-      );
+      const matches = await ideInstance.workspace.findFiles(pattern, undefined, AMBIGUITY_THRESHOLD);
       if (matches.length === 1) {
         return { uri: matches[0], resolvedVia: 'filename-fallback' };
       }

--- a/packages/rangelink-vscode-extension/src/utils/toInputSelection.ts
+++ b/packages/rangelink-vscode-extension/src/utils/toInputSelection.ts
@@ -54,10 +54,7 @@ export const toInputSelection = (
     try {
       const endLine = document.lineAt(sel.end.line);
       const startsAtBeginning = sel.start.character === 0;
-      const endsAtEndOfLine =
-        sel.end.character === endLine.range.end.character ||
-        sel.end.character >= endLine.text.length ||
-        includesTrailingNewline;
+      const endsAtEndOfLine = sel.end.character === endLine.range.end.character || sel.end.character >= endLine.text.length || includesTrailingNewline;
 
       if (startsAtBeginning && endsAtEndOfLine) {
         coverage = SelectionCoverage.FullLine;
@@ -86,8 +83,7 @@ export const toInputSelection = (
       return ExtensionResult.err(
         new RangeLinkExtensionError({
           code: RangeLinkExtensionErrorCodes.SELECTION_CONVERSION_FAILED,
-          message:
-            'Cannot generate link: document was modified and selection is no longer valid. Please reselect and try again.',
+          message: 'Cannot generate link: document was modified and selection is no longer valid. Please reselect and try again.',
           functionName: 'toInputSelection',
         }),
       );
@@ -96,9 +92,7 @@ export const toInputSelection = (
     // Normalize end line when selection includes trailing newline
     // VSCode reports (21, 0) for "line 20 + newline" - adjust to point to actual content line
     const adjustedEndLine = includesTrailingNewline ? sel.end.line - 1 : sel.end.line;
-    const adjustedEndCharacter = includesTrailingNewline
-      ? document.lineAt(adjustedEndLine).text.length
-      : sel.end.character;
+    const adjustedEndCharacter = includesTrailingNewline ? document.lineAt(adjustedEndLine).text.length : sel.end.character;
 
     selections.push({
       start: { line: sel.start.line, character: sel.start.character },

--- a/packages/rangelink-vscode-extension/src/utils/validateTerminalDefined.ts
+++ b/packages/rangelink-vscode-extension/src/utils/validateTerminalDefined.ts
@@ -4,9 +4,7 @@ import { ExtensionResult } from '../types/ExtensionResult';
 
 import type * as vscode from 'vscode';
 
-export const validateTerminalDefined = (
-  terminal: vscode.Terminal | undefined,
-): ExtensionResult<vscode.Terminal> => {
+export const validateTerminalDefined = (terminal: vscode.Terminal | undefined): ExtensionResult<vscode.Terminal> => {
   if (!terminal) {
     return ExtensionResult.err(
       new RangeLinkExtensionError({

--- a/packages/rangelink-vscode-extension/src/wireSubscriptions.ts
+++ b/packages/rangelink-vscode-extension/src/wireSubscriptions.ts
@@ -56,12 +56,7 @@ import {
 } from './constants';
 import type { WiringServices } from './createWiringServices';
 import type { SubscriptionRegistrar } from './SubscriptionRegistrar';
-import {
-  type AIAssistantDestinationKind,
-  type FilePathClickArgs,
-  PathFormat,
-  type RangeLinkClickArgs,
-} from './types';
+import { type AIAssistantDestinationKind, type FilePathClickArgs, PathFormat, type RangeLinkClickArgs } from './types';
 
 import type * as vscode from 'vscode';
 
@@ -69,10 +64,7 @@ import type * as vscode from 'vscode';
  * Wire all commands and providers into subscriptions.
  * Pure wiring — receives pre-built services and a registrar abstraction.
  */
-export const wireSubscriptions = (
-  registrar: SubscriptionRegistrar,
-  services: WiringServices,
-): void => {
+export const wireSubscriptions = (registrar: SubscriptionRegistrar, services: WiringServices): void => {
   const {
     ideAdapter,
     logger,
@@ -116,45 +108,20 @@ export const wireSubscriptions = (
   registrar.pushDisposable(contextKeyService);
 
   // Link providers
-  registrar.registerTerminalLinkProvider(
-    filePathTerminalProvider,
-    'File path terminal link provider registered',
-  );
-  registrar.registerDocumentLinkProvider(
-    [{ scheme: 'file' }, { scheme: 'untitled' }],
-    filePathDocumentProvider,
-    'File path document link provider registered',
-  );
+  registrar.registerTerminalLinkProvider(filePathTerminalProvider, 'File path terminal link provider registered');
+  registrar.registerDocumentLinkProvider([{ scheme: 'file' }, { scheme: 'untitled' }], filePathDocumentProvider, 'File path document link provider registered');
   registrar.registerTerminalLinkProvider(terminalLinkProvider, 'Terminal link provider registered');
-  registrar.registerDocumentLinkProvider(
-    [{ scheme: 'file' }, { scheme: 'untitled' }],
-    documentLinkProvider,
-    'Document link provider registered',
-  );
+  registrar.registerDocumentLinkProvider([{ scheme: 'file' }, { scheme: 'untitled' }], documentLinkProvider, 'Document link provider registered');
 
   // Commands
   registrar.registerCommand(CMD_OPEN_STATUS_BAR_MENU, () => statusBar.openMenu());
-  registrar.registerCommand(CMD_COPY_LINK_RELATIVE, () =>
-    linkGenerator.createLink(PathFormat.WorkspaceRelative),
-  );
-  registrar.registerCommand(CMD_COPY_LINK_ABSOLUTE, () =>
-    linkGenerator.createLink(PathFormat.Absolute),
-  );
-  registrar.registerCommand(CMD_COPY_PORTABLE_LINK_RELATIVE, () =>
-    linkGenerator.createPortableLink(PathFormat.WorkspaceRelative),
-  );
-  registrar.registerCommand(CMD_COPY_PORTABLE_LINK_ABSOLUTE, () =>
-    linkGenerator.createPortableLink(PathFormat.Absolute),
-  );
-  registrar.registerCommand(CMD_COPY_LINK_ONLY_RELATIVE, () =>
-    linkGenerator.createLinkOnly(PathFormat.WorkspaceRelative),
-  );
-  registrar.registerCommand(CMD_COPY_LINK_ONLY_ABSOLUTE, () =>
-    linkGenerator.createLinkOnly(PathFormat.Absolute),
-  );
-  registrar.registerCommand(CMD_PASTE_TO_DESTINATION, () =>
-    textSelectionPaster.pasteSelectedTextToDestination(),
-  );
+  registrar.registerCommand(CMD_COPY_LINK_RELATIVE, () => linkGenerator.createLink(PathFormat.WorkspaceRelative));
+  registrar.registerCommand(CMD_COPY_LINK_ABSOLUTE, () => linkGenerator.createLink(PathFormat.Absolute));
+  registrar.registerCommand(CMD_COPY_PORTABLE_LINK_RELATIVE, () => linkGenerator.createPortableLink(PathFormat.WorkspaceRelative));
+  registrar.registerCommand(CMD_COPY_PORTABLE_LINK_ABSOLUTE, () => linkGenerator.createPortableLink(PathFormat.Absolute));
+  registrar.registerCommand(CMD_COPY_LINK_ONLY_RELATIVE, () => linkGenerator.createLinkOnly(PathFormat.WorkspaceRelative));
+  registrar.registerCommand(CMD_COPY_LINK_ONLY_ABSOLUTE, () => linkGenerator.createLinkOnly(PathFormat.Absolute));
+  registrar.registerCommand(CMD_PASTE_TO_DESTINATION, () => textSelectionPaster.pasteSelectedTextToDestination());
   registrar.registerCommand(CMD_SHOW_VERSION, () => showVersionCommand.execute());
   registrar.registerCommand(CMD_BIND_TO_TERMINAL, bindToTerminalHandler);
   registrar.registerCommand(CMD_BIND_TO_TERMINAL_HERE, bindToTerminalHandler);
@@ -167,22 +134,10 @@ export const wireSubscriptions = (
     [CMD_BIND_TO_GEMINI_CODE_ASSIST, 'gemini-code-assist'],
     [CMD_BIND_TO_GITHUB_COPILOT_CHAT, 'github-copilot-chat'],
   ] satisfies [string, AIAssistantDestinationKind][]) {
-    registrar.registerCommand(
-      cmd,
-      createBindAIAssistantCommand(
-        kind,
-        availabilityService,
-        destinationManager,
-        ideAdapter,
-        logger,
-      ),
-    );
+    registrar.registerCommand(cmd, createBindAIAssistantCommand(kind, availabilityService, destinationManager, ideAdapter, logger));
   }
 
-  registrar.registerCommand(
-    CMD_BIND_TO_CUSTOM_AI_BY_ID,
-    createBindToCustomAiByIdCommand(customAssistants, destinationManager, logger),
-  );
+  registrar.registerCommand(CMD_BIND_TO_CUSTOM_AI_BY_ID, createBindToCustomAiByIdCommand(customAssistants, destinationManager, logger));
 
   registrar.registerCommand(CMD_UNBIND_DESTINATION, () => {
     destinationManager.unbind();
@@ -193,33 +148,19 @@ export const wireSubscriptions = (
   registrar.registerCommand(CMD_JUMP_TO_DESTINATION, async () => {
     await jumpToDestinationCommand.execute();
   });
-  registrar.registerCommand(CMD_HANDLE_DOCUMENT_LINK_CLICK, (args) =>
-    documentLinkProvider.handleLinkClick(args as RangeLinkClickArgs),
-  );
-  registrar.registerCommand(CMD_HANDLE_FILE_PATH_CLICK, (args) =>
-    filePathDocumentProvider.handleLinkClick(args as FilePathClickArgs),
-  );
+  registrar.registerCommand(CMD_HANDLE_DOCUMENT_LINK_CLICK, (args) => documentLinkProvider.handleLinkClick(args as RangeLinkClickArgs));
+  registrar.registerCommand(CMD_HANDLE_FILE_PATH_CLICK, (args) => filePathDocumentProvider.handleLinkClick(args as FilePathClickArgs));
   registrar.registerCommand(CMD_GO_TO_RANGELINK, () => goToRangeLinkCommand.execute());
   registrar.registerCommand(CMD_BOOKMARK_ADD, () => addBookmarkCommand.execute());
   registrar.registerCommand(CMD_BOOKMARK_LIST, () => listBookmarksCommand.execute());
   registrar.registerCommand(CMD_BOOKMARK_MANAGE, () => manageBookmarksCommand.execute());
 
-  registrar.registerCommand(CMD_PASTE_FILE_PATH_ABSOLUTE, (uri) =>
-    filePathPaster.pasteFilePathToDestination(uri as vscode.Uri, PathFormat.Absolute),
-  );
-  registrar.registerCommand(CMD_PASTE_FILE_PATH_RELATIVE, (uri) =>
-    filePathPaster.pasteFilePathToDestination(uri as vscode.Uri, PathFormat.WorkspaceRelative),
-  );
-  registrar.registerCommand(CMD_PASTE_CURRENT_FILE_PATH_ABSOLUTE, () =>
-    filePathPaster.pasteCurrentFilePathToDestination(PathFormat.Absolute),
-  );
-  registrar.registerCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE, () =>
-    filePathPaster.pasteCurrentFilePathToDestination(PathFormat.WorkspaceRelative),
-  );
+  registrar.registerCommand(CMD_PASTE_FILE_PATH_ABSOLUTE, (uri) => filePathPaster.pasteFilePathToDestination(uri as vscode.Uri, PathFormat.Absolute));
+  registrar.registerCommand(CMD_PASTE_FILE_PATH_RELATIVE, (uri) => filePathPaster.pasteFilePathToDestination(uri as vscode.Uri, PathFormat.WorkspaceRelative));
+  registrar.registerCommand(CMD_PASTE_CURRENT_FILE_PATH_ABSOLUTE, () => filePathPaster.pasteCurrentFilePathToDestination(PathFormat.Absolute));
+  registrar.registerCommand(CMD_PASTE_CURRENT_FILE_PATH_RELATIVE, () => filePathPaster.pasteCurrentFilePathToDestination(PathFormat.WorkspaceRelative));
 
-  registrar.registerCommand(CMD_CONTEXT_EXPLORER_PASTE_FILE_PATH, (uri) =>
-    filePathPaster.pasteFilePathToDestination(uri as vscode.Uri, PathFormat.Absolute),
-  );
+  registrar.registerCommand(CMD_CONTEXT_EXPLORER_PASTE_FILE_PATH, (uri) => filePathPaster.pasteFilePathToDestination(uri as vscode.Uri, PathFormat.Absolute));
   registrar.registerCommand(CMD_CONTEXT_EXPLORER_PASTE_RELATIVE_FILE_PATH, (uri) =>
     filePathPaster.pasteFilePathToDestination(uri as vscode.Uri, PathFormat.WorkspaceRelative),
   );
@@ -228,9 +169,7 @@ export const wireSubscriptions = (
     destinationManager.unbind();
   });
 
-  registrar.registerCommand(CMD_CONTEXT_EDITOR_TAB_PASTE_FILE_PATH, (uri) =>
-    filePathPaster.pasteFilePathToDestination(uri as vscode.Uri, PathFormat.Absolute),
-  );
+  registrar.registerCommand(CMD_CONTEXT_EDITOR_TAB_PASTE_FILE_PATH, (uri) => filePathPaster.pasteFilePathToDestination(uri as vscode.Uri, PathFormat.Absolute));
   registrar.registerCommand(CMD_CONTEXT_EDITOR_TAB_PASTE_RELATIVE_FILE_PATH, (uri) =>
     filePathPaster.pasteFilePathToDestination(uri as vscode.Uri, PathFormat.WorkspaceRelative),
   );
@@ -255,30 +194,14 @@ export const wireSubscriptions = (
     destinationManager.unbind();
   });
 
-  registrar.registerCommand(CMD_TERMINAL_PASTE_SELECTED_TEXT, () =>
-    terminalSelectionService.pasteTerminalSelectionToDestination(),
-  );
-  registrar.registerCommand(CMD_TERMINAL_LINK_BRIDGE, () =>
-    terminalSelectionService.terminalLinkBridge(),
-  );
-  registrar.registerCommand(CMD_TERMINAL_COPY_LINK_GUARD, () =>
-    terminalSelectionService.terminalCopyLinkGuard(),
-  );
+  registrar.registerCommand(CMD_TERMINAL_PASTE_SELECTED_TEXT, () => terminalSelectionService.pasteTerminalSelectionToDestination());
+  registrar.registerCommand(CMD_TERMINAL_LINK_BRIDGE, () => terminalSelectionService.terminalLinkBridge());
+  registrar.registerCommand(CMD_TERMINAL_COPY_LINK_GUARD, () => terminalSelectionService.terminalCopyLinkGuard());
 
-  registrar.registerCommand(CMD_CONTEXT_EDITOR_COPY_LINK, () =>
-    linkGenerator.createLink(PathFormat.WorkspaceRelative),
-  );
-  registrar.registerCommand(CMD_CONTEXT_EDITOR_COPY_LINK_ABSOLUTE, () =>
-    linkGenerator.createLink(PathFormat.Absolute),
-  );
-  registrar.registerCommand(CMD_CONTEXT_EDITOR_COPY_PORTABLE_LINK, () =>
-    linkGenerator.createPortableLink(PathFormat.WorkspaceRelative),
-  );
-  registrar.registerCommand(CMD_CONTEXT_EDITOR_COPY_PORTABLE_LINK_ABSOLUTE, () =>
-    linkGenerator.createPortableLink(PathFormat.Absolute),
-  );
-  registrar.registerCommand(CMD_CONTEXT_EDITOR_PASTE_SELECTED_TEXT, () =>
-    textSelectionPaster.pasteSelectedTextToDestination(),
-  );
+  registrar.registerCommand(CMD_CONTEXT_EDITOR_COPY_LINK, () => linkGenerator.createLink(PathFormat.WorkspaceRelative));
+  registrar.registerCommand(CMD_CONTEXT_EDITOR_COPY_LINK_ABSOLUTE, () => linkGenerator.createLink(PathFormat.Absolute));
+  registrar.registerCommand(CMD_CONTEXT_EDITOR_COPY_PORTABLE_LINK, () => linkGenerator.createPortableLink(PathFormat.WorkspaceRelative));
+  registrar.registerCommand(CMD_CONTEXT_EDITOR_COPY_PORTABLE_LINK_ABSOLUTE, () => linkGenerator.createPortableLink(PathFormat.Absolute));
+  registrar.registerCommand(CMD_CONTEXT_EDITOR_PASTE_SELECTED_TEXT, () => textSelectionPaster.pasteSelectedTextToDestination());
   registrar.registerCommand(CMD_CONTEXT_EDITOR_SAVE_BOOKMARK, () => addBookmarkCommand.execute());
 };

--- a/packages/rangelink-vscode-extension/test-fixtures/dummy-ai-extension/extension.js
+++ b/packages/rangelink-vscode-extension/test-fixtures/dummy-ai-extension/extension.js
@@ -43,9 +43,7 @@ function activate(context) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand('dummyAi.focusFail', async () => {
-      throw new Error(
-        'dummyAi.focusFail: intentional failure for TC-010 clipboard-preservation test',
-      );
+      throw new Error('dummyAi.focusFail: intentional failure for TC-010 clipboard-preservation test');
     }),
   );
 

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,6 +1,0 @@
-import baseConfig from '@couimet/eslint-config/prettier';
-
-export default {
-  ...baseConfig,
-  printWidth: 100,
-};


### PR DESCRIPTION
## Summary

The shared `@couimet/eslint-config/prettier` config defaults to `printWidth: 160`. RangeLink previously overrode this to `100` via a local `prettier.config.mjs` file. This change removes the override and moves the Prettier config reference to `package.json`.

## Changes

- Adopted upstream `printWidth: 160` from `@couimet/eslint-config/prettier`, removing the local `100` override
- Moved Prettier config reference to `package.json` (native shareable config string support), deleted `prettier.config.mjs`
- Reformatted the codebase at 160-char print width (362 files, formatting only)

## Test Plan

- [ ] All existing tests pass
- [ ] New tests added for: none (formatting only)
- [ ] Manual testing: none

## Related

- Closes https://github.com/couimet/rangeLink/issues/699

Generated by /finish-issue v2026.07.22@9fcae14 • [my-claude-skills](https://github.com/couimet/my-claude-skills)