### PR TITLE
Fix RangeLink context menu items missing in devcontainers and remote workspaces // fixes #679

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -620,6 +620,15 @@
   <do>Add new entries to [Unreleased] section only</do>
   <never>Edit content under versioned headers like `## [1.0.0]` or `## [0.5.0]`</never>
   <rationale>Past releases document what shipped; rewriting history misleads users</rationale>
+
+  <rule id="CH001" priority="critical">
+    <title>Credit external contributors in CHANGELOG entries</title>
+    <do>When a change was contributed by someone other than the maintainer (Charles Ouimet), append a trailing attribution: ` — Contributed by [@handle](https://github.com/handle).`</do>
+    <do>For milestone contributions (1st, 10th, etc.), append a celebratory suffix after the attribution: ` — Contributed by [@handle](https://github.com/handle). 🎉 First open-source contribution on the project!`</do>
+    <do>Use `Contributed by` for code/PR contributions; use `Thanks to [@handle] for reporting.` for issue reporters who don't submit code</do>
+    <never>Add attribution for maintainer-authored changes</never>
+    <rationale>External contributions are a gift — visible, permanent attribution in the CHANGELOG is the minimum recognition</rationale>
+  </rule>
 </changelog>
 
 <unreleased-markers>

--- a/packages/rangelink-vscode-extension/CHANGELOG.md
+++ b/packages/rangelink-vscode-extension/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **R-F (paste current file path) now works for any active tab that maps to a file** — image previews, notebooks, and diff views — not just text editors. (#643)
 - **RangeLinks inside parentheses now navigate correctly** — `(path#Lx-Ly)` no longer includes the leading `(` in the file path, so navigation works instead of failing with "Cannot find file: (path...". Also applies to `[]`, `{}`, `<>` wrappers, and trailing sentence terminators. (#661, #666)
 - **Generating a link from an empty selected line now works** — previously rejected as a zero-width selection, an empty line selection now correctly produces a `#L12` link. (#683)
-- **RangeLink context menu items now appear in devcontainers and other remote workspaces.** (#679)
+- **RangeLink context menu items now appear in remote and virtual workspaces** — devcontainers, SSH remotes, WSL, Codespaces (`vscode-remote://`), and GitHub's web editor (`vscode-vfs://`). These URI schemes are now recognized as writable, so link-generation, paste-file-path, and bind commands appear in context menus where they were previously hidden. (#679) — Contributed by [@lourot](https://github.com/lourot). 🎉 First open-source contribution on the project!
 
 <!-- markdownlint-disable MD038 -->
 

--- a/packages/rangelink-vscode-extension/CHANGELOG.md
+++ b/packages/rangelink-vscode-extension/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **R-F (paste current file path) now works for any active tab that maps to a file** — image previews, notebooks, and diff views — not just text editors. (#643)
 - **RangeLinks inside parentheses now navigate correctly** — `(path#Lx-Ly)` no longer includes the leading `(` in the file path, so navigation works instead of failing with "Cannot find file: (path...". Also applies to `[]`, `{}`, `<>` wrappers, and trailing sentence terminators. (#661, #666)
 - **Generating a link from an empty selected line now works** — previously rejected as a zero-width selection, an empty line selection now correctly produces a `#L12` link. (#683)
+- **RangeLink context menu items now appear in devcontainers and other remote workspaces.** (#679)
 
 <!-- markdownlint-disable MD038 -->
 

--- a/packages/rangelink-vscode-extension/package.json
+++ b/packages/rangelink-vscode-extension/package.json
@@ -834,22 +834,22 @@
       ],
       "editor/context": [
         {
-          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled)",
+          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)",
           "command": "rangelink.editorContext.copyLink",
           "group": "8_rangelink@0"
         },
         {
-          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled)",
+          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)",
           "command": "rangelink.editorContext.copyLinkAbsolute",
           "group": "8_rangelink@1"
         },
         {
-          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled)",
+          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)",
           "command": "rangelink.editorContext.copyPortableLink",
           "group": "8_rangelink@2"
         },
         {
-          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled)",
+          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)",
           "command": "rangelink.editorContext.copyPortableLinkAbsolute",
           "group": "8_rangelink@3"
         },
