### PR TITLE
[issues/695] Replace retired VS Code Marketplace badges in `README` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
   <img src="./assets/icon.png" alt="RangeLink Logo" width="128" />
 </div>
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/couimet.rangelink-vscode-extension?label=VS%20Code%20Marketplace&color=blue)](https://marketplace.visualstudio.com/items?itemName=couimet.rangelink-vscode-extension)
-[![Open VSX Version](https://img.shields.io/open-vsx/v/couimet/rangelink-vscode-extension?label=Open%20VSX&color=blue)](https://open-vsx.org/extension/couimet/rangelink-vscode-extension)
+[![Open VSX / Cursor Version](https://img.shields.io/open-vsx/v/couimet/rangelink-vscode-extension?label=Open%20VSX%20%2F%20Cursor&color=blue)](https://open-vsx.org/extension/couimet/rangelink-vscode-extension) [![Open VSX / Cursor Downloads](https://img.shields.io/open-vsx/dt/couimet/rangelink-vscode-extension?label=Open%20VSX%20%2F%20Cursor%20Downloads&color=blue)](https://open-vsx.org/extension/couimet/rangelink-vscode-extension)
+[![VS Code Marketplace Version](https://vsmarketplacebadges.dev/version/couimet.rangelink-vscode-extension.svg)](https://marketplace.visualstudio.com/items?itemName=couimet.rangelink-vscode-extension) [![VS Code Marketplace Installs](https://vsmarketplacebadges.dev/downloads-short/couimet.rangelink-vscode-extension.svg)](https://marketplace.visualstudio.com/items?itemName=couimet.rangelink-vscode-extension)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 ![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/couimet/rangeLink?label=CodeRabbit+Reviews)
 

--- a/packages/rangelink-vscode-extension/README.md
+++ b/packages/rangelink-vscode-extension/README.md
@@ -4,8 +4,8 @@
   <img src="https://raw.githubusercontent.com/couimet/rangelink/main/assets/icon.png" alt="RangeLink Logo" width="128" />
 </div>
 
-[![Version](https://img.shields.io/visual-studio-marketplace/v/couimet.rangelink-vscode-extension)](https://marketplace.visualstudio.com/items?itemName=couimet.rangelink-vscode-extension)
-[![Open VSX Version](https://img.shields.io/open-vsx/v/couimet/rangelink-vscode-extension?label=Open%20VSX&color=blue)](https://open-vsx.org/extension/couimet/rangelink-vscode-extension)
+[![Open VSX / Cursor Version](https://img.shields.io/open-vsx/v/couimet/rangelink-vscode-extension?label=Open%20VSX%20%2F%20Cursor&color=blue)](https://open-vsx.org/extension/couimet/rangelink-vscode-extension) [![Open VSX / Cursor Downloads](https://img.shields.io/open-vsx/dt/couimet/rangelink-vscode-extension?label=Open%20VSX%20%2F%20Cursor%20Downloads&color=blue)](https://open-vsx.org/extension/couimet/rangelink-vscode-extension)
+[![VS Code Marketplace Version](https://vsmarketplacebadges.dev/version/couimet.rangelink-vscode-extension.svg)](https://marketplace.visualstudio.com/items?itemName=couimet.rangelink-vscode-extension) [![VS Code Marketplace Installs](https://vsmarketplacebadges.dev/downloads-short/couimet.rangelink-vscode-extension.svg)](https://marketplace.visualstudio.com/items?itemName=couimet.rangelink-vscode-extension)
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/couimet/rangelink/blob/main/LICENSE)
 
 > **"Claude Code today. Cursor AI tomorrow. Different shortcuts, different muscle memory."**<br />


### PR DESCRIPTION
## Summary

Shields.io retired its `visual-studio-marketplace/v` badge endpoint, causing both READMEs to render "retired badge" instead of the extension version. Replaced with `vsmarketplacebadges.dev` (version + installs), added an OpenVSX downloads badge via Shields.io, and grouped badges by marketplace with OpenVSX / Cursor listed first.

## Changes

- Replaced retired Shields.io VS Code Marketplace version badge with `vsmarketplacebadges.dev/version/` in both `README.md` and `packages/rangelink-vscode-extension/README.md`
- Added VS Code Marketplace installs badge via `vsmarketplacebadges.dev/downloads-short/`
- Added OpenVSX / Cursor downloads badge via `img.shields.io/open-vsx/dt/`
- Grouped badges per line by marketplace: OpenVSX / Cursor (version, downloads) on one line, VS Code Marketplace (version, installs) on the next
- Reordered so OpenVSX / Cursor appears first, reflecting higher download volume
- Preserved all existing marketplace destination links and License/CodeRabbit badges

## Test Plan

- [x] All existing tests pass (2080 tests, 118 suites)
- [x] No new tests needed (documentation-only change)
- [x] Verified replacement badges render correctly at `vsmarketplacebadges.dev`

## Related

- Closes https://github.com/couimet/rangeLink/issues/695
- Part of https://github.com/couimet/idea-garden/issues/13

Generated by /finish-issue v2026.07.22@9fcae14 • [my-claude-skills](https://github.com/couimet/my-claude-skills)

@coderabbitai ignore