### PR TITLE
[issues/660] Expand test dynamism — upgrade, new utilities, more coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,8 +233,11 @@
 
 <rule id="T013" priority="critical">
   <title>Named constants for test thresholds</title>
-  <do>Overflow thresholds, item counts, and setup sizes in tests must use SCREAMING_SNAKE_CASE constants</do>
-  <rationale>Cross-references P003. Prevents magic numbers in test loops and assertions from drifting when thresholds change.</rationale>
+  <scope>Module-level only — values shared across multiple tests or between beforeEach/setup and assertions. Local test-function plumbing uses camelCase or dynamic values; do not hoist single-test offsets to module-level SCREAMING_SNAKE_CASE.</scope>
+  <do>Use SCREAMING_SNAKE_CASE for module-level constants shared between setup and assertions</do>
+  <do>Prefer `getUniqueInt()` or `getUniqueString()` from `@couimet/dynamic-testing` for arbitrary plumbing offsets that only need to be consistent within a single test — dynamic values prove the value passes through rather than matching a hardcoded default at the destination</do>
+  <never>Use SCREAMING_SNAKE_CASE for `const` variables declared inside `it()` blocks — those are local variables and use camelCase</never>
+  <rationale>SCREAMING_SNAKE_CASE signals "this value is a frozen contract" (cross-references P003). Test-internal plumbing values are arbitrary — a `getUniqueInt()` offset proves the value passes through rather than matching a hardcoded default. Module-level constants are the exception: values shared between beforeEach and assertions must be the same, so a single frozen constant at module level is correct.</rationale>
 </rule>
 
 <rule id="T014" priority="critical">
@@ -329,6 +332,7 @@
 
 <rule id="P003" priority="critical">
   <title>No magic numbers</title>
+  <scope>Production code only. Test code follows T013.</scope>
   <do>Define named constants for all numeric literals with semantic meaning</do>
   <do>Use SCREAMING_SNAKE_CASE for constant names</do>
 </rule>

--- a/packages/rangelink-core-ts/package.json
+++ b/packages/rangelink-core-ts/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@couimet/detailed-error-testing": "^0.1.5",
     "@couimet/detailed-result-testing": "^0.2.1",
-    "@couimet/dynamic-testing": "^0.1.0",
+    "@couimet/dynamic-testing": "^1.0.0",
     "@couimet/logger-contract-testing": "^1.0.0",
     "@types/jest": "^29.5.0",
     "@types/node": "^18.0.0",

--- a/packages/rangelink-core-ts/src/__tests__/external-deps/couimet/dynamic-testing/uniqueFilePath.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/external-deps/couimet/dynamic-testing/uniqueFilePath.test.ts
@@ -8,6 +8,8 @@ import {
   getUniqueRelativePathsNamed,
 } from '../../../../external-deps/couimet/dynamic-testing/uniqueFilePath';
 
