### PR TITLE
[issues/718] Automate release issues and board rotation

### DIFF
--- a/.claude/skills/release-prep/SKILL.md
+++ b/.claude/skills/release-prep/SKILL.md
@@ -62,7 +62,7 @@ Run:
 packages/rangelink-vscode-extension/scripts/add-issue-to-release-board.sh <cross-repo issue URL>
 ```
 
-The script resolves the `RangeLink vX.Y.Z release` board for the version in package.json, adds the issue, and sets Status to Ready when the board has a Ready option (warn and skip otherwise, matching the release lock script's rule). Pass `--dry-run` to preview without GitHub calls.
+The script resolves the `RangeLink vX.Y.Z release` board for the version in package.json, adds the issue, and sets Status to Ready when the board has a Ready option (warn and skip otherwise, matching the release lock script's rule). Pass `--dry-run` to preview without GitHub calls. Capture the `Board URL:` value printed in the script's final output, for use in the Step 6 report.
 
 ## Step 6: Report
 
@@ -75,7 +75,7 @@ Cross-repo:    <cross-repo issue URL>
 Board:         <board URL>
 ```
 
-If an existing cross-repo issue was reused, mark it in the report so the reader knows no new issue was created.
+The board URL is the `Board URL:` value captured in Step 5. If an existing cross-repo issue was reused, mark it in the report so the reader knows no new issue was created.
 
 ## Output Format
 