@@ -864,19 +864,19 @@
           "group": "8_rangelink@5"
         },
         {
-          "when": "resourceScheme == file || resourceScheme == untitled",
+          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote",
           "command": "rangelink.editorContent.pasteFilePath",
           "group": "8_rangelink_files@0"
         },
         {
-          "when": "resourceScheme == file || resourceScheme == untitled",
+          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote",
           "command": "rangelink.editorContent.pasteRelativeFilePath",
           "group": "8_rangelink_files@1"
         },
         {
           "command": "rangelink.editorContent.bind",
           "group": "8_rangelink_files@2",
-          "when": "resourceScheme == file || resourceScheme == untitled"
+          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote"
         },
         {
           "when": "rangelink.isBound",
@@ -886,19 +886,19 @@
       ],
       "editor/title/context": [
         {
-          "when": "resourceScheme == file || resourceScheme == untitled",
+          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote",
           "command": "rangelink.editorTab.pasteFilePath",
           "group": "3_rangelink@1"
         },
         {
-          "when": "resourceScheme == file || resourceScheme == untitled",
+          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote",
           "command": "rangelink.editorTab.pasteRelativeFilePath",
           "group": "3_rangelink@2"
         },
         {
           "command": "rangelink.editorContent.bind",
           "group": "3_rangelink@3",
-          "when": "resourceScheme == file || resourceScheme == untitled"
+          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote"
         },
         {
           "when": "rangelink.isBound",

--- a/packages/rangelink-vscode-extension/package.json
+++ b/packages/rangelink-vscode-extension/package.json
@@ -834,22 +834,22 @@
       ],
       "editor/context": [
         {
-          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)",
+          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs)",
           "command": "rangelink.editorContext.copyLink",
           "group": "8_rangelink@0"
         },
         {
-          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)",
+          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs)",
           "command": "rangelink.editorContext.copyLinkAbsolute",
           "group": "8_rangelink@1"
         },
         {
-          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)",
+          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs)",
           "command": "rangelink.editorContext.copyPortableLink",
           "group": "8_rangelink@2"
         },
         {
-          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)",
+          "when": "editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs)",
           "command": "rangelink.editorContext.copyPortableLinkAbsolute",
           "group": "8_rangelink@3"
         },
@@ -864,19 +864,19 @@
           "group": "8_rangelink@5"
         },
         {
-          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote",
+          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs",
           "command": "rangelink.editorContent.pasteFilePath",
           "group": "8_rangelink_files@0"
         },
         {
-          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote",
+          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs",
           "command": "rangelink.editorContent.pasteRelativeFilePath",
           "group": "8_rangelink_files@1"
         },
         {
           "command": "rangelink.editorContent.bind",
           "group": "8_rangelink_files@2",
-          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote"
+          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs"
         },
         {
           "when": "rangelink.isBound",
@@ -886,19 +886,19 @@
       ],
       "editor/title/context": [
         {
-          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote",
+          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs",
           "command": "rangelink.editorTab.pasteFilePath",
           "group": "3_rangelink@1"
         },
         {
-          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote",
+          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs",
           "command": "rangelink.editorTab.pasteRelativeFilePath",
           "group": "3_rangelink@2"
         },
         {
           "command": "rangelink.editorContent.bind",
           "group": "3_rangelink@3",
-          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote"
+          "when": "resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs"
         },
         {
           "when": "rangelink.isBound",

--- a/packages/rangelink-vscode-extension/qa/.devcontainer/devcontainer.json
+++ b/packages/rangelink-vscode-extension/qa/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "RangeLink QA",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
+  "workspaceMount": "source=${localWorkspaceFolder}/../..,target=/workspaces/rangeLink,type=bind",
+  "workspaceFolder": "/workspaces/rangeLink",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "extensions.verifySignature": false
+      }
+    }
+  }
+}

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases.yaml
@@ -1499,6 +1499,7 @@ test_cases:
       - 'RangeLink extension installed in the devcontainer'
       - 'A writable source file open in the editor'
     steps:
+      - 'Select some text in the open source file'
       - 'Right-click in the editor to open the context menu'
       - 'Right-click on the editor tab to open the tab context menu'
     expected_result: '"Send RangeLink", "Send This File''s Path", and "RangeLink: Bind Here" all appear in the editor context menu for a writable file opened in a devcontainer. In the editor tab context menu, "Send File Path" and "Send Relative File Path" also appear. The when-clauses now match resourceScheme == vscode-remote.'
