### PR TITLE
[issues/720] `CLAUDE.md` rule: `couimet/*` actions use `@main`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,11 +363,12 @@
   <rationale>Logger is a cross-cutting concern, not a domain parameter. Placing it last keeps the primary parameters grouped together and makes the signature easier to read.</rationale>
 </rule>
 
-<rule id="CI001" priority="critical">
-  <title>couimet/github-actions actions always use @main, never a commit SHA</title>
-  <do>Reference all `couimet/github-actions/*` actions with `@main`: `uses: couimet/github-actions/typescript-ci@main`</do>
-  <never>Pin to a commit SHA for `couimet/github-actions` actions</never>
-  <rationale>`@main` is the rolling release channel for our own actions. We control the repo, so breaking changes are intentional and versioned. SHAs add pin-update churn with no benefit for first-party actions.</rationale>
+<!-- rule-id: couimet-actions-main -->
+<rule id="couimet-actions-main" priority="critical">
+  <title>couimet/* GitHub Actions always use @main</title>
+  <never>Pin a `couimet/*` GitHub Action to a commit SHA in CI workflows</never>
+  <do>Always reference `couimet/*` actions with `@main` to get the latest version</do>
+  <rationale>The author wants these actions to auto-update across all repos</rationale>
 </rule>
 
 </critical-rules>


### PR DESCRIPTION
## Summary

Adds a critical rule to the repository-root `CLAUDE.md` requiring all `couimet/*` GitHub Actions to be referenced with `@main` and prohibiting commit-SHA pinning, so automated tools and reviewers stop proposing incompatible SHA pins. The rule replaces the previous `CI001` rule, which only covered `couimet/github-actions/*`.

## Changes

- Repository-root `CLAUDE.md` now requires `@main` for all `couimet/*` GitHub Actions and prohibits commit-SHA pinning, replacing the narrower `couimet/github-actions/*`-only `CI001` rule
- The `couimet-actions-main` rule block (id and wording, plus the `rule-id` marker comment) is kept verbatim from `couimet/github-actions#105`, matching the cross-repo convention established in `couimet.github.io` https://github.com/couimet/couimet.github.io/pull/188 and `my-claude-skills` https://github.com/couimet/my-claude-skills/pull/224

## Key Discoveries

- Every `couimet/*` action in `.github/workflows/ci.yml` was already referenced with `@main`, so the rule codifies existing practice rather than introducing new behavior
- The reference implementation keeps the rule id and wording identical across repos because tooling scans `rule-id` markers; replacing `CI001` (a subset of the new scope) avoids a duplicate overlapping rule

## Test Plan

- [x] All existing tests pass (2084 tests, 118 suites)
- [x] prettier format clean; markdownlint clean on `CLAUDE.md`
- [x] Manual: reviewed `git diff` — only the `CI001` → `couimet-actions-main` replacement

## Related

- Closes https://github.com/couimet/rangeLink/issues/720

Generated by /finish-issue v2026.08.19@3c1c2ab • [my-claude-skills](https://github.com/couimet/my-claude-skills)

@coderabbitai ignore