--- a/.claude/skills/release-prep/SKILL.md
+++ b/.claude/skills/release-prep/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: release-prep
+version: 2026.08.19.1
+description: Finish release tracking after release:lock has run: create the couimet.github.io article-registration issue, add it to the release board, and report all tracking issue URLs. Argument: target version X.Y.Z
+allowed-tools: Read, Write, Glob, Grep, Bash
+---
+
+# Release Prep
+
+Finish the GitHub tracking artifacts for a release of the VS Code extension after the release lock workflow has run. The lock script (`pnpm release:lock:vscode-extension X.Y.Z`) creates the QA issue and the dev.to issue and adds them to the release board; this skill creates the remaining cross-repo couimet.github.io article-registration issue, adds it to the board, and reports all three URLs.
+
+**Input:** `X.Y.Z` target version (e.g., `/release-prep 2.1.0`)
+
+## Step 1: Verify the release lock completed
+
+The lock workflow must have run first; its console summary prints this skill prompt. Confirm its state:
+
+- `packages/rangelink-vscode-extension/qa/release-testing-instructions-vX.Y.Z.md` exists
+- Its frontmatter contains both `qa_issue_url:` and `devto_issue_url:` with real URLs
+
+If either check fails, stop and print: run `pnpm release:lock:vscode-extension X.Y.Z` first, then re-run this skill.
+
+## Step 2: Read the issue URLs from the instructions frontmatter
+
+Extract both URLs from the frontmatter of `packages/rangelink-vscode-extension/qa/release-testing-instructions-vX.Y.Z.md`:
+
+- QA issue URL: the value of `qa_issue_url`
+- Dev.to issue URL: the value of `devto_issue_url`
+
+These are the issues the lock script created and already added to the release board.
+
+## Step 3: Check for an existing cross-repo issue
+
+The article-registration issue lives in couimet/couimet.github.io. Check for an existing open issue before creating a new one:
+
+```text
+gh issue list --repo couimet/couimet.github.io --state open --search "Register RangeLink X.Y.Z article on the site in:title"
+```
+
+If an open issue with that title is returned, reuse its URL for the board step and skip creation. This makes the skill re-runnable.
+
+## Step 4: Create the cross-repo issue
+
+Write a draft body with the Write tool to a temporary file (e.g., `/tmp/release-prep-2.1.0.md`), then invoke the /create-github-issue skill, passing the draft file path as its argument.
+
+The draft needs these elements:
+
+- First line: `**Target repo:** couimet/couimet.github.io` (the /create-github-issue target repo override)
+- Title: `Register RangeLink X.Y.Z article on the site`
+- Body: reference https://github.com/couimet/couimet.github.io/pull/94 as the registration pattern to follow (the `articles.yml` entry plus associated content). Do NOT embed an `articles.yml` snippet: the PR is the reference, so the body cannot rot as the site template changes
+- Blocked-by line: `Blocked by <dev.to issue URL>` so /create-github-issue detects the dependency and links it with its link-dependency.sh script
+
+Generated issues carry no labels. When /create-github-issue runs label discovery, select no labels so the `--label` flag is omitted.
+
+Capture the returned issue URL.
+
+## Step 5: Add the cross-repo issue to the release board
+
+Run:
+
+```text
+packages/rangelink-vscode-extension/scripts/add-issue-to-release-board.sh <cross-repo issue URL>
+```
+
+The script resolves the `RangeLink vX.Y.Z release` board for the version in package.json, adds the issue, and sets Status to Ready when the board has a Ready option (warn and skip otherwise, matching the release lock script's rule). Pass `--dry-run` to preview without GitHub calls.
+
+## Step 6: Report
+
+Print all three issue URLs and the board link:
+
+```text
+QA issue:      <qa issue URL>
+Dev.to issue:  <dev.to issue URL>
+Cross-repo:    <cross-repo issue URL>
+Board:         <board URL>
+```
+
+If an existing cross-repo issue was reused, mark it in the report so the reader knows no new issue was created.
+
+## Output Format
+
+Never hard-wrap prose output; each paragraph is one continuous line, with line breaks for structure only.

--- a/.claude/skills/release-prep/SKILL.md
+++ b/.claude/skills/release-prep/SKILL.md
@@ -31,17 +31,23 @@ These are the issues the lock script created and already added to the release bo
 
 ## Step 3: Check for an existing cross-repo issue
 
-The article-registration issue lives in couimet/couimet.github.io. Check for an existing open issue before creating a new one:
+The article-registration issue lives in couimet/couimet.github.io. Check for an existing open issue with an exact title match before creating a new one, capturing the URL when one exists:
 
 ```text
-gh issue list --repo couimet/couimet.github.io --state open --search "Register RangeLink X.Y.Z article on the site in:title"
+EXISTING_ISSUE_URL=$(gh issue list \
+  --repo couimet/couimet.github.io \
+  --state open \
+  --search "Register RangeLink X.Y.Z article on the site in:title" \
+  --json title,url --limit 100 \
+  --jq '.[] | select(.title == "Register RangeLink X.Y.Z article on the site") | .url' \
+  | head -1)
 ```
 
-If an open issue with that title is returned, reuse its URL for the board step and skip creation. This makes the skill re-runnable.
+The `--jq` filter selects only an issue whose title EXACTLY matches `Register RangeLink X.Y.Z article on the site`, and `--limit 100` covers the full expected result set; together they guard against an older open issue with a similar title being misidentified as this release's registration issue. If `$EXISTING_ISSUE_URL` is non-empty, reuse that exact URL for the Step 5 board step and the Step 6 report and skip creation, preserving the skill's re-runnability. Step 4 (creation) runs only when no exact match was found.
 
 ## Step 4: Create the cross-repo issue
 
-Write a draft body with the Write tool to a temporary file (e.g., `/tmp/release-prep-2.1.0.md`), then invoke the /create-github-issue skill, passing the draft file path as its argument.
+Run this step only when Step 3 found no exact match (`$EXISTING_ISSUE_URL` is empty). Write a draft body with the Write tool to a temporary file (e.g., `/tmp/release-prep-2.1.0.md`), then invoke the /create-github-issue skill, passing the draft file path as its argument.
 
 The draft needs these elements:
 
@@ -62,7 +68,7 @@ Run:
 packages/rangelink-vscode-extension/scripts/add-issue-to-release-board.sh <cross-repo issue URL>
 ```
 
-The script resolves the `RangeLink vX.Y.Z release` board for the version in package.json, adds the issue, and sets Status to Ready when the board has a Ready option (warn and skip otherwise, matching the release lock script's rule). Pass `--dry-run` to preview without GitHub calls. Capture the `Board URL:` value printed in the script's final output, for use in the Step 6 report.
+The script resolves the `RangeLink vX.Y.Z release` board for the version in package.json, adds the issue, and sets Status to Ready when the board has a Ready option (warn and skip otherwise, matching the release lock script's rule). When Step 3 found an existing issue, pass `$EXISTING_ISSUE_URL` as the `<cross-repo issue URL>`. Pass `--dry-run` to preview without GitHub calls. Capture the `Board URL:` value printed in the script's final output, for use in the Step 6 report.
 
 ## Step 6: Report
 

--- a/bats-tests/shell/add-issue-to-release-board.bats
+++ b/bats-tests/shell/add-issue-to-release-board.bats
@@ -68,6 +68,7 @@ write_happy_projects() {
   {
     "id": "PVT_kwBOARD",
     "number": 12,
+    "url": "https://github.com/users/couimet/projects/12",
     "title": "RangeLink v9.9.9 release",
     "fields": {"nodes": [
       {
@@ -83,6 +84,7 @@ write_happy_projects() {
   {
     "id": "PVT_kbOTHER",
     "number": 3,
+    "url": "https://github.com/users/couimet/projects/3",
     "title": "RangeLink v9.8.0 release",
     "fields": {"nodes": []}
   }
@@ -100,6 +102,7 @@ EOF
   [[ "$status" -eq 0 ]]
   [[ "$output" =~ "Resolved release board: RangeLink v9.9.9 release (project #12)" ]]
   [[ "$output" =~ "Added: https://github.com/couimet/couimet.github.io/issues/12 to RangeLink v9.9.9 release (project #12), status: Ready" ]]
+  [[ "$output" =~ "Board URL: https://github.com/users/couimet/projects/12" ]]
 
   # The board listing query.
   grep -q 'projectsV2' "$GH_CALL_LOG"
@@ -121,8 +124,8 @@ EOF
   setup_fixture
   cat > "$PROJECTS_RESPONSE_FILE" <<'EOF'
 {"data": {"viewer": {"projectsV2": {"nodes": [
-  {"id": "PVT_1", "number": 3, "title": "RangeLink v9.8.0 release", "fields": {"nodes": []}},
-  {"id": "PVT_2", "number": 7, "title": "Backlog board", "fields": {"nodes": []}}
+  {"id": "PVT_1", "number": 3, "url": "https://github.com/users/couimet/projects/3", "title": "RangeLink v9.8.0 release", "fields": {"nodes": []}},
+  {"id": "PVT_2", "number": 7, "url": "https://github.com/users/couimet/projects/7", "title": "Backlog board", "fields": {"nodes": []}}
 ]}}}}
 EOF
 
@@ -143,6 +146,7 @@ EOF
   {
     "id": "PVT_kwBOARD",
     "number": 12,
+    "url": "https://github.com/users/couimet/projects/12",
     "title": "RangeLink v9.9.9 release",
     "fields": {"nodes": [
       {
@@ -159,6 +163,7 @@ EOF
   [[ "$status" -eq 0 ]]
   [[ "$output" =~ "no 'Status' field with a 'Ready' option" ]]
   [[ "$output" =~ "status: unset" ]]
+  [[ "$output" =~ "Board URL: https://github.com/users/couimet/projects/12" ]]
 
   # Item is still added to the board, but no status mutation runs.
   grep -Fq 'addProjectV2ItemById' "$GH_CALL_LOG"

--- a/bats-tests/shell/add-issue-to-release-board.bats
+++ b/bats-tests/shell/add-issue-to-release-board.bats
@@ -1,0 +1,194 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+REAL_SCRIPT="$PROJECT_ROOT/packages/rangelink-vscode-extension/scripts/add-issue-to-release-board.sh"
+
+setup_fixture() {
+  export FIXTURE_ROOT="$TEST_TEMP_DIR"
+  mkdir -p "$FIXTURE_ROOT/scripts"
+
+  cp "$REAL_SCRIPT" "$FIXTURE_ROOT/scripts/add-issue-to-release-board.sh"
+  cp "$PROJECT_ROOT/packages/rangelink-vscode-extension/scripts/release-board-lib.sh" "$FIXTURE_ROOT/scripts/"
+
+  # Fake package.json so the version lookup works.
+  cat > "$FIXTURE_ROOT/package.json" <<'EOF'
+{"version": "9.9.9"}
+EOF
+
+  stub_dir
+
+  export GH_CALL_LOG="$FIXTURE_ROOT/gh-calls.log"
+  : > "$GH_CALL_LOG"
+  export PROJECTS_RESPONSE_FILE="$FIXTURE_ROOT/projects-response.json"
+  export ISSUE_VIEW_URL=""
+
+  make_stub "gh" <<'ENDOFSTUB'
+#!/usr/bin/env bash
+echo "gh $*" >> "$GH_CALL_LOG"
+
+case "${1:-}" in
+  api)
+    if [[ "${2:-}" == "user" ]]; then
+      echo "couimet"
+      exit 0
+    fi
+    if [[ "${2:-}" == "graphql" ]]; then
+      payload="$4"
+      echo "graphql --input $payload" >> "$GH_CALL_LOG"
+      cat "$payload" >> "$GH_CALL_LOG"
+      echo "" >> "$GH_CALL_LOG"
+      if grep -q 'addProjectV2ItemById' "$payload"; then
+        echo '{"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_CROSS"}}}}'
+      elif grep -q 'updateProjectV2ItemFieldValue' "$payload"; then
+        echo '{"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_CROSS"}}}}'
+      elif grep -q 'projectsV2' "$payload"; then
+        cat "$PROJECTS_RESPONSE_FILE"
+      fi
+      exit 0
+    fi
+    ;;
+  issue)
+    if [[ "${2:-}" == "view" ]]; then
+      echo "issue view ${3}" >> "$GH_CALL_LOG"
+      echo "NODE_CROSS"
+      exit 0
+    fi
+    ;;
+esac
+exit 1
+ENDOFSTUB
+
+  SCRIPT="$FIXTURE_ROOT/scripts/add-issue-to-release-board.sh"
+}
+
+write_happy_projects() {
+  cat > "$PROJECTS_RESPONSE_FILE" <<'EOF'
+{"data": {"viewer": {"projectsV2": {"nodes": [
+  {
+    "id": "PVT_kwBOARD",
+    "number": 12,
+    "title": "RangeLink v9.9.9 release",
+    "fields": {"nodes": [
+      {
+        "id": "FIELD_STATUS",
+        "name": "Status",
+        "options": [
+          {"id": "OPT_READY", "name": "Ready"},
+          {"id": "OPT_IN_PROGRESS", "name": "In Progress"}
+        ]
+      }
+    ]}
+  },
+  {
+    "id": "PVT_kbOTHER",
+    "number": 3,
+    "title": "RangeLink v9.8.0 release",
+    "fields": {"nodes": []}
+  }
+]}}}}
+EOF
+}
+
+# ── Happy path ─────────────────────────────────────────────────────────────────
+
+@test "adds an issue from any repository to the release board with Status Ready" {
+  setup_fixture
+  write_happy_projects
+
+  run "$SCRIPT" "https://github.com/couimet/couimet.github.io/issues/12"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "Resolved release board: RangeLink v9.9.9 release (project #12)" ]]
+  [[ "$output" =~ "Added: https://github.com/couimet/couimet.github.io/issues/12 to RangeLink v9.9.9 release (project #12), status: Ready" ]]
+
+  # The board listing query.
+  grep -q 'projectsV2' "$GH_CALL_LOG"
+
+  # Cross-repo issue node id resolved via gh issue view.
+  grep -Fq 'issue view https://github.com/couimet/couimet.github.io/issues/12' "$GH_CALL_LOG"
+
+  # Item added with the resolved node id, then Status set to Ready.
+  grep -Fq 'addProjectV2ItemById' "$GH_CALL_LOG"
+  grep -Fq 'NODE_CROSS' "$GH_CALL_LOG"
+  grep -Fq 'updateProjectV2ItemFieldValue' "$GH_CALL_LOG"
+  grep -Fq 'OPT_READY' "$GH_CALL_LOG"
+  grep -Fq 'ITEM_CROSS' "$GH_CALL_LOG"
+}
+
+# ── Error paths ─────────────────────────────────────────────────────────────────
+
+@test "fails with candidate titles when the release board is not found" {
+  setup_fixture
+  cat > "$PROJECTS_RESPONSE_FILE" <<'EOF'
+{"data": {"viewer": {"projectsV2": {"nodes": [
+  {"id": "PVT_1", "number": 3, "title": "RangeLink v9.8.0 release", "fields": {"nodes": []}},
+  {"id": "PVT_2", "number": 7, "title": "Backlog board", "fields": {"nodes": []}}
+]}}}}
+EOF
+
+  run "$SCRIPT" "https://github.com/couimet/couimet.github.io/issues/12"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "no project board titled 'RangeLink v9.9.9 release'" ]]
+  [[ "$output" =~ "RangeLink v9.8.0 release" ]]
+  [[ "$output" =~ "Backlog board" ]]
+
+  # Nothing was mutated.
+  ! grep -q 'addProjectV2ItemById' "$GH_CALL_LOG"
+}
+
+@test "warns and skips status update when the board has no Ready option" {
+  setup_fixture
+  cat > "$PROJECTS_RESPONSE_FILE" <<'EOF'
+{"data": {"viewer": {"projectsV2": {"nodes": [
+  {
+    "id": "PVT_kwBOARD",
+    "number": 12,
+    "title": "RangeLink v9.9.9 release",
+    "fields": {"nodes": [
+      {
+        "id": "FIELD_STATUS",
+        "name": "Status",
+        "options": [{"id": "OPT_IN_PROGRESS", "name": "In Progress"}]
+      }
+    ]}
+  }
+]}}}}
+EOF
+
+  run "$SCRIPT" "https://github.com/couimet/couimet.github.io/issues/12"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "no 'Status' field with a 'Ready' option" ]]
+  [[ "$output" =~ "status: unset" ]]
+
+  # Item is still added to the board, but no status mutation runs.
+  grep -Fq 'addProjectV2ItemById' "$GH_CALL_LOG"
+  ! grep -q 'updateProjectV2ItemFieldValue' "$GH_CALL_LOG"
+}
+
+# ── Usage and dry-run ───────────────────────────────────────────────────────────
+
+@test "missing issue URL prints usage" {
+  setup_fixture
+
+  run "$SCRIPT"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "Usage:" ]]
+  [[ "$output" =~ "<issue-url>" ]]
+}
+
+@test "rejects a malformed issue URL" {
+  setup_fixture
+
+  run "$SCRIPT" "not-a-valid-url"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "must look like https://github.com/<owner>/<repo>/issues/<number>" ]]
+}
+
+@test "--dry-run prints the resolved inputs without calling gh" {
+  setup_fixture
+
+  run "$SCRIPT" --dry-run "https://github.com/couimet/couimet.github.io/issues/12"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "DRY-RUN: would add https://github.com/couimet/couimet.github.io/issues/12 to 'RangeLink v9.9.9 release' with Status: Ready" ]]
+  [[ ! -s "$GH_CALL_LOG" ]]
+}

--- a/bats-tests/shell/generate-release-issues.bats
+++ b/bats-tests/shell/generate-release-issues.bats
@@ -58,6 +58,7 @@ case "${1:-}" in
   issue)
     if [[ "${2:-}" == "create" ]]; then
       echo "issue create title=$4" >> "$GH_CALL_LOG"
+      echo "issue create repo=${8:-}" >> "$GH_CALL_LOG"
       echo "$6" > "$ISSUE_BODY_LOG"
       echo "$ISSUE_CREATE_URL"
       exit 0
@@ -117,8 +118,9 @@ EOF
   # The board listing query.
   grep -q 'projectsV2' "$GH_CALL_LOG"
 
-  # Issue create: title and body.
+  # Issue create: title, body, and pinned repo (must match the GraphQL lookup repo).
   grep -Fq 'issue create title=Prepare dev.to post for v9.9.9 release' "$GH_CALL_LOG"
+  grep -Fq 'issue create repo=couimet/rangeLink' "$GH_CALL_LOG"
   grep -Fq 'Draft article written (after feature freeze)' "$ISSUE_BODY_LOG"
 
   # GraphQL node id resolution for both issues.

--- a/bats-tests/shell/generate-release-issues.bats
+++ b/bats-tests/shell/generate-release-issues.bats
@@ -1,0 +1,244 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+REAL_SCRIPT="$PROJECT_ROOT/packages/rangelink-vscode-extension/scripts/generate-release-issues.sh"
+
+setup_fixture() {
+  export FIXTURE_ROOT="$TEST_TEMP_DIR"
+  mkdir -p "$FIXTURE_ROOT/scripts"
+
+  cp "$REAL_SCRIPT" "$FIXTURE_ROOT/scripts/generate-release-issues.sh"
+  cp "$PROJECT_ROOT/packages/rangelink-vscode-extension/scripts/release-board-lib.sh" "$FIXTURE_ROOT/scripts/"
+
+  # Fake package.json so the version lookup works.
+  cat > "$FIXTURE_ROOT/package.json" <<'EOF'
+{"version": "9.9.9"}
+EOF
+
+  stub_dir
+
+  export GH_CALL_LOG="$FIXTURE_ROOT/gh-calls.log"
+  : > "$GH_CALL_LOG"
+  export ISSUE_BODY_LOG="$FIXTURE_ROOT/issue-body.log"
+  export ISSUE_CREATE_URL="https://github.com/couimet/rangeLink/issues/1000"
+  export PROJECTS_RESPONSE_FILE="$FIXTURE_ROOT/projects-response.json"
+
+  make_stub "gh" <<'ENDOFSTUB'
+#!/usr/bin/env bash
+echo "gh $*" >> "$GH_CALL_LOG"
+
+case "${1:-}" in
+  api)
+    if [[ "${2:-}" == "user" ]]; then
+      echo "couimet"
+      exit 0
+    fi
+    if [[ "${2:-}" == "graphql" ]]; then
+      payload="$4"
+      echo "graphql --input $payload" >> "$GH_CALL_LOG"
+      cat "$payload" >> "$GH_CALL_LOG"
+      echo "" >> "$GH_CALL_LOG"
+      if grep -q 'addProjectV2ItemById' "$payload"; then
+        if grep -q 'NODE_QA' "$payload"; then
+          echo '{"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_QA"}}}}'
+        else
+          echo '{"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_DEVTO"}}}}'
+        fi
+      elif grep -q 'updateProjectV2ItemFieldValue' "$payload"; then
+        echo '{"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_DEVTO"}}}}'
+      elif grep -q 'issue(number:' "$payload"; then
+        echo '{"data": {"repository": {"devto": {"id": "NODE_DEVTO"}, "qa": {"id": "NODE_QA"}}}}'
+      elif grep -q 'projectsV2' "$payload"; then
+        cat "$PROJECTS_RESPONSE_FILE"
+      fi
+      exit 0
+    fi
+    ;;
+  issue)
+    if [[ "${2:-}" == "create" ]]; then
+      echo "issue create title=$4" >> "$GH_CALL_LOG"
+      echo "$6" > "$ISSUE_BODY_LOG"
+      echo "$ISSUE_CREATE_URL"
+      exit 0
+    fi
+    ;;
+esac
+exit 1
+ENDOFSTUB
+
+  SCRIPT="$FIXTURE_ROOT/scripts/generate-release-issues.sh"
+}
+
+write_happy_projects() {
+  cat > "$PROJECTS_RESPONSE_FILE" <<'EOF'
+{"data": {"viewer": {"projectsV2": {"nodes": [
+  {
+    "id": "PVT_kwBOARD",
+    "number": 12,
+    "title": "RangeLink v9.9.9 release",
+    "fields": {"nodes": [
+      {
+        "id": "FIELD_STATUS",
+        "name": "Status",
+        "options": [
+          {"id": "OPT_READY", "name": "Ready"},
+          {"id": "OPT_IN_PROGRESS", "name": "In Progress"}
+        ]
+      },
+      {
+        "id": "FIELD_PRIORITY",
+        "name": "Priority",
+        "options": [{"id": "OPT_HIGH", "name": "High"}]
+      }
+    ]}
+  },
+  {
+    "id": "PVT_kbOTHER",
+    "number": 3,
+    "title": "RangeLink v9.8.0 release",
+    "fields": {"nodes": []}
+  }
+]}}}}
+EOF
+}
+
+# ── Happy path ─────────────────────────────────────────────────────────────────
+
+@test "creates dev.to issue and adds both issues to the release board" {
+  setup_fixture
+  write_happy_projects
+
+  run "$SCRIPT" "https://github.com/couimet/rangeLink/issues/555"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "Created: https://github.com/couimet/rangeLink/issues/1000" ]]
+  [[ "$output" =~ "Resolved release board: RangeLink v9.9.9 release (project #12)" ]]
+
+  # The board listing query.
+  grep -q 'projectsV2' "$GH_CALL_LOG"
+
+  # Issue create: title and body.
+  grep -Fq 'issue create title=Prepare dev.to post for v9.9.9 release' "$GH_CALL_LOG"
+  grep -Fq 'Draft article written (after feature freeze)' "$ISSUE_BODY_LOG"
+
+  # GraphQL node id resolution for both issues.
+  grep -Fq 'issue(number: 1000)' "$GH_CALL_LOG"
+  grep -Fq 'issue(number: 555)' "$GH_CALL_LOG"
+
+  # Both items added to the board.
+  grep -Fq 'addProjectV2ItemById' "$GH_CALL_LOG"
+  grep -Fq 'NODE_DEVTO' "$GH_CALL_LOG"
+  grep -Fq 'NODE_QA' "$GH_CALL_LOG"
+
+  # Status set to Ready for each added item (item ids flow into the mutation).
+  grep -Fq 'updateProjectV2ItemFieldValue' "$GH_CALL_LOG"
+  grep -Fq 'OPT_READY' "$GH_CALL_LOG"
+  grep -Fq 'ITEM_DEVTO' "$GH_CALL_LOG"
+  grep -Fq 'ITEM_QA' "$GH_CALL_LOG"
+
+  # Board summary lines reference both issues.
+  [[ "$output" =~ "dev.to issue: https://github.com/couimet/rangeLink/issues/1000" ]]
+  [[ "$output" =~ "QA issue: https://github.com/couimet/rangeLink/issues/555" ]]
+}
+
+@test "issue title and body follow the dev.to post template" {
+  setup_fixture
+  write_happy_projects
+
+  run "$SCRIPT" "https://github.com/couimet/rangeLink/issues/555"
+  [[ "$status" -eq 0 ]]
+
+  grep -Fq 'issue create title=Prepare dev.to post for v9.9.9 release' "$GH_CALL_LOG"
+  grep -Fq 'Prepare a dev.to article announcing the RangeLink v9.9.9 release' "$ISSUE_BODY_LOG"
+  grep -Fq -- '- [ ] Draft article written (after feature freeze)' "$ISSUE_BODY_LOG"
+  grep -Fq -- '- [ ] Screenshots/GIFs prepared' "$ISSUE_BODY_LOG"
+  grep -Fq -- '- [ ] Article reviewed' "$ISSUE_BODY_LOG"
+  grep -Fq -- '- [ ] Ready to publish on release day' "$ISSUE_BODY_LOG"
+  grep -Fq 'media/devto-post-vscode-extension-v9.9.9.md' "$ISSUE_BODY_LOG"
+  grep -Fq 'packages/rangelink-vscode-extension/README.md#featured-in' "$ISSUE_BODY_LOG"
+}
+
+# ── Error paths ─────────────────────────────────────────────────────────────────
+
+@test "fails with candidate titles when the release board is not found" {
+  setup_fixture
+  cat > "$PROJECTS_RESPONSE_FILE" <<'EOF'
+{"data": {"viewer": {"projectsV2": {"nodes": [
+  {"id": "PVT_1", "number": 3, "title": "RangeLink v9.8.0 release", "fields": {"nodes": []}},
+  {"id": "PVT_2", "number": 7, "title": "Backlog board", "fields": {"nodes": []}}
+]}}}}
+EOF
+
+  run "$SCRIPT" "https://github.com/couimet/rangeLink/issues/555"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "no project board titled 'RangeLink v9.9.9 release'" ]]
+  [[ "$output" =~ "RangeLink v9.8.0 release" ]]
+  [[ "$output" =~ "Backlog board" ]]
+
+  # Nothing was created or mutated.
+  ! grep -q 'issue create' "$GH_CALL_LOG"
+  ! grep -q 'addProjectV2ItemById' "$GH_CALL_LOG"
+}
+
+@test "warns and skips status updates when the board has no Ready option" {
+  setup_fixture
+  cat > "$PROJECTS_RESPONSE_FILE" <<'EOF'
+{"data": {"viewer": {"projectsV2": {"nodes": [
+  {
+    "id": "PVT_kwBOARD",
+    "number": 12,
+    "title": "RangeLink v9.9.9 release",
+    "fields": {"nodes": [
+      {
+        "id": "FIELD_STATUS",
+        "name": "Status",
+        "options": [{"id": "OPT_IN_PROGRESS", "name": "In Progress"}]
+      }
+    ]}
+  }
+]}}}}
+EOF
+
+  run "$SCRIPT" "https://github.com/couimet/rangeLink/issues/555"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "no 'Status' field with a 'Ready' option" ]]
+  [[ "$output" =~ "status: unset" ]]
+
+  # Items are still added to the board.
+  grep -Fq 'addProjectV2ItemById' "$GH_CALL_LOG"
+  grep -Fq 'NODE_DEVTO' "$GH_CALL_LOG"
+  grep -Fq 'NODE_QA' "$GH_CALL_LOG"
+
+  # But no status mutation runs.
+  ! grep -q 'updateProjectV2ItemFieldValue' "$GH_CALL_LOG"
+}
+
+# ── Usage and dry-run ───────────────────────────────────────────────────────────
+
+@test "missing QA issue URL prints usage" {
+  setup_fixture
+
+  run "$SCRIPT"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "Usage:" ]]
+  [[ "$output" =~ "<qa-issue-url>" ]]
+}
+
+@test "rejects a malformed QA issue URL" {
+  setup_fixture
+
+  run "$SCRIPT" "not-a-valid-url"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "must look like https://github.com/<owner>/<repo>/issues/<number>" ]]
+}
+
+@test "--dry-run prints the issue without calling gh" {
+  setup_fixture
+
+  run "$SCRIPT" --dry-run "https://github.com/couimet/rangeLink/issues/555"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "DRY-RUN issue: Prepare dev.to post for v9.9.9 release" ]]
+  [[ "$output" =~ "--- Body ---" ]]
+  [[ "$output" =~ "Ready to publish on release day" ]]
+  [[ ! -s "$GH_CALL_LOG" ]]
+}

--- a/bats-tests/shell/generate-release-testing-instructions.bats
+++ b/bats-tests/shell/generate-release-testing-instructions.bats
@@ -64,11 +64,13 @@ EOF
   # Frontmatter present.
   head -1 "$out" | grep -q "^---$"
   grep -q "qa_issue_url:" "$out"
+  grep -q "devto_issue_url:" "$out"
   grep -q "generated:" "$out"
   # Scope line correct.
   grep -q "Changes from v1.0.0 → Unreleased" "$out"
-  # QA tracker placeholder and next steps section.
+  # QA tracker and Dev.to post placeholders, next steps section.
   grep -q "QA tracker:" "$out"
+  grep -q "Dev.to post:" "$out"
   grep -q "## Next steps" "$out"
 }
 

--- a/bats-tests/shell/orchestrate-release-lock.bats
+++ b/bats-tests/shell/orchestrate-release-lock.bats
@@ -82,6 +82,7 @@ if [[ ! -f "$INSTRUCTIONS_FILE" ]]; then
 ---
 version: PLACEHOLDER
 qa_issue_url: ''
+devto_issue_url: ''
 generated: 2026-01-01T00:00:00Z
 ---
 
@@ -89,6 +90,7 @@ generated: 2026-01-01T00:00:00Z
 
 **Scope:** Changes from v1.0.0 → vPLACEHOLDER
 **QA tracker:** <to be filled by release:lock>
+**Dev.to post:** <to be filled by release:lock>
 INSTEOF
 fi
 STUBEOF
@@ -100,6 +102,16 @@ STUBEOF
 echo "Created QA issue: https://github.com/couimet/rangeLink/issues/999"
 STUBEOF
   chmod +x "$FIXTURE_ROOT/scripts/generate-qa-issue.sh"
+
+  # Stub generate-release-issues.sh (logs its args so tests can assert the QA URL was passed).
+  cat > "$FIXTURE_ROOT/scripts/generate-release-issues.sh" <<'STUBEOF'
+#!/usr/bin/env bash
+echo "generate-release-issues.sh $*" >> "$GEN_ISSUES_CALL_LOG"
+echo "Created dev.to issue: https://github.com/couimet/rangeLink/issues/1000"
+STUBEOF
+  chmod +x "$FIXTURE_ROOT/scripts/generate-release-issues.sh"
+  export GEN_ISSUES_CALL_LOG="$FIXTURE_ROOT/generate-issues-calls.log"
+  : > "$GEN_ISSUES_CALL_LOG"
 
   # Stub validate-qa-coverage.sh (exits with QA_VALIDATE_EXIT).
   cat > "$FIXTURE_ROOT/scripts/validate-qa-coverage.sh" <<'STUBEOF'
@@ -124,7 +136,7 @@ STUBEOF
   [[ -f "$FIXTURE_ROOT/.commit-msgs/0001-lock-version-v1.0.0.txt" ]]
 }
 
-@test "first run: sed injects QA issue URL into instructions frontmatter" {
+@test "first run: sed injects QA and dev.to issue URLs into instructions frontmatter" {
   setup_fixture
   export GIT_BRANCH_EXISTS=1
 
@@ -135,6 +147,18 @@ STUBEOF
   [[ -f "$ins" ]]
   grep -q "qa_issue_url: 'https://github.com/couimet/rangeLink/issues/999'" "$ins"
   grep -q '\*\*QA tracker:\*\* https://github.com/couimet/rangeLink/issues/999' "$ins"
+  grep -q "devto_issue_url: 'https://github.com/couimet/rangeLink/issues/1000'" "$ins"
+  grep -q '\*\*Dev.to post:\*\* https://github.com/couimet/rangeLink/issues/1000' "$ins"
+}
+
+@test "first run: generate-release-issues.sh receives the QA issue URL" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=1
+
+  run "$SCRIPT" "1.0.0"
+  [[ "$status" -eq 0 ]]
+
+  grep -q 'https://github.com/couimet/rangeLink/issues/999' "$GEN_ISSUES_CALL_LOG"
 }
 
 # ── Re-run (branch exists, already on it) ──────────────────────────────────────────
@@ -176,6 +200,44 @@ INSTEOF
   [[ "$status" -eq 0 ]]
   [[ "$output" =~ "Prior QA issue found" ]]
   [[ "$output" =~ "Closed prior issue" ]]
+}
+
+@test "re-run: dev.to supersession closes prior dev.to issue" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=0
+  export GIT_CURRENT_BRANCH="release/v1.0.0"
+
+  # Write instructions with a prior devto_issue_url to simulate first run.
+  local ins="$FIXTURE_ROOT/qa/release-testing-instructions-v1.0.0.md"
+  mkdir -p "$(dirname "$ins")"
+  cat > "$ins" <<'INSTEOF'
+---
+version: 1.0.0
+qa_issue_url: 'https://github.com/couimet/rangeLink/issues/888'
+devto_issue_url: 'https://github.com/couimet/rangeLink/issues/777'
+generated: 2026-01-01T00:00:00Z
+---
+
+# Release Testing: Placeholder
+
+**Scope:** Changes from v1.0.0 → v1.0.0
+**QA tracker:** https://github.com/couimet/rangeLink/issues/888
+**Dev.to post:** https://github.com/couimet/rangeLink/issues/777
+INSTEOF
+
+  run "$SCRIPT" "1.0.0"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "Prior dev.to issue found" ]]
+  [[ "$output" =~ "Closed prior dev.to issue" ]]
+
+  # Prior issue closed with supersession comment, new issue gets the backref.
+  grep -q 'issue close https://github.com/couimet/rangeLink/issues/777' "$GH_CALL_LOG"
+  grep -q 'Superseded by https://github.com/couimet/rangeLink/issues/1000 (release:lock re-run).' "$GH_CALL_LOG"
+  grep -q 'Supersedes https://github.com/couimet/rangeLink/issues/777.' "$GH_CALL_LOG"
+
+  # Old URL replaced with new URL in the instructions file.
+  grep -q "devto_issue_url: 'https://github.com/couimet/rangeLink/issues/1000'" "$ins"
+  ! grep -q 'issues/777' "$ins"
 }
 
 @test "re-run: sed replaces existing qa_issue_url (not just empty placeholder)" {
@@ -386,6 +448,44 @@ INSTEOF
   [[ "$body" =~ "pnpm release:prepare:vscode-extension" ]]
 }
 
+@test "workflow comment includes dev.to issue row" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=1
+
+  run "$SCRIPT" "1.0.0"
+  [[ "$status" -eq 0 ]]
+
+  # The workflow comment body contains the dev.to issue row linking the issue.
+  grep -q 'Dev.to issue: https://github.com/couimet/rangeLink/issues/1000' "$GH_CALL_LOG"
+}
+
+@test "commit message contains dev.to issue bullet" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=1
+
+  run "$SCRIPT" "1.0.0"
+  [[ "$status" -eq 0 ]]
+
+  local msg="$FIXTURE_ROOT/.commit-msgs/0001-lock-version-v1.0.0.txt"
+  grep -q "Generated dev.to issue: https://github.com/couimet/rangeLink/issues/1000" "$msg"
+}
+
+@test "fails when dev.to issue URL is missing from generate-release-issues.sh output" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=1
+
+  # Override the stub to produce output without an issue URL.
+  cat > "$FIXTURE_ROOT/scripts/generate-release-issues.sh" <<'STUBEOF'
+#!/usr/bin/env bash
+echo "Board: https://github.com/users/couimet/projects/42"
+STUBEOF
+  chmod +x "$FIXTURE_ROOT/scripts/generate-release-issues.sh"
+
+  run "$SCRIPT" "1.0.0"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "could not extract dev.to issue URL" ]]
+}
+
 @test "workflow comment shows existing PR when PR exists" {
   setup_fixture
   export GIT_BRANCH_EXISTS=1
@@ -421,6 +521,16 @@ INSTEOF
   [[ "$output" =~ "3. Push: git push" ]]
   [[ "$output" =~ "4. Create PR: gh pr create --title \"[release] Lock version v1.0.0\"" ]]
   ! [[ "$output" =~ "Push and create PR" ]]
+}
+
+@test "console summary instructs running the release-prep skill for cross-repo tracking" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=1
+
+  run "$SCRIPT" "1.0.0"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "/release-prep 1.0.0" ]]
+  [[ "$output" =~ "couimet.github.io article-registration issue" ]]
 }
 
 @test "validate-qa-coverage passes: script continues" {

--- a/bats-tests/shell/orchestrate-release-lock.bats
+++ b/bats-tests/shell/orchestrate-release-lock.bats
@@ -13,6 +13,8 @@ setup_fixture() {
   cp "$REAL_SCRIPT" "$FIXTURE_ROOT/scripts/orchestrate-release-lock.sh"
   cp "$PROJECT_ROOT/packages/rangelink-vscode-extension/scripts/check-dirty-tree.sh" \
      "$FIXTURE_ROOT/scripts/check-dirty-tree.sh"
+  cp "$PROJECT_ROOT/packages/rangelink-vscode-extension/scripts/release-board-lib.sh" \
+     "$FIXTURE_ROOT/scripts/release-board-lib.sh"
   SCRIPT="$FIXTURE_ROOT/scripts/orchestrate-release-lock.sh"
 
   # Default: branch does not exist, we are on main, working tree clean.
@@ -56,6 +58,9 @@ ENDOFSTUB
 
   # gh stub that logs each call so tests can assert on the workflow comment body.
   # Set EXISTING_PR_URL to make `gh pr list --head` return a PR URL.
+  # Board-cleanup calls (`gh api graphql --input <file>`, `gh issue view`) only
+  # happen on re-runs that supersede a prior issue; they dispatch on the payload
+  # content against the PROJECTS_RESPONSE_FILE / ITEMS_RESPONSE_FILE fixtures.
   make_stub "gh" <<'ENDOFSTUB'
 #!/usr/bin/env bash
 echo "gh $*" >> "$GH_CALL_LOG"
@@ -65,11 +70,64 @@ case "$*" in
       echo "${EXISTING_PR_URL}"
     fi
     ;;
+  *"api graphql --input"*)
+    PAYLOAD="${@: -1}"
+    echo "graphql --input $PAYLOAD" >> "$GH_CALL_LOG"
+    cat "$PAYLOAD" >> "$GH_CALL_LOG"
+    echo "" >> "$GH_CALL_LOG"
+    if grep -q 'updateProjectV2ItemFieldValue' "$PAYLOAD"; then
+      echo '{"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "PVTI_X"}}}}'
+    elif grep -q 'deleteProjectV2Item' "$PAYLOAD"; then
+      echo '{"data": {"deleteProjectV2Item": {"deletedItemId": "PVTI_X"}}}'
+    elif grep -q 'items(first' "$PAYLOAD"; then
+      cat "$ITEMS_RESPONSE_FILE"
+    elif grep -q 'projectsV2' "$PAYLOAD"; then
+      cat "$PROJECTS_RESPONSE_FILE"
+    fi
+    ;;
+  *"issue view"*)
+    echo "issue view ${*}" >> "$GH_CALL_LOG"
+    # Derive the node id from the issue number: issues/888 → I_kw_888.
+    NUMBER=$(echo "$*" | grep -o 'issues/[0-9]*' | head -1 | sed 's|issues/||')
+    echo "I_kw_${NUMBER}"
+    ;;
 esac
 exit 0
 ENDOFSTUB
   export GH_CALL_LOG="$FIXTURE_ROOT/gh-calls.log"
   : > "$GH_CALL_LOG"
+
+  # Board-cleanup fixtures for the re-run supersession tests. Default projects
+  # fixture lists the release board (with a Status/Done option); default items
+  # fixture has the prior issues' board items.
+  export PROJECTS_RESPONSE_FILE="$FIXTURE_ROOT/projects-response.json"
+  export ITEMS_RESPONSE_FILE="$FIXTURE_ROOT/items-response.json"
+  cat > "$PROJECTS_RESPONSE_FILE" <<'EOF'
+{"data": {"viewer": {"projectsV2": {"nodes": [
+  {
+    "id": "PVT_BOARD",
+    "number": 7,
+    "title": "RangeLink v1.0.0 release",
+    "url": "https://github.com/users/couimet/projects/7",
+    "fields": {"nodes": [
+      {
+        "id": "FIELD_STATUS",
+        "name": "Status",
+        "options": [
+          {"id": "OPT_DONE", "name": "Done"},
+          {"id": "OPT_READY", "name": "Ready"}
+        ]
+      }
+    ]}
+  }
+]}}}}
+EOF
+  cat > "$ITEMS_RESPONSE_FILE" <<'EOF'
+{"data": {"node": {"items": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": [
+  {"id": "PVTI_PRIOR", "content": {"__typename": "Issue", "id": "I_kw_888"}},
+  {"id": "PVTI_DEVTO", "content": {"__typename": "Issue", "id": "I_kw_777"}}
+]}}}}
+EOF
 
   # Stub lock-version.sh (idempotent: does not clobber existing instructions).
   cat > "$FIXTURE_ROOT/scripts/lock-version.sh" <<'STUBEOF'
@@ -200,6 +258,11 @@ INSTEOF
   [[ "$status" -eq 0 ]]
   [[ "$output" =~ "Prior QA issue found" ]]
   [[ "$output" =~ "Closed prior issue" ]]
+
+  # Prior issue's board item marked Done before the issue is closed.
+  [[ "$output" =~ "Marked superseded board item Done" ]]
+  grep -q 'updateProjectV2ItemFieldValue' "$GH_CALL_LOG"
+  grep -q 'OPT_DONE' "$GH_CALL_LOG"
 }
 
 @test "re-run: dev.to supersession closes prior dev.to issue" {
@@ -235,9 +298,99 @@ INSTEOF
   grep -q 'Superseded by https://github.com/couimet/rangeLink/issues/1000 (release:lock re-run).' "$GH_CALL_LOG"
   grep -q 'Supersedes https://github.com/couimet/rangeLink/issues/777.' "$GH_CALL_LOG"
 
+  # Both prior issues' board items marked Done.
+  grep -q 'updateProjectV2ItemFieldValue' "$GH_CALL_LOG"
+  grep -q 'OPT_DONE' "$GH_CALL_LOG"
+
   # Old URL replaced with new URL in the instructions file.
   grep -q "devto_issue_url: 'https://github.com/couimet/rangeLink/issues/1000'" "$ins"
   ! grep -q 'issues/777' "$ins"
+}
+
+@test "re-run: board cleanup removes the item when the board has no Done option" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=0
+  export GIT_CURRENT_BRANCH="release/v1.0.0"
+
+  # Projects fixture with Status options but no Done → delete path.
+  cat > "$PROJECTS_RESPONSE_FILE" <<'EOF'
+{"data": {"viewer": {"projectsV2": {"nodes": [
+  {
+    "id": "PVT_BOARD",
+    "number": 7,
+    "title": "RangeLink v1.0.0 release",
+    "url": "https://github.com/users/couimet/projects/7",
+    "fields": {"nodes": [
+      {
+        "id": "FIELD_STATUS",
+        "name": "Status",
+        "options": [{"id": "OPT_READY", "name": "Ready"}]
+      }
+    ]}
+  }
+]}}}}
+EOF
+
+  # Same instructions as the dev.to supersession test.
+  local ins="$FIXTURE_ROOT/qa/release-testing-instructions-v1.0.0.md"
+  mkdir -p "$(dirname "$ins")"
+  cat > "$ins" <<'INSTEOF'
+---
+version: 1.0.0
+qa_issue_url: 'https://github.com/couimet/rangeLink/issues/888'
+devto_issue_url: 'https://github.com/couimet/rangeLink/issues/777'
+generated: 2026-01-01T00:00:00Z
+---
+
+# Release Testing: Placeholder
+
+**Scope:** Changes from v1.0.0 → v1.0.0
+**QA tracker:** https://github.com/couimet/rangeLink/issues/888
+**Dev.to post:** https://github.com/couimet/rangeLink/issues/777
+INSTEOF
+
+  run "$SCRIPT" "1.0.0"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "Removed superseded board item" ]]
+
+  # Item deleted, never updated to Done.
+  grep -q 'deleteProjectV2Item' "$GH_CALL_LOG"
+  ! grep -q 'updateProjectV2ItemFieldValue' "$GH_CALL_LOG"
+}
+
+@test "re-run: board cleanup warns and continues when the board is missing" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=0
+  export GIT_CURRENT_BRANCH="release/v1.0.0"
+
+  # Projects fixture with no board matching "RangeLink v1.0.0 release".
+  cat > "$PROJECTS_RESPONSE_FILE" <<'EOF'
+{"data": {"viewer": {"projectsV2": {"nodes": [
+  {"id": "PVT_OTHER", "number": 3, "title": "Backlog board", "fields": {"nodes": []}}
+]}}}}
+EOF
+
+  local ins="$FIXTURE_ROOT/qa/release-testing-instructions-v1.0.0.md"
+  mkdir -p "$(dirname "$ins")"
+  cat > "$ins" <<'INSTEOF'
+---
+version: 1.0.0
+qa_issue_url: 'https://github.com/couimet/rangeLink/issues/888'
+generated: 2026-01-01T00:00:00Z
+---
+
+# Release Testing: Placeholder
+
+**Scope:** Changes from v1.0.0 → v1.0.0
+**QA tracker:** https://github.com/couimet/rangeLink/issues/888
+INSTEOF
+
+  run "$SCRIPT" "1.0.0"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "no project board titled 'RangeLink v1.0.0 release'" ]]
+
+  # Best-effort: the prior issue is still closed despite the missing board.
+  grep -q 'issue close https://github.com/couimet/rangeLink/issues/888' "$GH_CALL_LOG"
 }
 
 @test "re-run: sed replaces existing qa_issue_url (not just empty placeholder)" {
@@ -324,6 +477,10 @@ INSTEOF
   [[ "$status" -eq 0 ]]
   [[ "$output" =~ "Prior QA issue found" ]]
   [[ "$output" =~ "Closed prior issue" ]]
+
+  # Board cleanup runs even on the branch-delete re-run path.
+  [[ "$output" =~ "Marked superseded board item Done" ]]
+  grep -q 'updateProjectV2ItemFieldValue' "$GH_CALL_LOG"
 }
 
 @test "re-run: prompts when branch exists — abort" {

--- a/bats-tests/shell/orchestrate-release-lock.bats
+++ b/bats-tests/shell/orchestrate-release-lock.bats
@@ -80,8 +80,16 @@ case "$*" in
     elif grep -q 'deleteProjectV2Item' "$PAYLOAD"; then
       echo '{"data": {"deleteProjectV2Item": {"deletedItemId": "PVTI_X"}}}'
     elif grep -q 'items(first' "$PAYLOAD"; then
+      if [[ "${ITEMS_API_EXIT:-0}" -ne 0 ]]; then
+        echo "items API failed (exit ${ITEMS_API_EXIT})" >&2
+        exit "$ITEMS_API_EXIT"
+      fi
       cat "$ITEMS_RESPONSE_FILE"
     elif grep -q 'projectsV2' "$PAYLOAD"; then
+      if [[ "${PROJECTS_API_EXIT:-0}" -ne 0 ]]; then
+        echo "projects API failed (exit ${PROJECTS_API_EXIT})" >&2
+        exit "$PROJECTS_API_EXIT"
+      fi
       cat "$PROJECTS_RESPONSE_FILE"
     fi
     ;;
@@ -390,6 +398,66 @@ INSTEOF
   [[ "$output" =~ "no project board titled 'RangeLink v1.0.0 release'" ]]
 
   # Best-effort: the prior issue is still closed despite the missing board.
+  grep -q 'issue close https://github.com/couimet/rangeLink/issues/888' "$GH_CALL_LOG"
+}
+
+@test "re-run: board cleanup warns and continues when the project lookup fails" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=0
+  export GIT_CURRENT_BRANCH="release/v1.0.0"
+  export PROJECTS_API_EXIT=1
+
+  # Write an instructions file with a prior qa_issue_url to simulate first run.
+  local ins="$FIXTURE_ROOT/qa/release-testing-instructions-v1.0.0.md"
+  mkdir -p "$(dirname "$ins")"
+  cat > "$ins" <<'INSTEOF'
+---
+version: 1.0.0
+qa_issue_url: 'https://github.com/couimet/rangeLink/issues/888'
+generated: 2026-01-01T00:00:00Z
+---
+
+# Release Testing: Placeholder
+
+**Scope:** Changes from v1.0.0 → v1.0.0
+**QA tracker:** https://github.com/couimet/rangeLink/issues/888
+INSTEOF
+
+  run "$SCRIPT" "1.0.0"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "could not list release projects" ]]
+
+  # Best-effort: the prior issue is still closed despite the failed lookup.
+  grep -q 'issue close https://github.com/couimet/rangeLink/issues/888' "$GH_CALL_LOG"
+}
+
+@test "re-run: board cleanup warns and continues when the board item lookup fails" {
+  setup_fixture
+  export GIT_BRANCH_EXISTS=0
+  export GIT_CURRENT_BRANCH="release/v1.0.0"
+  export ITEMS_API_EXIT=1
+
+  # Write an instructions file with a prior qa_issue_url to simulate first run.
+  local ins="$FIXTURE_ROOT/qa/release-testing-instructions-v1.0.0.md"
+  mkdir -p "$(dirname "$ins")"
+  cat > "$ins" <<'INSTEOF'
+---
+version: 1.0.0
+qa_issue_url: 'https://github.com/couimet/rangeLink/issues/888'
+generated: 2026-01-01T00:00:00Z
+---
+
+# Release Testing: Placeholder
+
+**Scope:** Changes from v1.0.0 → v1.0.0
+**QA tracker:** https://github.com/couimet/rangeLink/issues/888
+INSTEOF
+
+  run "$SCRIPT" "1.0.0"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "could not look up board item" ]]
+
+  # Best-effort: the prior issue is still closed despite the failed lookup.
   grep -q 'issue close https://github.com/couimet/rangeLink/issues/888' "$GH_CALL_LOG"
 }
 

--- a/bats-tests/shell/rotate-release-board.bats
+++ b/bats-tests/shell/rotate-release-board.bats
@@ -31,13 +31,13 @@ fi
 if grep -q 'addProjectV2DraftIssue' "$FILE"; then
   TITLE=$(jq -r '.variables.input.title' "$FILE")
   BODY=$(jq -r '.variables.input.body' "$FILE")
-  COUNT=$(( $(grep -c '^add ' "$MOVE_LOG" 2>/dev/null || true) + 1 ))
+  COUNT=$(( $(grep -Ec '^(add|draft) ' "$MOVE_LOG" 2>/dev/null || true) + 1 ))
   NEW_ID="PVTI_NEW_${COUNT}"
   echo "draft $TITLE $BODY" >> "$MOVE_LOG"
   echo "{\"data\": {\"addProjectV2DraftIssue\": {\"projectV2Item\": {\"id\": \"$NEW_ID\"}}}}"
 elif grep -q 'addProjectV2ItemById' "$FILE"; then
   CONTENT_ID=$(jq -r '.variables.input.contentId' "$FILE")
-  COUNT=$(( $(grep -c '^add ' "$MOVE_LOG" 2>/dev/null || true) + 1 ))
+  COUNT=$(( $(grep -Ec '^(add|draft) ' "$MOVE_LOG" 2>/dev/null || true) + 1 ))
   NEW_ID="PVTI_NEW_${COUNT}"
   echo "add $CONTENT_ID $NEW_ID" >> "$MOVE_LOG"
   echo "{\"data\": {\"addProjectV2ItemById\": {\"item\": {\"id\": \"$NEW_ID\"}}}}"
@@ -61,6 +61,8 @@ elif grep -q 'items(first' "$FILE"; then
   CURSOR=$(jq -r '.variables.cursor // ""' "$FILE")
   if [[ -n "$CURSOR" ]]; then
     cat "$GH_ITEMS_RESPONSE_2"
+  elif [[ "$(jq -r '.variables.id // ""' "$FILE")" == "PVT_NEW" ]]; then
+    cat "$GH_ITEMS_RESPONSE_NEW"
   else
     cat "$GH_ITEMS_RESPONSE"
   fi
@@ -92,6 +94,12 @@ EOF
 ]}}}}
 EOF
 
+  # A fresh copied project has no items (copyProjectV2 excludes draft issues);
+  # tests override this fixture when they need a populated destination.
+  cat > "$FIXTURE_ROOT/gh-items-new.json" <<'EOF'
+{"data": {"node": {"items": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": []}}}}
+EOF
+
   cat > "$FIXTURE_ROOT/gh-fields.json" <<'EOF'
 {"data": {"node": {"fields": {"nodes": [
   {"id": "PVTF_s_new", "name": "Status", "options": [{"id": "PVTO_done", "name": "Done"}, {"id": "PVTO_ip", "name": "In Progress"}, {"id": "PVTO_blocked", "name": "Blocked"}]},
@@ -105,6 +113,7 @@ EOF
   export GH_PROJECTS_RESPONSE="$FIXTURE_ROOT/gh-projects.json"
   export GH_ITEMS_RESPONSE="$FIXTURE_ROOT/gh-items.json"
   export GH_ITEMS_RESPONSE_2="$FIXTURE_ROOT/gh-items-2.json"
+  export GH_ITEMS_RESPONSE_NEW="$FIXTURE_ROOT/gh-items-new.json"
   export GH_FIELDS_RESPONSE="$FIXTURE_ROOT/gh-fields.json"
   : > "$GH_CALL_LOG"
   : > "$MOVE_LOG"
@@ -218,6 +227,28 @@ EOF
 
   grep -q '^draft Draft title Draft body$' "$MOVE_LOG"
   grep -q '^update PVTI_NEW_1 PVTF_s_new PVTO_ip$' "$MOVE_LOG"
+  grep -q '^delete PVTI_1$' "$MOVE_LOG"
+  [[ "$output" == *"Moved 1 item(s)"* ]]
+}
+
+@test "reuses a destination draft already carrying the source item marker on rerun" {
+  setup_fixture
+  cat > "$FIXTURE_ROOT/gh-items.json" <<'EOF'
+{"data": {"node": {"items": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": [
+  {"id": "PVTI_1", "content": {"__typename": "DraftIssue", "id": "D_1", "title": "Draft title", "body": "Draft body"}, "fieldValues": {"nodes": [{"name": "In Progress", "field": {"name": "Status"}}]}}
+]}}}}
+EOF
+  cat > "$FIXTURE_ROOT/gh-items-new.json" <<'EOF'
+{"data": {"node": {"items": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": [
+  {"id": "PVTI_NEW_D", "content": {"__typename": "DraftIssue", "id": "D_NEW", "title": "Draft title", "body": "Draft body\n<!-- rangelink-source-item: PVTI_1 -->"}, "fieldValues": {"nodes": []}}
+]}}}}
+EOF
+
+  run "$SCRIPT"
+  [[ "$status" -eq 0 ]]
+
+  ! grep -q '^draft ' "$MOVE_LOG"
+  grep -q '^update PVTI_NEW_D PVTF_s_new PVTO_ip$' "$MOVE_LOG"
   grep -q '^delete PVTI_1$' "$MOVE_LOG"
   [[ "$output" == *"Moved 1 item(s)"* ]]
 }

--- a/bats-tests/shell/rotate-release-board.bats
+++ b/bats-tests/shell/rotate-release-board.bats
@@ -28,7 +28,14 @@ done
 if [[ -z "$FILE" ]]; then
   exit 0
 fi
-if grep -q 'addProjectV2ItemById' "$FILE"; then
+if grep -q 'addProjectV2DraftIssue' "$FILE"; then
+  TITLE=$(jq -r '.variables.input.title' "$FILE")
+  BODY=$(jq -r '.variables.input.body' "$FILE")
+  COUNT=$(( $(grep -c '^add ' "$MOVE_LOG" 2>/dev/null || true) + 1 ))
+  NEW_ID="PVTI_NEW_${COUNT}"
+  echo "draft $TITLE $BODY" >> "$MOVE_LOG"
+  echo "{\"data\": {\"addProjectV2DraftIssue\": {\"projectV2Item\": {\"id\": \"$NEW_ID\"}}}}"
+elif grep -q 'addProjectV2ItemById' "$FILE"; then
   CONTENT_ID=$(jq -r '.variables.input.contentId' "$FILE")
   COUNT=$(( $(grep -c '^add ' "$MOVE_LOG" 2>/dev/null || true) + 1 ))
   NEW_ID="PVTI_NEW_${COUNT}"
@@ -46,11 +53,17 @@ elif grep -q 'deleteProjectV2Item' "$FILE"; then
   echo '{"data": {"deleteProjectV2Item": {"deletedItemId": "'"$ITEM_ID"'"}}}'
 elif grep -q 'copyProjectV2' "$FILE"; then
   TITLE=$(jq -r '.variables.input.title' "$FILE")
-  echo "copy $TITLE" >> "$MOVE_LOG"
+  OWNER_ID=$(jq -r '.variables.input.ownerId' "$FILE")
+  echo "copy $TITLE $OWNER_ID" >> "$MOVE_LOG"
   jq -n --arg title "$TITLE" \
     '{data: {copyProjectV2: {projectV2: {id: "PVT_NEW", title: $title, url: "https://github.com/users/couimet/projects/2"}}}}'
 elif grep -q 'items(first' "$FILE"; then
-  cat "$GH_ITEMS_RESPONSE"
+  CURSOR=$(jq -r '.variables.cursor // ""' "$FILE")
+  if [[ -n "$CURSOR" ]]; then
+    cat "$GH_ITEMS_RESPONSE_2"
+  else
+    cat "$GH_ITEMS_RESPONSE"
+  fi
 elif grep -q 'projectsV2' "$FILE"; then
   cat "$GH_PROJECTS_RESPONSE"
 elif grep -q 'SingleSelectField' "$FILE"; then
@@ -62,20 +75,20 @@ ENDOFSTUB
 
   cat > "$FIXTURE_ROOT/gh-projects.json" <<'EOF'
 {"data": {"viewer": {"projectsV2": {"nodes": [
-  {"id": "PVT_OLD", "title": "RangeLink v2.1.0 release", "url": "https://github.com/users/couimet/projects/1"}
+  {"id": "PVT_OLD", "title": "RangeLink v2.1.0 release", "url": "https://github.com/users/couimet/projects/1", "owner": {"id": "U_couimet"}}
 ]}}}}
 EOF
 
   cat > "$FIXTURE_ROOT/gh-items.json" <<'EOF'
-{"data": {"node": {"items": {"nodes": [
-  {"id": "PVTI_1", "content": {"id": "I_1"}, "fieldValues": {"nodes": [{"name": "In Progress", "field": {"name": "Status"}}]}},
-  {"id": "PVTI_2", "content": {"id": "I_2"}, "fieldValues": {"nodes": [
+{"data": {"node": {"items": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": [
+  {"id": "PVTI_1", "content": {"__typename": "Issue", "id": "I_1"}, "fieldValues": {"nodes": [{"name": "In Progress", "field": {"name": "Status"}}]}},
+  {"id": "PVTI_2", "content": {"__typename": "Issue", "id": "I_2"}, "fieldValues": {"nodes": [
     {"name": "Blocked", "field": {"name": "Status"}},
     {"name": "High", "field": {"name": "Priority"}},
     {"name": "Large", "field": {"name": "Size"}}
   ]}},
-  {"id": "PVTI_3", "content": {"id": "I_3"}, "fieldValues": {"nodes": [{"name": "Done", "field": {"name": "Status"}}]}},
-  {"id": "PVTI_4", "content": {"id": "I_4"}, "fieldValues": {"nodes": []}}
+  {"id": "PVTI_3", "content": {"__typename": "Issue", "id": "I_3"}, "fieldValues": {"nodes": [{"name": "Done", "field": {"name": "Status"}}]}},
+  {"id": "PVTI_4", "content": {"__typename": "Issue", "id": "I_4"}, "fieldValues": {"nodes": []}}
 ]}}}}
 EOF
 
@@ -91,6 +104,7 @@ EOF
   export MOVE_LOG="$FIXTURE_ROOT/move-ops.log"
   export GH_PROJECTS_RESPONSE="$FIXTURE_ROOT/gh-projects.json"
   export GH_ITEMS_RESPONSE="$FIXTURE_ROOT/gh-items.json"
+  export GH_ITEMS_RESPONSE_2="$FIXTURE_ROOT/gh-items-2.json"
   export GH_FIELDS_RESPONSE="$FIXTURE_ROOT/gh-fields.json"
   : > "$GH_CALL_LOG"
   : > "$MOVE_LOG"
@@ -110,7 +124,7 @@ EOF
   # fields → delete. The Done item (I_3) is untouched; the item without a
   # Status (I_4) is moved with no field restores.
   cat > "$FIXTURE_ROOT/expected-moves.log" <<'EOF'
-copy RangeLink v2.2.0 release
+copy RangeLink v2.2.0 release U_couimet
 add I_1 PVTI_NEW_1
 update PVTI_NEW_1 PVTF_s_new PVTO_ip
 delete PVTI_1
@@ -131,20 +145,81 @@ EOF
 
 # ── Idempotency ────────────────────────────────────────────────────────────────
 
-@test "skips when the next project already exists" {
+@test "reuses the existing next project as the migration destination" {
   setup_fixture
   cat > "$FIXTURE_ROOT/gh-projects.json" <<'EOF'
 {"data": {"viewer": {"projectsV2": {"nodes": [
-  {"id": "PVT_OLD", "title": "RangeLink v2.1.0 release", "url": "https://github.com/users/couimet/projects/1"},
-  {"id": "PVT_NEXT", "title": "RangeLink v2.2.0 release", "url": "https://github.com/users/couimet/projects/2"}
+  {"id": "PVT_OLD", "title": "RangeLink v2.1.0 release", "url": "https://github.com/users/couimet/projects/1", "owner": {"id": "U_couimet"}},
+  {"id": "PVT_NEXT", "title": "RangeLink v2.2.0 release", "url": "https://github.com/users/couimet/projects/2", "owner": {"id": "U_couimet"}}
 ]}}}}
 EOF
 
   run "$SCRIPT"
   [[ "$status" -eq 0 ]]
   [[ "$output" == *"already exists"* ]]
-  [[ "$output" == *"skipping rotation"* ]]
-  [[ ! -s "$MOVE_LOG" ]]
+  [[ "$output" == *"reusing it as the migration destination"* ]]
+  [[ "$output" == *"Moved 3 item(s)"* ]]
+  [[ "$output" == *"Next project: https://github.com/users/couimet/projects/2"* ]]
+  ! grep -q '^copy ' "$MOVE_LOG"
+  cat > "$FIXTURE_ROOT/expected-moves.log" <<'EOF'
+add I_1 PVTI_NEW_1
+update PVTI_NEW_1 PVTF_s_new PVTO_ip
+delete PVTI_1
+add I_2 PVTI_NEW_2
+update PVTI_NEW_2 PVTF_s_new PVTO_blocked
+update PVTI_NEW_2 PVTF_p_new PVTO_high
+update PVTI_NEW_2 PVTF_sz_new PVTO_large
+delete PVTI_2
+add I_4 PVTI_NEW_3
+delete PVTI_4
+EOF
+  diff -u "$FIXTURE_ROOT/expected-moves.log" "$MOVE_LOG"
+}
+
+@test "migrates items beyond the first page" {
+  setup_fixture
+  cat > "$FIXTURE_ROOT/gh-items.json" <<'EOF'
+{"data": {"node": {"items": {"pageInfo": {"hasNextPage": true, "endCursor": "CUR1"}, "nodes": [
+  {"id": "PVTI_1", "content": {"__typename": "Issue", "id": "I_1"}, "fieldValues": {"nodes": [{"name": "In Progress", "field": {"name": "Status"}}]}},
+  {"id": "PVTI_2", "content": {"__typename": "Issue", "id": "I_2"}, "fieldValues": {"nodes": [
+    {"name": "Blocked", "field": {"name": "Status"}},
+    {"name": "High", "field": {"name": "Priority"}},
+    {"name": "Large", "field": {"name": "Size"}}
+  ]}},
+  {"id": "PVTI_3", "content": {"__typename": "Issue", "id": "I_3"}, "fieldValues": {"nodes": [{"name": "Done", "field": {"name": "Status"}}]}},
+  {"id": "PVTI_4", "content": {"__typename": "Issue", "id": "I_4"}, "fieldValues": {"nodes": []}}
+]}}}}
+EOF
+  cat > "$FIXTURE_ROOT/gh-items-2.json" <<'EOF'
+{"data": {"node": {"items": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": [
+  {"id": "PVTI_5", "content": {"__typename": "Issue", "id": "I_5"}, "fieldValues": {"nodes": [{"name": "In Progress", "field": {"name": "Status"}}]}}
+]}}}}
+EOF
+
+  run "$SCRIPT"
+  [[ "$status" -eq 0 ]]
+
+  grep -q '^add I_5 PVTI_NEW_4$' "$MOVE_LOG"
+  grep -q '^update PVTI_NEW_4 PVTF_s_new PVTO_ip$' "$MOVE_LOG"
+  grep -q '^delete PVTI_5$' "$MOVE_LOG"
+  [[ "$output" == *"Moved 4 item(s)"* ]]
+}
+
+@test "migrates DraftIssue items via addProjectV2DraftIssue" {
+  setup_fixture
+  cat > "$FIXTURE_ROOT/gh-items.json" <<'EOF'
+{"data": {"node": {"items": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": [
+  {"id": "PVTI_1", "content": {"__typename": "DraftIssue", "id": "D_1", "title": "Draft title", "body": "Draft body"}, "fieldValues": {"nodes": [{"name": "In Progress", "field": {"name": "Status"}}]}}
+]}}}}
+EOF
+
+  run "$SCRIPT"
+  [[ "$status" -eq 0 ]]
+
+  grep -q '^draft Draft title Draft body$' "$MOVE_LOG"
+  grep -q '^update PVTI_NEW_1 PVTF_s_new PVTO_ip$' "$MOVE_LOG"
+  grep -q '^delete PVTI_1$' "$MOVE_LOG"
+  [[ "$output" == *"Moved 1 item(s)"* ]]
 }
 
 # ── Error paths ────────────────────────────────────────────────────────────────
@@ -153,7 +228,7 @@ EOF
   setup_fixture
   cat > "$FIXTURE_ROOT/gh-projects.json" <<'EOF'
 {"data": {"viewer": {"projectsV2": {"nodes": [
-  {"id": "PVT_PREV", "title": "RangeLink v2.0.0 release", "url": "https://github.com/users/couimet/projects/1"}
+  {"id": "PVT_PREV", "title": "RangeLink v2.0.0 release", "url": "https://github.com/users/couimet/projects/1", "owner": {"id": "U_couimet"}}
 ]}}}}
 EOF
 
@@ -172,7 +247,7 @@ EOF
 
   run "$SCRIPT" "3.0.0"
   [[ "$status" -eq 0 ]]
-  head -1 "$MOVE_LOG" | grep -q '^copy RangeLink v3.0.0 release$'
+  head -1 "$MOVE_LOG" | grep -q '^copy RangeLink v3.0.0 release U_couimet$'
 }
 
 @test "invalid next version exits 1" {

--- a/bats-tests/shell/rotate-release-board.bats
+++ b/bats-tests/shell/rotate-release-board.bats
@@ -1,0 +1,206 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+REAL_SCRIPT="$PROJECT_ROOT/packages/rangelink-vscode-extension/scripts/rotate-release-board.sh"
+
+setup_fixture() {
+  export FIXTURE_ROOT="$TEST_TEMP_DIR"
+  mkdir -p "$FIXTURE_ROOT/scripts"
+
+  cp "$REAL_SCRIPT" "$FIXTURE_ROOT/scripts/rotate-release-board.sh"
+  cp "$PROJECT_ROOT/packages/rangelink-vscode-extension/scripts/release-board-lib.sh" "$FIXTURE_ROOT/scripts/"
+
+  # Fake package.json so the version lookup works.
+  cat > "$FIXTURE_ROOT/package.json" <<'EOF'
+{"version": "2.1.0"}
+EOF
+
+  stub_dir
+
+  make_stub "gh" <<'ENDOFSTUB'
+#!/usr/bin/env bash
+echo "gh $*" >> "$GH_CALL_LOG"
+FILE=""
+for arg in "$@"; do
+  [[ -f "$arg" ]] && FILE="$arg" && break
+done
+if [[ -z "$FILE" ]]; then
+  exit 0
+fi
+if grep -q 'addProjectV2ItemById' "$FILE"; then
+  CONTENT_ID=$(jq -r '.variables.input.contentId' "$FILE")
+  COUNT=$(( $(grep -c '^add ' "$MOVE_LOG" 2>/dev/null || true) + 1 ))
+  NEW_ID="PVTI_NEW_${COUNT}"
+  echo "add $CONTENT_ID $NEW_ID" >> "$MOVE_LOG"
+  echo "{\"data\": {\"addProjectV2ItemById\": {\"item\": {\"id\": \"$NEW_ID\"}}}}"
+elif grep -q 'updateProjectV2ItemFieldValue' "$FILE"; then
+  ITEM_ID=$(jq -r '.variables.input.itemId' "$FILE")
+  FIELD_ID=$(jq -r '.variables.input.fieldId' "$FILE")
+  OPTION_ID=$(jq -r '.variables.input.value.singleSelectOptionId' "$FILE")
+  echo "update $ITEM_ID $FIELD_ID $OPTION_ID" >> "$MOVE_LOG"
+  echo '{"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "'"$ITEM_ID"'"}}}}'
+elif grep -q 'deleteProjectV2Item' "$FILE"; then
+  ITEM_ID=$(jq -r '.variables.input.itemId' "$FILE")
+  echo "delete $ITEM_ID" >> "$MOVE_LOG"
+  echo '{"data": {"deleteProjectV2Item": {"deletedItemId": "'"$ITEM_ID"'"}}}'
+elif grep -q 'copyProjectV2' "$FILE"; then
+  TITLE=$(jq -r '.variables.input.title' "$FILE")
+  echo "copy $TITLE" >> "$MOVE_LOG"
+  jq -n --arg title "$TITLE" \
+    '{data: {copyProjectV2: {projectV2: {id: "PVT_NEW", title: $title, url: "https://github.com/users/couimet/projects/2"}}}}'
+elif grep -q 'items(first' "$FILE"; then
+  cat "$GH_ITEMS_RESPONSE"
+elif grep -q 'projectsV2' "$FILE"; then
+  cat "$GH_PROJECTS_RESPONSE"
+elif grep -q 'SingleSelectField' "$FILE"; then
+  cat "$GH_FIELDS_RESPONSE"
+else
+  cat "$GH_PROJECTS_RESPONSE"
+fi
+ENDOFSTUB
+
+  cat > "$FIXTURE_ROOT/gh-projects.json" <<'EOF'
+{"data": {"viewer": {"projectsV2": {"nodes": [
+  {"id": "PVT_OLD", "title": "RangeLink v2.1.0 release", "url": "https://github.com/users/couimet/projects/1"}
+]}}}}
+EOF
+
+  cat > "$FIXTURE_ROOT/gh-items.json" <<'EOF'
+{"data": {"node": {"items": {"nodes": [
+  {"id": "PVTI_1", "content": {"id": "I_1"}, "fieldValues": {"nodes": [{"name": "In Progress", "field": {"name": "Status"}}]}},
+  {"id": "PVTI_2", "content": {"id": "I_2"}, "fieldValues": {"nodes": [
+    {"name": "Blocked", "field": {"name": "Status"}},
+    {"name": "High", "field": {"name": "Priority"}},
+    {"name": "Large", "field": {"name": "Size"}}
+  ]}},
+  {"id": "PVTI_3", "content": {"id": "I_3"}, "fieldValues": {"nodes": [{"name": "Done", "field": {"name": "Status"}}]}},
+  {"id": "PVTI_4", "content": {"id": "I_4"}, "fieldValues": {"nodes": []}}
+]}}}}
+EOF
+
+  cat > "$FIXTURE_ROOT/gh-fields.json" <<'EOF'
+{"data": {"node": {"fields": {"nodes": [
+  {"id": "PVTF_s_new", "name": "Status", "options": [{"id": "PVTO_done", "name": "Done"}, {"id": "PVTO_ip", "name": "In Progress"}, {"id": "PVTO_blocked", "name": "Blocked"}]},
+  {"id": "PVTF_p_new", "name": "Priority", "options": [{"id": "PVTO_high", "name": "High"}]},
+  {"id": "PVTF_sz_new", "name": "Size", "options": [{"id": "PVTO_large", "name": "Large"}]}
+]}}}}
+EOF
+
+  export GH_CALL_LOG="$FIXTURE_ROOT/gh-calls.log"
+  export MOVE_LOG="$FIXTURE_ROOT/move-ops.log"
+  export GH_PROJECTS_RESPONSE="$FIXTURE_ROOT/gh-projects.json"
+  export GH_ITEMS_RESPONSE="$FIXTURE_ROOT/gh-items.json"
+  export GH_FIELDS_RESPONSE="$FIXTURE_ROOT/gh-fields.json"
+  : > "$GH_CALL_LOG"
+  : > "$MOVE_LOG"
+
+  SCRIPT="$FIXTURE_ROOT/scripts/rotate-release-board.sh"
+}
+
+# ── Move order ─────────────────────────────────────────────────────────────────
+
+@test "moves non-Done items in order, restoring Status, Priority, and Size" {
+  setup_fixture
+
+  run "$SCRIPT"
+  [[ "$status" -eq 0 ]]
+
+  # Exact move sequence: create next project, then per item add → restore
+  # fields → delete. The Done item (I_3) is untouched; the item without a
+  # Status (I_4) is moved with no field restores.
+  cat > "$FIXTURE_ROOT/expected-moves.log" <<'EOF'
+copy RangeLink v2.2.0 release
+add I_1 PVTI_NEW_1
+update PVTI_NEW_1 PVTF_s_new PVTO_ip
+delete PVTI_1
+add I_2 PVTI_NEW_2
+update PVTI_NEW_2 PVTF_s_new PVTO_blocked
+update PVTI_NEW_2 PVTF_p_new PVTO_high
+update PVTI_NEW_2 PVTF_sz_new PVTO_large
+delete PVTI_2
+add I_4 PVTI_NEW_3
+delete PVTI_4
+EOF
+  diff -u "$FIXTURE_ROOT/expected-moves.log" "$MOVE_LOG"
+
+  [[ "$output" == *"Moved 3 item(s)"* ]]
+  [[ "$output" == *"Next project: https://github.com/users/couimet/projects/2"* ]]
+  [[ "$output" == *"Old project left open: RangeLink v2.1.0 release"* ]]
+}
+
+# ── Idempotency ────────────────────────────────────────────────────────────────
+
+@test "skips when the next project already exists" {
+  setup_fixture
+  cat > "$FIXTURE_ROOT/gh-projects.json" <<'EOF'
+{"data": {"viewer": {"projectsV2": {"nodes": [
+  {"id": "PVT_OLD", "title": "RangeLink v2.1.0 release", "url": "https://github.com/users/couimet/projects/1"},
+  {"id": "PVT_NEXT", "title": "RangeLink v2.2.0 release", "url": "https://github.com/users/couimet/projects/2"}
+]}}}}
+EOF
+
+  run "$SCRIPT"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"already exists"* ]]
+  [[ "$output" == *"skipping rotation"* ]]
+  [[ ! -s "$MOVE_LOG" ]]
+}
+
+# ── Error paths ────────────────────────────────────────────────────────────────
+
+@test "fails with a clear error when the current project is not found" {
+  setup_fixture
+  cat > "$FIXTURE_ROOT/gh-projects.json" <<'EOF'
+{"data": {"viewer": {"projectsV2": {"nodes": [
+  {"id": "PVT_PREV", "title": "RangeLink v2.0.0 release", "url": "https://github.com/users/couimet/projects/1"}
+]}}}}
+EOF
+
+  run "$SCRIPT"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"no project titled 'RangeLink v2.1.0 release' found"* ]]
+  [[ "$output" == *"Available projects:"* ]]
+  [[ "$output" == *"RangeLink v2.0.0 release"* ]]
+  [[ ! -s "$MOVE_LOG" ]]
+}
+
+# ── Version handling ───────────────────────────────────────────────────────────
+
+@test "explicit next version overrides the default minor bump" {
+  setup_fixture
+
+  run "$SCRIPT" "3.0.0"
+  [[ "$status" -eq 0 ]]
+  head -1 "$MOVE_LOG" | grep -q '^copy RangeLink v3.0.0 release$'
+}
+
+@test "invalid next version exits 1" {
+  setup_fixture
+
+  run "$SCRIPT" "3.0"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"next version must be SemVer"* ]]
+}
+
+# ── Dry run ────────────────────────────────────────────────────────────────────
+
+@test "--dry-run prints the plan without calling gh" {
+  setup_fixture
+
+  run "$SCRIPT" --dry-run
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"DRY RUN"* ]]
+  [[ "$output" == *"would create project 'RangeLink v2.2.0 release'"* ]]
+  [[ ! -s "$GH_CALL_LOG" ]]
+}
+
+# ── Argument validation ────────────────────────────────────────────────────────
+
+@test "unknown argument exits 1" {
+  setup_fixture
+
+  run "$SCRIPT" --bogus
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"Unknown argument: --bogus"* ]]
+}

--- a/bats-tests/shell/rotate-release-board.bats
+++ b/bats-tests/shell/rotate-release-board.bats
@@ -83,14 +83,10 @@ EOF
 
   cat > "$FIXTURE_ROOT/gh-items.json" <<'EOF'
 {"data": {"node": {"items": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": [
-  {"id": "PVTI_1", "content": {"__typename": "Issue", "id": "I_1"}, "fieldValues": {"nodes": [{"name": "In Progress", "field": {"name": "Status"}}]}},
-  {"id": "PVTI_2", "content": {"__typename": "Issue", "id": "I_2"}, "fieldValues": {"nodes": [
-    {"name": "Blocked", "field": {"name": "Status"}},
-    {"name": "High", "field": {"name": "Priority"}},
-    {"name": "Large", "field": {"name": "Size"}}
-  ]}},
-  {"id": "PVTI_3", "content": {"__typename": "Issue", "id": "I_3"}, "fieldValues": {"nodes": [{"name": "Done", "field": {"name": "Status"}}]}},
-  {"id": "PVTI_4", "content": {"__typename": "Issue", "id": "I_4"}, "fieldValues": {"nodes": []}}
+  {"id": "PVTI_1", "content": {"__typename": "Issue", "id": "I_1"}, "statusValue": {"name": "In Progress"}},
+  {"id": "PVTI_2", "content": {"__typename": "Issue", "id": "I_2"}, "statusValue": {"name": "Blocked"}, "priorityValue": {"name": "High"}, "sizeValue": {"name": "Large"}},
+  {"id": "PVTI_3", "content": {"__typename": "Issue", "id": "I_3"}, "statusValue": {"name": "Done"}},
+  {"id": "PVTI_4", "content": {"__typename": "Issue", "id": "I_4"}}
 ]}}}}
 EOF
 
@@ -189,19 +185,15 @@ EOF
   setup_fixture
   cat > "$FIXTURE_ROOT/gh-items.json" <<'EOF'
 {"data": {"node": {"items": {"pageInfo": {"hasNextPage": true, "endCursor": "CUR1"}, "nodes": [
-  {"id": "PVTI_1", "content": {"__typename": "Issue", "id": "I_1"}, "fieldValues": {"nodes": [{"name": "In Progress", "field": {"name": "Status"}}]}},
-  {"id": "PVTI_2", "content": {"__typename": "Issue", "id": "I_2"}, "fieldValues": {"nodes": [
-    {"name": "Blocked", "field": {"name": "Status"}},
-    {"name": "High", "field": {"name": "Priority"}},
-    {"name": "Large", "field": {"name": "Size"}}
-  ]}},
-  {"id": "PVTI_3", "content": {"__typename": "Issue", "id": "I_3"}, "fieldValues": {"nodes": [{"name": "Done", "field": {"name": "Status"}}]}},
-  {"id": "PVTI_4", "content": {"__typename": "Issue", "id": "I_4"}, "fieldValues": {"nodes": []}}
+  {"id": "PVTI_1", "content": {"__typename": "Issue", "id": "I_1"}, "statusValue": {"name": "In Progress"}},
+  {"id": "PVTI_2", "content": {"__typename": "Issue", "id": "I_2"}, "statusValue": {"name": "Blocked"}, "priorityValue": {"name": "High"}, "sizeValue": {"name": "Large"}},
+  {"id": "PVTI_3", "content": {"__typename": "Issue", "id": "I_3"}, "statusValue": {"name": "Done"}},
+  {"id": "PVTI_4", "content": {"__typename": "Issue", "id": "I_4"}}
 ]}}}}
 EOF
   cat > "$FIXTURE_ROOT/gh-items-2.json" <<'EOF'
 {"data": {"node": {"items": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": [
-  {"id": "PVTI_5", "content": {"__typename": "Issue", "id": "I_5"}, "fieldValues": {"nodes": [{"name": "In Progress", "field": {"name": "Status"}}]}}
+  {"id": "PVTI_5", "content": {"__typename": "Issue", "id": "I_5"}, "statusValue": {"name": "In Progress"}}
 ]}}}}
 EOF
 
@@ -218,7 +210,7 @@ EOF
   setup_fixture
   cat > "$FIXTURE_ROOT/gh-items.json" <<'EOF'
 {"data": {"node": {"items": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": [
-  {"id": "PVTI_1", "content": {"__typename": "DraftIssue", "id": "D_1", "title": "Draft title", "body": "Draft body"}, "fieldValues": {"nodes": [{"name": "In Progress", "field": {"name": "Status"}}]}}
+  {"id": "PVTI_1", "content": {"__typename": "DraftIssue", "id": "D_1", "title": "Draft title", "body": "Draft body"}, "statusValue": {"name": "In Progress"}}
 ]}}}}
 EOF
 
@@ -226,6 +218,7 @@ EOF
   [[ "$status" -eq 0 ]]
 
   grep -q '^draft Draft title Draft body$' "$MOVE_LOG"
+  grep -Fx '<!-- rangelink-source-item: PVTI_1 -->' "$MOVE_LOG"
   grep -q '^update PVTI_NEW_1 PVTF_s_new PVTO_ip$' "$MOVE_LOG"
   grep -q '^delete PVTI_1$' "$MOVE_LOG"
   [[ "$output" == *"Moved 1 item(s)"* ]]
@@ -235,7 +228,7 @@ EOF
   setup_fixture
   cat > "$FIXTURE_ROOT/gh-items.json" <<'EOF'
 {"data": {"node": {"items": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": [
-  {"id": "PVTI_1", "content": {"__typename": "DraftIssue", "id": "D_1", "title": "Draft title", "body": "Draft body"}, "fieldValues": {"nodes": [{"name": "In Progress", "field": {"name": "Status"}}]}}
+  {"id": "PVTI_1", "content": {"__typename": "DraftIssue", "id": "D_1", "title": "Draft title", "body": "Draft body"}, "statusValue": {"name": "In Progress"}}
 ]}}}}
 EOF
   cat > "$FIXTURE_ROOT/gh-items-new.json" <<'EOF'

--- a/bats-tests/shell/start-release.bats
+++ b/bats-tests/shell/start-release.bats
@@ -40,19 +40,20 @@ done
 [[ -z "$FILE" ]] && exit 0
 if grep -q 'copyProjectV2' "$FILE"; then
   TITLE=$(jq -r '.variables.input.title' "$FILE")
-  echo "copy $TITLE" >> "$GH_CALL_LOG"
+  OWNER_ID=$(jq -r '.variables.input.ownerId' "$FILE")
+  echo "copy $TITLE $OWNER_ID" >> "$GH_CALL_LOG"
   jq -n --arg title "$TITLE" \
     '{data: {copyProjectV2: {projectV2: {id: "PVT_NEW", title: $title, url: "https://github.com/users/couimet/projects/2"}}}}'
 elif grep -q 'items(first' "$FILE"; then
-  echo '{"data": {"node": {"items": {"nodes": []}}}}'
+  echo '{"data": {"node": {"items": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": []}}}}'
 elif grep -q 'projectsV2' "$FILE"; then
   jq -n --arg v "$VERSION" \
-    '{data: {viewer: {projectsV2: {nodes: [{id: "PVT_OLD", title: ("RangeLink v" + $v + " release"), url: "https://github.com/users/couimet/projects/1"}]}}}}'
+    '{data: {viewer: {projectsV2: {nodes: [{id: "PVT_OLD", title: ("RangeLink v" + $v + " release"), url: "https://github.com/users/couimet/projects/1", owner: {id: "U_couimet"}}]}}}}'
 elif grep -q 'SingleSelectField' "$FILE"; then
   echo '{"data": {"node": {"fields": {"nodes": []}}}}'
 else
   jq -n --arg v "$VERSION" \
-    '{data: {viewer: {projectsV2: {nodes: [{id: "PVT_OLD", title: ("RangeLink v" + $v + " release"), url: "https://github.com/users/couimet/projects/1"}]}}}}'
+    '{data: {viewer: {projectsV2: {nodes: [{id: "PVT_OLD", title: ("RangeLink v" + $v + " release"), url: "https://github.com/users/couimet/projects/1", owner: {id: "U_couimet"}}]}}}}'
 fi
 ENDOFSTUB
   export GH_CALL_LOG="$FIXTURE_ROOT/gh-calls.log"
@@ -127,7 +128,7 @@ EOF
 
   # Step 3: release board rotation ran (next version 2.1.0 = minor bump of 2.0.0).
   [[ "$output" == *"Step 3: Rotating release project board"* ]]
-  grep -q '^copy RangeLink v2.1.0 release$' "$GH_CALL_LOG"
+  grep -q '^copy RangeLink v2.1.0 release U_couimet$' "$GH_CALL_LOG"
 }
 
 @test "CHANGELOG: [Unreleased] has empty sections and existing content preserved below" {

--- a/bats-tests/shell/start-release.bats
+++ b/bats-tests/shell/start-release.bats
@@ -10,6 +10,10 @@ setup_fixture() {
   mkdir -p "$FIXTURE_ROOT/qa"
 
   cp "$REAL_SCRIPT" "$FIXTURE_ROOT/scripts/start-release.sh"
+  cp "$PROJECT_ROOT/packages/rangelink-vscode-extension/scripts/rotate-release-board.sh" \
+     "$FIXTURE_ROOT/scripts/rotate-release-board.sh"
+  cp "$PROJECT_ROOT/packages/rangelink-vscode-extension/scripts/release-board-lib.sh" \
+     "$FIXTURE_ROOT/scripts/"
   SCRIPT="$FIXTURE_ROOT/scripts/start-release.sh"
 
   stub_dir
@@ -22,6 +26,37 @@ ENDOFSTUB
   export FIXTURE_ROOT_FOR_GIT="$FIXTURE_ROOT"
 
   make_passive_stub "npx"
+
+  # Step 3 runs rotate-release-board.sh, which queries the GitHub projects
+  # API. Respond with the just-released project (title from fixture
+  # package.json) and an empty item list so the rotation completes.
+  make_stub "gh" <<'ENDOFSTUB'
+#!/usr/bin/env bash
+VERSION=$(jq -r '.version // "2.0.0"' "$PWD/package.json" 2>/dev/null || echo "2.0.0")
+FILE=""
+for arg in "$@"; do
+  [[ -f "$arg" ]] && FILE="$arg" && break
+done
+[[ -z "$FILE" ]] && exit 0
+if grep -q 'copyProjectV2' "$FILE"; then
+  TITLE=$(jq -r '.variables.input.title' "$FILE")
+  echo "copy $TITLE" >> "$GH_CALL_LOG"
+  jq -n --arg title "$TITLE" \
+    '{data: {copyProjectV2: {projectV2: {id: "PVT_NEW", title: $title, url: "https://github.com/users/couimet/projects/2"}}}}'
+elif grep -q 'items(first' "$FILE"; then
+  echo '{"data": {"node": {"items": {"nodes": []}}}}'
+elif grep -q 'projectsV2' "$FILE"; then
+  jq -n --arg v "$VERSION" \
+    '{data: {viewer: {projectsV2: {nodes: [{id: "PVT_OLD", title: ("RangeLink v" + $v + " release"), url: "https://github.com/users/couimet/projects/1"}]}}}}'
+elif grep -q 'SingleSelectField' "$FILE"; then
+  echo '{"data": {"node": {"fields": {"nodes": []}}}}'
+else
+  jq -n --arg v "$VERSION" \
+    '{data: {viewer: {projectsV2: {nodes: [{id: "PVT_OLD", title: ("RangeLink v" + $v + " release"), url: "https://github.com/users/couimet/projects/1"}]}}}}'
+fi
+ENDOFSTUB
+  export GH_CALL_LOG="$FIXTURE_ROOT/gh-calls.log"
+  : > "$GH_CALL_LOG"
 
   write_package_json() {
     cat > "$FIXTURE_ROOT/package.json"
@@ -89,6 +124,10 @@ EOF
   banner_line=$(grep -n '\[!IMPORTANT\]' "$FIXTURE_ROOT/README.md" | cut -d: -f1)
   first_section_line=$(grep -n '^## ' "$FIXTURE_ROOT/README.md" | head -1 | cut -d: -f1)
   [[ "$banner_line" -lt "$first_section_line" ]]
+
+  # Step 3: release board rotation ran (next version 2.1.0 = minor bump of 2.0.0).
+  [[ "$output" == *"Step 3: Rotating release project board"* ]]
+  grep -q '^copy RangeLink v2.1.0 release$' "$GH_CALL_LOG"
 }
 
 @test "CHANGELOG: [Unreleased] has empty sections and existing content preserved below" {

--- a/docs/RELEASE-STRATEGY.md
+++ b/docs/RELEASE-STRATEGY.md
@@ -146,14 +146,14 @@ Three verbs, three phases: **lock** (freeze the version for QA), **prepare** (ma
 
 Releasing a package involves these phases:
 
-1. **Lock** — `pnpm release:lock:vscode-extension X.Y.Z` — soft-lock the version for QA
+1. **Lock** — `pnpm release:lock:vscode-extension X.Y.Z` — soft-lock the version for QA and create the release tracking issues. The script ends with the exact `/release-prep` skill prompt to run for the cross-repo article-registration issue.
 2. **QA Pass** — manual + automated TCs against the versioned YAML
 3. **Prepare** — `pnpm release:prepare:vscode-extension` — date-stamp CHANGELOG, strip `<sup>Unreleased</sup>` markers, remove `[!IMPORTANT]` banner, generate publishing instructions
 4. **Build & Test** - Package and validate locally
 5. **Publish** - Deploy to marketplace(s) and create GitHub release
 6. **Tag** - Create annotated git tag following [tagging convention](#tagging-convention)
 7. **Verify** - Confirm publication and test installation
-8. **Next cycle** — `pnpm release:start:vscode-extension` to begin the next development cycle
+8. **Next cycle** — `pnpm release:start:vscode-extension` to begin the next development cycle. Also rotates the release project board: creates the next "RangeLink vX.Y.0 release" project and moves non-Done items with status preserved
 
 ### Package-Specific Instructions
 

--- a/docs/RELEASE-STRATEGY.md
+++ b/docs/RELEASE-STRATEGY.md
@@ -153,7 +153,7 @@ Releasing a package involves these phases:
 5. **Publish** - Deploy to marketplace(s) and create GitHub release
 6. **Tag** - Create annotated git tag following [tagging convention](#tagging-convention)
 7. **Verify** - Confirm publication and test installation
-8. **Next cycle** — `pnpm release:start:vscode-extension` to begin the next development cycle. Also rotates the release project board: creates the next "RangeLink vX.Y.0 release" project and moves non-Done items with status preserved
+8. **Next cycle** — `pnpm release:start:vscode-extension` to begin the next development cycle. Also rotates the release project board: creates the next "RangeLink vA.B.C release" project and moves non-Done items with status preserved
 
 ### Package-Specific Instructions
 

--- a/packages/rangelink-vscode-extension/scripts/add-issue-to-release-board.sh
+++ b/packages/rangelink-vscode-extension/scripts/add-issue-to-release-board.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 # Adds an existing GitHub issue (any repository) to the release project board
 # for the version in package.json, with Status set to Ready where the board
 # has a Ready option. Used by the release-prep skill for the cross-repo
-# couimet.github.io article-registration issue.
+# couimet.github.io article-registration issue; prints the board URL for the
+# skill's final report.
 #
 # The release board is resolved by exact title match on the current user's
 # projectsV2; candidates are listed when no exact match exists. With
@@ -91,6 +92,7 @@ PROJECTS_RESPONSE=$(list_release_projects)
 BOARD_RESOLVED=$(resolve_release_board "$BOARD_TITLE")
 BOARD_ID=$(echo "$BOARD_RESOLVED" | cut -f1)
 BOARD_NUMBER=$(echo "$BOARD_RESOLVED" | cut -f2)
+BOARD_URL=$(echo "$BOARD_RESOLVED" | cut -f3)
 
 STATUS_READY=$(resolve_status_ready "$PROJECTS_RESPONSE" "$BOARD_ID")
 STATUS_FIELD_ID=$(echo "$STATUS_READY" | cut -f1)
@@ -127,3 +129,4 @@ fi
 echo ""
 echo -e "${GREEN}Done.${NC}"
 echo "Added: $ISSUE_URL to $BOARD_TITLE (project #$BOARD_NUMBER), status: $STATUS_VALUE"
+echo "Board URL: $BOARD_URL"

--- a/packages/rangelink-vscode-extension/scripts/add-issue-to-release-board.sh
+++ b/packages/rangelink-vscode-extension/scripts/add-issue-to-release-board.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/add-issue-to-release-board.sh <issue-url> [--dry-run]
+#
+# Adds an existing GitHub issue (any repository) to the release project board
+# for the version in package.json, with Status set to Ready where the board
+# has a Ready option. Used by the release-prep skill for the cross-repo
+# couimet.github.io article-registration issue.
+#
+# The release board is resolved by exact title match on the current user's
+# projectsV2; candidates are listed when no exact match exists. With
+# --dry-run, prints the resolved inputs without making any GitHub calls.
+# Board operations live in release-board-lib.sh (sourced).
+#
+# Requires:
+#   jq         — reads .version from package.json and builds GraphQL payloads
+#   gh CLI     — authenticated with access to the issue and the user's projectsV2
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+DRY_RUN=false
+ISSUE_URL=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --) ;;
+    -*) echo "Unknown argument: $arg" >&2; exit 1 ;;
+    *)
+      if [[ -n "$ISSUE_URL" ]]; then
+        echo -e "${RED}Error: unexpected extra argument: $arg${NC}" >&2
+        exit 1
+      fi
+      ISSUE_URL="$arg"
+      ;;
+  esac
+done
+
+if [[ -z "$ISSUE_URL" ]]; then
+  echo -e "${RED}Usage: $0 <issue-url> [--dry-run]${NC}" >&2
+  echo "Example: $0 https://github.com/couimet/couimet.github.io/issues/12" >&2
+  exit 1
+fi
+
+if [[ "$ISSUE_URL" =~ ^https://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/issues/([0-9]+)$ ]]; then
+  ISSUE_REPO="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+else
+  echo -e "${RED}Error: issue URL must look like https://github.com/<owner>/<repo>/issues/<number>${NC}" >&2
+  echo "  got: $ISSUE_URL" >&2
+  exit 1
+fi
+
+if [[ "$DRY_RUN" == false ]] && ! command -v gh &>/dev/null; then
+  echo "Error: gh CLI is required but not found on PATH" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(dirname "$SCRIPT_DIR")"
+
+source "$SCRIPT_DIR/release-board-lib.sh"
+
+VERSION=$(jq -r '.version // empty' "$PACKAGE_DIR/package.json")
+if [[ -z "$VERSION" ]]; then
+  echo -e "${RED}Error: .version not set in $PACKAGE_DIR/package.json${NC}" >&2
+  exit 1
+fi
+
+BOARD_TITLE="RangeLink v${VERSION} release"
+
+echo "Release board add"
+echo "  Version : v$VERSION"
+echo "  Board   : $BOARD_TITLE"
+echo "  Issue   : $ISSUE_URL ($ISSUE_REPO)"
+[[ "$DRY_RUN" == true ]] && echo "  Mode    : DRY RUN (no GitHub calls)"
+echo ""
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo "DRY-RUN: would add $ISSUE_URL to '$BOARD_TITLE' with Status: Ready"
+  exit 0
+fi
+
+# --- Resolve the release board ---
+
+PROJECTS_RESPONSE=$(list_release_projects)
+
+BOARD_RESOLVED=$(resolve_release_board "$BOARD_TITLE")
+BOARD_ID=$(echo "$BOARD_RESOLVED" | cut -f1)
+BOARD_NUMBER=$(echo "$BOARD_RESOLVED" | cut -f2)
+
+STATUS_READY=$(resolve_status_ready "$PROJECTS_RESPONSE" "$BOARD_ID")
+STATUS_FIELD_ID=$(echo "$STATUS_READY" | cut -f1)
+READY_OPTION_ID=$(echo "$STATUS_READY" | cut -f2)
+
+echo -e "${GREEN}Resolved release board: $BOARD_TITLE (project #$BOARD_NUMBER)${NC}"
+
+# --- Resolve the issue node id ---
+
+ISSUE_NODE_ID=$(gh issue view "$ISSUE_URL" --json id --jq .id)
+if [[ -z "$ISSUE_NODE_ID" || "$ISSUE_NODE_ID" == "null" ]]; then
+  echo -e "${RED}Error: could not resolve node id for $ISSUE_URL${NC}" >&2
+  exit 1
+fi
+
+# --- Add the issue to the board and set Status to Ready ---
+
+ITEM_ID=$(add_board_item "$BOARD_ID" "$ISSUE_NODE_ID")
+if [[ -z "$ITEM_ID" || "$ITEM_ID" == "null" ]]; then
+  echo -e "${RED}Error: addProjectV2ItemById did not return an item id${NC}" >&2
+  exit 1
+fi
+
+echo -e "${GREEN}Added issue to the release board.${NC}"
+
+if [[ -z "$STATUS_FIELD_ID" || -z "$READY_OPTION_ID" ]]; then
+  echo -e "${YELLOW}Warning: release board has no 'Status' field with a 'Ready' option — status left unset${NC}"
+  STATUS_VALUE="unset"
+else
+  set_board_field_value "$BOARD_ID" "$ITEM_ID" "$STATUS_FIELD_ID" "$READY_OPTION_ID"
+  STATUS_VALUE="Ready"
+fi
+
+echo ""
+echo -e "${GREEN}Done.${NC}"
+echo "Added: $ISSUE_URL to $BOARD_TITLE (project #$BOARD_NUMBER), status: $STATUS_VALUE"

--- a/packages/rangelink-vscode-extension/scripts/check-dirty-tree.sh
+++ b/packages/rangelink-vscode-extension/scripts/check-dirty-tree.sh
@@ -11,6 +11,11 @@
 
 check_dirty_tree() {
   local repo_root="$1"
+  # In-place test runs carry uncommitted guard scripts, so relax the check.
+  if [[ -n "${RELEASE_LOCK_INPLACE:-}" ]]; then
+    echo -e "${YELLOW:-}RELEASE_LOCK_INPLACE set — skipping dirty-tree check.${NC:-}"
+    return 0
+  fi
   local artifact_glob='packages/rangelink-vscode-extension/qa/release-testing-instructions-v*.md'
   local dirty
   dirty=$(git -C "$repo_root" status --porcelain -- ":(exclude)$artifact_glob")

--- a/packages/rangelink-vscode-extension/scripts/generate-release-issues.sh
+++ b/packages/rangelink-vscode-extension/scripts/generate-release-issues.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/generate-release-issues.sh <qa-issue-url> [--dry-run]
+#
+# Creates the dev.to post issue for the version in package.json and adds it
+# plus the QA issue to the "RangeLink vX.Y.Z release" project board, with
+# Status set to Ready where the board has a Ready option.
+#
+# The release board is resolved by exact title match on the current user's
+# projectsV2; candidates are listed when no exact match exists. With
+# --dry-run, prints the issue title and body without making any GitHub calls.
+# Board operations live in release-board-lib.sh (sourced).
+#
+# Requires:
+#   jq         — reads .version from package.json and builds GraphQL payloads
+#   gh CLI     — authenticated with write access to the repo (not needed with --dry-run)
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+DRY_RUN=false
+QA_ISSUE_URL=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --) ;;
+    -*) echo "Unknown argument: $arg" >&2; exit 1 ;;
+    *)
+      if [[ -n "$QA_ISSUE_URL" ]]; then
+        echo -e "${RED}Error: unexpected extra argument: $arg${NC}" >&2
+        exit 1
+      fi
+      QA_ISSUE_URL="$arg"
+      ;;
+  esac
+done
+
+if [[ -z "$QA_ISSUE_URL" ]]; then
+  echo -e "${RED}Usage: $0 <qa-issue-url> [--dry-run]${NC}" >&2
+  echo "Example: $0 https://github.com/couimet/rangeLink/issues/123" >&2
+  exit 1
+fi
+
+if [[ "$QA_ISSUE_URL" =~ ^https://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/issues/([0-9]+)$ ]]; then
+  REPO_OWNER="${BASH_REMATCH[1]}"
+  REPO_NAME="${BASH_REMATCH[2]}"
+  QA_ISSUE_NUMBER="${BASH_REMATCH[3]}"
+else
+  echo -e "${RED}Error: QA issue URL must look like https://github.com/<owner>/<repo>/issues/<number>${NC}" >&2
+  echo "  got: $QA_ISSUE_URL" >&2
+  exit 1
+fi
+
+if [[ "$DRY_RUN" == false ]] && ! command -v gh &>/dev/null; then
+  echo "Error: gh CLI is required but not found on PATH" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(dirname "$SCRIPT_DIR")"
+
+source "$SCRIPT_DIR/release-board-lib.sh"
+
+VERSION=$(jq -r '.version // empty' "$PACKAGE_DIR/package.json")
+if [[ -z "$VERSION" ]]; then
+  echo -e "${RED}Error: .version not set in $PACKAGE_DIR/package.json${NC}" >&2
+  exit 1
+fi
+
+BOARD_TITLE="RangeLink v${VERSION} release"
+DEVTO_TITLE="Prepare dev.to post for v${VERSION} release"
+DEVTO_BODY="Prepare a dev.to article announcing the RangeLink v${VERSION} release to the broader developer community.
+
+## Acceptance Criteria
+
+- [ ] Draft article written (after feature freeze)
+- [ ] Screenshots/GIFs prepared
+- [ ] Article reviewed
+- [ ] Ready to publish on release day
+
+## Resources
+
+- Draft template: \`media/devto-post-vscode-extension-v${VERSION}.md\`
+- Update the [Featured In](packages/rangelink-vscode-extension/README.md#featured-in) section of the extension README with the published article link"
+
+echo "Release issue generator"
+echo "  Version  : v$VERSION"
+echo "  Board    : $BOARD_TITLE"
+echo "  QA issue : $QA_ISSUE_URL"
+[[ "$DRY_RUN" == true ]] && echo "  Mode     : DRY RUN (no GitHub calls)"
+echo ""
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo "DRY-RUN issue: $DEVTO_TITLE"
+  echo ""
+  echo "--- Body ---"
+  echo "$DEVTO_BODY"
+  echo "---"
+  echo "DRY-RUN: skipping board lookup and project updates"
+  exit 0
+fi
+
+# --- Resolve the release board ---
+
+PROJECTS_RESPONSE=$(list_release_projects)
+
+BOARD_RESOLVED=$(resolve_release_board "$BOARD_TITLE")
+BOARD_ID=$(echo "$BOARD_RESOLVED" | cut -f1)
+BOARD_NUMBER=$(echo "$BOARD_RESOLVED" | cut -f2)
+
+STATUS_READY=$(resolve_status_ready "$PROJECTS_RESPONSE" "$BOARD_ID")
+STATUS_FIELD_ID=$(echo "$STATUS_READY" | cut -f1)
+READY_OPTION_ID=$(echo "$STATUS_READY" | cut -f2)
+
+echo -e "${GREEN}Resolved release board: $BOARD_TITLE (project #$BOARD_NUMBER)${NC}"
+echo ""
+
+# --- Create the dev.to issue ---
+
+echo -e "${GREEN}Creating dev.to post issue...${NC}"
+DEVTO_URL=$(gh issue create --title "$DEVTO_TITLE" --body "$DEVTO_BODY")
+echo "Created: $DEVTO_URL"
+echo ""
+
+DEVTO_ISSUE_NUMBER=$(echo "$DEVTO_URL" | sed -E 's|.*/issues/([0-9]+)$|\1|')
+
+# --- Resolve GraphQL node ids for both issues ---
+
+ISSUE_IDS_QUERY="query { repository(owner: \"$REPO_OWNER\", name: \"$REPO_NAME\") { devto: issue(number: $DEVTO_ISSUE_NUMBER) { id } qa: issue(number: $QA_ISSUE_NUMBER) { id } } }"
+ISSUE_IDS_RESPONSE=$(graphql_call "$(jq -n --arg q "$ISSUE_IDS_QUERY" '{query: $q, variables: {}}')")
+
+DEVTO_NODE_ID=$(echo "$ISSUE_IDS_RESPONSE" | jq -r '.data.repository.devto.id')
+QA_NODE_ID=$(echo "$ISSUE_IDS_RESPONSE" | jq -r '.data.repository.qa.id')
+if [[ -z "$DEVTO_NODE_ID" || "$DEVTO_NODE_ID" == "null" || -z "$QA_NODE_ID" || "$QA_NODE_ID" == "null" ]]; then
+  echo -e "${RED}Error: could not resolve GraphQL node ids for $DEVTO_URL and $QA_ISSUE_URL${NC}" >&2
+  exit 1
+fi
+
+# --- Add both issues to the board and set Status to Ready ---
+
+echo -e "${GREEN}Adding issues to the release board...${NC}"
+
+DEVTO_ITEM_ID=$(add_board_item "$BOARD_ID" "$DEVTO_NODE_ID")
+QA_ITEM_ID=$(add_board_item "$BOARD_ID" "$QA_NODE_ID")
+
+if [[ -z "$STATUS_FIELD_ID" || -z "$READY_OPTION_ID" ]]; then
+  echo -e "${YELLOW}Warning: release board has no 'Status' field with a 'Ready' option — skipping status updates${NC}"
+  DEVTO_STATUS="unset"
+  QA_STATUS="unset"
+else
+  set_board_field_value "$BOARD_ID" "$DEVTO_ITEM_ID" "$STATUS_FIELD_ID" "$READY_OPTION_ID"
+  set_board_field_value "$BOARD_ID" "$QA_ITEM_ID" "$STATUS_FIELD_ID" "$READY_OPTION_ID"
+  DEVTO_STATUS="Ready"
+  QA_STATUS="Ready"
+fi
+
+echo ""
+echo -e "${GREEN}Release issues ready.${NC}"
+echo "  Board: $BOARD_TITLE (project #$BOARD_NUMBER)"
+echo "  - dev.to issue: $DEVTO_URL — status: $DEVTO_STATUS"
+echo "  - QA issue: $QA_ISSUE_URL — status: $QA_STATUS"

--- a/packages/rangelink-vscode-extension/scripts/generate-release-issues.sh
+++ b/packages/rangelink-vscode-extension/scripts/generate-release-issues.sh
@@ -122,7 +122,7 @@ echo ""
 # --- Create the dev.to issue ---
 
 echo -e "${GREEN}Creating dev.to post issue...${NC}"
-DEVTO_URL=$(gh issue create --title "$DEVTO_TITLE" --body "$DEVTO_BODY")
+DEVTO_URL=$(gh issue create --title "$DEVTO_TITLE" --body "$DEVTO_BODY" --repo "$REPO_OWNER/$REPO_NAME")
 echo "Created: $DEVTO_URL"
 echo ""
 

--- a/packages/rangelink-vscode-extension/scripts/generate-release-testing-instructions.sh
+++ b/packages/rangelink-vscode-extension/scripts/generate-release-testing-instructions.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #
 # Outputs a minimal markdown file that points at the QA GitHub issue — the issue
 # is the canonical source for the per-feature pnpm test:release:grep commands.
-# Frontmatter tracks version, QA issue URL, and generation timestamp.
+# Frontmatter tracks version, QA issue URL, dev.to issue URL, and generation timestamp.
 #
 # Usage:
 #   ./scripts/generate-release-testing-instructions.sh             → trunk-based dev (Unreleased)
@@ -51,6 +51,7 @@ cat > "$OUTPUT_FILE" <<EOF
 ---
 version: ${VERSION_ARG:-$PUBLISHED_VERSION}
 qa_issue_url: ''
+devto_issue_url: ''
 generated: ${GENERATED_TS}
 ---
 
@@ -58,6 +59,7 @@ generated: ${GENERATED_TS}
 
 **Scope:** ${SCOPE_LINE}
 **QA tracker:** <to be filled by release:lock>
+**Dev.to post:** <to be filled by release:lock>
 
 ## Next steps
 

--- a/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
+++ b/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
@@ -178,7 +178,10 @@ retire_superseded_board_item() {
   local projects_json board_resolved board_id node_id item_id status_done
   local done_field_id done_option_id
 
-  projects_json=$(list_release_projects)
+  if ! projects_json=$(list_release_projects); then
+    echo -e "${YELLOW}could not list release projects — board cleanup skipped for $issue_url${NC}"
+    return
+  fi
   if ! board_resolved=$(resolve_release_board "$board_title"); then
     echo -e "${YELLOW}board '$board_title' not found — board cleanup skipped for $issue_url${NC}"
     return
@@ -191,7 +194,10 @@ retire_superseded_board_item() {
     return
   fi
 
-  item_id=$(find_board_item_id "$board_id" "$node_id")
+  if ! item_id=$(find_board_item_id "$board_id" "$node_id"); then
+    echo -e "${YELLOW}could not look up board item for $issue_url — board cleanup skipped${NC}"
+    return
+  fi
   if [[ -z "$item_id" ]]; then
     echo -e "${YELLOW}$issue_url is not on the board — nothing to clean up${NC}"
     return

--- a/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
+++ b/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
@@ -53,7 +53,13 @@ check_dirty_tree "$REPO_ROOT"
 RELEASE_BRANCH="release/v${VERSION}"
 CURRENT_BRANCH=$(git -C "$REPO_ROOT" branch --show-current)
 
-if git -C "$REPO_ROOT" rev-parse --verify "$RELEASE_BRANCH" >/dev/null 2>&1; then
+# Temporary local-testing escape hatch: run the whole flow on the current
+# branch without creating/switching to a release branch. Lets the feature
+# branch's scripts (e.g. generate-release-issues.sh) stay in the working tree.
+if [[ -n "${RELEASE_LOCK_INPLACE:-}" ]]; then
+  echo -e "${YELLOW}RELEASE_LOCK_INPLACE set — skipping release branch dance; running on $CURRENT_BRANCH${NC}"
+  RELEASE_BRANCH="$CURRENT_BRANCH"
+elif git -C "$REPO_ROOT" rev-parse --verify "$RELEASE_BRANCH" >/dev/null 2>&1; then
   if [[ "$CURRENT_BRANCH" != "$RELEASE_BRANCH" ]]; then
     echo -e "${YELLOW}Branch $RELEASE_BRANCH already exists (current: $CURRENT_BRANCH).${NC}"
     echo ""

--- a/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
+++ b/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
@@ -202,10 +202,16 @@ retire_superseded_board_item() {
   done_option_id=$(echo "$status_done" | cut -f2)
 
   if [[ -n "$done_field_id" && -n "$done_option_id" ]]; then
-    set_board_field_value "$board_id" "$item_id" "$done_field_id" "$done_option_id"
+    if ! set_board_field_value "$board_id" "$item_id" "$done_field_id" "$done_option_id"; then
+      echo -e "${YELLOW}could not mark superseded board item Done for $issue_url — cleanup skipped${NC}"
+      return
+    fi
     echo -e "${GREEN}Marked superseded board item Done for $issue_url.${NC}"
   else
-    delete_board_item "$board_id" "$item_id"
+    if ! delete_board_item "$board_id" "$item_id"; then
+      echo -e "${YELLOW}could not remove superseded board item for $issue_url — cleanup skipped${NC}"
+      return
+    fi
     echo -e "${GREEN}Removed superseded board item for $issue_url (board has no Done option).${NC}"
   fi
 }

--- a/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
+++ b/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
@@ -45,6 +45,7 @@ INSTRUCTIONS_FILE="$PACKAGE_DIR/qa/release-testing-instructions-v${VERSION}.md"
 # --- Working tree must be clean (except for the release instructions artifact) ---
 
 source "$SCRIPT_DIR/check-dirty-tree.sh"
+source "$SCRIPT_DIR/release-board-lib.sh"
 check_dirty_tree "$REPO_ROOT"
 
 # --- Create or re-enter release branch ---
@@ -167,10 +168,53 @@ if [[ -z "$DEVTO_ISSUE_URL" ]]; then
   exit 1
 fi
 
+# Best-effort retirement of a superseded issue's board item: marks it Done
+# when the board has a Done option, otherwise deletes it. Every failure warns
+# and returns early — never a non-zero exit.
+retire_superseded_board_item() {
+  # $1 = issue URL
+  local issue_url="$1"
+  local board_title="RangeLink v${VERSION} release"
+  local projects_json board_resolved board_id node_id item_id status_done
+  local done_field_id done_option_id
+
+  projects_json=$(list_release_projects)
+  if ! board_resolved=$(resolve_release_board "$board_title"); then
+    echo -e "${YELLOW}board '$board_title' not found — board cleanup skipped for $issue_url${NC}"
+    return
+  fi
+  board_id=$(echo "$board_resolved" | cut -f1)
+
+  node_id=$(gh issue view "$issue_url" --json id --jq .id 2>/dev/null || true)
+  if [[ -z "$node_id" || "$node_id" == "null" ]]; then
+    echo -e "${YELLOW}could not resolve node id for $issue_url — board cleanup skipped${NC}"
+    return
+  fi
+
+  item_id=$(find_board_item_id "$board_id" "$node_id")
+  if [[ -z "$item_id" ]]; then
+    echo -e "${YELLOW}$issue_url is not on the board — nothing to clean up${NC}"
+    return
+  fi
+
+  status_done=$(resolve_status_done "$projects_json" "$board_id")
+  done_field_id=$(echo "$status_done" | cut -f1)
+  done_option_id=$(echo "$status_done" | cut -f2)
+
+  if [[ -n "$done_field_id" && -n "$done_option_id" ]]; then
+    set_board_field_value "$board_id" "$item_id" "$done_field_id" "$done_option_id"
+    echo -e "${GREEN}Marked superseded board item Done for $issue_url.${NC}"
+  else
+    delete_board_item "$board_id" "$item_id"
+    echo -e "${GREEN}Removed superseded board item for $issue_url (board has no Done option).${NC}"
+  fi
+}
+
 # --- Step 5: Supersede prior issues and update instructions ---
 
 if [[ -n "$PRIOR_ISSUE_URL" ]]; then
   echo -e "${YELLOW}Prior QA issue found: $PRIOR_ISSUE_URL${NC}"
+  retire_superseded_board_item "$PRIOR_ISSUE_URL"
   gh issue comment "$PRIOR_ISSUE_URL" --body "Superseded by $QA_ISSUE_URL (release:lock re-run)."
   gh issue close "$PRIOR_ISSUE_URL"
   gh issue comment "$QA_ISSUE_URL" --body "Supersedes $PRIOR_ISSUE_URL."
@@ -179,6 +223,7 @@ fi
 
 if [[ -n "$PRIOR_DEVTO_ISSUE_URL" ]]; then
   echo -e "${YELLOW}Prior dev.to issue found: $PRIOR_DEVTO_ISSUE_URL${NC}"
+  retire_superseded_board_item "$PRIOR_DEVTO_ISSUE_URL"
   gh issue comment "$PRIOR_DEVTO_ISSUE_URL" --body "Superseded by $DEVTO_ISSUE_URL (release:lock re-run)."
   gh issue close "$PRIOR_DEVTO_ISSUE_URL"
   gh issue comment "$DEVTO_ISSUE_URL" --body "Supersedes $PRIOR_DEVTO_ISSUE_URL."

--- a/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
+++ b/packages/rangelink-vscode-extension/scripts/orchestrate-release-lock.sh
@@ -7,12 +7,14 @@ set -euo pipefail
 #   1. Create a release/vX.Y.Z branch from main
 #   2. Run lock-version.sh (bump .version, regenerate instructions)
 #   3. Run generate-qa-issue.sh (create GitHub QA issue tracker)
-#   4. Inject the QA issue URL into the instructions file frontmatter
-#   5. Generate a commit message file
+#   4. Run generate-release-issues.sh (create the dev.to issue, add issues to the release board)
+#   5. Inject QA + dev.to issue URLs into the instructions file frontmatter
+#   6. Validate QA coverage
+#   7. Generate a commit message file
 #
 # Idempotent: safe to re-run after adding bug-fix TCs. On re-run,
-# detects the prior QA issue from the instructions frontmatter, closes it
-# with a "Superseded by #NEW" comment, and creates a fresh issue.
+# detects the prior QA and dev.to issues from the instructions frontmatter,
+# closes them with a "Superseded by #NEW" comment, and creates fresh issues.
 #
 # Tolerates uncommitted release-testing-instructions-vX.Y.Z.md so the
 # supersession logic can read its frontmatter on re-run. Any other dirty
@@ -63,9 +65,11 @@ if git -C "$REPO_ROOT" rev-parse --verify "$RELEASE_BRANCH" >/dev/null 2>&1; the
     case "$REPLY" in
       [dD])
         echo -e "${YELLOW}Deleting $RELEASE_BRANCH...${NC}"
-        # Snapshot the prior QA issue before the instructions file is destroyed.
+        # Snapshot the prior issues before the instructions file is destroyed.
         if [[ -f "$INSTRUCTIONS_FILE" ]]; then
           PRIOR_ISSUE_URL=$(sed -n '/^---$/,/^---$/p' "$INSTRUCTIONS_FILE" | grep 'qa_issue_url:' | sed "s/qa_issue_url: *['\"]*//;s/['\"]$//")
+          # || true: devto_issue_url may be absent (pre-dev.to-template instructions files).
+          PRIOR_DEVTO_ISSUE_URL=$(sed -n '/^---$/,/^---$/p' "$INSTRUCTIONS_FILE" | grep 'devto_issue_url:' | sed "s/devto_issue_url: *['\"]*//;s/['\"]$//" || true)
         fi
         git -C "$REPO_ROOT" branch -D "$RELEASE_BRANCH"
         if [[ "$CURRENT_BRANCH" != "main" ]]; then
@@ -117,12 +121,16 @@ fi
 "$SCRIPT_DIR/lock-version.sh" "$VERSION"
 echo ""
 
-# --- Step 2: Detect prior QA issue (idempotency re-run) ---
+# --- Step 2: Detect prior issues (idempotency re-run) ---
 
 # Only discover from the current instructions file if the "d"elete path
 # didn't already snapshot it before destroying the old branch.
 if [[ -z "${PRIOR_ISSUE_URL:-}" ]] && [[ -f "$INSTRUCTIONS_FILE" ]]; then
   PRIOR_ISSUE_URL=$(sed -n '/^---$/,/^---$/p' "$INSTRUCTIONS_FILE" | grep 'qa_issue_url:' | sed "s/qa_issue_url: *['\"]*//;s/['\"]$//")
+fi
+# || true: devto_issue_url may be absent (pre-dev.to-template instructions files).
+if [[ -z "${PRIOR_DEVTO_ISSUE_URL:-}" ]] && [[ -f "$INSTRUCTIONS_FILE" ]]; then
+  PRIOR_DEVTO_ISSUE_URL=$(sed -n '/^---$/,/^---$/p' "$INSTRUCTIONS_FILE" | grep 'devto_issue_url:' | sed "s/devto_issue_url: *['\"]*//;s/['\"]$//" || true)
 fi
 
 # --- Step 3: Generate QA issue ---
@@ -142,7 +150,24 @@ if [[ -z "$QA_ISSUE_URL" ]]; then
   exit 1
 fi
 
-# --- Step 4: Supersede prior issue and update instructions ---
+# --- Step 4: Generate dev.to issue ---
+
+echo -e "${GREEN}Step 4: Generating dev.to issue...${NC}"
+
+DEVTO_OUTPUT=$("$SCRIPT_DIR/generate-release-issues.sh" "$QA_ISSUE_URL") || {
+  echo -e "${RED}Error: generate-release-issues.sh failed${NC}" >&2
+  exit 1
+}
+echo "$DEVTO_OUTPUT"
+echo ""
+
+DEVTO_ISSUE_URL=$(echo "$DEVTO_OUTPUT" | grep '^Created' | grep -o 'https://github\.com/[^ ]*issues/[0-9]*' || true)
+if [[ -z "$DEVTO_ISSUE_URL" ]]; then
+  echo -e "${RED}Error: could not extract dev.to issue URL from generate-release-issues.sh output${NC}" >&2
+  exit 1
+fi
+
+# --- Step 5: Supersede prior issues and update instructions ---
 
 if [[ -n "$PRIOR_ISSUE_URL" ]]; then
   echo -e "${YELLOW}Prior QA issue found: $PRIOR_ISSUE_URL${NC}"
@@ -152,17 +177,27 @@ if [[ -n "$PRIOR_ISSUE_URL" ]]; then
   echo -e "${GREEN}Closed prior issue; new issue has backref.${NC}"
 fi
 
-# Inject the QA issue URL into the instructions file.
+if [[ -n "$PRIOR_DEVTO_ISSUE_URL" ]]; then
+  echo -e "${YELLOW}Prior dev.to issue found: $PRIOR_DEVTO_ISSUE_URL${NC}"
+  gh issue comment "$PRIOR_DEVTO_ISSUE_URL" --body "Superseded by $DEVTO_ISSUE_URL (release:lock re-run)."
+  gh issue close "$PRIOR_DEVTO_ISSUE_URL"
+  gh issue comment "$DEVTO_ISSUE_URL" --body "Supersedes $PRIOR_DEVTO_ISSUE_URL."
+  echo -e "${GREEN}Closed prior dev.to issue; new issue has backref.${NC}"
+fi
+
+# Inject the QA and dev.to issue URLs into the instructions file.
 sed -i.bak \
   -e "s|qa_issue_url: ['\"].*['\"]|qa_issue_url: '$QA_ISSUE_URL'|" \
   -e "s|\*\*QA tracker:\*\* .*|\*\*QA tracker:\*\* $QA_ISSUE_URL|" \
+  -e "s|devto_issue_url: ['\"].*['\"]|devto_issue_url: '$DEVTO_ISSUE_URL'|" \
+  -e "s|\*\*Dev.to post:\*\* .*|\*\*Dev.to post:\*\* $DEVTO_ISSUE_URL|" \
   "$INSTRUCTIONS_FILE" && rm -f "${INSTRUCTIONS_FILE}.bak"
 
-echo -e "${GREEN}QA issue URL injected into instructions file.${NC}"
+echo -e "${GREEN}QA and dev.to issue URLs injected into instructions file.${NC}"
 
-# --- Step 5: Validate QA coverage ---
+# --- Step 6: Validate QA coverage ---
 
-echo -e "${GREEN}Step 5: Validating QA coverage...${NC}"
+echo -e "${GREEN}Step 6: Validating QA coverage...${NC}"
 
 if "$SCRIPT_DIR/validate-qa-coverage.sh" > /dev/null 2>&1; then
   echo -e "${GREEN}QA coverage validation passed.${NC}"
@@ -171,7 +206,7 @@ else
   exit 1
 fi
 
-# --- Step 6: Generate commit message ---
+# --- Step 7: Generate commit message ---
 
 COMMIT_MSGS_DIR="$REPO_ROOT/.commit-msgs"
 mkdir -p "$COMMIT_MSGS_DIR"
@@ -188,6 +223,7 @@ Soft-lock the deferred "Unreleased" version for QA.
 - Bumped package.json .version → ${VERSION}
 - Regenerated release testing instructions
 - Generated QA issue tracker: ${QA_ISSUE_URL}
+- Generated dev.to issue: ${DEVTO_ISSUE_URL}
 
 EOF
 
@@ -224,12 +260,15 @@ All steps below run on the \`$RELEASE_BRANCH\` branch. When QA is clean, \`pnpm 
   \`\`\`
 ${PR_COMMENT_STEP}
 - [ ] Work through the checkboxes above — each row has the exact pnpm command
+- [ ] Dev.to issue: ${DEVTO_ISSUE_URL}
 - [ ] When all checkboxes pass: \`pnpm release:prepare:vscode-extension\`"
 
 # --- Summary ---
 
 echo ""
 echo -e "${GREEN}Release v${VERSION} locked on branch $RELEASE_BRANCH.${NC}"
+echo ""
+echo -e "${YELLOW}Cross-repo tracking: run /release-prep ${VERSION} in Claude Code to create the couimet.github.io article-registration issue and add it to the release board.${NC}"
 echo ""
 echo "Next steps:"
 echo "  1. Review the changes: git diff"

--- a/packages/rangelink-vscode-extension/scripts/release-board-lib.sh
+++ b/packages/rangelink-vscode-extension/scripts/release-board-lib.sh
@@ -14,7 +14,10 @@ graphql_call() {
   local tmp
   tmp="$(mktemp)"
   echo "$1" > "$tmp"
-  gh api graphql --input "$tmp"
+  if ! gh api graphql --input "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
   rm -f "$tmp"
 }
 

--- a/packages/rangelink-vscode-extension/scripts/release-board-lib.sh
+++ b/packages/rangelink-vscode-extension/scripts/release-board-lib.sh
@@ -19,19 +19,19 @@ graphql_call() {
 }
 
 list_release_projects() {
-  # Prints the viewer's projectsV2 JSON: nodes with id, number, title, and
-  # single-select fields (id, name, options).
-  graphql_call "$(jq -n --arg q 'query { viewer { projectsV2(first: 100) { nodes { id number title fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } } }' '{query: $q, variables: {}}')"
+  # Prints the viewer's projectsV2 JSON: nodes with id, number, title, url,
+  # owner, and single-select fields (id, name, options).
+  graphql_call "$(jq -n --arg q 'query { viewer { projectsV2(first: 100) { nodes { id number title url owner { ... on User { id } ... on Organization { id } } fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } } }' '{query: $q, variables: {}}')"
 }
 
 resolve_release_board() {
-  # $1 = board title. Prints "<board id>\t<board number>"; exits 1 with the
-  # candidate titles when no project matches the title exactly.
+  # $1 = board title. Prints "<board id>\t<board number>\t<board url>"; exits 1
+  # with the candidate titles when no project matches the title exactly.
   local title="$1"
   local projects_json
   projects_json=$(list_release_projects)
   local match
-  match=$(echo "$projects_json" | jq -r --arg title "$title" '.data.viewer.projectsV2.nodes // [] | .[] | select(.title == $title) | "\(.id)\t\(.number)"' | head -1)
+  match=$(echo "$projects_json" | jq -r --arg title "$title" '.data.viewer.projectsV2.nodes // [] | .[] | select(.title == $title) | "\(.id)\t\(.number)\t\(.url)"' | head -1)
   if [[ -z "$match" ]]; then
     echo -e "${RED:-}Error: no project board titled '$title' found.${NC:-}" >&2
     echo "Available project boards:" >&2
@@ -68,4 +68,89 @@ set_board_field_value() {
     --arg oid "$4" \
     '{query: "mutation($input: UpdateProjectV2ItemFieldValueInput!) { updateProjectV2ItemFieldValue(input: $input) { projectV2Item { id } } }", variables: {input: {projectId: $pid, itemId: $iid, fieldId: $fid, value: {singleSelectOptionId: $oid}}}}')
   graphql_call "$payload" > /dev/null
+}
+
+fetch_project_items() {
+  # $1 = project id. Prints the project's items JSON as
+  # {"data": {"node": {"items": {"nodes": [ ...all item nodes across all pages... ]}}}};
+  # pages through the items(first: 100) connection until hasNextPage is false.
+  local query='query ($id: ID!, $cursor: String) {
+    node(id: $id) {
+      ... on ProjectV2 {
+        items(first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            content {
+              __typename
+              ... on Issue { id }
+              ... on PullRequest { id }
+              ... on DraftIssue { id title body }
+            }
+            fieldValues(first: 40) {
+              nodes {
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                  field { name }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }'
+  local id="$1"
+  local cursor=""
+  local tmp
+  tmp="$(mktemp)"
+  while true; do
+    local page_json has_next end_cursor
+    page_json=$(graphql_call "$(jq -n --arg query "$query" --arg id "$id" --arg cursor "$cursor" '{query: $query, variables: {id: $id, cursor: $cursor}}')")
+    echo "$page_json" | jq -c '.data.node.items.nodes // []' >> "$tmp"
+    has_next=$(echo "$page_json" | jq -r '.data.node.items.pageInfo.hasNextPage')
+    end_cursor=$(echo "$page_json" | jq -r '.data.node.items.pageInfo.endCursor')
+    if [[ "$has_next" != "true" ]]; then
+      break
+    fi
+    cursor="$end_cursor"
+  done
+  jq -n --slurpfile pages "$tmp" '{data: {node: {items: {nodes: ($pages | add)}}}}'
+  rm -f "$tmp"
+}
+
+add_board_draft() {
+  # $1 = project id; $2 = draft title; $3 = draft body. Prints the new item id.
+  local payload
+  payload=$(jq -n \
+    --arg pid "$1" \
+    --arg title "$2" \
+    --arg body "$3" \
+    '{query: "mutation($input: AddProjectV2DraftIssueInput!) { addProjectV2DraftIssue(input: $input) { projectV2Item { id } } }", variables: {input: {projectId: $pid, title: $title, body: $body}}}')
+  graphql_call "$payload" | jq -r '.data.addProjectV2DraftIssue.projectV2Item.id'
+}
+
+delete_board_item() {
+  # $1 = project id; $2 = item id. Deletes the item; prints nothing.
+  local payload
+  payload=$(jq -n \
+    --arg pid "$1" \
+    --arg iid "$2" \
+    '{query: "mutation($input: DeleteProjectV2ItemInput!) { deleteProjectV2Item(input: $input) { deletedItemId } }", variables: {input: {projectId: $pid, itemId: $iid}}}')
+  graphql_call "$payload" > /dev/null
+}
+
+resolve_status_done() {
+  # $1 = projectsV2 JSON from list_release_projects; $2 = board id.
+  # Prints "<status field id>\t<done option id>"; prints nothing when the
+  # board has no Status field, and "<field id>" alone when Done is missing.
+  echo "$1" | jq -r --arg id "$2" '.data.viewer.projectsV2.nodes[] | select(.id == $id) | .fields.nodes[] | select(.name == "Status") | [.id, ((.options // [] | .[] | select(.name == "Done") | .id) // null)] | @tsv' | head -1
+}
+
+find_board_item_id() {
+  # $1 = project id; $2 = content node id (Issue/PullRequest/DraftIssue).
+  # Prints the project item id whose content matches, or nothing when absent.
+  local items_json
+  items_json=$(fetch_project_items "$1")
+  echo "$items_json" | jq -r --arg cid "$2" '.data.node.items.nodes[]? | select(.content.id == $cid) | .id' | head -1
 }

--- a/packages/rangelink-vscode-extension/scripts/release-board-lib.sh
+++ b/packages/rangelink-vscode-extension/scripts/release-board-lib.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Shared GitHub Projects V2 helpers sourced by the release scripts.
+# All functions print results on stdout and errors on stderr.
+#
+# gh api graphql -F does not parse nested JSON, so every GraphQL call writes
+# the query plus variables JSON to a temp file and runs gh api graphql --input.
+#
+# Usage:
+#   source "$SCRIPT_DIR/release-board-lib.sh"
+
+graphql_call() {
+  # $1 = JSON body with query and variables; prints the API response
+  local tmp
+  tmp="$(mktemp)"
+  echo "$1" > "$tmp"
+  gh api graphql --input "$tmp"
+  rm -f "$tmp"
+}
+
+list_release_projects() {
+  # Prints the viewer's projectsV2 JSON: nodes with id, number, title, and
+  # single-select fields (id, name, options).
+  graphql_call "$(jq -n --arg q 'query { viewer { projectsV2(first: 100) { nodes { id number title fields(first: 20) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } } }' '{query: $q, variables: {}}')"
+}
+
+resolve_release_board() {
+  # $1 = board title. Prints "<board id>\t<board number>"; exits 1 with the
+  # candidate titles when no project matches the title exactly.
+  local title="$1"
+  local projects_json
+  projects_json=$(list_release_projects)
+  local match
+  match=$(echo "$projects_json" | jq -r --arg title "$title" '.data.viewer.projectsV2.nodes // [] | .[] | select(.title == $title) | "\(.id)\t\(.number)"' | head -1)
+  if [[ -z "$match" ]]; then
+    echo -e "${RED:-}Error: no project board titled '$title' found.${NC:-}" >&2
+    echo "Available project boards:" >&2
+    echo "$projects_json" | jq -r '.data.viewer.projectsV2.nodes // [] | .[] | "  - \(.title) (project #\(.number))"' >&2
+    return 1
+  fi
+  echo "$match"
+}
+
+resolve_status_ready() {
+  # $1 = projectsV2 JSON from list_release_projects; $2 = board id.
+  # Prints "<status field id>\t<ready option id>"; prints nothing when the
+  # board has no Status field, and "<field id>" alone when Ready is missing.
+  echo "$1" | jq -r --arg id "$2" '.data.viewer.projectsV2.nodes[] | select(.id == $id) | .fields.nodes[] | select(.name == "Status") | [.id, ((.options // [] | .[] | select(.name == "Ready") | .id) // null)] | @tsv' | head -1
+}
+
+add_board_item() {
+  # $1 = project id; $2 = content node id. Prints the new item id.
+  local payload
+  payload=$(jq -n \
+    --arg pid "$1" \
+    --arg cid "$2" \
+    '{query: "mutation($input: AddProjectV2ItemByIdInput!) { addProjectV2ItemById(input: $input) { item { id } } }", variables: {input: {projectId: $pid, contentId: $cid}}}')
+  graphql_call "$payload" | jq -r '.data.addProjectV2ItemById.item.id'
+}
+
+set_board_field_value() {
+  # $1 = project id; $2 = item id; $3 = field id; $4 = single-select option id.
+  local payload
+  payload=$(jq -n \
+    --arg pid "$1" \
+    --arg iid "$2" \
+    --arg fid "$3" \
+    --arg oid "$4" \
+    '{query: "mutation($input: UpdateProjectV2ItemFieldValueInput!) { updateProjectV2ItemFieldValue(input: $input) { projectV2Item { id } } }", variables: {input: {projectId: $pid, itemId: $iid, fieldId: $fid, value: {singleSelectOptionId: $oid}}}}')
+  graphql_call "$payload" > /dev/null
+}

--- a/packages/rangelink-vscode-extension/scripts/release-board-lib.sh
+++ b/packages/rangelink-vscode-extension/scripts/release-board-lib.sh
@@ -76,7 +76,10 @@ set_board_field_value() {
 fetch_project_items() {
   # $1 = project id. Prints the project's items JSON as
   # {"data": {"node": {"items": {"nodes": [ ...all item nodes across all pages... ]}}}};
-  # pages through the items(first: 100) connection until hasNextPage is false.
+  # each item node carries statusValue/priorityValue/sizeValue — the single-select
+  # option names for Status/Priority/Size read via fieldValueByName so they survive
+  # items with more than 40 field values; pages through the items(first: 100)
+  # connection until hasNextPage is false.
   local query='query ($id: ID!, $cursor: String) {
     node(id: $id) {
       ... on ProjectV2 {
@@ -90,13 +93,14 @@ fetch_project_items() {
               ... on PullRequest { id }
               ... on DraftIssue { id title body }
             }
-            fieldValues(first: 40) {
-              nodes {
-                ... on ProjectV2ItemFieldSingleSelectValue {
-                  name
-                  field { name }
-                }
-              }
+            statusValue: fieldValueByName(name: "Status") {
+              ... on ProjectV2ItemFieldSingleSelectValue { name }
+            }
+            priorityValue: fieldValueByName(name: "Priority") {
+              ... on ProjectV2ItemFieldSingleSelectValue { name }
+            }
+            sizeValue: fieldValueByName(name: "Size") {
+              ... on ProjectV2ItemFieldSingleSelectValue { name }
             }
           }
         }
@@ -153,7 +157,14 @@ resolve_status_done() {
 find_board_item_id() {
   # $1 = project id; $2 = content node id (Issue/PullRequest/DraftIssue).
   # Prints the project item id whose content matches, or nothing when absent.
-  local items_json
+  # fetch_project_items yields nodes: null when the items GraphQL call failed;
+  # treat that as a lookup error so callers can distinguish it from an item
+  # that is genuinely not on the board.
+  local items_json nodes_missing
   items_json=$(fetch_project_items "$1")
+  nodes_missing=$(printf '%s' "$items_json" | jq -r '.data.node.items.nodes == null')
+  if [[ "$nodes_missing" == "true" ]]; then
+    return 1
+  fi
   echo "$items_json" | jq -r --arg cid "$2" '.data.node.items.nodes[]? | select(.content.id == $cid) | .id' | head -1
 }

--- a/packages/rangelink-vscode-extension/scripts/rotate-release-board.sh
+++ b/packages/rangelink-vscode-extension/scripts/rotate-release-board.sh
@@ -11,8 +11,10 @@ set -euo pipefail
 # The next version defaults to a minor bump of .version in package.json;
 # pass an explicit SemVer to override for pivots.
 #
-# Idempotent: if the next project already exists, prints a skip message and
-# exits 0. The old project is left open.
+# Idempotent and recoverable: if the next project already exists it is reused
+# as the migration destination without re-copying; a re-run after a partial
+# migration continues moving the remaining non-Done items, and a completed
+# re-run finds nothing left to move. The old project is left open.
 #
 # Requires:
 #   jq   — reads .version from package.json, builds GraphQL payloads, parses responses
@@ -101,31 +103,6 @@ COPY_QUERY='mutation ($input: CopyProjectV2Input!) {
   }
 }'
 
-ITEMS_QUERY='query ($id: ID!) {
-  node(id: $id) {
-    ... on ProjectV2 {
-      items(first: 100) {
-        nodes {
-          id
-          content {
-            ... on Issue { id }
-            ... on PullRequest { id }
-            ... on DraftIssue { id }
-          }
-          fieldValues(first: 40) {
-            nodes {
-              ... on ProjectV2ItemFieldSingleSelectValue {
-                name
-                field { name }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}'
-
 FIELDS_QUERY='query ($id: ID!) {
   node(id: $id) {
     ... on ProjectV2 {
@@ -145,12 +122,6 @@ FIELDS_QUERY='query ($id: ID!) {
   }
 }'
 
-DELETE_ITEM_QUERY='mutation ($input: DeleteProjectV2ItemInput!) {
-  deleteProjectV2Item(input: $input) {
-    deletedItemId
-  }
-}'
-
 # --- Step 1: Resolve the current project ---
 
 PROJECTS_JSON=$(list_release_projects)
@@ -167,42 +138,51 @@ if [[ -z "$OLD_PROJECT_ID" ]]; then
   exit 1
 fi
 
+OWNER_ID=$(echo "$PROJECTS_JSON" | jq -r --arg title "$CURRENT_PROJECT_TITLE" \
+  '.data.viewer.projectsV2.nodes[]? | select(.title == $title) | .owner.id // empty')
+if [[ -z "$OWNER_ID" ]]; then
+  echo -e "${RED}Error: could not resolve owner id for project '$CURRENT_PROJECT_TITLE'${NC}" >&2
+  exit 1
+fi
+
 echo -e "${GREEN}Found current project: $CURRENT_PROJECT_TITLE${NC}"
 
-# --- Step 2: Idempotency — skip when the next project already exists ---
+# --- Step 2: Recovery — reuse the next project when it already exists ---
 
 NEXT_PROJECT_ID=$(echo "$PROJECTS_JSON" | jq -r --arg title "$NEXT_PROJECT_TITLE" \
   '.data.viewer.projectsV2.nodes[]? | select(.title == $title) | .id // empty')
 if [[ -n "$NEXT_PROJECT_ID" ]]; then
-  echo -e "${YELLOW}Project '$NEXT_PROJECT_TITLE' already exists — skipping rotation.${NC}"
-  exit 0
-fi
+  echo -e "${YELLOW}Project '$NEXT_PROJECT_TITLE' already exists — reusing it as the migration destination.${NC}"
+  NEW_PROJECT_ID="$NEXT_PROJECT_ID"
+  NEW_PROJECT_URL=$(echo "$PROJECTS_JSON" | jq -r --arg title "$NEXT_PROJECT_TITLE" \
+    '.data.viewer.projectsV2.nodes[]? | select(.title == $title) | .url // empty')
+else
+  # --- Step 3: Create the next project (copying fields and views) ---
+  # Draft issues are not copied (includeDraftIssues: false) — every non-Done
+  # item, drafts included, is moved explicitly in Step 6.
+  COPY_JSON=$(graphql_call "$(jq -n --arg query "$COPY_QUERY" \
+    --arg projectId "$OLD_PROJECT_ID" \
+    --arg title "$NEXT_PROJECT_TITLE" \
+    --arg ownerId "$OWNER_ID" \
+    '{query: $query, variables: {input: {projectId: $projectId, title: $title, ownerId: $ownerId, includeDraftIssues: false}}}')")
 
-# --- Step 3: Create the next project (copying fields and views) ---
-# Draft issues are not copied (includeDraftIssues: false) — every non-Done
-# item, drafts included, is moved explicitly in Step 6.
-COPY_JSON=$(graphql_call "$(jq -n --arg query "$COPY_QUERY" \
-  --arg projectId "$OLD_PROJECT_ID" \
-  --arg title "$NEXT_PROJECT_TITLE" \
-  '{query: $query, variables: {input: {projectId: $projectId, title: $title, includeDraftIssues: false}}}')")
-
-NEW_PROJECT_ID=$(echo "$COPY_JSON" | jq -r '.data.copyProjectV2.projectV2.id // empty')
-if [[ -z "$NEW_PROJECT_ID" ]]; then
-  echo -e "${RED}Error: copyProjectV2 did not return a project id${NC}" >&2
-  exit 1
+  NEW_PROJECT_ID=$(echo "$COPY_JSON" | jq -r '.data.copyProjectV2.projectV2.id // empty')
+  if [[ -z "$NEW_PROJECT_ID" ]]; then
+    echo -e "${RED}Error: copyProjectV2 did not return a project id${NC}" >&2
+    exit 1
+  fi
+  NEW_PROJECT_URL=$(echo "$COPY_JSON" | jq -r '.data.copyProjectV2.projectV2.url // empty')
+  echo -e "${GREEN}Created project: $NEXT_PROJECT_TITLE ($NEW_PROJECT_URL)${NC}"
 fi
-NEW_PROJECT_URL=$(echo "$COPY_JSON" | jq -r '.data.copyProjectV2.projectV2.url // empty')
-echo -e "${GREEN}Created project: $NEXT_PROJECT_TITLE ($NEW_PROJECT_URL)${NC}"
 
 # --- Step 4: Enumerate the old project's items with their field values ---
 
-ITEMS_JSON=$(graphql_call "$(jq -n --arg query "$ITEMS_QUERY" --arg id "$OLD_PROJECT_ID" \
-  '{query: $query, variables: {id: $id}}')")
+ITEMS_JSON=$(fetch_project_items "$OLD_PROJECT_ID")
 
-# Each row: <item id> <content id> <status> <priority> <size> (tab-separated)
+# Each row: <item id> <content id> <content type> <status> <priority> <size> (tab-separated)
 ITEM_ROWS=$(echo "$ITEMS_JSON" | jq -r '
   .data.node.items.nodes[]?
-  | [.id, .content.id,
+  | [.id, .content.id, .content.__typename,
      ([.fieldValues.nodes[]? | select(.field.name == "Status") | .name] | first // ""),
      ([.fieldValues.nodes[]? | select(.field.name == "Priority") | .name] | first // ""),
      ([.fieldValues.nodes[]? | select(.field.name == "Size") | .name] | first // "")]
@@ -240,15 +220,27 @@ MOVED=0
 # A herestring always ends in a newline, so an empty ITEM_ROWS would run the
 # loop once with empty fields — guard the loop instead.
 if [[ -n "$ITEM_ROWS" ]]; then
-  while IFS=$'\t' read -r ITEM_ID CONTENT_ID STATUS PRIORITY SIZE; do
+  while IFS=$'\t' read -r ITEM_ID CONTENT_ID CONTENT_TYPE STATUS PRIORITY SIZE; do
     if [[ "$STATUS" == "Done" ]]; then
       continue
     fi
 
-    NEW_ITEM_ID=$(add_board_item "$NEW_PROJECT_ID" "$CONTENT_ID")
-    if [[ -z "$NEW_ITEM_ID" ]]; then
-      echo -e "${RED}Error: addProjectV2ItemById did not return an item id${NC}" >&2
-      exit 1
+    if [[ "$CONTENT_TYPE" == "DraftIssue" ]]; then
+      DRAFT_TITLE=$(echo "$ITEMS_JSON" | jq -r --arg itemId "$ITEM_ID" \
+        '.data.node.items.nodes[]? | select(.id == $itemId) | .content.title // ""')
+      DRAFT_BODY=$(echo "$ITEMS_JSON" | jq -r --arg itemId "$ITEM_ID" \
+        '.data.node.items.nodes[]? | select(.id == $itemId) | .content.body // ""')
+      NEW_ITEM_ID=$(add_board_draft "$NEW_PROJECT_ID" "$DRAFT_TITLE" "$DRAFT_BODY")
+      if [[ -z "$NEW_ITEM_ID" ]]; then
+        echo -e "${RED}Error: addProjectV2DraftIssue did not return an item id${NC}" >&2
+        exit 1
+      fi
+    else
+      NEW_ITEM_ID=$(add_board_item "$NEW_PROJECT_ID" "$CONTENT_ID")
+      if [[ -z "$NEW_ITEM_ID" ]]; then
+        echo -e "${RED}Error: addProjectV2ItemById did not return an item id${NC}" >&2
+        exit 1
+      fi
     fi
 
     if [[ -n "$STATUS" ]]; then
@@ -261,10 +253,7 @@ if [[ -n "$ITEM_ROWS" ]]; then
       update_single_select_field "Size" "$SIZE" "$NEW_ITEM_ID"
     fi
 
-    graphql_call "$(jq -n --arg query "$DELETE_ITEM_QUERY" \
-      --arg projectId "$OLD_PROJECT_ID" \
-      --arg itemId "$ITEM_ID" \
-      '{query: $query, variables: {input: {projectId: $projectId, itemId: $itemId}}}')" > /dev/null
+    delete_board_item "$OLD_PROJECT_ID" "$ITEM_ID"
 
     if [[ -n "$STATUS" ]]; then
       echo "  Moved item (Status: $STATUS)"

--- a/packages/rangelink-vscode-extension/scripts/rotate-release-board.sh
+++ b/packages/rangelink-vscode-extension/scripts/rotate-release-board.sh
@@ -216,6 +216,8 @@ update_single_select_field() {
 
 # --- Step 6: Move every non-Done item ---
 
+SOURCE_ITEM_MARKER="rangelink-source-item"
+DEST_ITEMS_JSON=""
 MOVED=0
 # A herestring always ends in a newline, so an empty ITEM_ROWS would run the
 # loop once with empty fields — guard the loop instead.
@@ -230,7 +232,19 @@ if [[ -n "$ITEM_ROWS" ]]; then
         '.data.node.items.nodes[]? | select(.id == $itemId) | .content.title // ""')
       DRAFT_BODY=$(echo "$ITEMS_JSON" | jq -r --arg itemId "$ITEM_ID" \
         '.data.node.items.nodes[]? | select(.id == $itemId) | .content.body // ""')
-      NEW_ITEM_ID=$(add_board_draft "$NEW_PROJECT_ID" "$DRAFT_TITLE" "$DRAFT_BODY")
+      # A draft body is the only payload we fully control, so the source item id
+      # is stashed in an HTML comment marker to make a rerun after a partial
+      # migration reuse the already-created destination draft instead of
+      # duplicating it.
+      MARKER="<!-- ${SOURCE_ITEM_MARKER}: ${ITEM_ID} -->"
+      if [[ -z "$DEST_ITEMS_JSON" ]]; then
+        DEST_ITEMS_JSON=$(fetch_project_items "$NEW_PROJECT_ID")
+      fi
+      NEW_ITEM_ID=$(echo "$DEST_ITEMS_JSON" | jq -r --arg marker "$MARKER" \
+        '.data.node.items.nodes[]? | select(.content.__typename == "DraftIssue") | select(.content.body | contains($marker)) | .id' | head -1)
+      if [[ -z "$NEW_ITEM_ID" ]]; then
+        NEW_ITEM_ID=$(add_board_draft "$NEW_PROJECT_ID" "$DRAFT_TITLE" "$DRAFT_BODY"$'\n'"$MARKER")
+      fi
       if [[ -z "$NEW_ITEM_ID" ]]; then
         echo -e "${RED}Error: addProjectV2DraftIssue did not return an item id${NC}" >&2
         exit 1

--- a/packages/rangelink-vscode-extension/scripts/rotate-release-board.sh
+++ b/packages/rangelink-vscode-extension/scripts/rotate-release-board.sh
@@ -183,9 +183,9 @@ ITEMS_JSON=$(fetch_project_items "$OLD_PROJECT_ID")
 ITEM_ROWS=$(echo "$ITEMS_JSON" | jq -r '
   .data.node.items.nodes[]?
   | [.id, .content.id, .content.__typename,
-     ([.fieldValues.nodes[]? | select(.field.name == "Status") | .name] | first // ""),
-     ([.fieldValues.nodes[]? | select(.field.name == "Priority") | .name] | first // ""),
-     ([.fieldValues.nodes[]? | select(.field.name == "Size") | .name] | first // "")]
+     (.statusValue.name // ""),
+     (.priorityValue.name // ""),
+     (.sizeValue.name // "")]
   | @tsv')
 
 # --- Step 5: Resolve the new project's single-select field and option ids ---

--- a/packages/rangelink-vscode-extension/scripts/rotate-release-board.sh
+++ b/packages/rangelink-vscode-extension/scripts/rotate-release-board.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/rotate-release-board.sh [next-version] [--dry-run]
+#
+# Rotates the release project board at the start of the next development
+# cycle: creates the "RangeLink vX.(Y+1).0 release" project (copying fields
+# and views from the just-released "RangeLink vX.Y.Z release" project) and
+# moves every non-Done item to it, restoring Status, Priority, and Size.
+#
+# The next version defaults to a minor bump of .version in package.json;
+# pass an explicit SemVer to override for pivots.
+#
+# Idempotent: if the next project already exists, prints a skip message and
+# exits 0. The old project is left open.
+#
+# Requires:
+#   jq   — reads .version from package.json, builds GraphQL payloads, parses responses
+#   gh   — authenticated with access to the user's projectsV2 (not needed with --dry-run)
+
+DRY_RUN=false
+NEXT_VERSION_ARG=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --) ;;
+    -*)
+      echo "Unknown argument: $arg" >&2
+      exit 1
+      ;;
+    *) NEXT_VERSION_ARG="$arg" ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(dirname "$SCRIPT_DIR")"
+PACKAGE_JSON="$PACKAGE_DIR/package.json"
+
+source "$SCRIPT_DIR/release-board-lib.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# --- Resolve versions ---
+
+VERSION=$(jq -r '.version // empty' "$PACKAGE_JSON")
+if [[ -z "$VERSION" ]]; then
+  echo -e "${RED}Error: .version not set in $PACKAGE_JSON${NC}" >&2
+  exit 1
+fi
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo -e "${RED}Error: .version must be SemVer (X.Y.Z), got '$VERSION'${NC}" >&2
+  exit 1
+fi
+
+if [[ -n "$NEXT_VERSION_ARG" ]]; then
+  if [[ ! "$NEXT_VERSION_ARG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo -e "${RED}Error: next version must be SemVer (X.Y.Z), got '$NEXT_VERSION_ARG'${NC}" >&2
+    exit 1
+  fi
+  NEXT_VERSION="$NEXT_VERSION_ARG"
+else
+  MAJOR="${VERSION%%.*}"
+  REST="${VERSION#*.}"
+  MINOR="${REST%%.*}"
+  NEXT_VERSION="${MAJOR}.$((MINOR + 1)).0"
+fi
+
+CURRENT_PROJECT_TITLE="RangeLink v${VERSION} release"
+NEXT_PROJECT_TITLE="RangeLink v${NEXT_VERSION} release"
+
+echo "Release board rotation"
+echo "  Released version : v$VERSION"
+echo "  Next version     : v$NEXT_VERSION"
+[[ "$DRY_RUN" == true ]] && echo "  Mode             : DRY RUN (no changes will be made)"
+echo ""
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo "DRY-RUN: would resolve project '$CURRENT_PROJECT_TITLE'"
+  echo "DRY-RUN: would create project '$NEXT_PROJECT_TITLE' via copyProjectV2"
+  echo "DRY-RUN: would move every non-Done item to the new project"
+  exit 0
+fi
+
+if ! command -v gh &>/dev/null; then
+  echo "Error: gh CLI is required but not found on PATH" >&2
+  exit 1
+fi
+
+COPY_QUERY='mutation ($input: CopyProjectV2Input!) {
+  copyProjectV2(input: $input) {
+    projectV2 {
+      id
+      title
+      url
+    }
+  }
+}'
+
+ITEMS_QUERY='query ($id: ID!) {
+  node(id: $id) {
+    ... on ProjectV2 {
+      items(first: 100) {
+        nodes {
+          id
+          content {
+            ... on Issue { id }
+            ... on PullRequest { id }
+            ... on DraftIssue { id }
+          }
+          fieldValues(first: 40) {
+            nodes {
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { name }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+
+FIELDS_QUERY='query ($id: ID!) {
+  node(id: $id) {
+    ... on ProjectV2 {
+      fields(first: 100) {
+        nodes {
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            options {
+              id
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+
+DELETE_ITEM_QUERY='mutation ($input: DeleteProjectV2ItemInput!) {
+  deleteProjectV2Item(input: $input) {
+    deletedItemId
+  }
+}'
+
+# --- Step 1: Resolve the current project ---
+
+PROJECTS_JSON=$(list_release_projects)
+
+OLD_PROJECT_ID=$(echo "$PROJECTS_JSON" | jq -r --arg title "$CURRENT_PROJECT_TITLE" \
+  '.data.viewer.projectsV2.nodes[]? | select(.title == $title) | .id // empty')
+if [[ -z "$OLD_PROJECT_ID" ]]; then
+  echo -e "${RED}Error: no project titled '$CURRENT_PROJECT_TITLE' found.${NC}" >&2
+  CANDIDATE_TITLES=$(echo "$PROJECTS_JSON" | jq -r '.data.viewer.projectsV2.nodes[]? | .title // empty')
+  if [[ -n "$CANDIDATE_TITLES" ]]; then
+    echo "Available projects:" >&2
+    echo "$CANDIDATE_TITLES" | sed 's/^/  - /' >&2
+  fi
+  exit 1
+fi
+
+echo -e "${GREEN}Found current project: $CURRENT_PROJECT_TITLE${NC}"
+
+# --- Step 2: Idempotency — skip when the next project already exists ---
+
+NEXT_PROJECT_ID=$(echo "$PROJECTS_JSON" | jq -r --arg title "$NEXT_PROJECT_TITLE" \
+  '.data.viewer.projectsV2.nodes[]? | select(.title == $title) | .id // empty')
+if [[ -n "$NEXT_PROJECT_ID" ]]; then
+  echo -e "${YELLOW}Project '$NEXT_PROJECT_TITLE' already exists — skipping rotation.${NC}"
+  exit 0
+fi
+
+# --- Step 3: Create the next project (copying fields and views) ---
+# Draft issues are not copied (includeDraftIssues: false) — every non-Done
+# item, drafts included, is moved explicitly in Step 6.
+COPY_JSON=$(graphql_call "$(jq -n --arg query "$COPY_QUERY" \
+  --arg projectId "$OLD_PROJECT_ID" \
+  --arg title "$NEXT_PROJECT_TITLE" \
+  '{query: $query, variables: {input: {projectId: $projectId, title: $title, includeDraftIssues: false}}}')")
+
+NEW_PROJECT_ID=$(echo "$COPY_JSON" | jq -r '.data.copyProjectV2.projectV2.id // empty')
+if [[ -z "$NEW_PROJECT_ID" ]]; then
+  echo -e "${RED}Error: copyProjectV2 did not return a project id${NC}" >&2
+  exit 1
+fi
+NEW_PROJECT_URL=$(echo "$COPY_JSON" | jq -r '.data.copyProjectV2.projectV2.url // empty')
+echo -e "${GREEN}Created project: $NEXT_PROJECT_TITLE ($NEW_PROJECT_URL)${NC}"
+
+# --- Step 4: Enumerate the old project's items with their field values ---
+
+ITEMS_JSON=$(graphql_call "$(jq -n --arg query "$ITEMS_QUERY" --arg id "$OLD_PROJECT_ID" \
+  '{query: $query, variables: {id: $id}}')")
+
+# Each row: <item id> <content id> <status> <priority> <size> (tab-separated)
+ITEM_ROWS=$(echo "$ITEMS_JSON" | jq -r '
+  .data.node.items.nodes[]?
+  | [.id, .content.id,
+     ([.fieldValues.nodes[]? | select(.field.name == "Status") | .name] | first // ""),
+     ([.fieldValues.nodes[]? | select(.field.name == "Priority") | .name] | first // ""),
+     ([.fieldValues.nodes[]? | select(.field.name == "Size") | .name] | first // "")]
+  | @tsv')
+
+# --- Step 5: Resolve the new project's single-select field and option ids ---
+
+FIELDS_JSON=$(graphql_call "$(jq -n --arg query "$FIELDS_QUERY" --arg id "$NEW_PROJECT_ID" \
+  '{query: $query, variables: {id: $id}}')")
+
+# Restore a single-select field value on a moved item. The option ids in the
+# copied project differ from the old project's, so they are re-resolved by name.
+update_single_select_field() {
+  local field_name="$1"
+  local option_name="$2"
+  local item_id="$3"
+
+  local field_id option_id
+  field_id=$(echo "$FIELDS_JSON" | jq -r --arg name "$field_name" \
+    '.data.node.fields.nodes[]? | select(.name == $name) | .id // empty')
+  option_id=$(echo "$FIELDS_JSON" | jq -r --arg field "$field_name" --arg option "$option_name" \
+    '.data.node.fields.nodes[]? | select(.name == $field) | .options[]? | select(.name == $option) | .id // empty')
+
+  if [[ -z "$field_id" ]] || [[ -z "$option_id" ]]; then
+    echo -e "${YELLOW}Warning: option '$option_name' not found for field '$field_name' in '$NEXT_PROJECT_TITLE' — value not restored.${NC}"
+    return
+  fi
+
+  set_board_field_value "$NEW_PROJECT_ID" "$item_id" "$field_id" "$option_id"
+}
+
+# --- Step 6: Move every non-Done item ---
+
+MOVED=0
+# A herestring always ends in a newline, so an empty ITEM_ROWS would run the
+# loop once with empty fields — guard the loop instead.
+if [[ -n "$ITEM_ROWS" ]]; then
+  while IFS=$'\t' read -r ITEM_ID CONTENT_ID STATUS PRIORITY SIZE; do
+    if [[ "$STATUS" == "Done" ]]; then
+      continue
+    fi
+
+    NEW_ITEM_ID=$(add_board_item "$NEW_PROJECT_ID" "$CONTENT_ID")
+    if [[ -z "$NEW_ITEM_ID" ]]; then
+      echo -e "${RED}Error: addProjectV2ItemById did not return an item id${NC}" >&2
+      exit 1
+    fi
+
+    if [[ -n "$STATUS" ]]; then
+      update_single_select_field "Status" "$STATUS" "$NEW_ITEM_ID"
+    fi
+    if [[ -n "$PRIORITY" ]]; then
+      update_single_select_field "Priority" "$PRIORITY" "$NEW_ITEM_ID"
+    fi
+    if [[ -n "$SIZE" ]]; then
+      update_single_select_field "Size" "$SIZE" "$NEW_ITEM_ID"
+    fi
+
+    graphql_call "$(jq -n --arg query "$DELETE_ITEM_QUERY" \
+      --arg projectId "$OLD_PROJECT_ID" \
+      --arg itemId "$ITEM_ID" \
+      '{query: $query, variables: {input: {projectId: $projectId, itemId: $itemId}}}')" > /dev/null
+
+    if [[ -n "$STATUS" ]]; then
+      echo "  Moved item (Status: $STATUS)"
+    else
+      echo "  Moved item (no Status)"
+    fi
+    MOVED=$((MOVED + 1))
+  done <<< "$ITEM_ROWS"
+fi
+
+# --- Summary ---
+
+echo ""
+echo -e "${GREEN}Moved $MOVED item(s) from '$CURRENT_PROJECT_TITLE' to '$NEXT_PROJECT_TITLE'${NC}"
+echo -e "Next project: $NEW_PROJECT_URL"
+echo -e "${YELLOW}Old project left open: $CURRENT_PROJECT_TITLE${NC}"

--- a/packages/rangelink-vscode-extension/scripts/start-release.sh
+++ b/packages/rangelink-vscode-extension/scripts/start-release.sh
@@ -10,8 +10,9 @@ set -euo pipefail
 #   0. If on main, create a post-release-v<VERSION> branch (otherwise apply in-place)
 #   1. Prepend [Unreleased] header with empty sections to CHANGELOG
 #   2. Re-add [!IMPORTANT] banner to README
+#   3. Rotate the release project board (rotate-release-board.sh)
 #
-# Requires: jq
+# Requires: jq, gh CLI (authenticated for project board rotation)
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -133,6 +134,12 @@ fi
 cd "$REPO_ROOT"
 npx prettier --write "$README" "$CHANGELOG" > /dev/null 2>&1
 cd "$PACKAGE_DIR"
+
+# --- Step 3: Rotate the release project board ---
+
+echo ""
+echo -e "${GREEN}Step 3: Rotating release project board...${NC}"
+"$SCRIPT_DIR/rotate-release-board.sh"
 
 # --- Summary ---
 

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/linkGeneration.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/linkGeneration.test.ts
@@ -27,14 +27,7 @@ standardSuite('Link Generation', (ss) => {
     assert.ok(!generatedLink.includes('#L21'), `Expected no #L21 in link but got: ${generatedLink}`);
   });
 