@@ -1526,9 +1527,10 @@ test_cases:
       - 'RangeLink extension installed in github.dev'
       - 'A source file open in the editor'
     steps:
+      - 'Select some text in the open source file'
       - 'Right-click in the editor to open the context menu'
       - 'Right-click on the editor tab to open the tab context menu'
-    expected_result: 'Open a repository in github.dev (press "." on any GitHub repo page). "Send RangeLink", "Send This File''s Path", and "RangeLink: Bind Here" all appear in the editor context menu for a writable file. The when-clauses now match resourceScheme == vscode-vfs.'
+    expected_result: '"Send RangeLink", "Send This File''s Path", and "RangeLink: Bind Here" all appear in the editor context menu for a writable file opened in github.dev. In the editor tab context menu, "Send File Path" and "Send Relative File Path" also appear. The when-clauses now match resourceScheme == vscode-vfs.'
     automated: false
     non_automatable_reason: workspace-specific
 

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases.yaml
@@ -18,8 +18,11 @@
 #                      false    — fully manual; preconditions and steps are required
 #   non_automatable_reason: Required when `automated: false`. Why this TC cannot be
 #                           automated (even assisted):
-#                             platform-specific — requires Win/Linux; CI runs on macOS
-#                             ide-specific      — requires Cursor IDE; not in VS Code host
+#                             platform-specific  — requires Win/Linux; CI runs on macOS
+#                             ide-specific       — requires Cursor IDE; not in VS Code host
+#                             workspace-specific — requires devcontainer, github.dev, or
+#                                                   Remote-SSH; CI cannot provision these
+#                                                   workspace environments
 
 test_cases:
   # ---------------------------------------------------------------------------
@@ -1461,13 +1464,13 @@ test_cases:
   - id: editor-binding-validation-001
     feature: 'editor-binding-validation'
     scenario: 'Search editor content area hides link-generation and bind commands'
-    expected_result: '"Send RangeLink", "Send This File''s Path", and "RangeLink: Bind Here" do NOT appear. "Send Selected Text" and "Unbind" are acceptable if present. The when-clauses restrict link-generation commands to resourceScheme == file || resourceScheme == untitled; the bind command carries the same restriction.'
+    expected_result: '"Send RangeLink", "Send This File''s Path", and "RangeLink: Bind Here" do NOT appear. "Send Selected Text" and "Unbind" are acceptable if present. The when-clauses restrict link-generation commands to writable URI schemes (see isWritableScheme.ts); the bind command carries the same restriction.'
     automated: assisted
 
   - id: editor-binding-validation-002
     feature: 'editor-binding-validation'
     scenario: 'Output panel hides file path and bind commands in its context menu'
-    expected_result: 'No "Send This File''s Path" or "RangeLink: Bind Here" appears. "Unbind" is acceptable. The when-clauses restrict editorContent.pasteFilePath and editorContent.bind to resourceScheme == file || resourceScheme == untitled.'
+    expected_result: 'No "Send This File''s Path" or "RangeLink: Bind Here" appears. "Unbind" is acceptable. The when-clauses restrict editorContent.pasteFilePath and editorContent.bind to writable URI schemes (see isWritableScheme.ts).'
     automated: assisted
 
   - id: editor-binding-validation-003
@@ -1485,8 +1488,49 @@ test_cases:
   - id: editor-binding-validation-005
     feature: 'editor-binding-validation'
     scenario: 'Search editor TAB hides file path commands in the tab context menu'
-    expected_result: 'No "Send File Path" or "Send Relative File Path" appears. "Unbind" is acceptable. The when-clause on editorTab.pasteFilePath and editorTab.pasteRelativeFilePath restricts them to resourceScheme == file || resourceScheme == untitled.'
+    expected_result: 'No "Send File Path" or "Send Relative File Path" appears. "Unbind" is acceptable. The when-clause on editorTab.pasteFilePath and editorTab.pasteRelativeFilePath restricts them to writable URI schemes (see isWritableScheme.ts).'
     automated: assisted
