### PR TITLE
[issues/723] CLAUDE.md rule covers composite action definitions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,7 +366,7 @@
 <!-- rule-id: couimet-actions-main -->
 <rule id="couimet-actions-main" priority="critical">
   <title>couimet/* GitHub Actions always use @main</title>
-  <never>Pin a `couimet/*` GitHub Action to a commit SHA in CI workflows</never>
+  <never>Pin a `couimet/*` GitHub Action to a commit SHA in workflows or composite action definitions</never>
   <do>Always reference `couimet/*` actions with `@main` to get the latest version</do>
   <rationale>The author wants these actions to auto-update across all repos</rationale>
 </rule>


### PR DESCRIPTION
## Summary

Updates the `couimet-actions-main` rule in the repository-root `CLAUDE.md` so the SHA prohibition covers composite action definitions as well as CI workflows, matching upstream (couimet/github-actions#105). The `<never>` clause now reads "in workflows or composite action definitions".

## Changes

- The `couimet-actions-main` rule's `<never>` clause now prohibits pinning `couimet/*` actions to a commit SHA in workflows or composite action definitions, not just CI workflows (via `CLAUDE.md`)

## Test Plan

- [ ] All existing tests pass (620 core-ts + 2084 vscode-extension)

## Related

- Closes https://github.com/couimet/rangeLink/issues/723

Generated by /finish-issue v2026.08.19@3c1c2ab • [my-claude-skills](https://github.com/couimet/my-claude-skills)

@coderabbitai ignore