### PR TITLE
[issues/696] Fix CodeRabbit badge links in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Open VSX / Cursor Version](https://img.shields.io/open-vsx/v/couimet/rangelink-vscode-extension?label=Open%20VSX%20%2F%20Cursor&color=blue)](https://open-vsx.org/extension/couimet/rangelink-vscode-extension) [![Open VSX / Cursor Downloads](https://img.shields.io/open-vsx/dt/couimet/rangelink-vscode-extension?label=Open%20VSX%20%2F%20Cursor%20Downloads&color=blue)](https://open-vsx.org/extension/couimet/rangelink-vscode-extension)
 [![VS Code Marketplace Version](https://vsmarketplacebadges.dev/version/couimet.rangelink-vscode-extension.svg)](https://marketplace.visualstudio.com/items?itemName=couimet.rangelink-vscode-extension) [![VS Code Marketplace Installs](https://vsmarketplacebadges.dev/downloads-short/couimet.rangelink-vscode-extension.svg)](https://marketplace.visualstudio.com/items?itemName=couimet.rangelink-vscode-extension)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
-![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/couimet/rangeLink?label=CodeRabbit+Reviews)
+[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/couimet/rangeLink?label=CodeRabbit+Reviews)](https://coderabbit.ai)
 
 **"Claude Code today. Cursor AI tomorrow. Different shortcuts, different muscle memory."** <br />
 **RangeLink ends it.** One keybinding. Any AI, any tool. Character-level precision. `recipes/baking/chickenpie.ts#L3C14-L314C16`

--- a/packages/rangelink-vscode-extension/README.md
+++ b/packages/rangelink-vscode-extension/README.md
@@ -7,6 +7,7 @@
 [![Open VSX / Cursor Version](https://img.shields.io/open-vsx/v/couimet/rangelink-vscode-extension?label=Open%20VSX%20%2F%20Cursor&color=blue)](https://open-vsx.org/extension/couimet/rangelink-vscode-extension) [![Open VSX / Cursor Downloads](https://img.shields.io/open-vsx/dt/couimet/rangelink-vscode-extension?label=Open%20VSX%20%2F%20Cursor%20Downloads&color=blue)](https://open-vsx.org/extension/couimet/rangelink-vscode-extension)
 [![VS Code Marketplace Version](https://vsmarketplacebadges.dev/version/couimet.rangelink-vscode-extension.svg)](https://marketplace.visualstudio.com/items?itemName=couimet.rangelink-vscode-extension) [![VS Code Marketplace Installs](https://vsmarketplacebadges.dev/downloads-short/couimet.rangelink-vscode-extension.svg)](https://marketplace.visualstudio.com/items?itemName=couimet.rangelink-vscode-extension)
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/couimet/rangelink/blob/main/LICENSE)
+[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/couimet/rangeLink?label=CodeRabbit+Reviews)](https://coderabbit.ai)
 
 > **"Claude Code today. Cursor AI tomorrow. Different shortcuts, different muscle memory."**<br />
 > **RangeLink ends it.** One keybinding. Any AI, any tool. Character-level precision. `recipes/baking/chickenpie.ts#L3C14-L314C16`


### PR DESCRIPTION
## Summary

The CodeRabbit review badge is kept, wrapped in a link to coderabbit.ai, and added to the extension README. The badge URL was verified to be CodeRabbit's officially supported format, so no URL change was needed.

## Changes

- The root README CodeRabbit badge now links to coderabbit.ai, matching the official badge format and the clickable pattern of the sibling badges (via README.md)
- The extension README shows the same linked CodeRabbit badge after its badge row, keeping the two primary READMEs consistent (via packages/rangelink-vscode-extension/README.md)

## Key Discoveries

- The "provider or repo not found" badge state from the audit was an intermittent CodeRabbit-side API problem, not a broken URL; the URL renders "CodeRabbit Reviews: 180" as of 2026-08-19
- CodeRabbit's stats API is case-sensitive: mixed-case rangeLink returns 180 reviews while lowercase rangelink returns 0, so the existing casing must be kept

## Test Plan

- [ ] All existing tests pass (118 suites, 2080 tests)
- [ ] Manual testing: badge URL verified via curl to render "CodeRabbit Reviews: 180", not "provider or repo not found"

## Related

- Closes https://github.com/couimet/rangeLink/issues/696
- Parent tracking issue: https://github.com/couimet/idea-garden/issues/13

Generated by /finish-issue v2026.08.18@86bafb9 • [my-claude-skills](https://github.com/couimet/my-claude-skills)

@coderabbitai ignore