### PR TITLE
[issues/710] Bump `@couimet/logger-contract-testing` to `^1.0.2`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
       timezone: 'America/Toronto'
     versioning-strategy: increase
     groups:
+      couimet:
+        patterns:
+          - '@couimet/*'
       deps:
         patterns:
           - '*'

--- a/packages/rangelink-core-ts/package.json
+++ b/packages/rangelink-core-ts/package.json
@@ -39,7 +39,7 @@
     "@couimet/detailed-error-testing": "^0.1.5",
     "@couimet/detailed-result-testing": "^0.2.1",
     "@couimet/dynamic-testing": "^1.0.0",
-    "@couimet/logger-contract-testing": "^1.0.0",
+    "@couimet/logger-contract-testing": "^1.0.2",
     "@types/jest": "^29.5.0",
     "@types/node": "^18.0.0",
     "jest": "^29.5.0",

--- a/packages/rangelink-vscode-extension/package.json
+++ b/packages/rangelink-vscode-extension/package.json
@@ -971,7 +971,7 @@
     "@couimet/detailed-error-testing": "^0.1.5",
     "@couimet/detailed-result-testing": "^0.2.1",
     "@couimet/dynamic-testing": "^1.0.0",
-    "@couimet/logger-contract-testing": "^1.0.0",
+    "@couimet/logger-contract-testing": "^1.0.2",
     "@types/jest": "^29.5.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "^20.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0(@couimet/detailed-error@1.0.0)
       '@couimet/logger-contract-testing':
-        specifier: ^1.0.0
-        version: 1.0.1(@couimet/logger-contract@1.0.0)(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.130))
+        specifier: ^1.0.2
+        version: 1.0.2(@couimet/logger-contract@1.0.0)(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.130))
       '@types/jest':
         specifier: ^29.5.0
         version: 29.5.14
@@ -95,8 +95,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0(@couimet/detailed-error@1.0.0)
       '@couimet/logger-contract-testing':
-        specifier: ^1.0.0
-        version: 1.0.1(@couimet/logger-contract@1.0.0)(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.19.43))
+        specifier: ^1.0.2
+        version: 1.0.2(@couimet/logger-contract@1.0.0)(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.19.43))
       '@types/jest':
         specifier: ^29.5.0
         version: 29.5.14
@@ -416,11 +416,11 @@ packages:
     peerDependencies:
       eslint: '>=10.4.0'
 
-  '@couimet/logger-contract-testing@1.0.1':
-    resolution: {integrity: sha512-+omIjwVUism+RIsbl8a9C6lmwzb2tSY2XKEO3n2kJn2a9USQ7W1E+38k7fSE04gzMLY1Vs/75CotbLzBJI5TtA==}
+  '@couimet/logger-contract-testing@1.0.2':
+    resolution: {integrity: sha512-hJcH4GNm7HcjrX7xCga6H3EZD10xAItcq0DDhtgYZWHnAdBDQYdEPtMiyyqL/Fz2/IqF6+2dxkMuXOlQXJmfOw==}
     peerDependencies:
       '@couimet/logger-contract': 1.0.0
-      '@jest/globals': '>=30.0.0'
+      '@jest/globals': '>=29.0.0'
       jest: '>=29.0.0'
 
   '@couimet/logger-contract@1.0.0':
@@ -3553,13 +3553,13 @@ snapshots:
     dependencies:
       eslint: 10.8.0
 
-  '@couimet/logger-contract-testing@1.0.1(@couimet/logger-contract@1.0.0)(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.130))':
+  '@couimet/logger-contract-testing@1.0.2(@couimet/logger-contract@1.0.0)(@jest/globals@29.7.0)(jest@29.7.0(@types/node@18.19.130))':
     dependencies:
       '@couimet/logger-contract': 1.0.0
       '@jest/globals': 29.7.0
       jest: 29.7.0(@types/node@18.19.130)
 
-  '@couimet/logger-contract-testing@1.0.1(@couimet/logger-contract@1.0.0)(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.19.43))':
+  '@couimet/logger-contract-testing@1.0.2(@couimet/logger-contract@1.0.0)(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.19.43))':
     dependencies:
       '@couimet/logger-contract': 1.0.0
       '@jest/globals': 29.7.0


### PR DESCRIPTION
## Summary

Audited all seven @couimet/* packages against their latest npm registry versions. Six were already at latest. `@couimet/logger-contract-testing` was bumped from `^1.0.0` to `^1.0.2`, which required first fixing an overly strict `@jest/globals@>=30.0.0` peer dependency upstream (https://github.com/couimet/ts-npm-packages/issues/133, shipped in v1.0.2). Dependabot config was split so @couimet updates arrive in their own PR group.

## Changes

- @couimet/logger-contract-testing bumped from ^1.0.0 to ^1.0.2 in both rangelink-core-ts and rangelink-vscode-extension (v1.0.2 relaxed the @jest/globals peer dep from >=30.0.0 to >=29.0.0; API is identical)
- Dependabot npm config split into two groups: @couimet/* packages get their own PR, all other npm deps in a separate PR — prevents the bundling problem seen in PR #702

## Key Discoveries

- v1.0.1 was blocked by `@jest/globals@>=30.0.0` in peerDependencies, but `@jest/globals@29.7.0` already exports `jest` — the import worked at runtime. Filed https://github.com/couimet/ts-npm-packages/issues/133 to relax the constraint; shipped as v1.0.2.
- `@couimet/detailed-error-testing@0.1.5` and `@couimet/detailed-result-testing@0.2.1` have the same `@jest/globals@>=30.0.0` peer dep issue — can be addressed the same way when bumped.

## Test Plan

- [x] All existing tests pass (core 620/620, extension 2042/2042 — same as origin/main)
- [ ] No new tests needed — dependency bump with zero behavioral impact

## Related

- Closes https://github.com/couimet/rangeLink/issues/710
- Unblocked by https://github.com/couimet/ts-npm-packages/pull/135

Generated by /finish-issue v2026.07.31@f2725bf • [my-claude-skills](https://github.com/couimet/my-claude-skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update grouping for related packages.
  * Updated development tooling to a newer version for improved contract testing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->