### PR TITLE
[issues/728] Apply stylistic feedback from PR 721 review

### DIFF
--- a/packages/rangelink-vscode-extension/src/__tests__/services/LinkGenerator.test.ts
+++ b/packages/rangelink-vscode-extension/src/__tests__/services/LinkGenerator.test.ts
@@ -108,7 +108,6 @@ describe('LinkGenerator', () => {
       const { mockDoc, validated } = createValidatedResult();
       mockSelectionValidator.validateSelectionsAndShowError.mockReturnValue(validated);
       jest.spyOn(mockAdapter, 'getActiveTextEditorUri').mockReturnValue(mockDoc.uri);
-      jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(undefined);
       const link = createMockFormattedLink('src/file.ts#L1');
       mockGenLink.mockReturnValue(DetailedResult.success(link));
       mockSendRouter.resolveDestination.mockResolvedValue({
@@ -148,7 +147,6 @@ describe('LinkGenerator', () => {
       const { mockDoc, validated } = createValidatedResult();
       mockSelectionValidator.validateSelectionsAndShowError.mockReturnValue(validated);
       jest.spyOn(mockAdapter, 'getActiveTextEditorUri').mockReturnValue(mockDoc.uri);
-      jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(undefined);
       mockGenLink.mockReturnValue(DetailedResult.failure(new Error('generation failed')));
 
       await generator.createLink();
@@ -164,7 +162,6 @@ describe('LinkGenerator', () => {
       const { mockDoc, validated } = createValidatedResult();
       mockSelectionValidator.validateSelectionsAndShowError.mockReturnValue(validated);
       jest.spyOn(mockAdapter, 'getActiveTextEditorUri').mockReturnValue(mockDoc.uri);
-      jest.spyOn(mockAdapter, 'getWorkspaceFolder').mockReturnValue(undefined);
       mockGenLink.mockReturnValue(DetailedResult.success(createMockFormattedLink('src/file.ts#L1')));
       jest.spyOn(mockAdapter, 'getActiveTextEditorUri').mockReturnValue(undefined);
 

--- a/packages/rangelink-vscode-extension/src/destinations/BoundSession.ts
+++ b/packages/rangelink-vscode-extension/src/destinations/BoundSession.ts
@@ -201,7 +201,7 @@ export class BoundSession implements vscode.Disposable {
     this.disposables.push(disposable);
   }
 
-  private setupFileRenameListener(): void {
+  private setupFileRenameListener = (): void => {
     const disposable = this.events.onDidRenameFiles((event) => {
       if (!isEditorDestination(this.bound)) {
         return;
@@ -230,5 +230,5 @@ export class BoundSession implements vscode.Disposable {
     });
 
     this.disposables.push(disposable);
-  }
+  };
 }

--- a/packages/rangelink-vscode-extension/src/ide/EventSubscriptionProvider.ts
+++ b/packages/rangelink-vscode-extension/src/ide/EventSubscriptionProvider.ts
@@ -8,5 +8,5 @@ export interface EventSubscriptionProvider {
   onDidCloseTerminal(listener: (terminal: vscode.Terminal) => void): vscode.Disposable;
   onDidCloseTextDocument(listener: (document: vscode.TextDocument) => void): vscode.Disposable;
   onDidChangeTabs(listener: (event: vscode.TabChangeEvent) => void): vscode.Disposable;
-  onDidRenameFiles(listener: (event: vscode.FileRenameEvent) => void): vscode.Disposable;
+  onDidRenameFiles: (listener: (event: vscode.FileRenameEvent) => void) => vscode.Disposable;
 }

--- a/packages/rangelink-vscode-extension/src/ide/vscode/VscodeAdapter.ts
+++ b/packages/rangelink-vscode-extension/src/ide/vscode/VscodeAdapter.ts
@@ -100,6 +100,16 @@ export class VscodeAdapter
   ) {}
 
   /**
+   * Register event listener for file renames.
+   *
+   * @param listener - Callback invoked when files are renamed
+   * @returns Disposable to unregister the listener
+   */
+  onDidRenameFiles = (listener: (event: vscode.FileRenameEvent) => void): vscode.Disposable => {
+    return this.ideInstance.workspace.onDidRenameFiles(listener);
+  };
+
+  /**
    * Read text from clipboard using VSCode API.
    *
    * Prefer {@link ClipboardService} for logging and error handling.
@@ -742,16 +752,6 @@ export class VscodeAdapter
    */
   onDidCloseTextDocument(listener: (document: vscode.TextDocument) => void): vscode.Disposable {
     return this.ideInstance.workspace.onDidCloseTextDocument(listener);
-  }
-
-  /**
-   * Register event listener for file renames.
-   *
-   * @param listener - Callback invoked when files are renamed
-   * @returns Disposable to unregister the listener
-   */
-  onDidRenameFiles(listener: (event: vscode.FileRenameEvent) => void): vscode.Disposable {
-    return this.ideInstance.workspace.onDidRenameFiles(listener);
   }
 
   /**


### PR DESCRIPTION
## Summary

Applies the deferred, non-functional CodeRabbit feedback from the file-rename auto-unbind PR (#721). The file-rename lifecycle listeners now use arrow-function members, and redundant workspace-folder spies were removed from the LinkGenerator tests. No behavior changes.

## Changes

- File-rename lifecycle listeners now use arrow-function members (`EventSubscriptionProvider.onDidRenameFiles`, `VscodeAdapter.onDidRenameFiles`, `BoundSession.setupFileRenameListener`), so `this` stays bound if they are passed as callbacks
- Removed three redundant `getWorkspaceFolder` spy setups from the LinkGenerator tests that duplicated the mock's default `undefined` return; the spy its own test asserts on is kept

## Key Discoveries

- Item 7's original premise was stale: `getWorkspaceFolder` IS called during link generation via `getReferencePath` in FilePathPaster.ts, so the "dead" spies were actually live. Only the redundant ones were removed, and the spy asserted by its own test was kept.
- Item 6 (redundant `viewColumn: 1` overrides in BoundSession.test.ts) was already resolved on the base branch, so it needed no work.
- Items 1-4 (direct leaf-module imports) were intentionally skipped to keep P005's barrel rule intact.

## Test Plan

- [ ] All existing tests pass (2169 tests, 99.54% coverage)

## Related

- Closes https://github.com/couimet/rangeLink/issues/728
- Came from https://github.com/couimet/rangeLink/issues/721

Generated by /finish-issue v2026.08.25@102ff9a • [my-claude-skills](https://github.com/couimet/my-claude-skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of file rename event subscriptions.
  * Preserved existing automatic behavior when files are renamed.
  * Simplified internal link-generation test setup without changing test coverage or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->