### PR TITLE
[issues/359] Clean up stale matcher references post-extraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,8 @@
 
 <rule id="T008" priority="critical">
   <title>Use custom matchers for Result and error assertions</title>
-  <do>Use `toBeDetailedError(code, { message, functionName, details?, cause? })` for both direct errors and error Result assertions — the matcher is Result-aware</do>
+  <do>Use `toHaveDetailedError(code, { message, functionName, details?, cause? })` for error Result assertions — the matcher is Result-aware and asserts on the failed DetailedResult's error (from @couimet/detailed-result-testing)</do>
+  <do>Use `toBeDetailedError(code, { message, functionName, details?, cause? })` for assertions on an already-caught or directly-held error value (from @couimet/detailed-error-testing)</do>
   <do>Use `toBeSuccessWith((value) => { expect(value).toStrictEqual({...}) })` for success Result assertions</do>
   <do>Use `toStrictEqual()` on the full value object inside `toBeSuccessWith` callbacks — never pick individual properties</do>
   <never>Use `result.success` + `if` guard patterns to manually unwrap Result types</never>
@@ -164,7 +165,8 @@
     - `toBeSuccess()` / `toBeFailure()` - simple success/error check (from @couimet/detailed-result-testing)
     - `toBeSuccessWith(callback)` - success with value assertion (from @couimet/detailed-result-testing)
     - `toBeFailureWith(callback)` - error with assertion (from @couimet/detailed-result-testing)
-    - `toBeDetailedError(code, expected)` - direct error validation (from @couimet/detailed-error-testing)
+    - `toHaveDetailedError(code, expected)` - error Result assertion, Result-aware (from @couimet/detailed-result-testing)
+    - `toBeDetailedError(code, expected)` - direct/caught error validation, not Result-aware (from @couimet/detailed-error-testing)
     - `toThrowDetailedError(code, expected)` - sync throw (from @couimet/detailed-error-testing)
     - `toThrowDetailedErrorAsync(code, expected)` - async throw (from @couimet/detailed-error-testing)
   </available-matchers>
@@ -179,7 +181,7 @@
   </bad-example>
   <good-example>
     ```typescript
-    expect(result).toBeDetailedError('DESTINATION_NOT_BOUND', {
+    expect(result).toHaveDetailedError('DESTINATION_NOT_BOUND', {
       message: 'No destination is currently bound',
       functionName: 'PasteDestinationManager.focusBoundDestination',
     });
@@ -565,36 +567,6 @@
     ```
   </bad-example>
 </presentation-layer-testing>
-
-<custom-matchers>
-
-  <matcher name="toThrowRangeLinkError">
-    <when>Testing functions that throw errors</when>
-    <example>
-      ```typescript
-      expect(() => validateInputSelection(input)).toThrowRangeLinkError({
-        code: RangeLinkErrorCodes.SELECTION_EMPTY,
-        message: 'Selections array must not be empty',
-        functionName: 'validateInputSelection',
-      });
-      ```
-    </example>
-  </matcher>
-
-  <matcher name="toBeRangeLinkErrorErr">
-    <when>Testing Result-returning functions</when>
-    <example>
-      ```typescript
-      const result = computeRangeSpec(input);
-      expect(result).toBeRangeLinkErrorErr('SELECTION_EMPTY', {
-        message: 'Selections array must not be empty',
-        functionName: 'validateInputSelection',
-      });
-      ```
-    </example>
-  </matcher>
-
-</custom-matchers>
 
 <spy-verification>
   <do>Always verify jest.spyOn() calls were made with exact parameters</do>

