### PR TITLE
[issues/706] Set up Codecov for rangeLink

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,37 @@
+# Codecov configuration for couimet/rangeLink monorepo.
+# See: https://docs.codecov.com/docs/codecov-yaml
+
+coverage:
+  status:
+    project:
+      core-ts:
+        target: 100%
+        threshold: 0%
+        flags:
+          - core-ts
+      vscode-extension:
+        target: 98%
+        threshold: 0%
+        flags:
+          - vscode-extension
+
+    patch:
+      default:
+        informational: true
+
+flag_management:
+  default_rules:
+    carryforward: true
+
+flags:
+  core-ts:
+    paths:
+      - packages/rangelink-core-ts/
+  vscode-extension:
+    paths:
+      - packages/rangelink-vscode-extension/
+
+comment:
+  layout: 'reach, diff, flags, files, footer'
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary

Adds Codecov configuration for the rangeLink monorepo with per-package coverage targets that match existing Jest thresholds. Enables the `codecov-upload: true` option in the upcoming `issues/improve-ci` CI workflow migration.

## Changes

- New `codecov.yml` with per-package flags: `core-ts` at 100% (matching `rangelink-core-ts` Jest lines threshold) and `vscode-extension` at 98% (matching `rangelink-vscode-extension` Jest lines threshold)
- Patch coverage is informational only (no blocking)
- `carryforward: true` on both flags so PRs touching only one package don't fail the other's status check
- Comment layout configured with `reach, diff, flags, files, footer`

## Key Discoveries

- Codecov flags enable per-package coverage targets in a monorepo, keeping the `core-ts` (100%) and `vscode-extension` (98%) thresholds independent
- The `flag_coverage_not_uploaded_behavior` / `carryforward` setting prevents status-check noise from packages not touched by a PR

## Test Plan

- [x] All existing tests pass (563 core-ts, 2080 vscode-extension)
- [ ] Codecov GitHub App installed on the repo (manual — done)
- [ ] Coverage upload verified once `issues/improve-ci` wires `codecov-upload: true`

## Related

- Closes https://github.com/couimet/rangeLink/issues/706
- Unblocks `codecov-upload: true` for https://github.com/couimet/rangeLink/issues/675

Generated by /finish-issue v2026.07.22@9fcae14 • [my-claude-skills](https://github.com/couimet/my-claude-skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added coverage reporting configuration for the monorepo.
  * Defined coverage tracking for core and editor extension components.
  * Improved pull request coverage comments and reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->