+const EXTENSION_SAMPLE_SIZE = 50;
+
 describe('getUniqueFileExtension', () => {
   it('returns a string starting with a dot', () => {
     const ext = getUniqueFileExtension();
@@ -18,7 +20,7 @@ describe('getUniqueFileExtension', () => {
   it('returns from the curated list', () => {
     const CURATED = ['ts', 'js', 'json', 'tsx', 'jsx', 'css', 'html', 'md', 'txt'];
     // Sample many calls; every result must be in the curated set.
-    const results = Array.from({ length: 50 }, () => getUniqueFileExtension().slice(1));
+    const results = Array.from({ length: EXTENSION_SAMPLE_SIZE }, () => getUniqueFileExtension().slice(1));
     for (const r of results) {
       expect(CURATED).toContain(r);
     }
@@ -51,15 +53,15 @@ describe('getUniqueRelativePath', () => {
 
     it('does NOT throw when depth is 0, filename explicit, but folders: [] is provided', () => {
       // folders: [] is explicit — we inject a unique folder.
-      expect(() => getUniqueRelativePath({ depth: 0, folders: [], filename: 'config.ts' })).not.toThrow();
+      getUniqueRelativePath({ depth: 0, folders: [], filename: 'config.ts' });
     });
 
     it('does NOT throw when depth is 0 and filename is auto-generated', () => {
-      expect(() => getUniqueRelativePath({ depth: 0 })).not.toThrow();
+      getUniqueRelativePath({ depth: 0 });
     });
 
     it('does NOT throw when depth is 0, filename explicit, but unique: false', () => {
-      expect(() => getUniqueRelativePath({ depth: 0, filename: 'config.ts', unique: false })).not.toThrow();
+      getUniqueRelativePath({ depth: 0, filename: 'config.ts', unique: false });
     });
   });
 
@@ -67,6 +69,16 @@ describe('getUniqueRelativePath', () => {
     it('throws when maxLength is too small for minimum filename', () => {
       // Minimum: "-N.ext" where N is counter (at least 5 chars with suffix)
       expect(() => getUniqueRelativePath({ maxLength: 1 })).toThrow('MAXLENGTH_TOO_SMALL');
+    });
+
+    it('throws when maxLength is too small for non-unique filename (extension alone)', () => {
+      expect(() => getUniqueRelativePath({ depth: 0, unique: false, maxLength: 2, extension: 'ts' })).toThrow('MAXLENGTH_TOO_SMALL');
+    });
+
+    it('allows maxLength exactly one char above extension length', () => {
+      const path = getUniqueRelativePath({ depth: 0, unique: false, maxLength: 4, extension: 'ts' });
+      expect(path.length).toBe(4);
+      expect(path.endsWith('.ts')).toBe(true);
     });
   });
 
@@ -311,6 +323,10 @@ describe('getUniqueRelativePaths', () => {
     expect(() => getUniqueRelativePaths(-1)).toThrow('COUNT_NOT_POSITIVE_INTEGER');
   });
 
+  it('throws when count is not an integer', () => {
+    expect(() => getUniqueRelativePaths(2.5)).toThrow('COUNT_NOT_POSITIVE_INTEGER');
+  });
+
   it('returns array of requested length', () => {
     const paths = getUniqueRelativePaths(3);
     expect(paths).toHaveLength(3);
@@ -356,6 +372,10 @@ describe('getUniqueRelativePathsNamed', () => {
 describe('getUniqueAbsolutePaths', () => {
   it('throws when count is 0', () => {
     expect(() => getUniqueAbsolutePaths(0)).toThrow('COUNT_NOT_POSITIVE_INTEGER');
+  });
+
+  it('throws when count is not an integer', () => {
+    expect(() => getUniqueAbsolutePaths(2.5)).toThrow('COUNT_NOT_POSITIVE_INTEGER');
   });
 
   it('returns array of requested length', () => {

--- a/packages/rangelink-core-ts/src/__tests__/external-deps/couimet/dynamic-testing/uniqueFilePath.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/external-deps/couimet/dynamic-testing/uniqueFilePath.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../../external-deps/couimet/dynamic-testing/uniqueFilePath';
 
 const EXTENSION_SAMPLE_SIZE = 50;
+const REQUESTED_COUNT = 3;
 
 describe('getUniqueFileExtension', () => {
   it('returns a string starting with a dot', () => {
@@ -328,8 +329,12 @@ describe('getUniqueRelativePaths', () => {
   });
 
   it('returns array of requested length', () => {
-    const paths = getUniqueRelativePaths(3);
-    expect(paths).toHaveLength(3);
+    const paths = getUniqueRelativePaths(REQUESTED_COUNT);
+    expect(paths).toHaveLength(REQUESTED_COUNT);
+    for (const p of paths) {
+      expect(p.startsWith('/')).toBe(false);
+      expect(p).not.toContain('://');
+    }
   });
 
   it('each path is unique', () => {

--- a/packages/rangelink-core-ts/src/__tests__/external-deps/couimet/dynamic-testing/uniqueFilePath.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/external-deps/couimet/dynamic-testing/uniqueFilePath.test.ts
@@ -1,0 +1,381 @@
+import {
+  getUniqueAbsolutePath,
+  getUniqueAbsolutePaths,
+  getUniqueAbsolutePathsNamed,
+  getUniqueFileExtension,
+  getUniqueRelativePath,
+  getUniqueRelativePaths,
+  getUniqueRelativePathsNamed,
+} from '../../../../external-deps/couimet/dynamic-testing/uniqueFilePath';
+
+describe('getUniqueFileExtension', () => {
+  it('returns a string starting with a dot', () => {
+    const ext = getUniqueFileExtension();
+    expect(ext.startsWith('.')).toBe(true);
+    expect(ext.length).toBeGreaterThan(1);
+  });
+
+  it('returns from the curated list', () => {
+    const CURATED = ['ts', 'js', 'json', 'tsx', 'jsx', 'css', 'html', 'md', 'txt'];
+    // Sample many calls; every result must be in the curated set.
+    const results = Array.from({ length: 50 }, () => getUniqueFileExtension().slice(1));
+    for (const r of results) {
+      expect(CURATED).toContain(r);
+    }
+  });
+});
+
+describe('getUniqueRelativePath', () => {
+  describe('filename / basename conflict validation', () => {
+    it('throws when filename and basename are both provided', () => {
+      expect(() => getUniqueRelativePath({ filename: 'config.ts', basename: 'config' })).toThrow('FILENAME_BASENAME_CONFLICT');
+    });
+
+    it('throws when filename and extension are both provided', () => {
+      expect(() => getUniqueRelativePath({ filename: 'config.ts', extension: 'ts' })).toThrow('FILENAME_BASENAME_CONFLICT');
+    });
+
+    it('throws when filename, basename, and extension are all provided', () => {
+      expect(() => getUniqueRelativePath({ filename: 'x.ts', basename: 'y', extension: 'js' })).toThrow('FILENAME_BASENAME_CONFLICT');
+    });
+  });
+
+  describe('depth: 0 + explicit name + unique: true → error', () => {
+    it('throws when depth is 0 with explicit filename and no explicit folders', () => {
+      expect(() => getUniqueRelativePath({ depth: 0, filename: 'config.ts' })).toThrow('UNIQUE_PATH_NO_DIRECTORY');
+    });
+
+    it('throws when depth is 0 with explicit basename and no explicit folders', () => {
+      expect(() => getUniqueRelativePath({ depth: 0, basename: 'config' })).toThrow('UNIQUE_PATH_NO_DIRECTORY');
+    });
+
+    it('does NOT throw when depth is 0, filename explicit, but folders: [] is provided', () => {
+      // folders: [] is explicit — we inject a unique folder.
+      expect(() => getUniqueRelativePath({ depth: 0, folders: [], filename: 'config.ts' })).not.toThrow();
+    });
+
+    it('does NOT throw when depth is 0 and filename is auto-generated', () => {
+      expect(() => getUniqueRelativePath({ depth: 0 })).not.toThrow();
+    });
+
+    it('does NOT throw when depth is 0, filename explicit, but unique: false', () => {
+      expect(() => getUniqueRelativePath({ depth: 0, filename: 'config.ts', unique: false })).not.toThrow();
+    });
+  });
+
+  describe('maxLength validation', () => {
+    it('throws when maxLength is too small for minimum filename', () => {
+      // Minimum: "-N.ext" where N is counter (at least 5 chars with suffix)
+      expect(() => getUniqueRelativePath({ maxLength: 1 })).toThrow('MAXLENGTH_TOO_SMALL');
+    });
+  });
+
+  describe('uniqueness — suffix placement', () => {
+    it('auto folders + auto name: suffix in filename', () => {
+      const path = getUniqueRelativePath({ depth: 2 });
+      const parts = path.split('/');
+      // 2 folders + filename = 3 parts
+      expect(parts).toHaveLength(3);
+      // Filename (last part) contains unique counter pattern: "-N."
+      expect(parts[2]).toMatch(/-\d+\./);
+    });
+
+    it('auto folders + explicit filename: suffix in last folder', () => {
+      const path = getUniqueRelativePath({ depth: 2, filename: 'config.ts' });
+      const parts = path.split('/');
+      // 2 folders + filename = 3 parts; last folder has suffix, filename is clean
+      expect(parts).toHaveLength(3);
+      expect(parts[1]).toMatch(/-\d+$/);
+      expect(parts[2]).toBe('config.ts');
+    });
+
+    it('explicit folders + auto name: suffix in filename', () => {
+      const path = getUniqueRelativePath({ folders: ['lib', 'core'] });
+      const parts = path.split('/');
+      expect(parts[0]).toBe('lib');
+      expect(parts[1]).toBe('core');
+      expect(parts[2]).toMatch(/-\d+\./);
+    });
+
+    it('explicit folders + explicit filename: injected unique folder', () => {
+      const path = getUniqueRelativePath({ folders: ['lib', 'core'], filename: 'types.ts' });
+      const parts = path.split('/');
+      // lib / core / injected-unique-folder / types.ts
+      expect(parts).toHaveLength(4);
+      expect(parts[0]).toBe('lib');
+      expect(parts[1]).toBe('core');
+      expect(parts[2]).toMatch(/-\d+$/);
+      expect(parts[3]).toBe('types.ts');
+    });
+
+    it('unique: false — no suffix anywhere', () => {
+      const path = getUniqueRelativePath({
+        folders: ['lib'],
+        filename: 'config.ts',
+        unique: false,
+      });
+      expect(path).toBe('lib/config.ts');
+    });
+
+    it('unique: false with auto name — no suffix anywhere', () => {
+      const path = getUniqueRelativePath({ depth: 1, unique: false });
+      const parts = path.split('/');
+      expect(parts).toHaveLength(2);
+      // No counter in filename
+      expect(parts[1]).not.toMatch(/-\d+/);
+    });
+  });
+
+  describe('basename — extension behavior', () => {
+    it('uses random extension when basename is provided without extension', () => {
+      const path = getUniqueRelativePath({ basename: 'config' });
+      const filename = path.split('/').pop()!;
+      expect(filename.startsWith('config.')).toBe(true);
+    });
+
+    it('uses provided extension when both basename and extension are given', () => {
+      const path = getUniqueRelativePath({ depth: 0, unique: false, basename: 'config', extension: 'json' });
+      expect(path).toBe('config.json');
+    });
+
+    it('normalizes extension without leading dot', () => {
+      const path = getUniqueRelativePath({ depth: 0, unique: false, basename: 'config', extension: 'ts' });
+      expect(path).toBe('config.ts');
+    });
+  });
+
+  describe('path structure options', () => {
+    it('depth controls number of directory levels', () => {
+      const path = getUniqueRelativePath({ depth: 1 });
+      const parts = path.split('/');
+      expect(parts).toHaveLength(2); // 1 folder + filename
+    });
+
+    it('depth: 0 produces bare filename', () => {
+      const path = getUniqueRelativePath({ depth: 0 });
+      expect(path).not.toContain('/');
+      expect(path).toMatch(/\.\w+$/);
+    });
+
+    it('folders: [] produces bare filename (with unique: false)', () => {
+      const path = getUniqueRelativePath({ folders: [], filename: 'f.ts', unique: false });
+      expect(path).toBe('f.ts');
+    });
+
+    it('folders: [] with unique: true and explicit name injects a folder', () => {
+      const path = getUniqueRelativePath({ folders: [], filename: 'f.ts' });
+      const parts = path.split('/');
+      expect(parts).toHaveLength(2);
+      expect(parts[0]).toMatch(/-\d+$/);
+      expect(parts[1]).toBe('f.ts');
+    });
+
+    it('upLevels prepends ../ segments', () => {
+      const path = getUniqueRelativePath({ depth: 1, upLevels: 2 });
+      expect(path.startsWith('../../')).toBe(true);
+    });
+
+    it('upLevels: 0 adds no prefix', () => {
+      const path = getUniqueRelativePath({ depth: 1, upLevels: 0 });
+      expect(path.startsWith('..')).toBe(false);
+    });
+
+    it('custom separator is used throughout', () => {
+      const path = getUniqueRelativePath({
+        depth: 2,
+        folders: ['a', 'b'],
+        filename: 'c.ts',
+        unique: false,
+        separator: '\\',
+      });
+      expect(path).toBe('a\\b\\c.ts');
+    });
+
+    it('custom separator with upLevels', () => {
+      const path = getUniqueRelativePath({
+        depth: 1,
+        upLevels: 1,
+        folders: ['src'],
+        filename: 'f.ts',
+        unique: false,
+        separator: '\\',
+      });
+      expect(path).toBe('..\\src\\f.ts');
+    });
+  });
+
+  describe('extension normalization', () => {
+    it('accepts extension with leading dot', () => {
+      const path = getUniqueRelativePath({
+        depth: 0,
+        unique: false,
+        basename: 'file',
+        extension: '.ts',
+      });
+      expect(path).toBe('file.ts');
+    });
+
+    it('accepts extension without leading dot', () => {
+      const path = getUniqueRelativePath({
+        depth: 0,
+        unique: false,
+        basename: 'file',
+        extension: 'js',
+      });
+      expect(path).toBe('file.js');
+    });
+  });
+
+  describe('auto-generated name with explicit extension', () => {
+    it('uses provided extension when name is auto-generated', () => {
+      const path = getUniqueRelativePath({ depth: 0, extension: 'json' });
+      expect(path.endsWith('.json')).toBe(true);
+    });
+
+    it('uses maxLength with unique: false to cap name length', () => {
+      const path = getUniqueRelativePath({ depth: 0, unique: false, maxLength: 10, extension: 'ts' });
+      // 10 chars total: name.ts = 7 char name + '.ts'
+      const name = path.split('/').pop()!;
+      expect(name.endsWith('.ts')).toBe(true);
+      expect(name.length).toBeLessThanOrEqual(10);
+    });
+  });
+
+  describe('all-auto path has expected shape', () => {
+    it('produces a path with folders, separator, and dotted extension', () => {
+      const path = getUniqueRelativePath();
+      expect(path).toContain('/');
+      expect(path).toMatch(/\.\w{2,4}$/);
+    });
+  });
+});
+
+describe('getUniqueAbsolutePath', () => {
+  it('prepends default root by default', () => {
+    const path = getUniqueAbsolutePath({ depth: 0 });
+    expect(path.startsWith('/home/user/project/')).toBe(true);
+  });
+
+  it('uses custom root when provided', () => {
+    const path = getUniqueAbsolutePath({ depth: 0, root: '/tmp' });
+    expect(path.startsWith('/tmp/')).toBe(true);
+  });
+
+  it('normalizes trailing separator on root', () => {
+    const path = getUniqueAbsolutePath({ depth: 0, root: '/tmp/' });
+    expect(path.startsWith('/tmp/')).toBe(true);
+    expect(path).not.toContain('//');
+  });
+
+  it('respects custom separator', () => {
+    const path = getUniqueAbsolutePath({
+      depth: 0,
+      root: 'C:\\Users',
+      separator: '\\',
+    });
+    expect(path).toContain('C:\\Users\\');
+  });
+
+  it('root: empty string behaves like relative path', () => {
+    const path = getUniqueAbsolutePath({ depth: 0, root: '' });
+    // When root is '', root.endsWith('/') is false, so normalized is ''.
+    // Then '' + '/' + relative = '/relative'. With depth:0 this is '/bareFilename'.
+    // Actually empty root with separator: normalizedRoot = '' (not ending with /), then '' + '/' + name
+    expect(path.startsWith('/')).toBe(true);
+    expect(path).not.toContain('//');
+  });
+
+  it('works with no arguments (all defaults)', () => {
+    const path = getUniqueAbsolutePath();
+    expect(path.startsWith('/home/user/project/')).toBe(true);
+    expect(path).toMatch(/\.\w{2,4}$/);
+  });
+
+  it('delegates options to relative path (unique: false)', () => {
+    const path = getUniqueAbsolutePath({
+      folders: ['lib'],
+      filename: 'config.ts',
+      unique: false,
+      root: '/app',
+    });
+    expect(path).toBe('/app/lib/config.ts');
+  });
+});
+
+describe('getUniqueRelativePaths', () => {
+  it('throws when count is 0', () => {
+    expect(() => getUniqueRelativePaths(0)).toThrow('COUNT_NOT_POSITIVE_INTEGER');
+  });
+
+  it('throws when count is negative', () => {
+    expect(() => getUniqueRelativePaths(-1)).toThrow('COUNT_NOT_POSITIVE_INTEGER');
+  });
+
+  it('returns array of requested length', () => {
+    const paths = getUniqueRelativePaths(3);
+    expect(paths).toHaveLength(3);
+  });
+
+  it('each path is unique', () => {
+    const paths = getUniqueRelativePaths(5);
+    expect(new Set(paths).size).toBe(5);
+  });
+
+  it('passes options through', () => {
+    const paths = getUniqueRelativePaths(2, { depth: 0, unique: false, filename: 'f.ts' });
+    expect(paths).toStrictEqual(['f.ts', 'f.ts']);
+  });
+});
+
+describe('getUniqueRelativePathsNamed', () => {
+  it('throws when keys is empty', () => {
+    expect(() => getUniqueRelativePathsNamed([])).toThrow('KEYS_ARRAY_EMPTY');
+  });
+
+  it('returns object with requested keys', () => {
+    const result = getUniqueRelativePathsNamed(['alpha', 'beta'] as const);
+    expect(Object.keys(result)).toStrictEqual(['alpha', 'beta']);
+  });
+
+  it('each value is a string path', () => {
+    const result = getUniqueRelativePathsNamed(['x'] as const);
+    expect(typeof result.x).toBe('string');
+    expect(result.x).toContain('/');
+  });
+
+  it('passes options through', () => {
+    const result = getUniqueRelativePathsNamed(['a'], {
+      depth: 0,
+      unique: false,
+      filename: 'f.ts',
+    });
+    expect(result.a).toBe('f.ts');
+  });
+});
+
+describe('getUniqueAbsolutePaths', () => {
+  it('throws when count is 0', () => {
+    expect(() => getUniqueAbsolutePaths(0)).toThrow('COUNT_NOT_POSITIVE_INTEGER');
+  });
+
+  it('returns array of requested length', () => {
+    const paths = getUniqueAbsolutePaths(3, { depth: 0 });
+    expect(paths).toHaveLength(3);
+    for (const p of paths) {
+      expect(p.startsWith('/home/user/project/')).toBe(true);
+    }
+  });
+});
+
+describe('getUniqueAbsolutePathsNamed', () => {
+  it('throws when keys is empty', () => {
+    expect(() => getUniqueAbsolutePathsNamed([])).toThrow('KEYS_ARRAY_EMPTY');
+  });
+
+  it('returns absolute paths for each key', () => {
+    const result = getUniqueAbsolutePathsNamed(['main', 'test'] as const, { depth: 0 });
+    expect(Object.keys(result)).toStrictEqual(['main', 'test']);
+    expect(result.main.startsWith('/home/user/project/')).toBe(true);
+    expect(result.test.startsWith('/home/user/project/')).toBe(true);
+  });
+});

--- a/packages/rangelink-core-ts/src/__tests__/formatting/formatLink.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/formatting/formatLink.test.ts
@@ -1,3 +1,4 @@
+import { getUniqueRelativePath } from '../../external-deps/couimet/dynamic-testing/uniqueFilePath';
 import { formatLink } from '../../formatting/formatLink';
 import { DelimiterConfig } from '../../types/DelimiterConfig';
 import { InputSelection } from '../../types/InputSelection';
@@ -26,12 +27,14 @@ describe('formatLink', () => {
   let endLine: number;
   let startPosition: number;
   let endPosition: number;
+  let filePath: string;
 
   beforeEach(() => {
     startLine = getUniqueInt();
     endLine = getUniqueInt();
     startPosition = getUniqueInt();
     endPosition = getUniqueInt();
+    filePath = getUniqueRelativePath();
   });
 
   it('should format a simple multi-line selection', () => {
@@ -50,11 +53,11 @@ describe('formatLink', () => {
       ],
       selectionType: SelectionType.Normal,
     };
-    const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS);
+    const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS);
 
     expect(result).toBeSuccess({
-      link: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}`,
-      rawLink: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}`,
+      link: `${filePath}#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}`,
+      rawLink: `${filePath}#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}`,
       linkType: 'regular',
       rangeFormat: 'WithPositions',
       selectionType: 'Normal',
@@ -84,11 +87,11 @@ describe('formatLink', () => {
       ],
       selectionType: SelectionType.Normal,
     };
-    const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS);
+    const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS);
 
     expect(result).toBeSuccess({
-      link: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine}C${expectedEndPosition}`,
-      rawLink: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine}C${expectedEndPosition}`,
+      link: `${filePath}#L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine}C${expectedEndPosition}`,
+      rawLink: `${filePath}#L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine}C${expectedEndPosition}`,
       linkType: 'regular',
       rangeFormat: 'WithPositions',
       selectionType: 'Normal',
@@ -117,11 +120,11 @@ describe('formatLink', () => {
       ],
       selectionType: SelectionType.Normal,
     };
-    const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS);
+    const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS);
 
     expect(result).toBeSuccess({
-      link: `src/file.ts#L${expectedStartLine}-L${expectedEndLine}`,
-      rawLink: `src/file.ts#L${expectedStartLine}-L${expectedEndLine}`,
+      link: `${filePath}#L${expectedStartLine}-L${expectedEndLine}`,
+      rawLink: `${filePath}#L${expectedStartLine}-L${expectedEndLine}`,
       linkType: 'regular',
       rangeFormat: 'LineOnly',
       selectionType: 'Normal',
@@ -147,11 +150,11 @@ describe('formatLink', () => {
       ],
       selectionType: SelectionType.Normal,
     };
-    const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS);
+    const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS);
 
     expect(result).toBeSuccess({
-      link: `src/file.ts#L${expectedStartLine}`,
-      rawLink: `src/file.ts#L${expectedStartLine}`,
+      link: `${filePath}#L${expectedStartLine}`,
+      rawLink: `${filePath}#L${expectedStartLine}`,
       linkType: 'regular',
       rangeFormat: 'LineOnly',
       selectionType: 'Normal',
@@ -177,13 +180,13 @@ describe('formatLink', () => {
       ],
       selectionType: SelectionType.Normal,
     };
-    const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
+    const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS, {
       notation: RangeNotation.EnforceFullLine,
     });
 
     expect(result).toBeSuccess({
-      link: `src/file.ts#L${expectedStartLine}`,
-      rawLink: `src/file.ts#L${expectedStartLine}`,
+      link: `${filePath}#L${expectedStartLine}`,
+      rawLink: `${filePath}#L${expectedStartLine}`,
       linkType: 'regular',
       rangeFormat: 'LineOnly',
       selectionType: 'Normal',
@@ -202,7 +205,7 @@ describe('formatLink', () => {
       selectionType: SelectionType.Normal,
     };
 
-    const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS);
+    const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS);
     expect(result).toHaveDetailedError('SELECTION_EMPTY', {
       message: 'Selections array must not be empty',
       functionName: 'validateInputSelection',
@@ -232,11 +235,11 @@ describe('formatLink', () => {
       ],
       selectionType: SelectionType.Normal,
     };
-    const result = formatLink('path/to/file.ts', inputSelection, customDelimiters);
+    const result = formatLink(filePath, inputSelection, customDelimiters);
 
     expect(result).toBeSuccess({
-      link: `path/to/file.ts>>LINE${expectedStartLine}COL${expectedStartPosition}thruLINE${expectedEndLine}COL${expectedEndPosition}`,
-      rawLink: `path/to/file.ts>>LINE${expectedStartLine}COL${expectedStartPosition}thruLINE${expectedEndLine}COL${expectedEndPosition}`,
+      link: `${filePath}>>LINE${expectedStartLine}COL${expectedStartPosition}thruLINE${expectedEndLine}COL${expectedEndPosition}`,
+      rawLink: `${filePath}>>LINE${expectedStartLine}COL${expectedStartPosition}thruLINE${expectedEndLine}COL${expectedEndPosition}`,
       linkType: 'regular',
       rangeFormat: 'WithPositions',
       selectionType: 'Normal',
@@ -276,11 +279,11 @@ describe('formatLink', () => {
       ],
       selectionType: SelectionType.Rectangular,
     };
-    const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS);
+    const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS);
 
     expect(result).toBeSuccess({
-      link: `src/file.ts##L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine + 2}C${expectedEndPosition}`,
-      rawLink: `src/file.ts##L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine + 2}C${expectedEndPosition}`,
+      link: `${filePath}##L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine + 2}C${expectedEndPosition}`,
+      rawLink: `${filePath}##L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine + 2}C${expectedEndPosition}`,
       linkType: 'regular',
       rangeFormat: 'WithPositions',
       selectionType: 'Rectangular',
@@ -326,11 +329,11 @@ describe('formatLink', () => {
       ],
       selectionType: SelectionType.Rectangular,
     };
-    const result = formatLink('src/file.ts', inputSelection, customDelimiters);
+    const result = formatLink(filePath, inputSelection, customDelimiters);
 
     expect(result).toBeSuccess({
-      link: `src/file.ts@@X${expectedStartLine}Y${expectedStartPosition}..X${expectedStartLine + 2}Y${expectedEndPosition}`,
-      rawLink: `src/file.ts@@X${expectedStartLine}Y${expectedStartPosition}..X${expectedStartLine + 2}Y${expectedEndPosition}`,
+      link: `${filePath}@@X${expectedStartLine}Y${expectedStartPosition}..X${expectedStartLine + 2}Y${expectedEndPosition}`,
+      rawLink: `${filePath}@@X${expectedStartLine}Y${expectedStartPosition}..X${expectedStartLine + 2}Y${expectedEndPosition}`,
       linkType: 'regular',
       rangeFormat: 'WithPositions',
       selectionType: 'Rectangular',
@@ -376,11 +379,11 @@ describe('formatLink', () => {
       ],
       selectionType: SelectionType.Rectangular,
     };
-    const result = formatLink('src/file.ts', inputSelection, customDelimiters);
+    const result = formatLink(filePath, inputSelection, customDelimiters);
 
     expect(result).toBeSuccess({
-      link: `src/file.ts####LINE${expectedStartLine}COL${expectedStartPosition}TOLINE${expectedStartLine + 2}COL${expectedEndPosition}`,
-      rawLink: `src/file.ts####LINE${expectedStartLine}COL${expectedStartPosition}TOLINE${expectedStartLine + 2}COL${expectedEndPosition}`,
+      link: `${filePath}####LINE${expectedStartLine}COL${expectedStartPosition}TOLINE${expectedStartLine + 2}COL${expectedEndPosition}`,
+      rawLink: `${filePath}####LINE${expectedStartLine}COL${expectedStartPosition}TOLINE${expectedStartLine + 2}COL${expectedEndPosition}`,
       linkType: 'regular',
       rangeFormat: 'WithPositions',
       selectionType: 'Rectangular',
@@ -409,13 +412,13 @@ describe('formatLink', () => {
       ],
       selectionType: SelectionType.Normal,
     };
-    const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
+    const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS, {
       notation: RangeNotation.EnforcePositions,
     });
 
     expect(result).toBeSuccess({
-      link: `src/file.ts#L${expectedStartLine}C1-L${expectedEndLine}C1`,
-      rawLink: `src/file.ts#L${expectedStartLine}C1-L${expectedEndLine}C1`,
+      link: `${filePath}#L${expectedStartLine}C1-L${expectedEndLine}C1`,
+      rawLink: `${filePath}#L${expectedStartLine}C1-L${expectedEndLine}C1`,
       linkType: 'regular',
       rangeFormat: 'WithPositions',
       selectionType: 'Normal',
@@ -444,13 +447,13 @@ describe('formatLink', () => {
         ],
         selectionType: SelectionType.Normal,
       };
-      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
+      const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS, {
         linkType: LinkType.Portable,
       });
 
       expect(result).toBeSuccess({
-        link: `src/file.ts#L${expectedStartLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`,
-        rawLink: `src/file.ts#L${expectedStartLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`,
+        link: `${filePath}#L${expectedStartLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`,
+        rawLink: `${filePath}#L${expectedStartLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`,
         linkType: 'portable',
         rangeFormat: 'LineOnly',
         selectionType: 'Normal',
@@ -477,13 +480,13 @@ describe('formatLink', () => {
         ],
         selectionType: SelectionType.Normal,
       };
-      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
+      const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS, {
         linkType: LinkType.Portable,
       });
 
       expect(result).toBeSuccess({
-        link: `src/file.ts#L${expectedStartLine}-L${expectedEndLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`,
-        rawLink: `src/file.ts#L${expectedStartLine}-L${expectedEndLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`,
+        link: `${filePath}#L${expectedStartLine}-L${expectedEndLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`,
+        rawLink: `${filePath}#L${expectedStartLine}-L${expectedEndLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`,
         linkType: 'portable',
         rangeFormat: 'LineOnly',
         selectionType: 'Normal',
@@ -512,13 +515,13 @@ describe('formatLink', () => {
         ],
         selectionType: SelectionType.Normal,
       };
-      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
+      const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS, {
         linkType: LinkType.Portable,
       });
 
       expect(result).toBeSuccess({
-        link: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}${byodSuffix(DEFAULT_DELIMITERS, true)}`,
-        rawLink: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}${byodSuffix(DEFAULT_DELIMITERS, true)}`,
+        link: `${filePath}#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}${byodSuffix(DEFAULT_DELIMITERS, true)}`,
+        rawLink: `${filePath}#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}${byodSuffix(DEFAULT_DELIMITERS, true)}`,
         linkType: 'portable',
         rangeFormat: 'WithPositions',
         selectionType: 'Normal',
@@ -558,13 +561,13 @@ describe('formatLink', () => {
         ],
         selectionType: SelectionType.Rectangular,
       };
-      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
+      const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS, {
         linkType: LinkType.Portable,
       });
 
       expect(result).toBeSuccess({
-        link: `src/file.ts##L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine + 2}C${expectedEndPosition}${byodSuffix(DEFAULT_DELIMITERS, true)}`,
-        rawLink: `src/file.ts##L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine + 2}C${expectedEndPosition}${byodSuffix(DEFAULT_DELIMITERS, true)}`,
+        link: `${filePath}##L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine + 2}C${expectedEndPosition}${byodSuffix(DEFAULT_DELIMITERS, true)}`,
+        rawLink: `${filePath}##L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine + 2}C${expectedEndPosition}${byodSuffix(DEFAULT_DELIMITERS, true)}`,
         linkType: 'portable',
         rangeFormat: 'WithPositions',
         selectionType: 'Rectangular',
@@ -610,13 +613,13 @@ describe('formatLink', () => {
         ],
         selectionType: SelectionType.Rectangular,
       };
-      const result = formatLink('src/file.ts', inputSelection, customDelimiters, {
+      const result = formatLink(filePath, inputSelection, customDelimiters, {
         linkType: LinkType.Portable,
       });
 
       expect(result).toBeSuccess({
-        link: `src/file.ts##LINE${expectedStartLine}COL${expectedStartPosition}TOLINE${expectedStartLine + 2}COL${expectedEndPosition}${byodSuffix(customDelimiters, true)}`,
-        rawLink: `src/file.ts##LINE${expectedStartLine}COL${expectedStartPosition}TOLINE${expectedStartLine + 2}COL${expectedEndPosition}${byodSuffix(customDelimiters, true)}`,
+        link: `${filePath}##LINE${expectedStartLine}COL${expectedStartPosition}TOLINE${expectedStartLine + 2}COL${expectedEndPosition}${byodSuffix(customDelimiters, true)}`,
+        rawLink: `${filePath}##LINE${expectedStartLine}COL${expectedStartPosition}TOLINE${expectedStartLine + 2}COL${expectedEndPosition}${byodSuffix(customDelimiters, true)}`,
         linkType: 'portable',
         rangeFormat: 'WithPositions',
         selectionType: 'Rectangular',
@@ -651,13 +654,13 @@ describe('formatLink', () => {
         ],
         selectionType: SelectionType.Normal,
       };
-      const result = formatLink('path/to/file.ts', inputSelection, customDelimiters, {
+      const result = formatLink(filePath, inputSelection, customDelimiters, {
         linkType: LinkType.Portable,
       });
 
       expect(result).toBeSuccess({
-        link: `path/to/file.ts>>LINE${expectedStartLine}thruLINE${expectedEndLine}${byodSuffix(customDelimiters, false)}`,
-        rawLink: `path/to/file.ts>>LINE${expectedStartLine}thruLINE${expectedEndLine}${byodSuffix(customDelimiters, false)}`,
+        link: `${filePath}>>LINE${expectedStartLine}thruLINE${expectedEndLine}${byodSuffix(customDelimiters, false)}`,
+        rawLink: `${filePath}>>LINE${expectedStartLine}thruLINE${expectedEndLine}${byodSuffix(customDelimiters, false)}`,
         linkType: 'portable',
         rangeFormat: 'LineOnly',
         selectionType: 'Normal',
@@ -692,13 +695,13 @@ describe('formatLink', () => {
         ],
         selectionType: SelectionType.Normal,
       };
-      const result = formatLink('path/to/file.ts', inputSelection, customDelimiters, {
+      const result = formatLink(filePath, inputSelection, customDelimiters, {
         linkType: LinkType.Portable,
       });
 
       expect(result).toBeSuccess({
-        link: `path/to/file.ts>>LINE${expectedStartLine}COL${expectedStartPosition}thruLINE${expectedEndLine}COL${expectedEndPosition}${byodSuffix(customDelimiters, true)}`,
-        rawLink: `path/to/file.ts>>LINE${expectedStartLine}COL${expectedStartPosition}thruLINE${expectedEndLine}COL${expectedEndPosition}${byodSuffix(customDelimiters, true)}`,
+        link: `${filePath}>>LINE${expectedStartLine}COL${expectedStartPosition}thruLINE${expectedEndLine}COL${expectedEndPosition}${byodSuffix(customDelimiters, true)}`,
+        rawLink: `${filePath}>>LINE${expectedStartLine}COL${expectedStartPosition}thruLINE${expectedEndLine}COL${expectedEndPosition}${byodSuffix(customDelimiters, true)}`,
         linkType: 'portable',
         rangeFormat: 'WithPositions',
         selectionType: 'Normal',
@@ -726,14 +729,14 @@ describe('formatLink', () => {
         ],
         selectionType: SelectionType.Normal,
       };
-      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
+      const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS, {
         notation: RangeNotation.EnforceFullLine,
         linkType: LinkType.Portable,
       });
 
       expect(result).toBeSuccess({
-        link: `src/file.ts#L${expectedStartLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`,
-        rawLink: `src/file.ts#L${expectedStartLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`,
+        link: `${filePath}#L${expectedStartLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`,
+        rawLink: `${filePath}#L${expectedStartLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`,
         linkType: 'portable',
         rangeFormat: 'LineOnly',
         selectionType: 'Normal',
@@ -760,14 +763,14 @@ describe('formatLink', () => {
         ],
         selectionType: SelectionType.Normal,
       };
-      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
+      const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS, {
         notation: RangeNotation.EnforcePositions,
         linkType: LinkType.Portable,
       });
 
       expect(result).toBeSuccess({
-        link: `src/file.ts#L${expectedStartLine}C1-L${expectedEndLine}C1${byodSuffix(DEFAULT_DELIMITERS, true)}`,
-        rawLink: `src/file.ts#L${expectedStartLine}C1-L${expectedEndLine}C1${byodSuffix(DEFAULT_DELIMITERS, true)}`,
+        link: `${filePath}#L${expectedStartLine}C1-L${expectedEndLine}C1${byodSuffix(DEFAULT_DELIMITERS, true)}`,
+        rawLink: `${filePath}#L${expectedStartLine}C1-L${expectedEndLine}C1${byodSuffix(DEFAULT_DELIMITERS, true)}`,
         linkType: 'portable',
         rangeFormat: 'WithPositions',
         selectionType: 'Normal',
@@ -804,13 +807,13 @@ describe('formatLink', () => {
         selectionType: SelectionType.Normal,
       };
 
-      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
+      const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS, {
         linkType,
       });
 
       expect(result).toBeSuccess({
-        link: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}${suffix}`,
-        rawLink: `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}${suffix}`,
+        link: `${filePath}#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}${suffix}`,
+        rawLink: `${filePath}#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}${suffix}`,
         linkType: linkType === LinkType.Regular ? 'regular' : 'portable',
         rangeFormat: 'WithPositions',
         selectionType: 'Normal',
@@ -849,13 +852,13 @@ describe('formatLink', () => {
         selectionType: SelectionType.Rectangular,
       };
 
-      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
+      const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS, {
         linkType,
       });
 
       expect(result).toBeSuccess({
-        link: `src/file.ts##L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine + 1}C${expectedEndPosition}${suffix}`,
-        rawLink: `src/file.ts##L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine + 1}C${expectedEndPosition}${suffix}`,
+        link: `${filePath}##L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine + 1}C${expectedEndPosition}${suffix}`,
+        rawLink: `${filePath}##L${expectedStartLine}C${expectedStartPosition}-L${expectedStartLine + 1}C${expectedEndPosition}${suffix}`,
         linkType: linkType === LinkType.Regular ? 'regular' : 'portable',
         rangeFormat: 'WithPositions',
         selectionType: 'Rectangular',
@@ -876,7 +879,7 @@ describe('formatLink', () => {
         selectionType: SelectionType.Normal,
       };
 
-      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
+      const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS, {
         linkType,
       });
 
@@ -970,11 +973,11 @@ describe('formatLink', () => {
         selectionType: SelectionType.Normal,
       };
 
-      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS);
+      const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS);
 
       expect(result).toBeSuccessWith((value) => {
-        expect(value.link).toBe(`src/file.ts#L${expectedStartLine}`);
-        expect(value.rawLink).toBe(`src/file.ts#L${expectedStartLine}`);
+        expect(value.link).toBe(`${filePath}#L${expectedStartLine}`);
+        expect(value.rawLink).toBe(`${filePath}#L${expectedStartLine}`);
       });
     });
   });
@@ -1000,9 +1003,9 @@ describe('formatLink', () => {
         selectionType: SelectionType.Normal,
       };
 
-      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS);
+      const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS);
 
-      const expectedLink = `src/file.ts#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}`;
+      const expectedLink = `${filePath}#L${expectedStartLine}C${expectedStartPosition}-L${expectedEndLine}C${expectedEndPosition}`;
       expect(result).toBeSuccess({
         link: expectedLink,
         rawLink: expectedLink,
@@ -1051,11 +1054,11 @@ describe('formatLink', () => {
         selectionType: SelectionType.Normal,
       };
 
-      const result = formatLink('src/file.ts', inputSelection, DEFAULT_DELIMITERS, {
+      const result = formatLink(filePath, inputSelection, DEFAULT_DELIMITERS, {
         linkType: LinkType.Portable,
       });
 
-      const expectedLink = `src/file.ts#L${expectedStartLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`;
+      const expectedLink = `${filePath}#L${expectedStartLine}${byodSuffix(DEFAULT_DELIMITERS, false)}`;
       expect(result).toBeSuccess({
         link: expectedLink,
         rawLink: expectedLink,

--- a/packages/rangelink-core-ts/src/__tests__/selection/validateNormalMode.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/selection/validateNormalMode.test.ts
@@ -4,6 +4,8 @@ import { SelectionCoverage } from '../../types/SelectionCoverage';
 
 import { getUniqueInt } from '@couimet/dynamic-testing';
 
+const COORDINATE_OFFSET = 10;
+
 describe('validateNormalMode', () => {
   let startLine: number;
   let endLine: number;
@@ -12,9 +14,9 @@ describe('validateNormalMode', () => {
 
   beforeEach(() => {
     startLine = getUniqueInt();
-    endLine = startLine + 10;
+    endLine = startLine + COORDINATE_OFFSET;
     startChar = getUniqueInt();
-    endChar = startChar + 10;
+    endChar = startChar + COORDINATE_OFFSET;
   });
 
   describe('Multiple selections not allowed', () => {

--- a/packages/rangelink-core-ts/src/__tests__/selection/validateNormalMode.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/selection/validateNormalMode.test.ts
@@ -2,18 +2,32 @@ import { validateNormalMode } from '../../selection/validateNormalMode';
 import { InputSelection } from '../../types/InputSelection';
 import { SelectionCoverage } from '../../types/SelectionCoverage';
 
+import { getUniqueInt } from '@couimet/dynamic-testing';
+
 describe('validateNormalMode', () => {
+  let startLine: number;
+  let endLine: number;
+  let startChar: number;
+  let endChar: number;
+
+  beforeEach(() => {
+    startLine = getUniqueInt();
+    endLine = startLine + 10;
+    startChar = getUniqueInt();
+    endChar = startChar + 10;
+  });
+
   describe('Multiple selections not allowed', () => {
     it('should throw error for 2 selections', () => {
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 10, character: 5 },
-          end: { line: 10, character: 15 },
+          start: { line: startLine, character: startChar },
+          end: { line: startLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 15, character: 0 },
-          end: { line: 15, character: 10 },
+          start: { line: endLine, character: 0 },
+          end: { line: endLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
@@ -28,18 +42,18 @@ describe('validateNormalMode', () => {
     it('should throw error for 3 selections', () => {
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 10, character: 5 },
-          end: { line: 10, character: 15 },
+          start: { line: startLine, character: startChar },
+          end: { line: startLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 15, character: 0 },
-          end: { line: 15, character: 10 },
+          start: { line: endLine, character: 0 },
+          end: { line: endLine, character: startChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 20, character: 0 },
-          end: { line: 20, character: 10 },
+          start: { line: endLine + 5, character: 0 },
+          end: { line: endLine + 5, character: startChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
@@ -53,8 +67,8 @@ describe('validateNormalMode', () => {
 
     it('should throw error for 10 selections', () => {
       const selections: InputSelection['selections'] = Array.from({ length: 10 }, (_, i) => ({
-        start: { line: i * 10, character: 0 },
-        end: { line: i * 10, character: 10 },
+        start: { line: startLine + i * 5, character: 0 },
+        end: { line: startLine + i * 5, character: endChar },
         coverage: SelectionCoverage.PartialLine,
       }));
 
@@ -82,8 +96,8 @@ describe('validateNormalMode', () => {
     it('should not throw for single selection', () => {
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 10, character: 5 },
-          end: { line: 20, character: 15 },
+          start: { line: startLine, character: startChar },
+          end: { line: endLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
@@ -94,8 +108,8 @@ describe('validateNormalMode', () => {
     it('should not throw for single-line selection', () => {
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 42, character: 10 },
-          end: { line: 42, character: 50 },
+          start: { line: startLine, character: startChar },
+          end: { line: startLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
@@ -106,8 +120,8 @@ describe('validateNormalMode', () => {
     it('should not throw for multi-line selection', () => {
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 10, character: 5 },
-          end: { line: 100, character: 20 },
+          start: { line: startLine, character: startChar },
+          end: { line: endLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
@@ -119,7 +133,7 @@ describe('validateNormalMode', () => {
       const selections: InputSelection['selections'] = [
         {
           start: { line: 0, character: 0 },
-          end: { line: 0, character: 10 },
+          end: { line: 0, character: startChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];

--- a/packages/rangelink-core-ts/src/__tests__/selection/validateNormalMode.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/selection/validateNormalMode.test.ts
@@ -2,7 +2,7 @@ import { validateNormalMode } from '../../selection/validateNormalMode';
 import { InputSelection } from '../../types/InputSelection';
 import { SelectionCoverage } from '../../types/SelectionCoverage';
 
-import { getUniqueInt } from '@couimet/dynamic-testing';
+import { getRandomInt, getUniqueInt } from '@couimet/dynamic-testing';
 
 const COORDINATE_OFFSET = 10;
 
@@ -42,6 +42,7 @@ describe('validateNormalMode', () => {
     });
 
     it('should throw error for 3 selections', () => {
+      const additionalLineOffset = getRandomInt(2, 10);
       const selections: InputSelection['selections'] = [
         {
           start: { line: startLine, character: startChar },
@@ -54,8 +55,8 @@ describe('validateNormalMode', () => {
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: endLine + 5, character: 0 },
-          end: { line: endLine + 5, character: startChar },
+          start: { line: endLine + additionalLineOffset, character: 0 },
+          end: { line: endLine + additionalLineOffset, character: startChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
@@ -68,9 +69,10 @@ describe('validateNormalMode', () => {
     });
 
     it('should throw error for 10 selections', () => {
+      const lineSpacing = getRandomInt(2, 10);
       const selections: InputSelection['selections'] = Array.from({ length: 10 }, (_, i) => ({
-        start: { line: startLine + i * 5, character: 0 },
-        end: { line: startLine + i * 5, character: endChar },
+        start: { line: startLine + i * lineSpacing, character: 0 },
+        end: { line: startLine + i * lineSpacing, character: endChar },
         coverage: SelectionCoverage.PartialLine,
       }));
 

--- a/packages/rangelink-core-ts/src/__tests__/selection/validateRectangularMode.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/selection/validateRectangularMode.test.ts
@@ -2,7 +2,7 @@ import { validateRectangularMode } from '../../selection/validateRectangularMode
 import { InputSelection } from '../../types/InputSelection';
 import { SelectionCoverage } from '../../types/SelectionCoverage';
 
-import { getUniqueInt } from '@couimet/dynamic-testing';
+import { getRandomInt, getUniqueInt } from '@couimet/dynamic-testing';
 
 const COORDINATE_OFFSET = 10;
 
@@ -27,7 +27,7 @@ describe('validateRectangularMode', () => {
 
   describe('Single-line requirement', () => {
     it('should throw error when selection spans multiple lines', () => {
-      const endLine = startLine + 2;
+      const endLine = startLine + getRandomInt(2, 5);
       const selections: InputSelection['selections'] = [
         {
           start: { line: startLine, character: startChar },
@@ -49,7 +49,7 @@ describe('validateRectangularMode', () => {
 
     it('should throw error for second selection spanning multiple lines', () => {
       const badStartLine = startLine + 1;
-      const badEndLine = startLine + 3;
+      const badEndLine = badStartLine + getRandomInt(2, 5);
       const selections: InputSelection['selections'] = [
         {
           start: { line: startLine, character: startChar },
@@ -89,7 +89,7 @@ describe('validateRectangularMode', () => {
 
   describe('Consistent column range requirement', () => {
     it('should throw error for mismatched startCharacter', () => {
-      const mismatchedStartChar = startChar + 2;
+      const mismatchedStartChar = startChar + getRandomInt(1, 5);
       const selections: InputSelection['selections'] = [
         {
           start: { line: startLine, character: startChar },
@@ -117,7 +117,7 @@ describe('validateRectangularMode', () => {
     });
 
     it('should throw error for mismatched endCharacter', () => {
-      const mismatchedEndChar = endChar + 2;
+      const mismatchedEndChar = endChar + getRandomInt(1, 5);
       const selections: InputSelection['selections'] = [
         {
           start: { line: startLine, character: startChar },
@@ -145,8 +145,8 @@ describe('validateRectangularMode', () => {
     });
 
     it('should throw error for both startCharacter and endCharacter mismatched', () => {
-      const mismatchedStartChar = startChar - 2;
-      const mismatchedEndChar = endChar + 5;
+      const mismatchedStartChar = startChar - getRandomInt(1, 5);
+      const mismatchedEndChar = endChar + getRandomInt(1, 5);
       const selections: InputSelection['selections'] = [
         {
           start: { line: startLine, character: startChar },
@@ -198,7 +198,7 @@ describe('validateRectangularMode', () => {
 
   describe('Sorted by line number requirement', () => {
     it('should throw error for unsorted selections', () => {
-      const outOfOrderLine = startLine - 2;
+      const outOfOrderLine = startLine - getRandomInt(2, 5);
       const selections: InputSelection['selections'] = [
         {
           start: { line: startLine, character: startChar },
@@ -224,8 +224,9 @@ describe('validateRectangularMode', () => {
     });
 
     it('should throw error when middle selection is out of order', () => {
-      const jumpAheadLine = startLine + 5;
-      const outOfOrderLine = startLine + 2;
+      const outOfOrderDelta = getRandomInt(1, 5);
+      const jumpAheadLine = startLine + getRandomInt(outOfOrderDelta + 1, outOfOrderDelta + 5);
+      const outOfOrderLine = startLine + outOfOrderDelta;
       const selections: InputSelection['selections'] = [
         {
           start: { line: startLine, character: startChar },
@@ -280,7 +281,8 @@ describe('validateRectangularMode', () => {
 
   describe('Contiguous lines requirement', () => {
     it('should throw error for non-contiguous lines (gap of 1)', () => {
-      const skippedLine = startLine + 2;
+      const gap = getRandomInt(1, 5);
+      const skippedLine = startLine + gap + 1;
       const selections: InputSelection['selections'] = [
         {
           start: { line: startLine, character: startChar },
@@ -301,13 +303,14 @@ describe('validateRectangularMode', () => {
           selectionIndex: 1,
           previousLine: startLine,
           currentLine: skippedLine,
-          gap: 1,
+          gap,
         },
       });
     });
 
     it('should throw error for non-contiguous lines (gap of 5)', () => {
-      const skippedLine = startLine + 6;
+      const gap = getRandomInt(5, 10);
+      const skippedLine = startLine + gap + 1;
       const selections: InputSelection['selections'] = [
         {
           start: { line: startLine, character: startChar },
@@ -328,7 +331,7 @@ describe('validateRectangularMode', () => {
           selectionIndex: 1,
           previousLine: startLine,
           currentLine: skippedLine,
-          gap: 5,
+          gap,
         },
       });
     });

--- a/packages/rangelink-core-ts/src/__tests__/selection/validateRectangularMode.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/selection/validateRectangularMode.test.ts
@@ -2,59 +2,72 @@ import { validateRectangularMode } from '../../selection/validateRectangularMode
 import { InputSelection } from '../../types/InputSelection';
 import { SelectionCoverage } from '../../types/SelectionCoverage';
 
+import { getUniqueInt } from '@couimet/dynamic-testing';
+
 describe('validateRectangularMode', () => {
+  let startLine: number;
+  let startChar: number;
+  let endChar: number;
+
+  beforeEach(() => {
+    startLine = getUniqueInt();
+    startChar = getUniqueInt();
+    endChar = startChar + 10;
+  });
+
   describe('Empty selections array (defensive guard)', () => {
     it('should return early for empty array without throwing', () => {
       const selections: InputSelection['selections'] = [];
 
-      // This tests the defensive guard at line 127 (now line 18 in new module)
-      // Should not throw - just returns early
       validateRectangularMode(selections);
     });
   });
 
   describe('Single-line requirement', () => {
     it('should throw error when selection spans multiple lines', () => {
+      const endLine = startLine + 2;
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 10, character: 5 },
-          end: { line: 12, character: 15 }, // Multi-line
+          start: { line: startLine, character: startChar },
+          end: { line: endLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
 
       expect(() => validateRectangularMode(selections)).toThrowDetailedError('SELECTION_RECTANGULAR_MULTILINE', {
-        message: 'Rectangular mode requires single-line selections (selection 0 spans lines 10-12)',
+        message: `Rectangular mode requires single-line selections (selection 0 spans lines ${startLine}-${endLine})`,
         functionName: 'validateRectangularMode',
         details: {
           selectionIndex: 0,
-          startLine: 10,
-          endLine: 12,
+          startLine,
+          endLine,
         },
       });
     });
 
     it('should throw error for second selection spanning multiple lines', () => {
+      const badStartLine = startLine + 1;
+      const badEndLine = startLine + 3;
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 10, character: 5 },
-          end: { line: 10, character: 15 },
+          start: { line: startLine, character: startChar },
+          end: { line: startLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 11, character: 5 },
-          end: { line: 13, character: 15 }, // Multi-line
+          start: { line: badStartLine, character: startChar },
+          end: { line: badEndLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
 
       expect(() => validateRectangularMode(selections)).toThrowDetailedError('SELECTION_RECTANGULAR_MULTILINE', {
-        message: 'Rectangular mode requires single-line selections (selection 1 spans lines 11-13)',
+        message: `Rectangular mode requires single-line selections (selection 1 spans lines ${badStartLine}-${badEndLine})`,
         functionName: 'validateRectangularMode',
         details: {
           selectionIndex: 1,
-          startLine: 11,
-          endLine: 13,
+          startLine: badStartLine,
+          endLine: badEndLine,
         },
       });
     });
@@ -62,8 +75,8 @@ describe('validateRectangularMode', () => {
     it('should not throw for valid single-line selection', () => {
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 10, character: 5 },
-          end: { line: 10, character: 15 },
+          start: { line: startLine, character: startChar },
+          end: { line: startLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
@@ -74,82 +87,86 @@ describe('validateRectangularMode', () => {
 
   describe('Consistent column range requirement', () => {
     it('should throw error for mismatched startCharacter', () => {
+      const mismatchedStartChar = startChar + 2;
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 10, character: 5 },
-          end: { line: 10, character: 15 },
+          start: { line: startLine, character: startChar },
+          end: { line: startLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 11, character: 7 }, // Mismatched
-          end: { line: 11, character: 15 },
+          start: { line: startLine + 1, character: mismatchedStartChar },
+          end: { line: startLine + 1, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
 
       expect(() => validateRectangularMode(selections)).toThrowDetailedError('SELECTION_RECTANGULAR_MISMATCHED_COLUMNS', {
-        message: 'Rectangular mode requires consistent column range (expected 5-15, got 7-15 at selection 1)',
+        message: `Rectangular mode requires consistent column range (expected ${startChar}-${endChar}, got ${mismatchedStartChar}-${endChar} at selection 1)`,
         functionName: 'validateRectangularMode',
         details: {
           selectionIndex: 1,
-          expectedStartCharacter: 5,
-          expectedEndCharacter: 15,
-          actualStartCharacter: 7,
-          actualEndCharacter: 15,
+          expectedStartCharacter: startChar,
+          expectedEndCharacter: endChar,
+          actualStartCharacter: mismatchedStartChar,
+          actualEndCharacter: endChar,
         },
       });
     });
 
     it('should throw error for mismatched endCharacter', () => {
+      const mismatchedEndChar = endChar + 2;
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 10, character: 5 },
-          end: { line: 10, character: 15 },
+          start: { line: startLine, character: startChar },
+          end: { line: startLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 11, character: 5 },
-          end: { line: 11, character: 17 }, // Mismatched
+          start: { line: startLine + 1, character: startChar },
+          end: { line: startLine + 1, character: mismatchedEndChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
 
       expect(() => validateRectangularMode(selections)).toThrowDetailedError('SELECTION_RECTANGULAR_MISMATCHED_COLUMNS', {
-        message: 'Rectangular mode requires consistent column range (expected 5-15, got 5-17 at selection 1)',
+        message: `Rectangular mode requires consistent column range (expected ${startChar}-${endChar}, got ${startChar}-${mismatchedEndChar} at selection 1)`,
         functionName: 'validateRectangularMode',
         details: {
           selectionIndex: 1,
-          expectedStartCharacter: 5,
-          expectedEndCharacter: 15,
-          actualStartCharacter: 5,
-          actualEndCharacter: 17,
+          expectedStartCharacter: startChar,
+          expectedEndCharacter: endChar,
+          actualStartCharacter: startChar,
+          actualEndCharacter: mismatchedEndChar,
         },
       });
     });
 
     it('should throw error for both startCharacter and endCharacter mismatched', () => {
+      const mismatchedStartChar = startChar - 2;
+      const mismatchedEndChar = endChar + 5;
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 10, character: 5 },
-          end: { line: 10, character: 15 },
+          start: { line: startLine, character: startChar },
+          end: { line: startLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 11, character: 3 }, // Both mismatched
-          end: { line: 11, character: 20 },
+          start: { line: startLine + 1, character: mismatchedStartChar },
+          end: { line: startLine + 1, character: mismatchedEndChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
 
       expect(() => validateRectangularMode(selections)).toThrowDetailedError('SELECTION_RECTANGULAR_MISMATCHED_COLUMNS', {
-        message: 'Rectangular mode requires consistent column range (expected 5-15, got 3-20 at selection 1)',
+        message: `Rectangular mode requires consistent column range (expected ${startChar}-${endChar}, got ${mismatchedStartChar}-${mismatchedEndChar} at selection 1)`,
         functionName: 'validateRectangularMode',
         details: {
           selectionIndex: 1,
-          expectedStartCharacter: 5,
-          expectedEndCharacter: 15,
-          actualStartCharacter: 3,
-          actualEndCharacter: 20,
+          expectedStartCharacter: startChar,
+          expectedEndCharacter: endChar,
+          actualStartCharacter: mismatchedStartChar,
+          actualEndCharacter: mismatchedEndChar,
         },
       });
     });
@@ -157,18 +174,18 @@ describe('validateRectangularMode', () => {
     it('should not throw for consistent column ranges', () => {
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 10, character: 5 },
-          end: { line: 10, character: 15 },
+          start: { line: startLine, character: startChar },
+          end: { line: startLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 11, character: 5 },
-          end: { line: 11, character: 15 },
+          start: { line: startLine + 1, character: startChar },
+          end: { line: startLine + 1, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 12, character: 5 },
-          end: { line: 12, character: 15 },
+          start: { line: startLine + 2, character: startChar },
+          end: { line: startLine + 2, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
@@ -179,56 +196,59 @@ describe('validateRectangularMode', () => {
 
   describe('Sorted by line number requirement', () => {
     it('should throw error for unsorted selections', () => {
+      const outOfOrderLine = startLine - 2;
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 10, character: 5 },
-          end: { line: 10, character: 15 },
+          start: { line: startLine, character: startChar },
+          end: { line: startLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 8, character: 5 }, // Out of order
-          end: { line: 8, character: 15 },
+          start: { line: outOfOrderLine, character: startChar },
+          end: { line: outOfOrderLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
 
       expect(() => validateRectangularMode(selections)).toThrowDetailedError('SELECTION_RECTANGULAR_UNSORTED', {
-        message: 'Rectangular mode selections must be sorted by line number (line 8 comes after line 10)',
+        message: `Rectangular mode selections must be sorted by line number (line ${outOfOrderLine} comes after line ${startLine})`,
         functionName: 'validateRectangularMode',
         details: {
           selectionIndex: 1,
-          previousLine: 10,
-          currentLine: 8,
+          previousLine: startLine,
+          currentLine: outOfOrderLine,
         },
       });
     });
 
     it('should throw error when middle selection is out of order', () => {
+      const jumpAheadLine = startLine + 5;
+      const outOfOrderLine = startLine + 2;
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 10, character: 5 },
-          end: { line: 10, character: 15 },
+          start: { line: startLine, character: startChar },
+          end: { line: startLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 15, character: 5 }, // Jump ahead
-          end: { line: 15, character: 15 },
+          start: { line: jumpAheadLine, character: startChar },
+          end: { line: jumpAheadLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 12, character: 5 }, // Out of order
-          end: { line: 12, character: 15 },
+          start: { line: outOfOrderLine, character: startChar },
+          end: { line: outOfOrderLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
 
       expect(() => validateRectangularMode(selections)).toThrowDetailedError('SELECTION_RECTANGULAR_UNSORTED', {
-        message: 'Rectangular mode selections must be sorted by line number (line 12 comes after line 15)',
+        message: `Rectangular mode selections must be sorted by line number (line ${outOfOrderLine} comes after line ${jumpAheadLine})`,
         functionName: 'validateRectangularMode',
         details: {
           selectionIndex: 2,
-          previousLine: 15,
-          currentLine: 12,
+          previousLine: jumpAheadLine,
+          currentLine: outOfOrderLine,
         },
       });
     });
@@ -236,18 +256,18 @@ describe('validateRectangularMode', () => {
     it('should not throw for properly sorted selections', () => {
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 10, character: 5 },
-          end: { line: 10, character: 15 },
+          start: { line: startLine, character: startChar },
+          end: { line: startLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 11, character: 5 },
-          end: { line: 11, character: 15 },
+          start: { line: startLine + 1, character: startChar },
+          end: { line: startLine + 1, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 12, character: 5 },
-          end: { line: 12, character: 15 },
+          start: { line: startLine + 2, character: startChar },
+          end: { line: startLine + 2, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
@@ -258,52 +278,54 @@ describe('validateRectangularMode', () => {
 
   describe('Contiguous lines requirement', () => {
     it('should throw error for non-contiguous lines (gap of 1)', () => {
+      const skippedLine = startLine + 2;
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 10, character: 5 },
-          end: { line: 10, character: 15 },
+          start: { line: startLine, character: startChar },
+          end: { line: startLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 12, character: 5 }, // Gap (missing line 11)
-          end: { line: 12, character: 15 },
+          start: { line: skippedLine, character: startChar },
+          end: { line: skippedLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
 
       expect(() => validateRectangularMode(selections)).toThrowDetailedError('SELECTION_RECTANGULAR_NON_CONTIGUOUS', {
-        message: 'Rectangular mode requires contiguous lines (gap between line 10 and 12)',
+        message: `Rectangular mode requires contiguous lines (gap between line ${startLine} and ${skippedLine})`,
         functionName: 'validateRectangularMode',
         details: {
           selectionIndex: 1,
-          previousLine: 10,
-          currentLine: 12,
+          previousLine: startLine,
+          currentLine: skippedLine,
           gap: 1,
         },
       });
     });
 
     it('should throw error for non-contiguous lines (gap of 5)', () => {
+      const skippedLine = startLine + 6;
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 10, character: 5 },
-          end: { line: 10, character: 15 },
+          start: { line: startLine, character: startChar },
+          end: { line: startLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 16, character: 5 }, // Gap (missing lines 11-15)
-          end: { line: 16, character: 15 },
+          start: { line: skippedLine, character: startChar },
+          end: { line: skippedLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
 
       expect(() => validateRectangularMode(selections)).toThrowDetailedError('SELECTION_RECTANGULAR_NON_CONTIGUOUS', {
-        message: 'Rectangular mode requires contiguous lines (gap between line 10 and 16)',
+        message: `Rectangular mode requires contiguous lines (gap between line ${startLine} and ${skippedLine})`,
         functionName: 'validateRectangularMode',
         details: {
           selectionIndex: 1,
-          previousLine: 10,
-          currentLine: 16,
+          previousLine: startLine,
+          currentLine: skippedLine,
           gap: 5,
         },
       });
@@ -312,23 +334,23 @@ describe('validateRectangularMode', () => {
     it('should not throw for contiguous lines', () => {
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 10, character: 5 },
-          end: { line: 10, character: 15 },
+          start: { line: startLine, character: startChar },
+          end: { line: startLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 11, character: 5 },
-          end: { line: 11, character: 15 },
+          start: { line: startLine + 1, character: startChar },
+          end: { line: startLine + 1, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 12, character: 5 },
-          end: { line: 12, character: 15 },
+          start: { line: startLine + 2, character: startChar },
+          end: { line: startLine + 2, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 13, character: 5 },
-          end: { line: 13, character: 15 },
+          start: { line: startLine + 3, character: startChar },
+          end: { line: startLine + 3, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
@@ -341,8 +363,8 @@ describe('validateRectangularMode', () => {
     it('should not throw for single valid rectangular selection', () => {
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 42, character: 10 },
-          end: { line: 42, character: 20 },
+          start: { line: startLine, character: startChar },
+          end: { line: startLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
@@ -353,18 +375,18 @@ describe('validateRectangularMode', () => {
     it('should not throw for valid rectangular block (3 lines)', () => {
       const selections: InputSelection['selections'] = [
         {
-          start: { line: 10, character: 5 },
-          end: { line: 10, character: 15 },
+          start: { line: startLine, character: startChar },
+          end: { line: startLine, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 11, character: 5 },
-          end: { line: 11, character: 15 },
+          start: { line: startLine + 1, character: startChar },
+          end: { line: startLine + 1, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
-          start: { line: 12, character: 5 },
-          end: { line: 12, character: 15 },
+          start: { line: startLine + 2, character: startChar },
+          end: { line: startLine + 2, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
@@ -376,12 +398,12 @@ describe('validateRectangularMode', () => {
       const selections: InputSelection['selections'] = [
         {
           start: { line: 0, character: 0 },
-          end: { line: 0, character: 10 },
+          end: { line: 0, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
         {
           start: { line: 1, character: 0 },
-          end: { line: 1, character: 10 },
+          end: { line: 1, character: endChar },
           coverage: SelectionCoverage.PartialLine,
         },
       ];
@@ -391,8 +413,8 @@ describe('validateRectangularMode', () => {
 
     it('should not throw for large rectangular block (10 lines)', () => {
       const selections: InputSelection['selections'] = Array.from({ length: 10 }, (_, i) => ({
-        start: { line: 100 + i, character: 20 },
-        end: { line: 100 + i, character: 50 },
+        start: { line: startLine + i, character: startChar },
+        end: { line: startLine + i, character: endChar },
         coverage: SelectionCoverage.PartialLine,
       }));
 

--- a/packages/rangelink-core-ts/src/__tests__/selection/validateRectangularMode.test.ts
+++ b/packages/rangelink-core-ts/src/__tests__/selection/validateRectangularMode.test.ts
@@ -4,6 +4,8 @@ import { SelectionCoverage } from '../../types/SelectionCoverage';
 
 import { getUniqueInt } from '@couimet/dynamic-testing';
 
+const COORDINATE_OFFSET = 10;
+
 describe('validateRectangularMode', () => {
   let startLine: number;
   let startChar: number;
@@ -12,7 +14,7 @@ describe('validateRectangularMode', () => {
   beforeEach(() => {
     startLine = getUniqueInt();
     startChar = getUniqueInt();
-    endChar = startChar + 10;
+    endChar = startChar + COORDINATE_OFFSET;
   });
 
   describe('Empty selections array (defensive guard)', () => {

--- a/packages/rangelink-core-ts/src/external-deps/couimet/dynamic-testing/uniqueFilePath.ts
+++ b/packages/rangelink-core-ts/src/external-deps/couimet/dynamic-testing/uniqueFilePath.ts
@@ -9,6 +9,8 @@ const MAXLENGTH_TOO_SMALL = 'MAXLENGTH_TOO_SMALL';
 const DEFAULT_DEPTH = 3;
 const DEFAULT_SEPARATOR = '/';
 const DEFAULT_ROOT = '/home/user/project';
+const DEFAULT_SUFFIX_PREFIX_LENGTH = 6;
+const DEFAULT_FILENAME_PREFIX_LENGTH = 6;
 
 const CURATED_FOLDERS = [
   'src',
@@ -58,7 +60,7 @@ const normalizeExtension = (ext: string): string => (ext.startsWith('.') ? ext :
 
 const pickRandom = <T>(arr: readonly T[]): T => arr[getRandomInt(0, arr.length - 1)];
 
-const generateUniqueSuffix = (): string => `${getRandomAlphaString(6)}-${getUniqueInt()}`;
+const generateUniqueSuffix = (): string => `${getRandomAlphaString(DEFAULT_SUFFIX_PREFIX_LENGTH)}-${getUniqueInt()}`;
 
 const buildFolders = (explicit: string[] | undefined, depth: number): string[] => {
   if (explicit !== undefined) return explicit;
@@ -88,12 +90,12 @@ const buildFilename = (
     if (maxLength !== undefined && maxLength <= ext.length) {
       throw new Error(`${MAXLENGTH_TOO_SMALL}: maxLength (${maxLength}) too small for filename (extension alone = ${ext.length} chars)`);
     }
-    const len = maxLength !== undefined ? maxLength - ext.length : 6;
+    const len = maxLength !== undefined ? maxLength - ext.length : DEFAULT_FILENAME_PREFIX_LENGTH;
     return { value: `${getRandomAlphaString(len)}${ext}`, isExplicit: false };
   }
 
   const suffix = `-${getUniqueInt()}`;
-  const maxPrefixLen = maxLength !== undefined ? maxLength - suffix.length - ext.length : 6;
+  const maxPrefixLen = maxLength !== undefined ? maxLength - suffix.length - ext.length : DEFAULT_FILENAME_PREFIX_LENGTH;
   if (maxLength !== undefined && maxPrefixLen < 1) {
     throw new Error(
       `${MAXLENGTH_TOO_SMALL}: maxLength (${maxLength}) too small for minimum filename (suffix + extension = ${suffix.length + ext.length} chars)`,

--- a/packages/rangelink-core-ts/src/external-deps/couimet/dynamic-testing/uniqueFilePath.ts
+++ b/packages/rangelink-core-ts/src/external-deps/couimet/dynamic-testing/uniqueFilePath.ts
@@ -86,9 +86,7 @@ const buildFilename = (
 
   if (!unique) {
     if (maxLength !== undefined && maxLength <= ext.length) {
-      throw new Error(
-        `${MAXLENGTH_TOO_SMALL}: maxLength (${maxLength}) too small for filename (extension alone = ${ext.length} chars)`,
-      );
+      throw new Error(`${MAXLENGTH_TOO_SMALL}: maxLength (${maxLength}) too small for filename (extension alone = ${ext.length} chars)`);
     }
     const len = maxLength !== undefined ? maxLength - ext.length : 6;
     return { value: `${getRandomAlphaString(len)}${ext}`, isExplicit: false };

--- a/packages/rangelink-core-ts/src/external-deps/couimet/dynamic-testing/uniqueFilePath.ts
+++ b/packages/rangelink-core-ts/src/external-deps/couimet/dynamic-testing/uniqueFilePath.ts
@@ -85,7 +85,12 @@ const buildFilename = (
   const ext = extension !== undefined ? normalizeExtension(extension) : getUniqueFileExtension();
 
   if (!unique) {
-    const len = maxLength !== undefined ? Math.max(1, maxLength - ext.length) : 6;
+    if (maxLength !== undefined && maxLength <= ext.length) {
+      throw new Error(
+        `${MAXLENGTH_TOO_SMALL}: maxLength (${maxLength}) too small for filename (extension alone = ${ext.length} chars)`,
+      );
+    }
+    const len = maxLength !== undefined ? maxLength - ext.length : 6;
     return { value: `${getRandomAlphaString(len)}${ext}`, isExplicit: false };
   }
 
@@ -157,7 +162,7 @@ export const getUniqueAbsolutePath = (options: UniqueFilePathOptions = {}): stri
 
 /** Returns `count` unique relative file paths. */
 export const getUniqueRelativePaths = (count: number, options?: UniqueFilePathOptions): string[] => {
-  if (count < 1) {
+  if (count < 1 || !Number.isInteger(count)) {
     throw new Error(`COUNT_NOT_POSITIVE_INTEGER: count must be a positive integer, received ${count}`);
   }
   return Array.from({ length: count }, () => getUniqueRelativePath(options));
@@ -173,7 +178,7 @@ export const getUniqueRelativePathsNamed = <K extends string>(keys: readonly K[]
 
 /** Returns `count` unique absolute file paths. */
 export const getUniqueAbsolutePaths = (count: number, options?: UniqueFilePathOptions): string[] => {
-  if (count < 1) {
+  if (count < 1 || !Number.isInteger(count)) {
     throw new Error(`COUNT_NOT_POSITIVE_INTEGER: count must be a positive integer, received ${count}`);
   }
   return Array.from({ length: count }, () => getUniqueAbsolutePath(options));

--- a/packages/rangelink-core-ts/src/external-deps/couimet/dynamic-testing/uniqueFilePath.ts
+++ b/packages/rangelink-core-ts/src/external-deps/couimet/dynamic-testing/uniqueFilePath.ts
@@ -1,0 +1,188 @@
+import { getRandomAlphaString, getRandomInt, getUniqueInt } from '@couimet/dynamic-testing';
+
+// Error codes — plain Error pattern matching rabbit-maximizer incubation style.
+// Converted to DetailedError when contributed upstream.
+const FILENAME_BASENAME_CONFLICT = 'FILENAME_BASENAME_CONFLICT';
+const UNIQUE_PATH_NO_DIRECTORY = 'UNIQUE_PATH_NO_DIRECTORY';
+const MAXLENGTH_TOO_SMALL = 'MAXLENGTH_TOO_SMALL';
+
+const DEFAULT_DEPTH = 3;
+const DEFAULT_SEPARATOR = '/';
+const DEFAULT_ROOT = '/home/user/project';
+
+const CURATED_FOLDERS = [
+  'src',
+  'lib',
+  'utils',
+  'helpers',
+  'components',
+  'services',
+  'hooks',
+  'types',
+  'config',
+  'tests',
+  '__tests__',
+  'docs',
+  'assets',
+  'styles',
+  'data',
+  'models',
+  'views',
+  'controllers',
+  'middleware',
+  'routes',
+  'handlers',
+  'validators',
+  'formatters',
+  'parsers',
+  'adapters',
+  'repositories',
+];
+
+const CURATED_EXTENSIONS = ['ts', 'js', 'json', 'tsx', 'jsx', 'css', 'html', 'md', 'txt'];
+
+export interface UniqueFilePathOptions {
+  depth?: number;
+  folders?: string[];
+  upLevels?: number;
+  filename?: string;
+  basename?: string;
+  extension?: string;
+  maxLength?: number;
+  unique?: boolean;
+  separator?: string;
+  root?: string;
+}
+
+const normalizeExtension = (ext: string): string => (ext.startsWith('.') ? ext : `.${ext}`);
+
+const pickRandom = <T>(arr: readonly T[]): T => arr[getRandomInt(0, arr.length - 1)];
+
+const generateUniqueSuffix = (): string => `${getRandomAlphaString(6)}-${getUniqueInt()}`;
+
+const buildFolders = (explicit: string[] | undefined, depth: number): string[] => {
+  if (explicit !== undefined) return explicit;
+  return Array.from({ length: depth }, () => pickRandom(CURATED_FOLDERS));
+};
+
+const buildFilename = (
+  filename: string | undefined,
+  basename: string | undefined,
+  extension: string | undefined,
+  maxLength: number | undefined,
+  unique: boolean,
+): { value: string; isExplicit: boolean } => {
+  if (filename !== undefined) {
+    return { value: filename, isExplicit: true };
+  }
+
+  if (basename !== undefined) {
+    const ext = extension !== undefined ? normalizeExtension(extension) : getUniqueFileExtension();
+    return { value: `${basename}${ext}`, isExplicit: true };
+  }
+
+  // Auto-generated
+  const ext = extension !== undefined ? normalizeExtension(extension) : getUniqueFileExtension();
+
+  if (!unique) {
+    const len = maxLength !== undefined ? Math.max(1, maxLength - ext.length) : 6;
+    return { value: `${getRandomAlphaString(len)}${ext}`, isExplicit: false };
+  }
+
+  const suffix = `-${getUniqueInt()}`;
+  const maxPrefixLen = maxLength !== undefined ? maxLength - suffix.length - ext.length : 6;
+  if (maxLength !== undefined && maxPrefixLen < 1) {
+    throw new Error(
+      `${MAXLENGTH_TOO_SMALL}: maxLength (${maxLength}) too small for minimum filename (suffix + extension = ${suffix.length + ext.length} chars)`,
+    );
+  }
+  const prefix = getRandomAlphaString(Math.max(1, maxPrefixLen));
+  return { value: `${prefix}${suffix}${ext}`, isExplicit: false };
+};
+
+/** Returns a random file extension (with leading dot) from the curated common list. */
+export const getUniqueFileExtension = (): string => `.${pickRandom(CURATED_EXTENSIONS)}`;
+
+/** Returns a unique relative file path. */
+export const getUniqueRelativePath = (options: UniqueFilePathOptions = {}): string => {
+  const {
+    depth = DEFAULT_DEPTH,
+    folders: explicitFolders,
+    upLevels = 0,
+    filename,
+    basename,
+    extension,
+    maxLength,
+    unique = true,
+    separator = DEFAULT_SEPARATOR,
+  } = options;
+
+  if (filename !== undefined && (basename !== undefined || extension !== undefined)) {
+    throw new Error(`${FILENAME_BASENAME_CONFLICT}: filename cannot be combined with basename or extension`);
+  }
+
+  const { value: finalName, isExplicit: nameIsExplicit } = buildFilename(filename, basename, extension, maxLength, unique);
+
+  if (unique && nameIsExplicit && depth === 0 && explicitFolders === undefined) {
+    throw new Error(`${UNIQUE_PATH_NO_DIRECTORY}: depth must be at least 1 when filename/basename is explicit and unique is true; received depth=0`);
+  }
+
+  let folders = buildFolders(explicitFolders, depth);
+
+  if (unique) {
+    if (nameIsExplicit) {
+      // Suffix goes into the folder portion — either replace last auto folder
+      // or inject a new folder when all folders are caller-specified.
+      if (explicitFolders !== undefined) {
+        folders = [...folders, generateUniqueSuffix()];
+      } else {
+        folders = [...folders.slice(0, -1), generateUniqueSuffix()];
+      }
+    }
+    // When name is auto-generated, the suffix is already baked into finalName by buildFilename().
+  }
+
+  const upPrefix = upLevels > 0 ? `${'..' + separator}`.repeat(upLevels) : '';
+  const dirPart = folders.length > 0 ? folders.join(separator) + separator : '';
+  return `${upPrefix}${dirPart}${finalName}`;
+};
+
+/** Returns a unique absolute file path. */
+export const getUniqueAbsolutePath = (options: UniqueFilePathOptions = {}): string => {
+  const { root = DEFAULT_ROOT, separator = DEFAULT_SEPARATOR, ...rest } = options;
+  const relative = getUniqueRelativePath({ ...rest, separator });
+  const normalizedRoot = root.endsWith(separator) ? root.slice(0, -separator.length) : root;
+  return `${normalizedRoot}${separator}${relative}`;
+};
+
+/** Returns `count` unique relative file paths. */
+export const getUniqueRelativePaths = (count: number, options?: UniqueFilePathOptions): string[] => {
+  if (count < 1) {
+    throw new Error(`COUNT_NOT_POSITIVE_INTEGER: count must be a positive integer, received ${count}`);
+  }
+  return Array.from({ length: count }, () => getUniqueRelativePath(options));
+};
+
+/** Returns an object mapping each key to a unique relative file path. */
+export const getUniqueRelativePathsNamed = <K extends string>(keys: readonly K[], options?: UniqueFilePathOptions): Record<K, string> => {
+  if (keys.length === 0) {
+    throw new Error('KEYS_ARRAY_EMPTY: keys must not be empty');
+  }
+  return Object.fromEntries(keys.map((k) => [k, getUniqueRelativePath(options)])) as Record<K, string>;
+};
+
+/** Returns `count` unique absolute file paths. */
+export const getUniqueAbsolutePaths = (count: number, options?: UniqueFilePathOptions): string[] => {
+  if (count < 1) {
+    throw new Error(`COUNT_NOT_POSITIVE_INTEGER: count must be a positive integer, received ${count}`);
+  }
+  return Array.from({ length: count }, () => getUniqueAbsolutePath(options));
+};
+
+/** Returns an object mapping each key to a unique absolute file path. */
+export const getUniqueAbsolutePathsNamed = <K extends string>(keys: readonly K[], options?: UniqueFilePathOptions): Record<K, string> => {
+  if (keys.length === 0) {
+    throw new Error('KEYS_ARRAY_EMPTY: keys must not be empty');
+  }
+  return Object.fromEntries(keys.map((k) => [k, getUniqueAbsolutePath(options)])) as Record<K, string>;
+};

--- a/packages/rangelink-vscode-extension/package.json
+++ b/packages/rangelink-vscode-extension/package.json
@@ -970,7 +970,7 @@
   "devDependencies": {
     "@couimet/detailed-error-testing": "^0.1.5",
     "@couimet/detailed-result-testing": "^0.2.1",
-    "@couimet/dynamic-testing": "^0.1.0",
+    "@couimet/dynamic-testing": "^1.0.0",
     "@couimet/logger-contract-testing": "^1.0.0",
     "@types/jest": "^29.5.0",
     "@types/mocha": "^10.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1(@couimet/detailed-error-testing@0.1.5(@couimet/detailed-error@1.0.0)(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.130)))(@couimet/detailed-error@1.0.0)(@couimet/detailed-result@0.1.1(@couimet/detailed-error@1.0.0))(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.130))
       '@couimet/dynamic-testing':
-        specifier: ^0.1.0
-        version: 0.1.1
+        specifier: ^1.0.0
+        version: 1.0.0(@couimet/detailed-error@1.0.0)
       '@couimet/logger-contract-testing':
         specifier: ^1.0.0
         version: 1.0.1(@couimet/logger-contract@1.0.0)(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.130))
@@ -92,8 +92,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1(@couimet/detailed-error-testing@0.1.5(@couimet/detailed-error@1.0.0)(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.19.43)))(@couimet/detailed-error@1.0.0)(@couimet/detailed-result@0.1.1(@couimet/detailed-error@1.0.0))(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.19.43))
       '@couimet/dynamic-testing':
-        specifier: ^0.1.0
-        version: 0.1.1
+        specifier: ^1.0.0
+        version: 1.0.0(@couimet/detailed-error@1.0.0)
       '@couimet/logger-contract-testing':
         specifier: ^1.0.0
         version: 1.0.1(@couimet/logger-contract@1.0.0)(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.19.43))
@@ -386,9 +386,10 @@ packages:
     peerDependencies:
       '@couimet/detailed-error': '>=1.0.0'
 
-  '@couimet/dynamic-testing@0.1.1':
-    resolution: {integrity: sha512-7rf2k8GYRRxk2X5lhOV+HDZuG3dPdgfyzj6qaNz4Ms4JBGebqmsrtNZbOgwNmteaJawwaqbDwE9fJf1ro2oDjg==}
+  '@couimet/dynamic-testing@1.0.0':
+    resolution: {integrity: sha512-JIKyuQFpSducoz+YXx+rHQ+X6KJXgbhKP7AxJ5I2Azv6v+hTRIXi0dbobkDKN/vpbuykMyyUIuS+6l42F7RbTA==}
     peerDependencies:
+      '@couimet/detailed-error': '>=1.0.0'
       decimal.js: '>=10.0.0'
     peerDependenciesMeta:
       decimal.js:
@@ -3100,6 +3101,10 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
+
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
@@ -3523,7 +3528,10 @@ snapshots:
     dependencies:
       '@couimet/detailed-error': 1.0.0
 
-  '@couimet/dynamic-testing@0.1.1': {}
+  '@couimet/dynamic-testing@1.0.0(@couimet/detailed-error@1.0.0)':
+    dependencies:
+      '@couimet/detailed-error': 1.0.0
+      uuid: 11.1.1
 
   '@couimet/eslint-config@1.1.0(@couimet/eslint-plugin-barrel-imports@0.1.0(eslint@10.8.0))(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@5.9.3))(eslint@10.8.0)(typescript@5.9.3))(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@5.9.3))(eslint-config-prettier@10.1.8(eslint@10.8.0))(eslint-plugin-barrel-boundary@1.1.1(eslint@10.8.0))(eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@10.8.0))(eslint@10.8.0)(prettier@3.9.6))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.0))(eslint-plugin-unicorn@72.0.0(eslint@10.8.0))(eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@5.9.3))(eslint@10.8.0)(typescript@5.9.3))(eslint@10.8.0))(eslint@10.8.0)(globals@16.5.0)(prettier@3.9.6)':
     dependencies:
@@ -6703,6 +6711,8 @@ snapshots:
   url-join@4.0.1: {}
 
   util-deprecate@1.0.2: {}
+
+  uuid@11.1.1: {}
 
   v8-to-istanbul@9.3.0:
     dependencies:


### PR DESCRIPTION
## Summary

Completes the test dynamism work started in PR #676. Upgrades @couimet/dynamic-testing from ^0.1.0 to ^1.0.0, converts 2 more test files to dynamically generated values, and incubates unique file path generation utilities for test use across the monorepo. Two files from the original plan were intentionally skipped after in-flight assessment showed their hardcoded values are semantically meaningful.

## Changes

- Upgraded @couimet/dynamic-testing from ^0.1.0 to ^1.0.0 across both packages — catches up through 5 releases with no breaking changes to functions already in use
- Converted validateRectangularMode.test.ts (70 hardcoded values) and validateNormalMode.test.ts (18 values) to getUniqueInt() with computed relationships, completing the validate*Mode module
- Converted formatLink.test.ts hardcoded 'src/file.ts' strings to getUniqueRelativePath() with the rabbit-maximizer pattern: capture the generated value as a const, reuse it in both mock setup and assertions
- Incubated uniqueFilePath.ts under external-deps/couimet/dynamic-testing/ with 8 exports (getUniqueRelativePath, getUniqueAbsolutePath, getUniqueFileExtension, plus batch/named variants), rich options API (depth, folders, separator, filename/basename/extension, upLevels, root, unique), and 53 tests at 100% branch coverage
- Intentionally skipped convertRangeLinkPosition.test.ts (boundary-condition values are the test contract) and RangeLinkNavigationHandler.test.ts (assertion-coupled linkText strings)

## Key Discoveries

- Faker's filePath() takes zero options — assessed and rejected as a building block. The incubated utility was built directly on @couimet/dynamic-testing primitives instead.
- The unique counter suffix moves to the rightmost auto-generated path component. When every component is caller-specified (explicit folders + explicit filename), a new auto-generated folder is injected to house the suffix. A unique: false escape hatch (following the allowTrailingZero precedent) lets callers bypass uniqueness when they guarantee it externally.

## Test Plan

- [x] All 2696 existing tests pass (616 core-ts + 2080 vscode-extension)
- [x] 53 new tests for uniqueFilePath with 100% statement, branch, function, and line coverage
- [x] Lint and format clean

## Related

- Closes https://github.com/couimet/rangeLink/issues/660

Generated by /finish-issue v2026.07.27@6dc7d1d • [my-claude-skills](https://github.com/couimet/my-claude-skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable utilities for generating unique relative and absolute file paths, including batch and named results.
  * Added support for custom filenames, extensions, separators, roots, folder depth, and path-length limits.
  * Added validation for invalid path-generation options and counts.

* **Tests**
  * Expanded coverage for unique path generation.
  * Updated link-formatting and selection validation tests to use dynamic, collision-resistant test data.
  * Improved coverage for path construction, naming, separators, roots, length limits, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->