--- a/docs/ERROR-HANDLING.md
+++ b/docs/ERROR-HANDLING.md
@@ -178,29 +178,6 @@ export function computeRangeSpec(inputSelection: InputSelection): Result<Compute
 }
 ```
 
-### Testing with Custom Matcher
-
-Use the `toBeRangeLinkError` matcher for comprehensive error validation:
-
-```typescript
-it('returns error when selections array is empty', () => {
-  const result = computeRangeSpec({
-    selections: [],
-    selectionType: 'Normal',
-  });
-
-  expect(result).toBeErr();
-  expect(result).toBeErrWith((error) => {
-    expect(error).toBeRangeLinkError({
-      code: RangeLinkErrorCodes.SELECTION_EMPTY,
-      message: 'Selections array must not be empty',
-      functionName: 'validateInputSelection',
-      details: { selectionsLength: 0, selectionType: 'Normal' },
-    });
-  });
-});
-```
-
 ### Benefits
 
 1. **Developer Ergonomics**: Validation logic reads naturally without Result boilerplate
@@ -238,13 +215,6 @@ Error code locations by category:
 - **Source**: `packages/rangelink-core-ts/src/types/RangeLinkMessageCode.ts`
 - **Contains**: All message types: `MSG_xxxx`, `WARN_xxxx`, `ERR_xxxx` (30 total)
 - **Usage**: `logger.error(RangeLinkMessageCode.CONFIG_ERR_DELIMITER_EMPTY, 'message')`
-
-### Shared Error Infrastructure
-
-- **DetailedError**: `packages/rangelink-core-ts/src/errors/detailedError.ts` - Base class for structured errors
-- **RangeLinkError**: `packages/rangelink-core-ts/src/errors/RangeLinkError.ts` - Main error class
-- **SharedErrorCodes**: `packages/rangelink-core-ts/src/errors/sharedErrorCodes.ts` - Generic error codes
-- **Custom Matcher**: `packages/rangelink-core-ts/src/__tests__/matchers/toBeRangeLinkError.ts` - Jest matcher for error assertions
 
 ## Related Documentation
 

--- a/packages/rangelink-core-ts/src/errors/RangeLinkErrorCodes.ts
+++ b/packages/rangelink-core-ts/src/errors/RangeLinkErrorCodes.ts
@@ -85,7 +85,7 @@ export type RangeLinkErrorCodes = RangeLinkSpecificCodes | SharedErrorCodes;
 
 /**
  * Merged error codes object.
- * Spread SharedErrorCodes LAST to avoid override issues (see sharedErrorCodes.ts docs).
+ * Spread SharedErrorCodes LAST to avoid override issues (SharedErrorCodes from @couimet/detailed-error).
  */
 export const RangeLinkErrorCodes = {
   ...RangeLinkSpecificCodes,

--- a/packages/rangelink-vscode-extension/src/errors/RangeLinkExtensionError.ts
+++ b/packages/rangelink-vscode-extension/src/errors/RangeLinkExtensionError.ts
@@ -11,8 +11,9 @@ import { DetailedError, type ErrorOptions } from '@couimet/detailed-error';
  * - Contextual details object
  * - Cause chaining
  *
- * Inherits shared error codes from rangelink-core-ts (VALIDATION, UNKNOWN, UNEXPECTED_CODE_PATH)
- * and adds extension-specific codes (DESTINATION_NOT_IMPLEMENTED, GENERATE_LINK_SELECTION_EMPTY, etc.).
+ * Includes the core RangeLinkErrorCodes from rangelink-core-ts (which merge RangeLinkSpecificCodes
+ * with SharedErrorCodes from @couimet/detailed-error) and adds extension-specific codes
+ * (DESTINATION_NOT_IMPLEMENTED, GENERATE_LINK_SELECTION_EMPTY, etc.).
  */
 export class RangeLinkExtensionError extends DetailedError<RangeLinkExtensionErrorCodes> {
   constructor(options: ErrorOptions<RangeLinkExtensionErrorCodes>) {


### PR DESCRIPTION
## Summary

Issue #359 proposed extracting RangeLink's error and Result infrastructure into reusable packages; that substance already shipped as @couimet/* packages through PRs #361, #684, and #697. What remained was the residual stale-reference cleanup those merges left behind: documentation still recommending removed local matchers and pointing at deleted core-ts files, a CLAUDE.md matcher block documenting removed matchers, and two code comments naming the deleted sharedErrorCodes.ts source. This PR removes every dead reference and makes CLAUDE.md's matcher guidance internally consistent with the external packages now in use.

## Changes

- Documentation: trimmed ERROR-HANDLING.md of the stale matcher-testing example and the shared-error-infrastructure pointer list, so no reference to the removed local matchers (toBeErr, toBeErrWith, toBeRangeLinkError) or the deleted core-ts files (detailedError.ts, sharedErrorCodes.ts, matchers/toBeRangeLinkError.ts) remains in docs/
- Consolidated CLAUDE.md's matcher guidance into a single authority: rule T008 now documents the current external matchers (toHaveDetailedError for Result error assertions, toBeDetailedError for already-caught errors, toThrowDetailedError and toThrowDetailedErrorAsync for throws), and the redundant custom-matchers block that still listed the removed toThrowRangeLinkError and toBeRangeLinkErrorErr matchers was deleted
- Corrected the two error-class comments in both packages that described shared error codes as inherited from rangelink-core-ts or pointed at the deleted sharedErrorCodes.ts; both now name SharedErrorCodes from @couimet/detailed-error

## Key Discoveries

- The issue's core intent shipped externally: DetailedError, SharedErrorCodes, and the test matchers were built in couimet/ts-npm-packages, published as @couimet/*, and adopted via PRs #361, #684, and #697, so this PR carries only the cleanup those merges left behind
- Rule T008 still described the pre-#697 local Result-aware toBeDetailedError wrapper; after adoption the Result-aware matcher is toHaveDetailedError from @couimet/detailed-result-testing (135 uses in the repo) while toBeDetailedError is not Result-aware (0 uses), so the fix corrected T008 into the single reference rather than aligning the block to an inaccurate rule

## Test Plan

- [ ] All existing tests pass

Documentation and source comments only; no new tests or manual testing required (format check clean, full Jest suite green).

## Related

- Closes https://github.com/couimet/rangeLink/issues/359

Generated by /finish-issue v2026.09.02@026b73f • [my-claude-skills](https://github.com/couimet/my-claude-skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated error-testing guidance to distinguish matchers for error Results and direct errors.
  * Removed obsolete custom matcher examples and shared error infrastructure references.
  * Clarified error-code documentation across core and extension components.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->