+
+  - id: editor-binding-validation-006
+    feature: 'editor-binding-validation'
+    scenario: 'Devcontainer: context menu items appear for writable files in a remote workspace (vscode-remote)'
+    preconditions:
+      - 'VS Code connected to a devcontainer (install Dev Containers extension + Docker, then "Dev Containers: Reopen in Container" from the command palette)'
+      - 'RangeLink extension installed in the devcontainer'
+      - 'A writable source file open in the editor'
+    steps:
+      - 'Right-click in the editor to open the context menu'
+      - 'Right-click on the editor tab to open the tab context menu'
+    expected_result: '"Send RangeLink", "Send This File''s Path", and "RangeLink: Bind Here" all appear in the editor context menu for a writable file opened in a devcontainer. In the editor tab context menu, "Send File Path" and "Send Relative File Path" also appear. The when-clauses now match resourceScheme == vscode-remote.'
+    automated: false
+    non_automatable_reason: workspace-specific
+
+  - id: editor-binding-validation-007
+    feature: 'editor-binding-validation'
+    scenario: 'Devcontainer: context menu items still hidden for non-writable schemes in a remote workspace'
+    preconditions:
+      - 'VS Code connected to a devcontainer (install Dev Containers extension + Docker, then "Dev Containers: Reopen in Container" from the command palette)'
+      - 'RangeLink extension installed in the devcontainer'
+    steps:
+      - 'Open a search results panel (Cmd+Shift+F, search for anything) and right-click in the search results editor'
+      - 'Open the Output panel (View → Output) and right-click in the output area'
+    expected_result: 'In a devcontainer, open a search results panel or output panel. "Send RangeLink", "Send This File''s Path", and "RangeLink: Bind Here" do NOT appear in the context menu for these non-writable schemes, even inside a devcontainer. The when-clauses still exclude read-only schemes like search, output, settings.'
+    automated: false
+    non_automatable_reason: workspace-specific
+
+  - id: editor-binding-validation-008
+    feature: 'editor-binding-validation'
+    scenario: 'GitHub Virtual Workspace: context menu items appear for writable files opened via vscode-vfs (github.dev)'
+    preconditions:
+      - 'A GitHub repository opened in github.dev (press "." on any GitHub repo page)'
+      - 'RangeLink extension installed in github.dev'
+      - 'A source file open in the editor'
+    steps:
+      - 'Right-click in the editor to open the context menu'
+      - 'Right-click on the editor tab to open the tab context menu'
+    expected_result: 'Open a repository in github.dev (press "." on any GitHub repo page). "Send RangeLink", "Send This File''s Path", and "RangeLink: Bind Here" all appear in the editor context menu for a writable file. The when-clauses now match resourceScheme == vscode-vfs.'
+    automated: false
+    non_automatable_reason: workspace-specific
 
   # ---------------------------------------------------------------------------
   # Section 13 — Bug Fix Regressions

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases.yaml
@@ -1496,7 +1496,7 @@ test_cases:
     scenario: 'Devcontainer: context menu items appear for writable files in a remote workspace (vscode-remote)'
     preconditions:
       - 'VS Code connected to a devcontainer (install Dev Containers extension + Docker; open the packages/rangelink-vscode-extension/qa/ folder via File → Open Folder…, then run "Dev Containers: Reopen in Container")'
-      - 'RangeLink extension installed in the devcontainer: `code --install-extension --force /workspaces/rangeLink/rangelink-vscode-extension/rangelink-vscode-extension-*.vsix' or `cursor --install-extension /workspaces/rangeLink/rangelink-vscode-extension/rangelink-vscode-extension-*.vsix`'
+      - 'RangeLink extension installed in the devcontainer: `code --install-extension --force /workspaces/rangeLink/rangelink-vscode-extension/rangelink-vscode-extension-*.vsix` or `cursor --install-extension /workspaces/rangeLink/rangelink-vscode-extension/rangelink-vscode-extension-*.vsix`'
       - 'After installing, run Developer: Reload Window so the extension activates'
       - 'A writable source file open in the editor'
     steps:
@@ -1512,7 +1512,7 @@ test_cases:
     scenario: 'Devcontainer: context menu items still hidden for non-writable schemes in a remote workspace'
     preconditions:
       - 'VS Code connected to a devcontainer (install Dev Containers extension + Docker; open the packages/rangelink-vscode-extension/qa/ folder via File → Open Folder…, then run "Dev Containers: Reopen in Container")'