-  const runWrappedNavigationTest = async (
-    tcId: string,
-    label: string,
-    wrapperDesc: string,
-    open: string,
-    close: string,
-    suffix: string,
-  ): Promise<void> => {
+  const runWrappedNavigationTest = async (tcId: string, label: string, wrapperDesc: string, open: string, close: string, suffix: string): Promise<void> => {
     const targetUri = ss.createWorkspaceFile(`wln-${tcId}-target`, 'line 1\nline 2\nline 3\nline 4\nTARGET LINE 5\nline 6\n');
     const relativePath = vscode.workspace.asRelativePath(targetUri, false);
     const displayLink = `${open}${relativePath}#L5${close}${suffix}`;

--- a/packages/rangelink-vscode-extension/src/__integration-tests__/suite/linkGeneration.test.ts
+++ b/packages/rangelink-vscode-extension/src/__integration-tests__/suite/linkGeneration.test.ts
@@ -27,93 +27,67 @@ standardSuite('Link Generation', (ss) => {
     assert.ok(!generatedLink.includes('#L21'), `Expected no #L21 in link but got: ${generatedLink}`);
   });
 
-  const WRAPPER_CASES = [
-    {
-      tcId: 'baseline',
-      label: 'plain',
-      wrapperDesc: 'a plain RangeLink with no wrapping characters',
-      open: '',
-      close: '',
-      suffix: '',
-    },
-    {
-      tcId: '001',
-      label: 'backtick-wrapped',
-      wrapperDesc: 'the RangeLink wrapped in backticks',
-      open: '`',
-      close: '`',
-      suffix: '',
-    },
-    {
-      tcId: '002',
-      label: 'single-quote-wrapped',
-      wrapperDesc: 'the RangeLink wrapped in single quotes',
-      open: "'",
-      close: "'",
-      suffix: '',
-    },
-    {
-      tcId: '003',
-      label: 'double-quote-wrapped',
-      wrapperDesc: 'the RangeLink wrapped in double quotes',
-      open: '"',
-      close: '"',
-      suffix: '',
-    },
-    {
-      tcId: '004',
-      label: 'angle-bracket-wrapped',
-      wrapperDesc: 'the RangeLink wrapped in angle brackets',
-      open: '<',
-      close: '>',
-      suffix: '',
-    },
-    {
-      tcId: '005',
-      label: 'paren-wrapped',
-      wrapperDesc: 'the RangeLink enclosed in parentheses',
-      open: '(',
-      close: ')',
-      suffix: '',
-    },
-    {
-      tcId: '006',
-      label: 'paren-then-colon-wrapped',
-      wrapperDesc: 'the RangeLink wrapped in parens with trailing colon',
-      open: '(',
-      close: ')',
-      suffix: ':',
-    },
-  ];
+  const runWrappedNavigationTest = async (
+    tcId: string,
+    label: string,
+    wrapperDesc: string,
+    open: string,
+    close: string,
+    suffix: string,
+  ): Promise<void> => {
+    const targetUri = ss.createWorkspaceFile(`wln-${tcId}-target`, 'line 1\nline 2\nline 3\nline 4\nTARGET LINE 5\nline 6\n');
+    const relativePath = vscode.workspace.asRelativePath(targetUri, false);
+    const displayLink = `${open}${relativePath}#L5${close}${suffix}`;
 
-  for (const { tcId, label, wrapperDesc, open, close, suffix } of WRAPPER_CASES) {
-    test(`[assisted] wrapped-link-navigation-${tcId}: ${label} RangeLink in terminal is clickable and navigates correctly`, async () => {
-      const targetUri = ss.createWorkspaceFile(`wln-${tcId}-target`, 'line 1\nline 2\nline 3\nline 4\nTARGET LINE 5\nline 6\n');
-      const relativePath = vscode.workspace.asRelativePath(targetUri, false);
-      const displayLink = `${open}${relativePath}#L5${close}${suffix}`;
+    ss.expectToastMessages([{ level: 'info', message: `Navigated to ${relativePath} @ 5` }]);
+    ss.expectContextKeys({ 'rangelink.isActiveTerminalBindable': true });
 
-      ss.expectToastMessages([{ level: 'info', message: `Navigated to ${relativePath} @ 5` }]);
-      ss.expectContextKeys({ 'rangelink.isActiveTerminalBindable': true });
+    const terminal = await ss.createTerminal(`wln-${tcId}`);
+    echoToTerminal(terminal, displayLink);
+    await ss.settle();
 
-      const terminal = await ss.createTerminal(`wln-${tcId}`);
-      echoToTerminal(terminal, displayLink);
-      await ss.settle();
+    const verdict = await waitForHumanVerdict(
+      `wrapped-link-navigation-${tcId}`,
+      `Cmd+click the RangeLink ${displayLink} in terminal "wln-${tcId}". Did VS Code open the target file showing "TARGET LINE 5"?`,
+      [
+        `1. Find terminal "wln-${tcId}" in the terminal panel`,
+        `2. Cmd+click on ${displayLink} — ${wrapperDesc}`,
+        '3. Verify the target file opens showing "TARGET LINE 5"',
+        'Verdict:',
+      ],
+    );
 
-      const verdict = await waitForHumanVerdict(
-        `wrapped-link-navigation-${tcId}`,
-        `Cmd+click the RangeLink ${displayLink} in terminal "wln-${tcId}". Did VS Code open the target file showing "TARGET LINE 5"?`,
-        [
-          `1. Find terminal "wln-${tcId}" in the terminal panel`,
-          `2. Cmd+click on ${displayLink} — ${wrapperDesc}`,
-          '3. Verify the target file opens showing "TARGET LINE 5"',
-          'Verdict:',
-        ],
-      );
+    assert.strictEqual(verdict, 'pass', `Human reported FAIL: ${label} RangeLink did not navigate correctly`);
+    ss.log(`✓ wrapped-link-navigation-${tcId} — ${label} RangeLink navigated (human verified)`);
+  };
 
-      assert.strictEqual(verdict, 'pass', `Human reported FAIL: ${label} RangeLink did not navigate correctly`);
-      ss.log(`✓ wrapped-link-navigation-${tcId} — ${label} RangeLink navigated (human verified)`);
-    });
-  }
+  test('[assisted] wrapped-link-navigation-baseline: plain RangeLink in terminal is clickable and navigates correctly', async () => {
+    await runWrappedNavigationTest('baseline', 'plain', 'a plain RangeLink with no wrapping characters', '', '', '');
+  });
+
+  test('[assisted] wrapped-link-navigation-001: backtick-wrapped RangeLink in terminal is clickable and navigates correctly', async () => {
+    await runWrappedNavigationTest('001', 'backtick-wrapped', 'the RangeLink wrapped in backticks', '`', '`', '');
+  });
+
+  test('[assisted] wrapped-link-navigation-002: single-quote-wrapped RangeLink in terminal is clickable and navigates correctly', async () => {
+    await runWrappedNavigationTest('002', 'single-quote-wrapped', 'the RangeLink wrapped in single quotes', "'", "'", '');
+  });
+
+  test('[assisted] wrapped-link-navigation-003: double-quote-wrapped RangeLink in terminal is clickable and navigates correctly', async () => {
+    await runWrappedNavigationTest('003', 'double-quote-wrapped', 'the RangeLink wrapped in double quotes', '"', '"', '');
+  });
+
+  test('[assisted] wrapped-link-navigation-004: angle-bracket-wrapped RangeLink in terminal is clickable and navigates correctly', async () => {
+    await runWrappedNavigationTest('004', 'angle-bracket-wrapped', 'the RangeLink wrapped in angle brackets', '<', '>', '');
+  });
+
+  test('[assisted] wrapped-link-navigation-005: paren-wrapped RangeLink in terminal is clickable and navigates correctly', async () => {
+    await runWrappedNavigationTest('005', 'paren-wrapped', 'the RangeLink enclosed in parentheses', '(', ')', '');
+  });
+
+  test('[assisted] wrapped-link-navigation-006: paren-then-colon-wrapped RangeLink in terminal is clickable and navigates correctly', async () => {
+    await runWrappedNavigationTest('006', 'paren-then-colon-wrapped', 'the RangeLink wrapped in parens with trailing colon', '(', ')', ':');
+  });
 
   test('[assisted] markdown-link-navigation-001: Markdown link [label](path#L5) in a document is clickable and navigates correctly', async () => {
     const targetUri = ss.createWorkspaceFile('mln-001-target', 'line 1\nline 2\nline 3\nline 4\nTARGET LINE 5\nline 6\n');


### PR DESCRIPTION
## Summary

`release:lock` is now the single entry point for release tracking: it generates the dev.to article issue, adds both tracking issues to the "RangeLink vX.Y.Z release" project board with Status Ready, and prints the exact /release-prep skill prompt for the cross-repo article-registration issue. release:start rotates the board to the next version, carrying unfinished items with their Status, Priority, and Size preserved. All board operations share one helper library, and the release-prep skill is now a thin post-lock orchestrator instead of embedding GraphQL.

## Changes

- release:lock chains generate-release-issues.sh after the QA issue extraction: creates the dev.to post issue from the acceptance-criteria template, supersedes any prior dev.to issue on re-runs, adds the dev.to and QA issues to the release board, and injects the dev.to URL into the instructions frontmatter
- The lock summary now prints the exact /release-prep X.Y.Z prompt, and docs/RELEASE-STRATEGY.md collapses the lock step to that single command
- New add-issue-to-release-board.sh adds an issue from any repository to the release board with Status Ready (or warns when the board has no Ready option); the release-prep skill verifies the lock state via the instructions frontmatter and delegates board operations to this script
- New release-board-lib.sh centralizes the GitHub Projects V2 GraphQL helpers used by generate-release-issues.sh, add-issue-to-release-board.sh, and rotate-release-board.sh: viewer-based board listing, exact-title resolution with candidate listing, Status/Ready resolution, add-item and set-field mutations
- release:start runs the new rotate-release-board.sh: copies the current project to the next minor version (overridable), moves non-Done items preserving Status, Priority, and Size, deletes the moved originals, skips when the next project already exists, and supports --dry-run
- Release-testing instructions frontmatter now records both qa_issue_url and devto_issue_url so the release-prep skill can verify lock completion without re-deriving anything

## Key Discoveries

- gh api graphql -F cannot pass nested JSON, so every board mutation writes the query and variables to a temp file and runs gh api graphql --input; this convention is now encoded once in release-board-lib.sh
- The board listing moved to the viewer projectsV2 query, eliminating the separate gh api user login lookup the scripts previously needed

## Test Plan

- [ ] All existing tests pass (230 BATS tests, 118 Jest suites and 2084 tests)
- [ ] New BATS suites for generate-release-issues.sh, add-issue-to-release-board.sh, and rotate-release-board.sh cover happy paths, board-not-found candidates, missing Ready option, and dry-run
- [ ] Manual testing: dogfood release-prep on 2.1.0 after merge to create the cross-repo issue and board entries

## Related

- Closes https://github.com/couimet/rangeLink/issues/718

Generated by /finish-issue v2026.08.18@86bafb9 • [my-claude-skills](https://github.com/couimet/my-claude-skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated tracking for QA and Dev.to release issues.
  - Release issues are added to the appropriate release board with Ready status when available.
  - Added dry-run support for reviewing planned release actions.
  - Release instructions now include Dev.to issue and post placeholders.

- **Release Workflow**
  - Release locking records both issue links in testing instructions, workflow comments, and commit summaries.
  - Release starting rotates project boards while preserving active work statuses.
  - Added `/release-prep` guidance for completing cross-repository release tracking.

- **Bug Fixes**
  - Improved rerun handling for superseded issues and partially completed board migrations.
  - Added safer handling when release-board lookups or cleanup operations fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->