-      - 'RangeLink extension installed in the devcontainer: `code --install-extension --force /workspaces/rangeLink/rangelink-vscode-extension/rangelink-vscode-extension-*.vsix' or `cursor --install-extension /workspaces/rangeLink/rangelink-vscode-extension/rangelink-vscode-extension-*.vsix`'
+      - 'RangeLink extension installed in the devcontainer: `code --install-extension --force /workspaces/rangeLink/rangelink-vscode-extension/rangelink-vscode-extension-*.vsix` or `cursor --install-extension /workspaces/rangeLink/rangelink-vscode-extension/rangelink-vscode-extension-*.vsix`'
       - 'After installing, run Developer: Reload Window so the extension activates'
     steps:
       - 'Open a search results panel (Cmd+Shift+F, search for anything) and right-click in the search results editor'

--- a/packages/rangelink-vscode-extension/qa/qa-test-cases.yaml
+++ b/packages/rangelink-vscode-extension/qa/qa-test-cases.yaml
@@ -1495,8 +1495,9 @@ test_cases:
     feature: 'editor-binding-validation'
     scenario: 'Devcontainer: context menu items appear for writable files in a remote workspace (vscode-remote)'
     preconditions:
-      - 'VS Code connected to a devcontainer (install Dev Containers extension + Docker, then "Dev Containers: Reopen in Container" from the command palette)'
-      - 'RangeLink extension installed in the devcontainer'
+      - 'VS Code connected to a devcontainer (install Dev Containers extension + Docker; open the packages/rangelink-vscode-extension/qa/ folder via File → Open Folder…, then run "Dev Containers: Reopen in Container")'
+      - 'RangeLink extension installed in the devcontainer: `code --install-extension --force /workspaces/rangeLink/rangelink-vscode-extension/rangelink-vscode-extension-*.vsix' or `cursor --install-extension /workspaces/rangeLink/rangelink-vscode-extension/rangelink-vscode-extension-*.vsix`'
+      - 'After installing, run Developer: Reload Window so the extension activates'
       - 'A writable source file open in the editor'
     steps:
       - 'Select some text in the open source file'
@@ -1510,8 +1511,9 @@ test_cases:
     feature: 'editor-binding-validation'
     scenario: 'Devcontainer: context menu items still hidden for non-writable schemes in a remote workspace'
     preconditions:
-      - 'VS Code connected to a devcontainer (install Dev Containers extension + Docker, then "Dev Containers: Reopen in Container" from the command palette)'
-      - 'RangeLink extension installed in the devcontainer'
+      - 'VS Code connected to a devcontainer (install Dev Containers extension + Docker; open the packages/rangelink-vscode-extension/qa/ folder via File → Open Folder…, then run "Dev Containers: Reopen in Container")'
+      - 'RangeLink extension installed in the devcontainer: `code --install-extension --force /workspaces/rangeLink/rangelink-vscode-extension/rangelink-vscode-extension-*.vsix' or `cursor --install-extension /workspaces/rangeLink/rangelink-vscode-extension/rangelink-vscode-extension-*.vsix`'
+      - 'After installing, run Developer: Reload Window so the extension activates'
     steps:
       - 'Open a search results panel (Cmd+Shift+F, search for anything) and right-click in the search results editor'
       - 'Open the Output panel (View → Output) and right-click in the output area'

--- a/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
@@ -1021,7 +1021,7 @@ describe('package.json contributions', () => {
 
       it('editorContext.copyLink at top of RangeLink group', () => {
         expect(editorContextMenu[0]).toStrictEqual({
-          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled)',
+          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)',
           command: 'rangelink.editorContext.copyLink',
           group: '8_rangelink@0',
         });
@@ -1029,7 +1029,7 @@ describe('package.json contributions', () => {
 
       it('editorContext.copyLinkAbsolute in context menu', () => {
         expect(editorContextMenu[1]).toStrictEqual({
-          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled)',
+          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)',
           command: 'rangelink.editorContext.copyLinkAbsolute',
           group: '8_rangelink@1',
         });
@@ -1037,7 +1037,7 @@ describe('package.json contributions', () => {
 
       it('editorContext.copyPortableLink in context menu', () => {
         expect(editorContextMenu[2]).toStrictEqual({
-          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled)',
+          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)',
           command: 'rangelink.editorContext.copyPortableLink',
           group: '8_rangelink@2',
         });
@@ -1045,7 +1045,7 @@ describe('package.json contributions', () => {
 
       it('editorContext.copyPortableLinkAbsolute in context menu', () => {
         expect(editorContextMenu[3]).toStrictEqual({
-          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled)',
+          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)',
           command: 'rangelink.editorContext.copyPortableLinkAbsolute',
           group: '8_rangelink@3',
         });
@@ -1069,7 +1069,7 @@ describe('package.json contributions', () => {
 
       it('editorContent.pasteFilePath in context menu', () => {
         expect(editorContextMenu[6]).toStrictEqual({
-          when: 'resourceScheme == file || resourceScheme == untitled',
+          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote',
           command: 'rangelink.editorContent.pasteFilePath',
           group: '8_rangelink_files@0',
         });
@@ -1077,7 +1077,7 @@ describe('package.json contributions', () => {
 
       it('editorContent.pasteRelativeFilePath in context menu', () => {
         expect(editorContextMenu[7]).toStrictEqual({
-          when: 'resourceScheme == file || resourceScheme == untitled',
+          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote',
           command: 'rangelink.editorContent.pasteRelativeFilePath',
           group: '8_rangelink_files@1',
         });
@@ -1087,7 +1087,7 @@ describe('package.json contributions', () => {
         expect(editorContextMenu[8]).toStrictEqual({
           command: 'rangelink.editorContent.bind',
           group: '8_rangelink_files@2',
-          when: 'resourceScheme == file || resourceScheme == untitled',
+          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote',
         });
       });
 
@@ -1109,7 +1109,7 @@ describe('package.json contributions', () => {
 
       it('editorTab.pasteFilePath in editor title context menu', () => {
         expect(editorTitleContextMenu[0]).toStrictEqual({
-          when: 'resourceScheme == file || resourceScheme == untitled',
+          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote',
           command: 'rangelink.editorTab.pasteFilePath',
           group: '3_rangelink@1',
         });
@@ -1117,7 +1117,7 @@ describe('package.json contributions', () => {
 
       it('editorTab.pasteRelativeFilePath in editor title context menu', () => {
         expect(editorTitleContextMenu[1]).toStrictEqual({
-          when: 'resourceScheme == file || resourceScheme == untitled',
+          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote',
           command: 'rangelink.editorTab.pasteRelativeFilePath',
           group: '3_rangelink@2',
         });
@@ -1127,7 +1127,7 @@ describe('package.json contributions', () => {
         expect(editorTitleContextMenu[2]).toStrictEqual({
           command: 'rangelink.editorContent.bind',
           group: '3_rangelink@3',
-          when: 'resourceScheme == file || resourceScheme == untitled',
+          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote',
         });
       });
 

--- a/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/constants/packageJsonContracts.test.ts
@@ -1021,7 +1021,7 @@ describe('package.json contributions', () => {
 
       it('editorContext.copyLink at top of RangeLink group', () => {
         expect(editorContextMenu[0]).toStrictEqual({
-          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)',
+          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs)',
           command: 'rangelink.editorContext.copyLink',
           group: '8_rangelink@0',
         });
@@ -1029,7 +1029,7 @@ describe('package.json contributions', () => {
 
       it('editorContext.copyLinkAbsolute in context menu', () => {
         expect(editorContextMenu[1]).toStrictEqual({
-          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)',
+          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs)',
           command: 'rangelink.editorContext.copyLinkAbsolute',
           group: '8_rangelink@1',
         });
@@ -1037,7 +1037,7 @@ describe('package.json contributions', () => {
 
       it('editorContext.copyPortableLink in context menu', () => {
         expect(editorContextMenu[2]).toStrictEqual({
-          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)',
+          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs)',
           command: 'rangelink.editorContext.copyPortableLink',
           group: '8_rangelink@2',
         });
@@ -1045,7 +1045,7 @@ describe('package.json contributions', () => {
 
       it('editorContext.copyPortableLinkAbsolute in context menu', () => {
         expect(editorContextMenu[3]).toStrictEqual({
-          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote)',
+          when: 'editorHasSelection && (resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs)',
           command: 'rangelink.editorContext.copyPortableLinkAbsolute',
           group: '8_rangelink@3',
         });
@@ -1069,7 +1069,7 @@ describe('package.json contributions', () => {
 
       it('editorContent.pasteFilePath in context menu', () => {
         expect(editorContextMenu[6]).toStrictEqual({
-          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote',
+          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs',
           command: 'rangelink.editorContent.pasteFilePath',
           group: '8_rangelink_files@0',
         });
@@ -1077,7 +1077,7 @@ describe('package.json contributions', () => {
 
       it('editorContent.pasteRelativeFilePath in context menu', () => {
         expect(editorContextMenu[7]).toStrictEqual({
-          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote',
+          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs',
           command: 'rangelink.editorContent.pasteRelativeFilePath',
           group: '8_rangelink_files@1',
         });
@@ -1087,7 +1087,7 @@ describe('package.json contributions', () => {
         expect(editorContextMenu[8]).toStrictEqual({
           command: 'rangelink.editorContent.bind',
           group: '8_rangelink_files@2',
-          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote',
+          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs',
         });
       });
 
@@ -1109,7 +1109,7 @@ describe('package.json contributions', () => {
 
       it('editorTab.pasteFilePath in editor title context menu', () => {
         expect(editorTitleContextMenu[0]).toStrictEqual({
-          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote',
+          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs',
           command: 'rangelink.editorTab.pasteFilePath',
           group: '3_rangelink@1',
         });
@@ -1117,7 +1117,7 @@ describe('package.json contributions', () => {
 
       it('editorTab.pasteRelativeFilePath in editor title context menu', () => {
         expect(editorTitleContextMenu[1]).toStrictEqual({
-          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote',
+          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs',
           command: 'rangelink.editorTab.pasteRelativeFilePath',
           group: '3_rangelink@2',
         });
@@ -1127,7 +1127,7 @@ describe('package.json contributions', () => {
         expect(editorTitleContextMenu[2]).toStrictEqual({
           command: 'rangelink.editorContent.bind',
           group: '3_rangelink@3',
-          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote',
+          when: 'resourceScheme == file || resourceScheme == untitled || resourceScheme == vscode-remote || resourceScheme == vscode-vfs',
         });
       });
 

--- a/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/isFileEligible.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/destinations/utils/isFileEligible.test.ts
@@ -13,6 +13,14 @@ describe('isFileEligible', () => {
     it('returns true for untitled even with binary-like path', () => {
       expect(isFileEligible('untitled', 'image.png')).toBe(true);
     });
+
+    it('returns true for vscode-remote scheme with text file', () => {
+      expect(isFileEligible('vscode-remote', '/workspace/src/app.ts')).toBe(true);
+    });
+
+    it('returns true for vscode-vfs scheme with text file', () => {
+      expect(isFileEligible('vscode-vfs', '/workspace/src/app.ts')).toBe(true);
+    });
   });
 
   describe('read-only schemes', () => {
@@ -30,8 +38,12 @@ describe('isFileEligible', () => {
   });
 
   describe('binary files', () => {
-    it('returns false for png file', () => {
+    it('returns false for png file with file scheme', () => {
       expect(isFileEligible('file', '/workspace/assets/logo.png')).toBe(false);
+    });
+
+    it('returns false for png file with vscode-remote scheme', () => {
+      expect(isFileEligible('vscode-remote', '/workspace/assets/logo.png')).toBe(false);
     });
 
     it('returns false for pdf file', () => {

--- a/packages/rangelink-vscode-extension/src/utils/__tests__/isWritableScheme.test.ts
+++ b/packages/rangelink-vscode-extension/src/utils/__tests__/isWritableScheme.test.ts
@@ -13,6 +13,10 @@ describe('isWritableScheme', () => {
     it('returns true for vscode-remote scheme', () => {
       expect(isWritableScheme('vscode-remote')).toBe(true);
     });
+
+    it('returns true for vscode-vfs scheme', () => {
+      expect(isWritableScheme('vscode-vfs')).toBe(true);
+    });
   });
 
   describe('read-only schemes', () => {

--- a/packages/rangelink-vscode-extension/src/utils/__tests__/isWritableScheme.test.ts
+++ b/packages/rangelink-vscode-extension/src/utils/__tests__/isWritableScheme.test.ts
@@ -9,6 +9,10 @@ describe('isWritableScheme', () => {
     it('returns true for untitled scheme', () => {
       expect(isWritableScheme('untitled')).toBe(true);
     });
+
+    it('returns true for vscode-remote scheme', () => {
+      expect(isWritableScheme('vscode-remote')).toBe(true);
+    });
   });
 
   describe('read-only schemes', () => {
@@ -26,10 +30,6 @@ describe('isWritableScheme', () => {
 
     it('returns false for debug scheme', () => {
       expect(isWritableScheme('debug')).toBe(false);
-    });
-
-    it('returns false for vscode-remote scheme', () => {
-      expect(isWritableScheme('vscode-remote')).toBe(false);
     });
 
     it('returns false for walkThrough scheme', () => {

--- a/packages/rangelink-vscode-extension/src/utils/isWritableScheme.ts
+++ b/packages/rangelink-vscode-extension/src/utils/isWritableScheme.ts
@@ -4,10 +4,11 @@
  * - `file` - Regular file system files
  * - `untitled` - New unsaved files
  * - `vscode-remote` - Files opened via a remote connection (e.g. devcontainers, SSH)
+ * - `vscode-vfs` - Files opened via a virtual filesystem (e.g. GitHub web editor)
  *
  * All other schemes (git, output, vscode-settings, etc.) are read-only.
  */
-const WRITABLE_SCHEMES = ['file', 'untitled', 'vscode-remote'];
+const WRITABLE_SCHEMES = ['file', 'untitled', 'vscode-remote', 'vscode-vfs'];
 
 /**
  * Check if a URI scheme supports text editing.

--- a/packages/rangelink-vscode-extension/src/utils/isWritableScheme.ts
+++ b/packages/rangelink-vscode-extension/src/utils/isWritableScheme.ts
@@ -3,10 +3,11 @@
  *
  * - `file` - Regular file system files
  * - `untitled` - New unsaved files
+ * - `vscode-remote` - Files opened via a remote connection (e.g. devcontainers, SSH)
  *
  * All other schemes (git, output, vscode-settings, etc.) are read-only.
  */
-const WRITABLE_SCHEMES = ['file', 'untitled'];
+const WRITABLE_SCHEMES = ['file', 'untitled', 'vscode-remote'];
 
 /**
  * Check if a URI scheme supports text editing.


### PR DESCRIPTION
Fix "Send RangeLink" ctx menu item missing in devcontainers // fixes #679

## Summary

RangeLink context menu items (copy link, paste file path, bind) were absent in devcontainers, Remote-SSH, and GitHub's web editor because those URI schemes (`vscode-remote`, `vscode-vfs`) were not recognized as writable. This PR adds both schemes to the writable list, making RangeLink fully functional in remote and virtual workspaces.

## Changes

- Remote workspace schemes (`vscode-remote`, `vscode-vfs`) are now recognized as writable, enabling link-generation, paste-file-path, and bind commands in devcontainers, SSH remotes, WSL, Codespaces, and github.dev
- Updated `editor/context` and `editor/title/context` `when` clauses to include the new schemes alongside `file` and `untitled`
- QA test plan: three new test cases for remote workspace context menu visibility (devcontainer and github.dev), plus updated expected results on existing editor-binding-validation TCs to reference the centralized writable-scheme list. Introduced `workspace-specific` as a new `non_automatable_reason` for scenarios that require container or cloud workspace infrastructure unavailable in CI
- Documentation: CHANGELOG entry crediting contributor @lourot. Project CLAUDE.md now requires external-contributor attribution in CHANGELOG entries

## Test Plan

- [x] All existing tests pass (118 suites, 2084 tests)
- [x] New test cases added for `isWritableScheme` (vscode-remote and vscode-vfs)
- [x] New test cases added for `isFileEligible` (remote workspace file eligibility)
- [x] Contract tests updated to reflect new `when` clause schemes

## Related

Closes https://github.com/couimet/rangeLink/issues/679

Generated by /finish-issue v2026.07.31@f2725bf • [my-claude-skills](https://github.com/couimet/my-claude-skills)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - RangeLink commands are now available in VS Code remote and virtual workspaces, including dev containers and GitHub virtual workspaces.
  - Users can copy links, copy file paths, and create bindings for supported text files in these environments.
  - Writable remote and virtual files are now recognized for editor binding actions.

- **Documentation**
  - Added release notes and expanded guidance for workspace-specific validation and supported URI schemes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->